### PR TITLE
feat: workspace views, mixer layout, and pro knob control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,6 +4171,7 @@ name = "vibez-core"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4201,6 +4202,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tempfile",
  "vibez-core",
 ]
 

--- a/crates/vibez-core/Cargo.toml
+++ b/crates/vibez-core/Cargo.toml
@@ -6,3 +6,6 @@ license.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/vibez-core/src/constants.rs
+++ b/crates/vibez-core/src/constants.rs
@@ -5,6 +5,15 @@ pub const DEFAULT_BPM: f64 = 120.0;
 pub const MIN_BPM: f64 = 20.0;
 pub const MAX_BPM: f64 = 999.0;
 
+/// Maximum number of tracks.
+pub const MAX_TRACKS: usize = 64;
+
+/// Default track gain (unity).
+pub const DEFAULT_TRACK_GAIN: f32 = 1.0;
+
+/// Default track pan (center). Range 0.0 (left) to 1.0 (right).
+pub const DEFAULT_TRACK_PAN: f32 = 0.5;
+
 /// Ring buffer capacity for engine commands/events.
 pub const RING_BUFFER_CAPACITY: usize = 1024;
 

--- a/crates/vibez-core/src/lib.rs
+++ b/crates/vibez-core/src/lib.rs
@@ -2,3 +2,4 @@ pub mod audio_buffer;
 pub mod constants;
 pub mod id;
 pub mod time;
+pub mod track;

--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -1,0 +1,132 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::id::{ClipId, TrackId};
+
+/// Serializable track metadata shared between engine and UI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackInfo {
+    pub id: TrackId,
+    pub name: String,
+    pub gain: f32,
+    pub pan: f32,
+    pub mute: bool,
+    pub solo: bool,
+}
+
+impl TrackInfo {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            id: TrackId::new(),
+            name: name.into(),
+            gain: crate::constants::DEFAULT_TRACK_GAIN,
+            pan: crate::constants::DEFAULT_TRACK_PAN,
+            mute: false,
+            solo: false,
+        }
+    }
+}
+
+/// Serializable clip metadata shared between engine and UI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClipInfo {
+    pub id: ClipId,
+    pub track_id: TrackId,
+    pub name: String,
+    /// Position on the timeline in samples.
+    pub position: u64,
+    /// Offset into the source audio in samples.
+    pub source_offset: u64,
+    /// Duration in samples.
+    pub duration: u64,
+    /// Path to the source audio file.
+    pub file_path: PathBuf,
+}
+
+impl ClipInfo {
+    /// The end position of this clip on the timeline (position + duration).
+    pub fn end_position(&self) -> u64 {
+        self.position.saturating_add(self.duration)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn track_info_defaults() {
+        let track = TrackInfo::new("Track 1");
+        assert_eq!(track.name, "Track 1");
+        assert!((track.gain - 1.0).abs() < f32::EPSILON);
+        assert!((track.pan - 0.5).abs() < f32::EPSILON);
+        assert!(!track.mute);
+        assert!(!track.solo);
+    }
+
+    #[test]
+    fn clip_end_position() {
+        let clip = ClipInfo {
+            id: ClipId::new(),
+            track_id: TrackId::new(),
+            name: "test".into(),
+            position: 1000,
+            source_offset: 0,
+            duration: 500,
+            file_path: PathBuf::from("test.wav"),
+        };
+        assert_eq!(clip.end_position(), 1500);
+    }
+
+    #[test]
+    fn clip_end_position_saturates() {
+        let clip = ClipInfo {
+            id: ClipId::new(),
+            track_id: TrackId::new(),
+            name: "test".into(),
+            position: u64::MAX - 10,
+            source_offset: 0,
+            duration: 100,
+            file_path: PathBuf::from("test.wav"),
+        };
+        assert_eq!(clip.end_position(), u64::MAX);
+    }
+
+    #[test]
+    fn unique_ids() {
+        let t1 = TrackInfo::new("A");
+        let t2 = TrackInfo::new("B");
+        assert_ne!(t1.id, t2.id);
+    }
+
+    #[test]
+    fn serde_roundtrip_track() {
+        let track = TrackInfo::new("Synth Lead");
+        let json = serde_json::to_string(&track).unwrap();
+        let deserialized: TrackInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(track.id, deserialized.id);
+        assert_eq!(track.name, deserialized.name);
+        assert!((track.gain - deserialized.gain).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn serde_roundtrip_clip() {
+        let clip = ClipInfo {
+            id: ClipId::new(),
+            track_id: TrackId::new(),
+            name: "vocal.wav".into(),
+            position: 44100,
+            source_offset: 1000,
+            duration: 88200,
+            file_path: PathBuf::from("/audio/vocal.wav"),
+        };
+        let json = serde_json::to_string(&clip).unwrap();
+        let deserialized: ClipInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(clip.id, deserialized.id);
+        assert_eq!(clip.position, deserialized.position);
+        assert_eq!(clip.source_offset, deserialized.source_offset);
+        assert_eq!(clip.duration, deserialized.duration);
+        assert_eq!(clip.file_path, deserialized.file_path);
+    }
+}

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use vibez_core::audio_buffer::DecodedAudio;
+use vibez_core::id::{ClipId, TrackId};
 
 /// Commands sent from the UI thread to the audio engine (via rtrb).
 ///
@@ -16,10 +17,41 @@ pub enum EngineCommand {
     Seek(u64),
     /// Change the project tempo.
     SetBpm(f64),
-    /// Load decoded audio into the engine for playback.
+    /// Load decoded audio into the engine for playback (legacy single-file).
     LoadAudio(Arc<DecodedAudio>),
-    /// Remove any loaded audio from the engine.
+    /// Remove any loaded audio from the engine (legacy single-file).
     UnloadAudio,
+
+    // -- Multi-track commands --
+    /// Add a new track with the given ID and name.
+    AddTrack(TrackId, String),
+    /// Remove a track by ID.
+    RemoveTrack(TrackId),
+    /// Add a clip to a track.
+    AddClip {
+        track_id: TrackId,
+        clip_id: ClipId,
+        audio: Arc<DecodedAudio>,
+        position: u64,
+        source_offset: u64,
+        duration: u64,
+    },
+    /// Remove a clip from a track.
+    RemoveClip(TrackId, ClipId),
+    /// Move a clip to a new position on the timeline.
+    MoveClip {
+        track_id: TrackId,
+        clip_id: ClipId,
+        new_position: u64,
+    },
+    /// Set the gain for a track.
+    SetTrackGain(TrackId, f32),
+    /// Set the pan for a track (0.0 = left, 0.5 = center, 1.0 = right).
+    SetTrackPan(TrackId, f32),
+    /// Set the mute state for a track.
+    SetTrackMute(TrackId, bool),
+    /// Set the solo state for a track.
+    SetTrackSolo(TrackId, bool),
 }
 
 #[cfg(test)]
@@ -39,6 +71,37 @@ mod tests {
         });
         let _load = EngineCommand::LoadAudio(audio);
         let _unload = EngineCommand::UnloadAudio;
+    }
+
+    #[test]
+    fn multitrack_command_variants() {
+        let tid = TrackId::new();
+        let cid = ClipId::new();
+        let audio = Arc::new(DecodedAudio {
+            channels: vec![vec![0.0; 100]],
+            sample_rate: 44_100,
+        });
+
+        let _add_track = EngineCommand::AddTrack(tid, "Track 1".into());
+        let _remove_track = EngineCommand::RemoveTrack(tid);
+        let _add_clip = EngineCommand::AddClip {
+            track_id: tid,
+            clip_id: cid,
+            audio,
+            position: 0,
+            source_offset: 0,
+            duration: 100,
+        };
+        let _remove_clip = EngineCommand::RemoveClip(tid, cid);
+        let _move_clip = EngineCommand::MoveClip {
+            track_id: tid,
+            clip_id: cid,
+            new_position: 500,
+        };
+        let _gain = EngineCommand::SetTrackGain(tid, 0.8);
+        let _pan = EngineCommand::SetTrackPan(tid, 0.3);
+        let _mute = EngineCommand::SetTrackMute(tid, true);
+        let _solo = EngineCommand::SetTrackSolo(tid, true);
     }
 
     #[test]

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -7,6 +7,7 @@ use vibez_core::constants::RING_BUFFER_CAPACITY;
 use crate::commands::EngineCommand;
 use crate::events::EngineEvent;
 use crate::metering;
+use crate::mixer::{any_solo, calculate_total_length, equal_power_pan, EngineClip, EngineTrack};
 use crate::transport::Transport;
 
 /// The real-time audio engine.
@@ -27,7 +28,10 @@ use crate::transport::Transport;
 /// ```
 pub struct AudioEngine {
     transport: Transport,
+    /// Legacy single-audio field for backward compatibility.
     audio: Option<Arc<DecodedAudio>>,
+    /// Multi-track state.
+    tracks: Vec<EngineTrack>,
     cmd_rx: Consumer<EngineCommand>,
     event_tx: Producer<EngineEvent>,
 }
@@ -45,6 +49,7 @@ impl AudioEngine {
         let engine = Self {
             transport: Transport::new(),
             audio: None,
+            tracks: Vec::new(),
             cmd_rx,
             event_tx,
         };
@@ -60,58 +65,38 @@ impl AudioEngine {
     ///
     /// This method is **lock-free and allocation-free**.  It:
     /// 1. Drains all pending commands from the ring buffer.
-    /// 2. If playing and audio is loaded, copies samples into `output`.
-    /// 3. Advances the transport.
-    /// 4. Sends metering and position events to the UI thread.
+    /// 2. Zeros the output buffer.
+    /// 3. If tracks exist: renders each → applies gain/pan → sums into output.
+    /// 4. Otherwise: falls back to legacy single-audio path.
+    /// 5. Sends metering and position events to the UI thread.
     pub fn process(&mut self, output: &mut [f32], channels: usize) {
         // ---- 1. Drain commands ------------------------------------------
         self.drain_commands();
 
-        // ---- 2. Fill output buffer --------------------------------------
         let frames = if channels > 0 {
             output.len() / channels
         } else {
             0
         };
 
-        if self.transport.is_playing() {
-            if let Some(ref audio) = self.audio {
-                let pos = self.transport.position();
-                let audio_channels = audio.num_channels();
+        // ---- 2. Zero output buffer --------------------------------------
+        output.iter_mut().for_each(|s| *s = 0.0);
 
-                for frame in 0..frames {
-                    let sample_idx = pos as usize + frame;
-
-                    for ch in 0..channels {
-                        let sample = if ch < audio_channels {
-                            audio.sample(ch, sample_idx)
-                        } else if audio_channels > 0 {
-                            // If the output has more channels than the audio,
-                            // duplicate the last available channel.
-                            audio.sample(audio_channels - 1, sample_idx)
-                        } else {
-                            0.0
-                        };
-                        output[frame * channels + ch] = sample;
-                    }
-                }
-            } else {
-                // Playing but no audio loaded -- output silence.
-                output.iter_mut().for_each(|s| *s = 0.0);
-            }
+        if !self.tracks.is_empty() {
+            // ---- 3. Multi-track rendering path --------------------------
+            self.process_multitrack(output, frames, channels);
         } else {
-            // Stopped -- output silence.
-            output.iter_mut().for_each(|s| *s = 0.0);
+            // ---- 4. Legacy single-audio path ----------------------------
+            self.process_legacy(output, frames, channels);
         }
 
-        // ---- 3. Advance transport ---------------------------------------
+        // ---- 5. Advance transport and send events -----------------------
         let new_pos = self.transport.advance(frames as u64);
 
-        // ---- 4. Send events to the UI thread ----------------------------
         // Position event.
         let _ = self.event_tx.push(EngineEvent::PlaybackPosition(new_pos));
 
-        // Metering event.
+        // Master metering event.
         let meters = metering::calculate_meters(output, channels);
         let _ = self.event_tx.push(EngineEvent::Metering {
             peak_l: meters.peak_l,
@@ -131,9 +116,130 @@ impl AudioEngine {
         self.audio.as_ref()
     }
 
+    /// Read the tracks (for inspection / testing).
+    pub fn tracks(&self) -> &[EngineTrack] {
+        &self.tracks
+    }
+
     // ------------------------------------------------------------------
     // Private helpers
     // ------------------------------------------------------------------
+
+    /// Multi-track rendering: render each track, apply gain/pan, sum into output.
+    fn process_multitrack(&mut self, output: &mut [f32], frames: usize, channels: usize) {
+        if !self.transport.is_playing() {
+            return;
+        }
+
+        let pos = self.transport.position();
+        let has_solo = any_solo(&self.tracks);
+
+        for track_idx in 0..self.tracks.len() {
+            let track = &mut self.tracks[track_idx];
+
+            // Skip muted tracks always
+            if track.mute {
+                let _ = self.event_tx.push(EngineEvent::TrackMeter {
+                    track_id: track.id,
+                    peak_l: 0.0,
+                    peak_r: 0.0,
+                });
+                continue;
+            }
+
+            // If any track is soloed, skip non-soloed tracks
+            if has_solo && !track.solo {
+                let _ = self.event_tx.push(EngineEvent::TrackMeter {
+                    track_id: track.id,
+                    peak_l: 0.0,
+                    peak_r: 0.0,
+                });
+                continue;
+            }
+
+            let rendered = track.render(pos, frames, channels);
+            if !rendered {
+                let _ = self.event_tx.push(EngineEvent::TrackMeter {
+                    track_id: track.id,
+                    peak_l: 0.0,
+                    peak_r: 0.0,
+                });
+                continue;
+            }
+
+            let gain = track.gain;
+            let (pan_l, pan_r) = equal_power_pan(track.pan);
+            let track_id = track.id;
+            let buf_size = frames * channels;
+
+            // Apply gain and pan, sum into output
+            let mut track_peak_l: f32 = 0.0;
+            let mut track_peak_r: f32 = 0.0;
+
+            for frame in 0..frames {
+                for ch in 0..channels {
+                    let idx = frame * channels + ch;
+                    if idx >= buf_size {
+                        break;
+                    }
+                    let sample = track.mix_buffer[idx] * gain;
+                    let panned = if channels >= 2 {
+                        if ch == 0 {
+                            sample * pan_l
+                        } else if ch == 1 {
+                            sample * pan_r
+                        } else {
+                            sample
+                        }
+                    } else {
+                        sample
+                    };
+
+                    output[idx] += panned;
+
+                    // Track per-channel peaks
+                    if ch == 0 {
+                        track_peak_l = track_peak_l.max(panned.abs());
+                    } else if ch == 1 {
+                        track_peak_r = track_peak_r.max(panned.abs());
+                    }
+                }
+            }
+
+            let _ = self.event_tx.push(EngineEvent::TrackMeter {
+                track_id,
+                peak_l: track_peak_l,
+                peak_r: track_peak_r,
+            });
+        }
+    }
+
+    /// Legacy single-audio rendering path (Phase 1 compatibility).
+    fn process_legacy(&mut self, output: &mut [f32], frames: usize, channels: usize) {
+        if !self.transport.is_playing() {
+            return;
+        }
+
+        if let Some(ref audio) = self.audio {
+            let pos = self.transport.position();
+            let audio_channels = audio.num_channels();
+
+            for frame in 0..frames {
+                let sample_idx = pos as usize + frame;
+
+                for ch in 0..channels {
+                    let sample = if ch < audio_channels {
+                        audio.sample(ch, sample_idx)
+                    } else if audio_channels > 0 {
+                        audio.sample(audio_channels - 1, sample_idx)
+                    } else {
+                        0.0
+                    };
+                    output[frame * channels + ch] = sample;
+                }
+            }
+        }
+    }
 
     /// Drain all pending commands from the ring buffer without blocking.
     fn drain_commands(&mut self) {
@@ -164,7 +270,84 @@ impl AudioEngine {
                     self.transport.stop();
                     let _ = self.event_tx.push(EngineEvent::PlaybackStopped);
                 }
+                // -- Multi-track commands --
+                EngineCommand::AddTrack(id, _name) => {
+                    self.tracks.push(EngineTrack::new(id));
+                    self.recalculate_audio_length();
+                }
+                EngineCommand::RemoveTrack(id) => {
+                    self.tracks.retain(|t| t.id != id);
+                    self.recalculate_audio_length();
+                }
+                EngineCommand::AddClip {
+                    track_id,
+                    clip_id,
+                    audio,
+                    position,
+                    source_offset,
+                    duration,
+                } => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                        track.clips.push(EngineClip {
+                            id: clip_id,
+                            audio,
+                            position,
+                            source_offset,
+                            duration,
+                        });
+                    }
+                    self.recalculate_audio_length();
+                }
+                EngineCommand::RemoveClip(track_id, clip_id) => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                        track.clips.retain(|c| c.id != clip_id);
+                    }
+                    self.recalculate_audio_length();
+                }
+                EngineCommand::MoveClip {
+                    track_id,
+                    clip_id,
+                    new_position,
+                } => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                        if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
+                            clip.position = new_position;
+                        }
+                    }
+                    self.recalculate_audio_length();
+                }
+                EngineCommand::SetTrackGain(id, gain) => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == id) {
+                        track.gain = gain;
+                    }
+                }
+                EngineCommand::SetTrackPan(id, pan) => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == id) {
+                        track.pan = pan.clamp(0.0, 1.0);
+                    }
+                }
+                EngineCommand::SetTrackMute(id, mute) => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == id) {
+                        track.mute = mute;
+                    }
+                }
+                EngineCommand::SetTrackSolo(id, solo) => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == id) {
+                        track.solo = solo;
+                    }
+                }
             }
+        }
+    }
+
+    /// Recalculate transport audio length from all track clips.
+    fn recalculate_audio_length(&mut self) {
+        let total = calculate_total_length(&self.tracks);
+        if total > 0 {
+            self.transport.set_audio_length(Some(total));
+        } else if self.audio.is_none() {
+            // Only clear audio length if no legacy audio is loaded
+            self.transport.set_audio_length(None);
         }
     }
 }
@@ -173,6 +356,7 @@ impl AudioEngine {
 mod tests {
     use super::*;
     use vibez_core::audio_buffer::DecodedAudio;
+    use vibez_core::id::{ClipId, TrackId};
 
     /// Helper to create a simple stereo decoded audio with a known pattern.
     fn make_test_audio(frames: usize) -> Arc<DecodedAudio> {
@@ -182,6 +366,13 @@ mod tests {
             .collect();
         Arc::new(DecodedAudio {
             channels: vec![left, right],
+            sample_rate: 44_100,
+        })
+    }
+
+    fn make_constant_audio(frames: usize, value: f32) -> Arc<DecodedAudio> {
+        Arc::new(DecodedAudio {
+            channels: vec![vec![value; frames], vec![value; frames]],
             sample_rate: 44_100,
         })
     }
@@ -452,5 +643,404 @@ mod tests {
         let mut buf: Vec<f32> = vec![];
         // Should not panic.
         engine.process(&mut buf, 2);
+    }
+
+    // -- Multi-track tests --
+
+    #[test]
+    fn add_and_remove_tracks() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid1 = TrackId::new();
+        let tid2 = TrackId::new();
+
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid1, "Track 1".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid2, "Track 2".into()))
+            .unwrap();
+
+        let mut buf = vec![0.0f32; 8];
+        engine.process(&mut buf, 2);
+        assert_eq!(engine.tracks().len(), 2);
+
+        cmd_tx.push(EngineCommand::RemoveTrack(tid1)).unwrap();
+        engine.process(&mut buf, 2);
+        assert_eq!(engine.tracks().len(), 1);
+        assert_eq!(engine.tracks()[0].id, tid2);
+    }
+
+    #[test]
+    fn add_clip_and_play() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid = TrackId::new();
+        let cid = ClipId::new();
+        let audio = make_constant_audio(100, 0.5);
+
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid,
+                clip_id: cid,
+                audio,
+                position: 0,
+                source_offset: 0,
+                duration: 100,
+            })
+            .unwrap();
+        cmd_tx.push(EngineCommand::Play).unwrap();
+
+        let mut buf = vec![0.0f32; 16]; // 8 frames
+        engine.process(&mut buf, 2);
+
+        // With center pan (0.5), equal power gives ~0.707 on each channel
+        let expected = 0.5 * std::f32::consts::FRAC_1_SQRT_2;
+        for frame in 0..8 {
+            assert!(
+                (buf[frame * 2] - expected).abs() < 1e-4,
+                "frame {} L: expected {} got {}",
+                frame,
+                expected,
+                buf[frame * 2]
+            );
+            assert!(
+                (buf[frame * 2 + 1] - expected).abs() < 1e-4,
+                "frame {} R: expected {} got {}",
+                frame,
+                expected,
+                buf[frame * 2 + 1]
+            );
+        }
+    }
+
+    #[test]
+    fn mute_silences_track() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid = TrackId::new();
+        let cid = ClipId::new();
+        let audio = make_constant_audio(100, 0.8);
+
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid,
+                clip_id: cid,
+                audio,
+                position: 0,
+                source_offset: 0,
+                duration: 100,
+            })
+            .unwrap();
+        cmd_tx.push(EngineCommand::SetTrackMute(tid, true)).unwrap();
+        cmd_tx.push(EngineCommand::Play).unwrap();
+
+        let mut buf = vec![0.0f32; 16];
+        engine.process(&mut buf, 2);
+
+        assert!(buf.iter().all(|&s| s == 0.0));
+    }
+
+    #[test]
+    fn solo_isolates_track() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid1 = TrackId::new();
+        let tid2 = TrackId::new();
+        let cid1 = ClipId::new();
+        let cid2 = ClipId::new();
+
+        let audio1 = make_constant_audio(100, 0.5);
+        let audio2 = make_constant_audio(100, 0.3);
+
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid1, "Track 1".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid2, "Track 2".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid1,
+                clip_id: cid1,
+                audio: audio1,
+                position: 0,
+                source_offset: 0,
+                duration: 100,
+            })
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid2,
+                clip_id: cid2,
+                audio: audio2,
+                position: 0,
+                source_offset: 0,
+                duration: 100,
+            })
+            .unwrap();
+        // Solo track 1 only
+        cmd_tx
+            .push(EngineCommand::SetTrackSolo(tid1, true))
+            .unwrap();
+        cmd_tx.push(EngineCommand::Play).unwrap();
+
+        let mut buf = vec![0.0f32; 16]; // 8 frames
+        engine.process(&mut buf, 2);
+
+        // Only track 1 should be audible (0.5 * pan_gain)
+        let expected = 0.5 * std::f32::consts::FRAC_1_SQRT_2;
+        for frame in 0..8 {
+            assert!(
+                (buf[frame * 2] - expected).abs() < 1e-4,
+                "frame {} L: expected {} got {}",
+                frame,
+                expected,
+                buf[frame * 2]
+            );
+        }
+    }
+
+    #[test]
+    fn gain_scaling() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid = TrackId::new();
+        let cid = ClipId::new();
+        let audio = make_constant_audio(100, 1.0);
+
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid,
+                clip_id: cid,
+                audio,
+                position: 0,
+                source_offset: 0,
+                duration: 100,
+            })
+            .unwrap();
+        cmd_tx.push(EngineCommand::SetTrackGain(tid, 0.5)).unwrap();
+        cmd_tx.push(EngineCommand::Play).unwrap();
+
+        let mut buf = vec![0.0f32; 16];
+        engine.process(&mut buf, 2);
+
+        let expected = 0.5 * std::f32::consts::FRAC_1_SQRT_2;
+        assert!((buf[0] - expected).abs() < 1e-4);
+    }
+
+    #[test]
+    fn pan_hard_left() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid = TrackId::new();
+        let cid = ClipId::new();
+        let audio = make_constant_audio(100, 1.0);
+
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid,
+                clip_id: cid,
+                audio,
+                position: 0,
+                source_offset: 0,
+                duration: 100,
+            })
+            .unwrap();
+        cmd_tx.push(EngineCommand::SetTrackPan(tid, 0.0)).unwrap();
+        cmd_tx.push(EngineCommand::Play).unwrap();
+
+        let mut buf = vec![0.0f32; 16];
+        engine.process(&mut buf, 2);
+
+        // Left channel should be full (1.0 * 1.0), right should be ~0
+        assert!((buf[0] - 1.0).abs() < 1e-4, "left should be ~1.0");
+        assert!(buf[1].abs() < 1e-4, "right should be ~0.0");
+    }
+
+    #[test]
+    fn multi_track_summing() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid1 = TrackId::new();
+        let tid2 = TrackId::new();
+        let cid1 = ClipId::new();
+        let cid2 = ClipId::new();
+
+        let audio1 = make_constant_audio(100, 0.3);
+        let audio2 = make_constant_audio(100, 0.4);
+
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid1, "Track 1".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid2, "Track 2".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid1,
+                clip_id: cid1,
+                audio: audio1,
+                position: 0,
+                source_offset: 0,
+                duration: 100,
+            })
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid2,
+                clip_id: cid2,
+                audio: audio2,
+                position: 0,
+                source_offset: 0,
+                duration: 100,
+            })
+            .unwrap();
+        cmd_tx.push(EngineCommand::Play).unwrap();
+
+        let mut buf = vec![0.0f32; 16];
+        engine.process(&mut buf, 2);
+
+        // Both at center pan: each channel = (0.3 + 0.4) * FRAC_1_SQRT_2
+        let expected = (0.3 + 0.4) * std::f32::consts::FRAC_1_SQRT_2;
+        assert!(
+            (buf[0] - expected).abs() < 1e-3,
+            "expected {} got {}",
+            expected,
+            buf[0]
+        );
+    }
+
+    #[test]
+    fn legacy_compat_with_tracks_present() {
+        // When tracks exist, legacy audio is ignored (multi-track path is used)
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let legacy_audio = make_constant_audio(100, 0.9);
+        let tid = TrackId::new();
+
+        cmd_tx.push(EngineCommand::LoadAudio(legacy_audio)).unwrap();
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+            .unwrap();
+        cmd_tx.push(EngineCommand::Play).unwrap();
+
+        let mut buf = vec![0.0f32; 16];
+        engine.process(&mut buf, 2);
+
+        // Track has no clips, so output should be silent despite legacy audio being loaded
+        assert!(buf.iter().all(|&s| s == 0.0));
+    }
+
+    #[test]
+    fn per_track_metering_events() {
+        let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+        let tid = TrackId::new();
+        let cid = ClipId::new();
+        let audio = make_constant_audio(100, 0.5);
+
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid,
+                clip_id: cid,
+                audio,
+                position: 0,
+                source_offset: 0,
+                duration: 100,
+            })
+            .unwrap();
+        cmd_tx.push(EngineCommand::Play).unwrap();
+
+        let mut buf = vec![0.0f32; 16];
+        engine.process(&mut buf, 2);
+
+        let mut found_track_meter = false;
+        while let Ok(event) = event_rx.pop() {
+            if let EngineEvent::TrackMeter {
+                track_id,
+                peak_l,
+                peak_r,
+            } = event
+            {
+                if track_id == tid {
+                    found_track_meter = true;
+                    assert!(peak_l > 0.0);
+                    assert!(peak_r > 0.0);
+                }
+            }
+        }
+        assert!(found_track_meter);
+    }
+
+    #[test]
+    fn transport_auto_stop_multitrack() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid = TrackId::new();
+        let cid = ClipId::new();
+        let audio = make_constant_audio(16, 0.5);
+
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid,
+                clip_id: cid,
+                audio,
+                position: 0,
+                source_offset: 0,
+                duration: 16,
+            })
+            .unwrap();
+        cmd_tx.push(EngineCommand::Play).unwrap();
+
+        // Request 32 frames, but only 16 frames of audio exist
+        let mut buf = vec![0.0f32; 64];
+        engine.process(&mut buf, 2);
+
+        assert!(!engine.transport().is_playing());
+        assert_eq!(engine.transport().position(), 16);
+    }
+
+    #[test]
+    fn move_clip_changes_position() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid = TrackId::new();
+        let cid = ClipId::new();
+        let audio = make_constant_audio(100, 0.5);
+
+        cmd_tx
+            .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddClip {
+                track_id: tid,
+                clip_id: cid,
+                audio,
+                position: 0,
+                source_offset: 0,
+                duration: 100,
+            })
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::MoveClip {
+                track_id: tid,
+                clip_id: cid,
+                new_position: 50,
+            })
+            .unwrap();
+
+        let mut buf = vec![0.0f32; 8];
+        engine.process(&mut buf, 2);
+
+        // Clip is now at position 50, engine should recognize this
+        assert_eq!(engine.tracks()[0].clips[0].position, 50);
     }
 }

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -1,3 +1,5 @@
+use vibez_core::id::TrackId;
+
 /// Events sent from the audio engine back to the UI thread (via rtrb).
 ///
 /// These are pushed by the engine inside the real-time audio callback and
@@ -15,6 +17,13 @@ pub enum EngineEvent {
         peak_r: f32,
         rms_l: f32,
         rms_r: f32,
+    },
+
+    /// Per-track peak meter readings.
+    TrackMeter {
+        track_id: TrackId,
+        peak_l: f32,
+        peak_r: f32,
     },
 
     /// Playback has started (transport entered playing state).
@@ -36,6 +45,11 @@ mod tests {
             peak_r: 0.75,
             rms_l: 0.5,
             rms_r: 0.45,
+        };
+        let _track_meter = EngineEvent::TrackMeter {
+            track_id: TrackId::new(),
+            peak_l: 0.5,
+            peak_r: 0.4,
         };
         let _started = EngineEvent::PlaybackStarted;
         let _stopped = EngineEvent::PlaybackStopped;
@@ -76,6 +90,33 @@ mod tests {
         }
 
         assert_eq!(consumer.pop().unwrap(), EngineEvent::PlaybackStopped);
+    }
+
+    #[test]
+    fn track_meter_can_be_sent_through_rtrb() {
+        let (mut producer, mut consumer) = rtrb::RingBuffer::<EngineEvent>::new(16);
+        let tid = TrackId::new();
+
+        producer
+            .push(EngineEvent::TrackMeter {
+                track_id: tid,
+                peak_l: 0.7,
+                peak_r: 0.6,
+            })
+            .unwrap();
+
+        match consumer.pop().unwrap() {
+            EngineEvent::TrackMeter {
+                track_id,
+                peak_l,
+                peak_r,
+            } => {
+                assert_eq!(track_id, tid);
+                assert!((peak_l - 0.7).abs() < f32::EPSILON);
+                assert!((peak_r - 0.6).abs() < f32::EPSILON);
+            }
+            other => panic!("expected TrackMeter, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/vibez-engine/src/lib.rs
+++ b/crates/vibez-engine/src/lib.rs
@@ -2,4 +2,5 @@ pub mod commands;
 pub mod engine;
 pub mod events;
 pub mod metering;
+pub mod mixer;
 pub mod transport;

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -1,0 +1,304 @@
+use std::sync::Arc;
+
+use vibez_core::audio_buffer::DecodedAudio;
+use vibez_core::constants::{DEFAULT_TRACK_GAIN, DEFAULT_TRACK_PAN};
+use vibez_core::id::{ClipId, TrackId};
+
+/// A clip as it exists at runtime in the engine (on the audio thread).
+pub struct EngineClip {
+    pub id: ClipId,
+    pub audio: Arc<DecodedAudio>,
+    /// Position on the timeline in samples.
+    pub position: u64,
+    /// Offset into the source audio in samples.
+    pub source_offset: u64,
+    /// Duration in samples.
+    pub duration: u64,
+}
+
+impl EngineClip {
+    /// The end position of this clip on the timeline.
+    pub fn end_position(&self) -> u64 {
+        self.position.saturating_add(self.duration)
+    }
+
+    /// Whether this clip is active (has audio to contribute) at the given
+    /// global position for the given number of frames.
+    pub fn is_active(&self, pos: u64, frames: u64) -> bool {
+        let end = pos.saturating_add(frames);
+        // Clip overlaps the [pos, pos+frames) range
+        self.position < end && self.end_position() > pos
+    }
+}
+
+/// A track as it exists at runtime in the engine.
+pub struct EngineTrack {
+    pub id: TrackId,
+    pub clips: Vec<EngineClip>,
+    pub gain: f32,
+    pub pan: f32,
+    pub mute: bool,
+    pub solo: bool,
+    /// Pre-allocated per-track mix buffer (interleaved stereo).
+    pub mix_buffer: Vec<f32>,
+}
+
+impl EngineTrack {
+    pub fn new(id: TrackId) -> Self {
+        Self {
+            id,
+            clips: Vec::new(),
+            gain: DEFAULT_TRACK_GAIN,
+            pan: DEFAULT_TRACK_PAN,
+            mute: false,
+            solo: false,
+            mix_buffer: Vec::new(),
+        }
+    }
+
+    /// Ensure the mix buffer has at least `size` elements.
+    pub fn ensure_buffer(&mut self, size: usize) {
+        if self.mix_buffer.len() < size {
+            self.mix_buffer.resize(size, 0.0);
+        }
+    }
+
+    /// Render all active clips into the mix_buffer for the given position.
+    /// Returns `true` if any audio was rendered.
+    pub fn render(&mut self, pos: u64, frames: usize, channels: usize) -> bool {
+        let buf_size = frames * channels;
+        self.ensure_buffer(buf_size);
+
+        // Zero the buffer
+        for s in self.mix_buffer[..buf_size].iter_mut() {
+            *s = 0.0;
+        }
+
+        let mut rendered_any = false;
+
+        for clip in &self.clips {
+            if !clip.is_active(pos, frames as u64) {
+                continue;
+            }
+
+            rendered_any = true;
+            let audio_channels = clip.audio.num_channels();
+
+            for frame in 0..frames {
+                let global_frame = pos as usize + frame;
+
+                // Skip frames before clip starts
+                if (global_frame as u64) < clip.position {
+                    continue;
+                }
+                // Skip frames after clip ends
+                if (global_frame as u64) >= clip.end_position() {
+                    continue;
+                }
+
+                // Calculate the sample index into the source audio
+                let clip_frame = global_frame - clip.position as usize;
+                let source_frame = clip.source_offset as usize + clip_frame;
+
+                for ch in 0..channels {
+                    let sample = if ch < audio_channels {
+                        clip.audio.sample(ch, source_frame)
+                    } else if audio_channels > 0 {
+                        clip.audio.sample(audio_channels - 1, source_frame)
+                    } else {
+                        0.0
+                    };
+                    self.mix_buffer[frame * channels + ch] += sample;
+                }
+            }
+        }
+
+        rendered_any
+    }
+}
+
+/// Equal-power pan law.
+/// `pan` ranges from 0.0 (hard left) to 1.0 (hard right).
+/// Returns `(left_gain, right_gain)`.
+/// At center (0.5): both channels get ~0.707 (-3dB).
+pub fn equal_power_pan(pan: f32) -> (f32, f32) {
+    let pan = pan.clamp(0.0, 1.0);
+    let angle = pan * std::f32::consts::FRAC_PI_2;
+    (angle.cos(), angle.sin())
+}
+
+/// Returns `true` if any track in the slice has solo enabled.
+pub fn any_solo(tracks: &[EngineTrack]) -> bool {
+    tracks.iter().any(|t| t.solo)
+}
+
+/// Calculate the total length of audio across all tracks (max clip end position).
+pub fn calculate_total_length(tracks: &[EngineTrack]) -> u64 {
+    tracks
+        .iter()
+        .flat_map(|t| t.clips.iter())
+        .map(|c| c.end_position())
+        .max()
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_audio(frames: usize, value: f32) -> Arc<DecodedAudio> {
+        Arc::new(DecodedAudio {
+            channels: vec![vec![value; frames], vec![value; frames]],
+            sample_rate: 44_100,
+        })
+    }
+
+    #[test]
+    fn pan_law_hard_left() {
+        let (l, r) = equal_power_pan(0.0);
+        assert!((l - 1.0).abs() < 1e-6);
+        assert!(r.abs() < 1e-6);
+    }
+
+    #[test]
+    fn pan_law_hard_right() {
+        let (l, r) = equal_power_pan(1.0);
+        assert!(l.abs() < 1e-6);
+        assert!((r - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn pan_law_center() {
+        let (l, r) = equal_power_pan(0.5);
+        let expected = std::f32::consts::FRAC_1_SQRT_2; // ~0.707
+        assert!((l - expected).abs() < 1e-6);
+        assert!((r - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn pan_law_clamps_out_of_range() {
+        let (l, r) = equal_power_pan(-0.5);
+        assert!((l - 1.0).abs() < 1e-6);
+        assert!(r.abs() < 1e-6);
+
+        let (l, r) = equal_power_pan(1.5);
+        assert!(l.abs() < 1e-6);
+        assert!((r - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn single_clip_render() {
+        let audio = make_test_audio(64, 0.5);
+        let mut track = EngineTrack::new(TrackId::new());
+        track.clips.push(EngineClip {
+            id: ClipId::new(),
+            audio,
+            position: 0,
+            source_offset: 0,
+            duration: 64,
+        });
+
+        let rendered = track.render(0, 8, 2);
+        assert!(rendered);
+
+        // Check that samples were written
+        for i in 0..16 {
+            assert!((track.mix_buffer[i] - 0.5).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn clip_with_offset() {
+        let audio = Arc::new(DecodedAudio {
+            channels: vec![
+                (0..64).map(|i| i as f32 / 64.0).collect(),
+                (0..64).map(|i| i as f32 / 64.0).collect(),
+            ],
+            sample_rate: 44_100,
+        });
+
+        let mut track = EngineTrack::new(TrackId::new());
+        track.clips.push(EngineClip {
+            id: ClipId::new(),
+            audio: audio.clone(),
+            position: 0,
+            source_offset: 10,
+            duration: 20,
+        });
+
+        let rendered = track.render(0, 4, 2);
+        assert!(rendered);
+
+        // First frame should come from source_offset 10
+        let expected = audio.sample(0, 10);
+        assert!((track.mix_buffer[0] - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn no_clips_returns_false() {
+        let mut track = EngineTrack::new(TrackId::new());
+        let rendered = track.render(0, 8, 2);
+        assert!(!rendered);
+    }
+
+    #[test]
+    fn total_length_calculation() {
+        let audio = make_test_audio(100, 0.5);
+        let mut tracks = vec![EngineTrack::new(TrackId::new())];
+        tracks[0].clips.push(EngineClip {
+            id: ClipId::new(),
+            audio: audio.clone(),
+            position: 50,
+            source_offset: 0,
+            duration: 100,
+        });
+
+        assert_eq!(calculate_total_length(&tracks), 150);
+    }
+
+    #[test]
+    fn total_length_empty_tracks() {
+        let tracks: Vec<EngineTrack> = vec![];
+        assert_eq!(calculate_total_length(&tracks), 0);
+    }
+
+    #[test]
+    fn any_solo_detection() {
+        let mut tracks = vec![
+            EngineTrack::new(TrackId::new()),
+            EngineTrack::new(TrackId::new()),
+        ];
+        assert!(!any_solo(&tracks));
+
+        tracks[1].solo = true;
+        assert!(any_solo(&tracks));
+    }
+
+    #[test]
+    fn clip_not_active_before_position() {
+        let audio = make_test_audio(100, 0.5);
+        let clip = EngineClip {
+            id: ClipId::new(),
+            audio,
+            position: 100,
+            source_offset: 0,
+            duration: 50,
+        };
+        // Requesting frames 0..50 — clip starts at 100, not active
+        assert!(!clip.is_active(0, 50));
+    }
+
+    #[test]
+    fn clip_active_when_overlapping() {
+        let audio = make_test_audio(100, 0.5);
+        let clip = EngineClip {
+            id: ClipId::new(),
+            audio,
+            position: 40,
+            source_offset: 0,
+            duration: 50,
+        };
+        // Requesting frames 30..60 — clip is at 40..90, overlaps
+        assert!(clip.is_active(30, 30));
+    }
+}

--- a/crates/vibez-project/Cargo.toml
+++ b/crates/vibez-project/Cargo.toml
@@ -8,3 +8,6 @@ license.workspace = true
 vibez-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -1,1 +1,166 @@
-// Phase 2: Project save/load, serialization
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use vibez_core::track::{ClipInfo, TrackInfo};
+
+/// A serializable project containing tracks and clips.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    pub name: String,
+    pub bpm: f64,
+    pub sample_rate: u32,
+    pub tracks: Vec<TrackInfo>,
+    pub clips: Vec<ClipInfo>,
+}
+
+impl Default for Project {
+    fn default() -> Self {
+        Self {
+            name: "Untitled".to_string(),
+            bpm: vibez_core::constants::DEFAULT_BPM,
+            sample_rate: vibez_core::constants::DEFAULT_SAMPLE_RATE,
+            tracks: Vec::new(),
+            clips: Vec::new(),
+        }
+    }
+}
+
+/// Errors that can occur during project save/load.
+#[derive(Debug)]
+pub enum ProjectError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+}
+
+impl std::fmt::Display for ProjectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProjectError::Io(e) => write!(f, "I/O error: {e}"),
+            ProjectError::Json(e) => write!(f, "JSON error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ProjectError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ProjectError::Io(e) => Some(e),
+            ProjectError::Json(e) => Some(e),
+        }
+    }
+}
+
+impl From<std::io::Error> for ProjectError {
+    fn from(e: std::io::Error) -> Self {
+        ProjectError::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for ProjectError {
+    fn from(e: serde_json::Error) -> Self {
+        ProjectError::Json(e)
+    }
+}
+
+impl Project {
+    /// Save the project to a JSON file.
+    pub fn save_to_file(&self, path: &Path) -> Result<(), ProjectError> {
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json)?;
+        Ok(())
+    }
+
+    /// Load a project from a JSON file.
+    pub fn load_from_file(path: &Path) -> Result<Self, ProjectError> {
+        let json = std::fs::read_to_string(path)?;
+        let project = serde_json::from_str(&json)?;
+        Ok(project)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+    use std::path::PathBuf;
+    use vibez_core::id::{ClipId, TrackId};
+
+    #[test]
+    fn project_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.vibez");
+
+        let project = Project {
+            name: "Test Project".into(),
+            bpm: 140.0,
+            sample_rate: 48_000,
+            tracks: vec![TrackInfo::new("Synth"), TrackInfo::new("Bass")],
+            clips: vec![ClipInfo {
+                id: ClipId::new(),
+                track_id: TrackId::new(),
+                name: "loop.wav".into(),
+                position: 0,
+                source_offset: 0,
+                duration: 44100,
+                file_path: PathBuf::from("audio/loop.wav"),
+            }],
+        };
+
+        project.save_to_file(&path).unwrap();
+        let loaded = Project::load_from_file(&path).unwrap();
+
+        assert_eq!(loaded.name, "Test Project");
+        assert!((loaded.bpm - 140.0).abs() < f64::EPSILON);
+        assert_eq!(loaded.sample_rate, 48_000);
+        assert_eq!(loaded.tracks.len(), 2);
+        assert_eq!(loaded.tracks[0].name, "Synth");
+        assert_eq!(loaded.clips.len(), 1);
+        assert_eq!(loaded.clips[0].name, "loop.wav");
+    }
+
+    #[test]
+    fn empty_project_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.vibez");
+
+        let project = Project::default();
+        project.save_to_file(&path).unwrap();
+        let loaded = Project::load_from_file(&path).unwrap();
+
+        assert_eq!(loaded.name, "Untitled");
+        assert!(loaded.tracks.is_empty());
+        assert!(loaded.clips.is_empty());
+    }
+
+    #[test]
+    fn load_bad_path() {
+        let result = Project::load_from_file(Path::new("/nonexistent/path.vibez"));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, ProjectError::Io(_)));
+        assert!(err.to_string().contains("I/O error"));
+    }
+
+    #[test]
+    fn load_corrupt_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.vibez");
+        std::fs::write(&path, "not valid json {{{").unwrap();
+
+        let result = Project::load_from_file(&path);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ProjectError::Json(_)));
+    }
+
+    #[test]
+    fn error_implements_display_and_error() {
+        let io_err = ProjectError::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "test"));
+        assert!(io_err.to_string().contains("I/O error"));
+        assert!(io_err.source().is_some());
+
+        let json_str = "not json";
+        let json_err: Result<Project, _> = serde_json::from_str(json_str);
+        let project_err = ProjectError::Json(json_err.unwrap_err());
+        assert!(project_err.to_string().contains("JSON error"));
+    }
+}

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -16,15 +16,15 @@ use vibez_engine::engine::AudioEngine;
 use vibez_engine::events::EngineEvent;
 
 use crate::message::Message;
-use crate::state::{AppState, UiClip, UiTrack};
+use crate::state::{AppState, UiClip, UiTrack, Workspace};
 use crate::theme as vibez_theme;
 use crate::widgets::mixer_strip::view_mixer_strip;
-use crate::widgets::timeline::TimelineWidget;
+use crate::widgets::timeline::{RulerWidget, TrackClipCanvas};
+use crate::widgets::track_header::view_track_header;
 use crate::widgets::vu_meter::VuMeterWidget;
 
 struct App {
     state: AppState,
-    timeline: TimelineWidget,
     cmd_tx: Option<Producer<EngineCommand>>,
     event_rx: Option<Consumer<EngineEvent>>,
     _stream: Option<AudioOutputStream>,
@@ -64,7 +64,6 @@ impl App {
         (
             Self {
                 state,
-                timeline: TimelineWidget::new(),
                 cmd_tx: Some(cmd_tx),
                 event_rx: Some(event_rx),
                 _stream: stream,
@@ -90,7 +89,6 @@ impl App {
                 self.state.position_samples = 0;
                 self.send_command(EngineCommand::Stop);
                 self.send_command(EngineCommand::Seek(0));
-                self.timeline.set_playhead(0.0);
             }
             Message::TogglePlayback => {
                 if self.state.playing {
@@ -105,7 +103,6 @@ impl App {
                     let sample_pos = (normalized * total as f64) as u64;
                     self.state.position_samples = sample_pos;
                     self.send_command(EngineCommand::Seek(sample_pos));
-                    self.timeline.set_playhead(normalized);
                 }
             }
             Message::BpmChanged(val) => {
@@ -123,100 +120,17 @@ impl App {
                 }
             }
 
-            // -- Open file → new audio track + clip --
-            Message::OpenFileToNewTrack => {
-                return Task::perform(
-                    async {
-                        let handle = rfd::AsyncFileDialog::new()
-                            .set_title("Open Audio File")
-                            .add_filter("Audio", &["wav", "mp3", "flac", "ogg"])
-                            .pick_file()
-                            .await;
-                        handle.map(|h| h.path().to_path_buf())
-                    },
-                    Message::NewTrackFileSelected,
-                );
-            }
-            Message::NewTrackFileSelected(path) => {
-                if let Some(path) = path {
-                    let file_name = path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    self.state.status_text = format!("Loading {file_name}...");
-
-                    let track_id = TrackId::new();
-                    let clip_id = ClipId::new();
-
-                    return Task::perform(decode_file_async(path), move |result| match result {
-                        Ok(audio) => Message::NewTrackAudioDecoded(
-                            track_id,
-                            clip_id,
-                            Arc::new(audio),
-                            file_name.clone(),
-                        ),
-                        Err(e) => Message::NewTrackDecodeError(e),
-                    });
-                }
-            }
-            Message::NewTrackAudioDecoded(track_id, clip_id, audio, file_name) => {
-                let track_num = self.state.next_track_number;
-                self.state.next_track_number += 1;
-                let track_name = format!("Track {track_num}");
-                let duration = audio.num_frames() as u64;
-
-                // Create track in engine
-                self.send_command(EngineCommand::AddTrack(track_id, track_name.clone()));
-                // Add clip to track in engine
-                self.send_command(EngineCommand::AddClip {
-                    track_id,
-                    clip_id,
-                    audio: Arc::clone(&audio),
-                    position: 0,
-                    source_offset: 0,
-                    duration,
-                });
-
-                // Update UI state
-                let mut track = UiTrack::new(track_id, track_name);
-                track.clips.push(UiClip {
-                    id: clip_id,
-                    name: file_name.clone(),
-                    audio,
-                    position: 0,
-                    source_offset: 0,
-                    duration,
-                });
-                self.state.tracks.push(track);
-                self.state.selected_track = Some(track_id);
-
-                self.state.status_text = format!(
-                    "Track {track_num}: {file_name} — {:.1}s",
-                    duration as f64 / self.state.sample_rate as f64
-                );
-            }
-            Message::NewTrackDecodeError(err) => {
-                self.state.status_text = format!("Error: {err}");
+            // -- Workspace --
+            Message::SwitchWorkspace(ws) => {
+                self.state.workspace = ws;
             }
 
             // -- Engine events --
             Message::Tick => {
                 self.poll_engine_events();
-                let selected_idx = self
-                    .state
-                    .selected_track
-                    .and_then(|id| self.state.tracks.iter().position(|t| t.id == id));
-                self.timeline.sync_from_tracks(
-                    &self.state.tracks,
-                    selected_idx,
-                    self.state.duration_seconds(),
-                    self.state.sample_rate,
-                );
-                self.timeline.set_playhead(self.state.position_normalized());
             }
             Message::EnginePosition(pos) => {
                 self.state.position_samples = pos;
-                self.timeline.set_playhead(self.state.position_normalized());
             }
             Message::EngineMetering { peak_l, peak_r } => {
                 self.state.peak_l = peak_l;
@@ -245,7 +159,7 @@ impl App {
                     self.state.selected_track = self.state.tracks.first().map(|t| t.id);
                 }
                 if self.state.tracks.is_empty() {
-                    self.state.status_text = "Ready — Open a file or add a track".to_string();
+                    self.state.status_text = "Ready — Add a track to get started".to_string();
                 } else {
                     self.state.status_text = format!("{} tracks", self.state.tracks.len());
                 }
@@ -406,14 +320,21 @@ impl App {
         }
     }
 
+    // ── View ──
+
     fn view(&self) -> Element<Message> {
         let header = self.view_header();
-        let timeline = self.view_timeline();
-        let mixer = self.view_mixer();
+
+        let content = match self.state.workspace {
+            Workspace::Arrange => self.view_arrangement(),
+            Workspace::Mix => self.view_mixer(),
+        };
+
+        let detail_panel = self.view_detail_panel();
         let transport_bar = self.view_transport();
         let status_bar = self.view_status();
 
-        let layout = column![header, timeline, mixer, transport_bar, status_bar];
+        let layout = column![header, content, detail_panel, transport_bar, status_bar];
 
         container(layout)
             .width(Length::Fill)
@@ -424,15 +345,34 @@ impl App {
     fn view_header(&self) -> Element<Message> {
         let title = text("vibez").size(24).color(vibez_theme::ACCENT);
 
-        let open_btn = button(text("Open File").size(14))
-            .on_press(Message::OpenFileToNewTrack)
-            .padding([6, 16]);
+        // Workspace tabs
+        let arrange_tab = if self.state.workspace == Workspace::Arrange {
+            button(text("Arrange").size(13).color(vibez_theme::ACCENT))
+                .on_press(Message::SwitchWorkspace(Workspace::Arrange))
+                .padding([6, 14])
+        } else {
+            button(text("Arrange").size(13).color(vibez_theme::TEXT_DIM))
+                .on_press(Message::SwitchWorkspace(Workspace::Arrange))
+                .padding([6, 14])
+        };
+
+        let mix_tab = if self.state.workspace == Workspace::Mix {
+            button(text("Mix").size(13).color(vibez_theme::ACCENT))
+                .on_press(Message::SwitchWorkspace(Workspace::Mix))
+                .padding([6, 14])
+        } else {
+            button(text("Mix").size(13).color(vibez_theme::TEXT_DIM))
+                .on_press(Message::SwitchWorkspace(Workspace::Mix))
+                .padding([6, 14])
+        };
+
+        let tabs = row![arrange_tab, mix_tab].spacing(2);
 
         let add_track_btn = button(text("Add Track").size(14))
             .on_press(Message::AddTrack)
             .padding([6, 16]);
 
-        let mut header_row = row![title, horizontal_space(), add_track_btn].spacing(8);
+        let mut header_row = row![title, tabs, horizontal_space(), add_track_btn].spacing(8);
 
         if let Some(selected_id) = self.state.selected_track {
             let remove_btn = button(text("Remove Track").size(14))
@@ -440,8 +380,6 @@ impl App {
                 .padding([6, 16]);
             header_row = header_row.push(remove_btn);
         }
-
-        header_row = header_row.push(open_btn);
 
         let header = header_row.padding(12).align_y(iced::Alignment::Center);
 
@@ -454,10 +392,11 @@ impl App {
             .into()
     }
 
-    fn view_timeline(&self) -> Element<Message> {
+    // ── Arrangement view ──
+
+    fn view_arrangement(&self) -> Element<Message> {
         if self.state.tracks.is_empty() {
-            // Empty state
-            let prompt = text("Open a file or add a track to get started")
+            let prompt = text("Add a track to get started")
                 .size(16)
                 .color(vibez_theme::TEXT_DIM);
 
@@ -465,7 +404,7 @@ impl App {
 
             return container(centered)
                 .width(Length::Fill)
-                .height(Length::FillPortion(6))
+                .height(Length::FillPortion(5))
                 .style(|_theme: &Theme| container::Style {
                     background: Some(vibez_theme::BG_DARK.into()),
                     ..Default::default()
@@ -473,34 +412,96 @@ impl App {
                 .into();
         }
 
-        let timeline_canvas: Element<Message> = canvas(&self.timeline)
+        let playhead = self.state.position_normalized();
+        let duration = self.state.duration_seconds();
+        let sample_rate = self.state.sample_rate;
+
+        // Time ruler across the top (offset by track header width)
+        let ruler = RulerWidget {
+            playhead_position: playhead,
+            duration_seconds: duration,
+        };
+        let ruler_canvas: Element<Message> = canvas(ruler)
             .width(Length::Fill)
-            .height(Length::Fill)
+            .height(Length::Fixed(24.0))
             .into();
 
-        container(timeline_canvas)
+        // Spacer matching header width for the ruler row
+        let ruler_spacer = container(text(""))
+            .width(Length::Fixed(
+                crate::widgets::track_header::TRACK_HEADER_WIDTH,
+            ))
+            .height(Length::Fixed(24.0));
+
+        let ruler_row = row![ruler_spacer, ruler_canvas];
+
+        // Track rows: header widgets + clip canvas
+        let mut track_rows = column![].spacing(0);
+
+        for track in &self.state.tracks {
+            let selected = self.state.selected_track == Some(track.id);
+
+            // Track header (iced widgets)
+            let header = view_track_header(track);
+
+            // Clip canvas for this track
+            let clip_canvas_widget =
+                TrackClipCanvas::from_track(track, playhead, duration, sample_rate, selected);
+            let clip_canvas: Element<Message> = canvas(clip_canvas_widget)
+                .width(Length::Fill)
+                .height(Length::Fixed(80.0))
+                .into();
+
+            let track_row = row![header, clip_canvas].height(Length::Fixed(80.0));
+
+            track_rows = track_rows.push(track_row);
+        }
+
+        let content = column![ruler_row, track_rows];
+
+        let scrollable_content = scrollable(content).direction(scrollable::Direction::Vertical(
+            scrollable::Scrollbar::default(),
+        ));
+
+        container(scrollable_content)
             .width(Length::Fill)
-            .height(Length::FillPortion(6))
-            .padding([0, 8])
+            .height(Length::FillPortion(5))
+            .style(|_theme: &Theme| container::Style {
+                background: Some(vibez_theme::BG_DARK.into()),
+                ..Default::default()
+            })
             .into()
     }
 
+    // ── Mixer view ──
+
     fn view_mixer(&self) -> Element<Message> {
         if self.state.tracks.is_empty() {
-            return container(text(""))
+            let prompt = text("Add a track to get started")
+                .size(16)
+                .color(vibez_theme::TEXT_DIM);
+
+            let centered = center(prompt).width(Length::Fill).height(Length::Fill);
+
+            return container(centered)
                 .width(Length::Fill)
-                .height(Length::FillPortion(3))
+                .height(Length::FillPortion(5))
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(vibez_theme::BG_DARK.into()),
+                    ..Default::default()
+                })
                 .into();
         }
 
-        let mut strips = row![].spacing(4).padding(8);
+        // ── Channel strips + pinned master ──
+        let mut strips = row![].spacing(4).padding(8).height(Length::Fill);
 
         for track in &self.state.tracks {
             let strip = view_mixer_strip(track);
             strips = strips.push(strip);
         }
 
-        // Master strip
+        // Master strip — pinned to far right, fills height
         let master_label = text("Master").size(11).color(vibez_theme::TEXT);
         let master_meter = VuMeterWidget {
             peak_l: self.state.peak_l,
@@ -508,40 +509,88 @@ impl App {
         };
         let master_meter_canvas: Element<Message> = canvas(master_meter)
             .width(Length::Fixed(28.0))
-            .height(Length::Fixed(100.0))
+            .height(Length::Fill)
             .into();
 
-        let master_strip = column![master_label, master_meter_canvas]
+        let master_col = column![master_label, master_meter_canvas]
             .spacing(4)
             .padding(6)
             .width(Length::Fixed(60.0))
+            .height(Length::Fill)
             .align_x(iced::Alignment::Center);
 
-        let master_container = container(master_strip).style(|_theme: &Theme| container::Style {
-            background: Some(vibez_theme::BG_SURFACE.into()),
-            border: iced::Border {
-                color: vibez_theme::ACCENT,
-                width: 1.0,
-                radius: 2.0.into(),
-            },
-            ..Default::default()
-        });
+        let master_container =
+            container(master_col)
+                .height(Length::Fill)
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(vibez_theme::BG_SURFACE.into()),
+                    border: iced::Border {
+                        color: vibez_theme::ACCENT,
+                        width: 1.0,
+                        radius: 2.0.into(),
+                    },
+                    ..Default::default()
+                });
 
-        strips = strips.push(master_container);
+        let mixer_row = row![strips, horizontal_space(), master_container]
+            .spacing(4)
+            .padding([8, 4])
+            .height(Length::Fill);
 
-        let scrollable_mixer = scrollable(strips).direction(scrollable::Direction::Horizontal(
-            scrollable::Scrollbar::default(),
-        ));
-
-        container(scrollable_mixer)
+        container(mixer_row)
             .width(Length::Fill)
-            .height(Length::FillPortion(3))
+            .height(Length::FillPortion(5))
             .style(|_theme: &Theme| container::Style {
-                background: Some(vibez_theme::BG_DARK.into()),
+                background: Some(vibez_theme::BG_SURFACE.into()),
                 ..Default::default()
             })
             .into()
     }
+
+    // ── Detail panel (global — effects/instruments for selected track) ──
+
+    fn view_detail_panel(&self) -> Element<Message> {
+        let detail_content: Element<Message> = if let Some(track) = self
+            .state
+            .selected_track
+            .and_then(|id| self.state.find_track(id))
+        {
+            let label = text(format!("{} — Effects / Instruments", track.name))
+                .size(14)
+                .color(vibez_theme::TEXT_DIM);
+            center(label)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into()
+        } else {
+            let label = text("Select a track to view effects / instruments")
+                .size(14)
+                .color(vibez_theme::TEXT_DIM);
+            center(label)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into()
+        };
+
+        container(detail_content)
+            .width(Length::Fill)
+            .height(Length::FillPortion(2))
+            .style(|_theme: &Theme| container::Style {
+                background: Some(vibez_theme::BG_DARK.into()),
+                border: iced::Border {
+                    color: iced::Color {
+                        a: 0.2,
+                        ..vibez_theme::TEXT_DIM
+                    },
+                    width: 1.0,
+                    radius: 0.0.into(),
+                },
+                ..Default::default()
+            })
+            .into()
+    }
+
+    // ── Transport bar ──
 
     fn view_transport(&self) -> Element<Message> {
         let play_btn = if self.state.playing {
@@ -578,11 +627,22 @@ impl App {
             text("").size(12).color(vibez_theme::TEXT_DIM)
         };
 
+        // Master VU meter in the transport bar
+        let master_meter = VuMeterWidget {
+            peak_l: self.state.peak_l,
+            peak_r: self.state.peak_r,
+        };
+        let master_meter_canvas: Element<Message> = canvas(master_meter)
+            .width(Length::Fixed(24.0))
+            .height(Length::Fixed(28.0))
+            .into();
+
         let transport = row![
             play_btn,
             horizontal_space(),
             time_text,
             horizontal_space(),
+            master_meter_canvas,
             track_count,
             bpm_input,
             bpm_label,

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -1,20 +1,25 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use iced::widget::{button, canvas, column, container, horizontal_space, row, text, text_input};
+use iced::widget::{
+    button, canvas, column, container, horizontal_space, row, scrollable, text, text_input,
+};
 use iced::{Element, Length, Subscription, Task, Theme};
 
 use rtrb::{Consumer, Producer};
 use vibez_audio_io::audio_stream::AudioOutputStream;
 use vibez_audio_io::file_io;
 use vibez_core::constants::UI_TICK_MS;
+use vibez_core::id::{ClipId, TrackId};
 use vibez_engine::commands::EngineCommand;
 use vibez_engine::engine::AudioEngine;
 use vibez_engine::events::EngineEvent;
 
 use crate::message::Message;
-use crate::state::AppState;
+use crate::state::{AppState, UiClip, UiTrack};
 use crate::theme as vibez_theme;
+use crate::widgets::mixer_strip::view_mixer_strip;
+use crate::widgets::timeline::TimelineWidget;
 use crate::widgets::vu_meter::VuMeterWidget;
 use crate::widgets::waveform::WaveformWidget;
 
@@ -22,6 +27,7 @@ struct App {
     state: AppState,
     waveform: WaveformWidget,
     vu_meter: VuMeterWidget,
+    timeline: TimelineWidget,
     cmd_tx: Option<Producer<EngineCommand>>,
     event_rx: Option<Consumer<EngineEvent>>,
     _stream: Option<AudioOutputStream>,
@@ -31,7 +37,7 @@ pub fn run() -> iced::Result {
     iced::application("vibez", App::update, App::view)
         .theme(App::theme)
         .subscription(App::subscription)
-        .window_size((1100.0, 700.0))
+        .window_size((1400.0, 900.0))
         .run_with(App::new)
 }
 
@@ -63,6 +69,7 @@ impl App {
                 state,
                 waveform: WaveformWidget::new(),
                 vu_meter: VuMeterWidget::new(),
+                timeline: TimelineWidget::new(),
                 cmd_tx: Some(cmd_tx),
                 event_rx: Some(event_rx),
                 _stream: stream,
@@ -89,6 +96,7 @@ impl App {
                 self.send_command(EngineCommand::Stop);
                 self.send_command(EngineCommand::Seek(0));
                 self.waveform.set_playhead(0.0);
+                self.timeline.set_playhead(0.0);
             }
             Message::TogglePlayback => {
                 if self.state.playing {
@@ -98,11 +106,24 @@ impl App {
                 }
             }
             Message::Seek(normalized) => {
-                if let Some(ref audio) = self.state.audio {
-                    let sample_pos = (normalized * audio.num_frames() as f64) as u64;
+                let duration_samples = self.state.total_duration_samples();
+                let legacy_frames = self
+                    .state
+                    .audio
+                    .as_ref()
+                    .map_or(0, |a| a.num_frames() as u64);
+                let total = if duration_samples > 0 {
+                    duration_samples
+                } else {
+                    legacy_frames
+                };
+
+                if total > 0 {
+                    let sample_pos = (normalized * total as f64) as u64;
                     self.state.position_samples = sample_pos;
                     self.send_command(EngineCommand::Seek(sample_pos));
                     self.waveform.set_playhead(normalized);
+                    self.timeline.set_playhead(normalized);
                 }
             }
             Message::BpmChanged(val) => {
@@ -176,10 +197,23 @@ impl App {
             }
             Message::Tick => {
                 self.poll_engine_events();
+                // Sync timeline
+                let selected_idx = self
+                    .state
+                    .selected_track
+                    .and_then(|id| self.state.tracks.iter().position(|t| t.id == id));
+                self.timeline.sync_from_tracks(
+                    &self.state.tracks,
+                    selected_idx,
+                    self.state.duration_seconds(),
+                    self.state.sample_rate,
+                );
+                self.timeline.set_playhead(self.state.position_normalized());
             }
             Message::EnginePosition(pos) => {
                 self.state.position_samples = pos;
                 self.waveform.set_playhead(self.state.position_normalized());
+                self.timeline.set_playhead(self.state.position_normalized());
             }
             Message::EngineMetering { peak_l, peak_r } => {
                 self.state.peak_l = peak_l;
@@ -189,6 +223,150 @@ impl App {
             }
             Message::EngineStopped => {
                 self.state.playing = false;
+            }
+
+            // -- Multi-track messages --
+            Message::AddTrack => {
+                let track_num = self.state.next_track_number;
+                self.state.next_track_number += 1;
+                let id = TrackId::new();
+                let name = format!("Track {track_num}");
+
+                self.send_command(EngineCommand::AddTrack(id, name.clone()));
+                self.state.tracks.push(UiTrack::new(id, name));
+                self.state.selected_track = Some(id);
+                self.state.status_text = format!("{} tracks", self.state.tracks.len());
+            }
+            Message::RemoveTrack(track_id) => {
+                self.send_command(EngineCommand::RemoveTrack(track_id));
+                self.state.tracks.retain(|t| t.id != track_id);
+                if self.state.selected_track == Some(track_id) {
+                    self.state.selected_track = self.state.tracks.first().map(|t| t.id);
+                }
+                self.state.status_text = format!("{} tracks", self.state.tracks.len());
+            }
+            Message::SelectTrack(track_id) => {
+                self.state.selected_track = Some(track_id);
+            }
+            Message::AddClipToTrack(track_id) => {
+                return Task::perform(
+                    async {
+                        let handle = rfd::AsyncFileDialog::new()
+                            .set_title("Add Audio Clip")
+                            .add_filter("Audio", &["wav", "mp3", "flac", "ogg"])
+                            .pick_file()
+                            .await;
+                        handle.map(|h| h.path().to_path_buf())
+                    },
+                    move |path| Message::ClipFileSelected(track_id, path),
+                );
+            }
+            Message::ClipFileSelected(track_id, path) => {
+                if let Some(path) = path {
+                    let file_name = path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    self.state.status_text = format!("Loading {file_name}...");
+                    let clip_id = ClipId::new();
+
+                    return Task::perform(decode_file_async(path), move |result| match result {
+                        Ok(audio) => Message::ClipAudioDecoded(
+                            track_id,
+                            clip_id,
+                            Arc::new(audio),
+                            file_name.clone(),
+                        ),
+                        Err(e) => Message::ClipDecodeError(track_id, e),
+                    });
+                }
+            }
+            Message::ClipAudioDecoded(track_id, clip_id, audio, name) => {
+                // Place clip at the end of existing clips on this track
+                let existing_end = self
+                    .state
+                    .find_track(track_id)
+                    .map(|t| {
+                        t.clips
+                            .iter()
+                            .map(|c| c.position.saturating_add(c.duration))
+                            .max()
+                            .unwrap_or(0)
+                    })
+                    .unwrap_or(0);
+
+                let duration = audio.num_frames() as u64;
+
+                // Send to engine
+                self.send_command(EngineCommand::AddClip {
+                    track_id,
+                    clip_id,
+                    audio: Arc::clone(&audio),
+                    position: existing_end,
+                    source_offset: 0,
+                    duration,
+                });
+
+                // Update UI state
+                if let Some(track) = self.state.find_track_mut(track_id) {
+                    track.clips.push(UiClip {
+                        id: clip_id,
+                        name: name.clone(),
+                        audio,
+                        position: existing_end,
+                        source_offset: 0,
+                        duration,
+                    });
+                }
+
+                self.state.status_text = format!("Added clip: {name}");
+            }
+            Message::ClipDecodeError(_, err) => {
+                self.state.status_text = format!("Error: {err}");
+            }
+            Message::RemoveClip(track_id, clip_id) => {
+                self.send_command(EngineCommand::RemoveClip(track_id, clip_id));
+                if let Some(track) = self.state.find_track_mut(track_id) {
+                    track.clips.retain(|c| c.id != clip_id);
+                }
+            }
+            Message::SetTrackGain(track_id, gain) => {
+                let gain = gain.clamp(0.0, 2.0);
+                self.send_command(EngineCommand::SetTrackGain(track_id, gain));
+                if let Some(track) = self.state.find_track_mut(track_id) {
+                    track.gain = gain;
+                }
+            }
+            Message::SetTrackPan(track_id, pan) => {
+                let pan = pan.clamp(0.0, 1.0);
+                self.send_command(EngineCommand::SetTrackPan(track_id, pan));
+                if let Some(track) = self.state.find_track_mut(track_id) {
+                    track.pan = pan;
+                }
+            }
+            Message::SetTrackMute(track_id) => {
+                if let Some(track) = self.state.find_track_mut(track_id) {
+                    track.mute = !track.mute;
+                    let mute = track.mute;
+                    self.send_command(EngineCommand::SetTrackMute(track_id, mute));
+                }
+            }
+            Message::SetTrackSolo(track_id) => {
+                if let Some(track) = self.state.find_track_mut(track_id) {
+                    track.solo = !track.solo;
+                    let solo = track.solo;
+                    self.send_command(EngineCommand::SetTrackSolo(track_id, solo));
+                }
+            }
+            Message::EngineTrackMeter {
+                track_id,
+                peak_l,
+                peak_r,
+            } => {
+                if let Some(track) = self.state.find_track_mut(track_id) {
+                    track.peak_l = peak_l.max(track.peak_l * 0.85);
+                    track.peak_r = peak_r.max(track.peak_r * 0.85);
+                }
             }
         }
         Task::none()
@@ -203,7 +381,6 @@ impl App {
                         self.waveform.set_playhead(self.state.position_normalized());
                     }
                     EngineEvent::Metering { peak_l, peak_r, .. } => {
-                        // Smooth the meter with a simple decay
                         self.state.peak_l = peak_l.max(self.state.peak_l * 0.85);
                         self.state.peak_r = peak_r.max(self.state.peak_r * 0.85);
                         self.vu_meter.peak_l = self.state.peak_l;
@@ -215,6 +392,16 @@ impl App {
                     EngineEvent::PlaybackStarted => {
                         self.state.playing = true;
                     }
+                    EngineEvent::TrackMeter {
+                        track_id,
+                        peak_l,
+                        peak_r,
+                    } => {
+                        if let Some(track) = self.state.find_track_mut(track_id) {
+                            track.peak_l = peak_l.max(track.peak_l * 0.85);
+                            track.peak_r = peak_r.max(track.peak_r * 0.85);
+                        }
+                    }
                 }
             }
         }
@@ -222,11 +409,22 @@ impl App {
 
     fn view(&self) -> Element<Message> {
         let header = self.view_header();
-        let waveform_area = self.view_waveform();
+
+        let main_content = if self.state.tracks.is_empty() {
+            // Legacy view: waveform + meter
+            self.view_waveform()
+        } else {
+            // Multi-track view: timeline + mixer
+            let timeline = self.view_timeline();
+            let mixer = self.view_mixer();
+
+            column![timeline, mixer].spacing(2).into()
+        };
+
         let transport_bar = self.view_transport();
         let status_bar = self.view_status();
 
-        let layout = column![header, waveform_area, transport_bar, status_bar];
+        let layout = column![header, main_content, transport_bar, status_bar];
 
         container(layout)
             .width(Length::Fill)
@@ -241,10 +439,23 @@ impl App {
             .on_press(Message::OpenFile)
             .padding([6, 16]);
 
-        let header = row![title, horizontal_space(), open_btn]
-            .spacing(16)
-            .padding(12)
-            .align_y(iced::Alignment::Center);
+        let add_track_btn = button(text("Add Track").size(14))
+            .on_press(Message::AddTrack)
+            .padding([6, 16]);
+
+        let mut header_row = row![title, horizontal_space(), add_track_btn].spacing(8);
+
+        // Show remove track button if a track is selected
+        if let Some(selected_id) = self.state.selected_track {
+            let remove_btn = button(text("Remove Track").size(14))
+                .on_press(Message::RemoveTrack(selected_id))
+                .padding([6, 16]);
+            header_row = header_row.push(remove_btn);
+        }
+
+        header_row = header_row.push(open_btn);
+
+        let header = header_row.padding(12).align_y(iced::Alignment::Center);
 
         container(header)
             .width(Length::Fill)
@@ -275,6 +486,70 @@ impl App {
             .into()
     }
 
+    fn view_timeline(&self) -> Element<Message> {
+        let timeline_canvas: Element<Message> = canvas(&self.timeline)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into();
+
+        container(timeline_canvas)
+            .width(Length::Fill)
+            .height(Length::FillPortion(6))
+            .padding([0, 8])
+            .into()
+    }
+
+    fn view_mixer(&self) -> Element<Message> {
+        let mut strips = row![].spacing(4).padding(8);
+
+        for track in &self.state.tracks {
+            let strip = view_mixer_strip(track);
+            strips = strips.push(strip);
+        }
+
+        // Master strip
+        let master_label = text("Master").size(11).color(vibez_theme::TEXT);
+        let master_meter = VuMeterWidget {
+            peak_l: self.state.peak_l,
+            peak_r: self.state.peak_r,
+        };
+        let master_meter_canvas: Element<Message> = canvas(master_meter)
+            .width(Length::Fixed(28.0))
+            .height(Length::Fixed(100.0))
+            .into();
+
+        let master_strip = column![master_label, master_meter_canvas]
+            .spacing(4)
+            .padding(6)
+            .width(Length::Fixed(60.0))
+            .align_x(iced::Alignment::Center);
+
+        let master_container = container(master_strip).style(|_theme: &Theme| container::Style {
+            background: Some(vibez_theme::BG_SURFACE.into()),
+            border: iced::Border {
+                color: vibez_theme::ACCENT,
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            ..Default::default()
+        });
+
+        strips = strips.push(master_container);
+
+        let scrollable_mixer = scrollable(strips).direction(scrollable::Direction::Horizontal(
+            scrollable::Scrollbar::default(),
+        ));
+
+        container(scrollable_mixer)
+            .width(Length::Fill)
+            .height(Length::FillPortion(3))
+            .style(|_theme: &Theme| container::Style {
+                background: Some(vibez_theme::BG_DARK.into()),
+                ..Default::default()
+            })
+            .into()
+    }
+
     fn view_transport(&self) -> Element<Message> {
         let play_btn = if self.state.playing {
             button(text("Stop").size(14))
@@ -302,11 +577,20 @@ impl App {
 
         let bpm_label = text("BPM").size(12).color(vibez_theme::TEXT_DIM);
 
+        let track_count = if !self.state.tracks.is_empty() {
+            text(format!("{} tracks", self.state.tracks.len()))
+                .size(12)
+                .color(vibez_theme::TEXT_DIM)
+        } else {
+            text("").size(12).color(vibez_theme::TEXT_DIM)
+        };
+
         let transport = row![
             play_btn,
             horizontal_space(),
             time_text,
             horizontal_space(),
+            track_count,
             bpm_input,
             bpm_label,
         ]

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use iced::widget::{
-    button, canvas, column, container, horizontal_space, row, scrollable, text, text_input,
+    button, canvas, center, column, container, horizontal_space, row, scrollable, text, text_input,
 };
 use iced::{Element, Length, Subscription, Task, Theme};
 
@@ -21,12 +21,9 @@ use crate::theme as vibez_theme;
 use crate::widgets::mixer_strip::view_mixer_strip;
 use crate::widgets::timeline::TimelineWidget;
 use crate::widgets::vu_meter::VuMeterWidget;
-use crate::widgets::waveform::WaveformWidget;
 
 struct App {
     state: AppState,
-    waveform: WaveformWidget,
-    vu_meter: VuMeterWidget,
     timeline: TimelineWidget,
     cmd_tx: Option<Producer<EngineCommand>>,
     event_rx: Option<Consumer<EngineEvent>>,
@@ -67,8 +64,6 @@ impl App {
         (
             Self {
                 state,
-                waveform: WaveformWidget::new(),
-                vu_meter: VuMeterWidget::new(),
                 timeline: TimelineWidget::new(),
                 cmd_tx: Some(cmd_tx),
                 event_rx: Some(event_rx),
@@ -95,7 +90,6 @@ impl App {
                 self.state.position_samples = 0;
                 self.send_command(EngineCommand::Stop);
                 self.send_command(EngineCommand::Seek(0));
-                self.waveform.set_playhead(0.0);
                 self.timeline.set_playhead(0.0);
             }
             Message::TogglePlayback => {
@@ -106,23 +100,11 @@ impl App {
                 }
             }
             Message::Seek(normalized) => {
-                let duration_samples = self.state.total_duration_samples();
-                let legacy_frames = self
-                    .state
-                    .audio
-                    .as_ref()
-                    .map_or(0, |a| a.num_frames() as u64);
-                let total = if duration_samples > 0 {
-                    duration_samples
-                } else {
-                    legacy_frames
-                };
-
+                let total = self.state.total_duration_samples();
                 if total > 0 {
                     let sample_pos = (normalized * total as f64) as u64;
                     self.state.position_samples = sample_pos;
                     self.send_command(EngineCommand::Seek(sample_pos));
-                    self.waveform.set_playhead(normalized);
                     self.timeline.set_playhead(normalized);
                 }
             }
@@ -140,7 +122,9 @@ impl App {
                     self.state.bpm_text = format!("{bpm:.0}");
                 }
             }
-            Message::OpenFile => {
+
+            // -- Open file → new audio track + clip --
+            Message::OpenFileToNewTrack => {
                 return Task::perform(
                     async {
                         let handle = rfd::AsyncFileDialog::new()
@@ -150,54 +134,74 @@ impl App {
                             .await;
                         handle.map(|h| h.path().to_path_buf())
                     },
-                    Message::FileSelected,
+                    Message::NewTrackFileSelected,
                 );
             }
-            Message::FileSelected(path) => {
+            Message::NewTrackFileSelected(path) => {
                 if let Some(path) = path {
                     let file_name = path
                         .file_name()
                         .map(|n| n.to_string_lossy().to_string())
                         .unwrap_or_default();
-                    self.state.loading = true;
                     self.state.status_text = format!("Loading {file_name}...");
-                    self.state.file_name = Some(file_name);
 
-                    return Task::perform(decode_file_async(path), |result| match result {
-                        Ok(audio) => Message::AudioDecoded(Arc::new(audio)),
-                        Err(e) => Message::DecodeError(e),
+                    let track_id = TrackId::new();
+                    let clip_id = ClipId::new();
+
+                    return Task::perform(decode_file_async(path), move |result| match result {
+                        Ok(audio) => Message::NewTrackAudioDecoded(
+                            track_id,
+                            clip_id,
+                            Arc::new(audio),
+                            file_name.clone(),
+                        ),
+                        Err(e) => Message::NewTrackDecodeError(e),
                     });
                 }
             }
-            Message::AudioDecoded(audio) => {
-                self.state.loading = false;
-                self.state.sample_rate = audio.sample_rate;
-                let name = self.state.file_name.as_deref().unwrap_or("audio");
+            Message::NewTrackAudioDecoded(track_id, clip_id, audio, file_name) => {
+                let track_num = self.state.next_track_number;
+                self.state.next_track_number += 1;
+                let track_name = format!("Track {track_num}");
+                let duration = audio.num_frames() as u64;
+
+                // Create track in engine
+                self.send_command(EngineCommand::AddTrack(track_id, track_name.clone()));
+                // Add clip to track in engine
+                self.send_command(EngineCommand::AddClip {
+                    track_id,
+                    clip_id,
+                    audio: Arc::clone(&audio),
+                    position: 0,
+                    source_offset: 0,
+                    duration,
+                });
+
+                // Update UI state
+                let mut track = UiTrack::new(track_id, track_name);
+                track.clips.push(UiClip {
+                    id: clip_id,
+                    name: file_name.clone(),
+                    audio,
+                    position: 0,
+                    source_offset: 0,
+                    duration,
+                });
+                self.state.tracks.push(track);
+                self.state.selected_track = Some(track_id);
+
                 self.state.status_text = format!(
-                    "{} — {:.1}s, {}ch, {}Hz",
-                    name,
-                    audio.duration_seconds(),
-                    audio.num_channels(),
-                    audio.sample_rate,
+                    "Track {track_num}: {file_name} — {:.1}s",
+                    duration as f64 / self.state.sample_rate as f64
                 );
-
-                self.waveform.set_audio(Some(Arc::clone(&audio)));
-                self.waveform.set_playhead(0.0);
-                self.state.position_samples = 0;
-                self.state.playing = false;
-
-                self.send_command(EngineCommand::Stop);
-                self.send_command(EngineCommand::Seek(0));
-                self.send_command(EngineCommand::LoadAudio(audio));
-                self.state.audio = self.waveform.audio.clone();
             }
-            Message::DecodeError(err) => {
-                self.state.loading = false;
+            Message::NewTrackDecodeError(err) => {
                 self.state.status_text = format!("Error: {err}");
             }
+
+            // -- Engine events --
             Message::Tick => {
                 self.poll_engine_events();
-                // Sync timeline
                 let selected_idx = self
                     .state
                     .selected_track
@@ -212,14 +216,11 @@ impl App {
             }
             Message::EnginePosition(pos) => {
                 self.state.position_samples = pos;
-                self.waveform.set_playhead(self.state.position_normalized());
                 self.timeline.set_playhead(self.state.position_normalized());
             }
             Message::EngineMetering { peak_l, peak_r } => {
                 self.state.peak_l = peak_l;
                 self.state.peak_r = peak_r;
-                self.vu_meter.peak_l = peak_l;
-                self.vu_meter.peak_r = peak_r;
             }
             Message::EngineStopped => {
                 self.state.playing = false;
@@ -243,7 +244,11 @@ impl App {
                 if self.state.selected_track == Some(track_id) {
                     self.state.selected_track = self.state.tracks.first().map(|t| t.id);
                 }
-                self.state.status_text = format!("{} tracks", self.state.tracks.len());
+                if self.state.tracks.is_empty() {
+                    self.state.status_text = "Ready — Open a file or add a track".to_string();
+                } else {
+                    self.state.status_text = format!("{} tracks", self.state.tracks.len());
+                }
             }
             Message::SelectTrack(track_id) => {
                 self.state.selected_track = Some(track_id);
@@ -282,7 +287,6 @@ impl App {
                 }
             }
             Message::ClipAudioDecoded(track_id, clip_id, audio, name) => {
-                // Place clip at the end of existing clips on this track
                 let existing_end = self
                     .state
                     .find_track(track_id)
@@ -297,7 +301,6 @@ impl App {
 
                 let duration = audio.num_frames() as u64;
 
-                // Send to engine
                 self.send_command(EngineCommand::AddClip {
                     track_id,
                     clip_id,
@@ -307,7 +310,6 @@ impl App {
                     duration,
                 });
 
-                // Update UI state
                 if let Some(track) = self.state.find_track_mut(track_id) {
                     track.clips.push(UiClip {
                         id: clip_id,
@@ -378,13 +380,10 @@ impl App {
                 match event {
                     EngineEvent::PlaybackPosition(pos) => {
                         self.state.position_samples = pos;
-                        self.waveform.set_playhead(self.state.position_normalized());
                     }
                     EngineEvent::Metering { peak_l, peak_r, .. } => {
                         self.state.peak_l = peak_l.max(self.state.peak_l * 0.85);
                         self.state.peak_r = peak_r.max(self.state.peak_r * 0.85);
-                        self.vu_meter.peak_l = self.state.peak_l;
-                        self.vu_meter.peak_r = self.state.peak_r;
                     }
                     EngineEvent::PlaybackStopped => {
                         self.state.playing = false;
@@ -409,22 +408,12 @@ impl App {
 
     fn view(&self) -> Element<Message> {
         let header = self.view_header();
-
-        let main_content = if self.state.tracks.is_empty() {
-            // Legacy view: waveform + meter
-            self.view_waveform()
-        } else {
-            // Multi-track view: timeline + mixer
-            let timeline = self.view_timeline();
-            let mixer = self.view_mixer();
-
-            column![timeline, mixer].spacing(2).into()
-        };
-
+        let timeline = self.view_timeline();
+        let mixer = self.view_mixer();
         let transport_bar = self.view_transport();
         let status_bar = self.view_status();
 
-        let layout = column![header, main_content, transport_bar, status_bar];
+        let layout = column![header, timeline, mixer, transport_bar, status_bar];
 
         container(layout)
             .width(Length::Fill)
@@ -435,8 +424,8 @@ impl App {
     fn view_header(&self) -> Element<Message> {
         let title = text("vibez").size(24).color(vibez_theme::ACCENT);
 
-        let open_btn = button(text("Open").size(14))
-            .on_press(Message::OpenFile)
+        let open_btn = button(text("Open File").size(14))
+            .on_press(Message::OpenFileToNewTrack)
             .padding([6, 16]);
 
         let add_track_btn = button(text("Add Track").size(14))
@@ -445,7 +434,6 @@ impl App {
 
         let mut header_row = row![title, horizontal_space(), add_track_btn].spacing(8);
 
-        // Show remove track button if a track is selected
         if let Some(selected_id) = self.state.selected_track {
             let remove_btn = button(text("Remove Track").size(14))
                 .on_press(Message::RemoveTrack(selected_id))
@@ -466,27 +454,25 @@ impl App {
             .into()
     }
 
-    fn view_waveform(&self) -> Element<Message> {
-        let waveform_canvas: Element<Message> = canvas(&self.waveform)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .into();
-
-        let meter_canvas: Element<Message> = canvas(&self.vu_meter)
-            .width(Length::Fixed(40.0))
-            .height(Length::Fill)
-            .into();
-
-        let content = row![waveform_canvas, meter_canvas].spacing(4);
-
-        container(content)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .padding(8)
-            .into()
-    }
-
     fn view_timeline(&self) -> Element<Message> {
+        if self.state.tracks.is_empty() {
+            // Empty state
+            let prompt = text("Open a file or add a track to get started")
+                .size(16)
+                .color(vibez_theme::TEXT_DIM);
+
+            let centered = center(prompt).width(Length::Fill).height(Length::Fill);
+
+            return container(centered)
+                .width(Length::Fill)
+                .height(Length::FillPortion(6))
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(vibez_theme::BG_DARK.into()),
+                    ..Default::default()
+                })
+                .into();
+        }
+
         let timeline_canvas: Element<Message> = canvas(&self.timeline)
             .width(Length::Fill)
             .height(Length::Fill)
@@ -500,6 +486,13 @@ impl App {
     }
 
     fn view_mixer(&self) -> Element<Message> {
+        if self.state.tracks.is_empty() {
+            return container(text(""))
+                .width(Length::Fill)
+                .height(Length::FillPortion(3))
+                .into();
+        }
+
         let mut strips = row![].spacing(4).padding(8);
 
         for track in &self.state.tracks {
@@ -630,7 +623,6 @@ impl App {
 async fn decode_file_async(
     path: PathBuf,
 ) -> Result<vibez_core::audio_buffer::DecodedAudio, String> {
-    // Run decoding on a blocking thread
     tokio::task::spawn_blocking(move || {
         file_io::decode_audio_file(&path).map_err(|e| e.to_string())
     })

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -322,7 +322,7 @@ impl App {
 
     // ── View ──
 
-    fn view(&self) -> Element<Message> {
+    fn view(&self) -> Element<'_, Message> {
         let header = self.view_header();
 
         let content = match self.state.workspace {
@@ -342,7 +342,7 @@ impl App {
             .into()
     }
 
-    fn view_header(&self) -> Element<Message> {
+    fn view_header(&self) -> Element<'_, Message> {
         let title = text("vibez").size(24).color(vibez_theme::ACCENT);
 
         // Workspace tabs
@@ -394,7 +394,7 @@ impl App {
 
     // ── Arrangement view ──
 
-    fn view_arrangement(&self) -> Element<Message> {
+    fn view_arrangement(&self) -> Element<'_, Message> {
         if self.state.tracks.is_empty() {
             let prompt = text("Add a track to get started")
                 .size(16)
@@ -475,7 +475,7 @@ impl App {
 
     // ── Mixer view ──
 
-    fn view_mixer(&self) -> Element<Message> {
+    fn view_mixer(&self) -> Element<'_, Message> {
         if self.state.tracks.is_empty() {
             let prompt = text("Add a track to get started")
                 .size(16)
@@ -549,7 +549,7 @@ impl App {
 
     // ── Detail panel (global — effects/instruments for selected track) ──
 
-    fn view_detail_panel(&self) -> Element<Message> {
+    fn view_detail_panel(&self) -> Element<'_, Message> {
         let detail_content: Element<Message> = if let Some(track) = self
             .state
             .selected_track
@@ -592,7 +592,7 @@ impl App {
 
     // ── Transport bar ──
 
-    fn view_transport(&self) -> Element<Message> {
+    fn view_transport(&self) -> Element<'_, Message> {
         let play_btn = if self.state.playing {
             button(text("Stop").size(14))
                 .on_press(Message::Stop)
@@ -660,7 +660,7 @@ impl App {
             .into()
     }
 
-    fn view_status(&self) -> Element<Message> {
+    fn view_status(&self) -> Element<'_, Message> {
         let status = text(&self.state.status_text)
             .size(12)
             .color(vibez_theme::TEXT_DIM);

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -16,11 +16,11 @@ pub enum Message {
     BpmChanged(String),
     BpmSubmit,
 
-    // File (legacy single-file)
-    OpenFile,
-    FileSelected(Option<PathBuf>),
-    AudioDecoded(Arc<DecodedAudio>),
-    DecodeError(String),
+    // Open file → creates audio track + clip
+    OpenFileToNewTrack,
+    NewTrackFileSelected(Option<PathBuf>),
+    NewTrackAudioDecoded(TrackId, ClipId, Arc<DecodedAudio>, String),
+    NewTrackDecodeError(String),
 
     // Engine events (polled at 60fps)
     Tick,

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use vibez_core::audio_buffer::DecodedAudio;
+use vibez_core::id::{ClipId, TrackId};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -15,7 +16,7 @@ pub enum Message {
     BpmChanged(String),
     BpmSubmit,
 
-    // File
+    // File (legacy single-file)
     OpenFile,
     FileSelected(Option<PathBuf>),
     AudioDecoded(Arc<DecodedAudio>),
@@ -24,6 +25,32 @@ pub enum Message {
     // Engine events (polled at 60fps)
     Tick,
     EnginePosition(u64),
-    EngineMetering { peak_l: f32, peak_r: f32 },
+    EngineMetering {
+        peak_l: f32,
+        peak_r: f32,
+    },
     EngineStopped,
+
+    // Multi-track
+    AddTrack,
+    RemoveTrack(TrackId),
+    SelectTrack(TrackId),
+    AddClipToTrack(TrackId),
+    ClipFileSelected(TrackId, Option<PathBuf>),
+    ClipAudioDecoded(TrackId, ClipId, Arc<DecodedAudio>, String),
+    ClipDecodeError(TrackId, String),
+    RemoveClip(TrackId, ClipId),
+
+    // Track controls
+    SetTrackGain(TrackId, f32),
+    SetTrackPan(TrackId, f32),
+    SetTrackMute(TrackId),
+    SetTrackSolo(TrackId),
+
+    // Per-track metering
+    EngineTrackMeter {
+        track_id: TrackId,
+        peak_l: f32,
+        peak_r: f32,
+    },
 }

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::id::{ClipId, TrackId};
 
+use crate::state::Workspace;
+
 #[derive(Debug, Clone)]
 pub enum Message {
     // Transport
@@ -16,11 +18,8 @@ pub enum Message {
     BpmChanged(String),
     BpmSubmit,
 
-    // Open file → creates audio track + clip
-    OpenFileToNewTrack,
-    NewTrackFileSelected(Option<PathBuf>),
-    NewTrackAudioDecoded(TrackId, ClipId, Arc<DecodedAudio>, String),
-    NewTrackDecodeError(String),
+    // Workspace
+    SwitchWorkspace(Workspace),
 
     // Engine events (polled at 60fps)
     Tick,

--- a/crates/vibez-ui/src/state.rs
+++ b/crates/vibez-ui/src/state.rs
@@ -2,9 +2,54 @@ use std::sync::Arc;
 
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::constants::DEFAULT_BPM;
+use vibez_core::id::{ClipId, TrackId};
+
+/// A clip as represented in the UI.
+#[derive(Debug, Clone)]
+pub struct UiClip {
+    pub id: ClipId,
+    pub name: String,
+    pub audio: Arc<DecodedAudio>,
+    /// Position on the timeline in samples.
+    pub position: u64,
+    /// Offset into the source audio in samples.
+    pub source_offset: u64,
+    /// Duration in samples.
+    pub duration: u64,
+}
+
+/// A track as represented in the UI.
+#[derive(Debug, Clone)]
+pub struct UiTrack {
+    pub id: TrackId,
+    pub name: String,
+    pub clips: Vec<UiClip>,
+    pub gain: f32,
+    pub pan: f32,
+    pub mute: bool,
+    pub solo: bool,
+    pub peak_l: f32,
+    pub peak_r: f32,
+}
+
+impl UiTrack {
+    pub fn new(id: TrackId, name: String) -> Self {
+        Self {
+            id,
+            name,
+            clips: Vec::new(),
+            gain: 1.0,
+            pan: 0.5,
+            mute: false,
+            solo: false,
+            peak_l: 0.0,
+            peak_r: 0.0,
+        }
+    }
+}
 
 pub struct AppState {
-    // Audio data
+    // Audio data (legacy single-file)
     pub audio: Option<Arc<DecodedAudio>>,
     pub file_name: Option<String>,
 
@@ -17,13 +62,18 @@ pub struct AppState {
     pub bpm: f64,
     pub bpm_text: String,
 
-    // Metering
+    // Metering (master)
     pub peak_l: f32,
     pub peak_r: f32,
 
     // UI
     pub loading: bool,
     pub status_text: String,
+
+    // Multi-track
+    pub tracks: Vec<UiTrack>,
+    pub selected_track: Option<TrackId>,
+    pub next_track_number: u32,
 }
 
 impl Default for AppState {
@@ -39,7 +89,10 @@ impl Default for AppState {
             peak_l: 0.0,
             peak_r: 0.0,
             loading: false,
-            status_text: "Ready — Open a file to begin".to_string(),
+            status_text: "Ready — Open a file or add a track".to_string(),
+            tracks: Vec::new(),
+            selected_track: None,
+            next_track_number: 1,
         }
     }
 }
@@ -50,7 +103,13 @@ impl AppState {
     }
 
     pub fn duration_seconds(&self) -> f64 {
-        self.audio.as_ref().map_or(0.0, |a| a.duration_seconds())
+        // Prefer multi-track duration if tracks exist
+        let track_dur = self.total_duration_samples();
+        if track_dur > 0 {
+            track_dur as f64 / self.sample_rate as f64
+        } else {
+            self.audio.as_ref().map_or(0.0, |a| a.duration_seconds())
+        }
     }
 
     pub fn position_normalized(&self) -> f64 {
@@ -66,5 +125,23 @@ impl AppState {
         let mins = (seconds / 60.0) as u32;
         let secs = seconds % 60.0;
         format!("{mins:02}:{secs:05.2}")
+    }
+
+    pub fn find_track(&self, id: TrackId) -> Option<&UiTrack> {
+        self.tracks.iter().find(|t| t.id == id)
+    }
+
+    pub fn find_track_mut(&mut self, id: TrackId) -> Option<&mut UiTrack> {
+        self.tracks.iter_mut().find(|t| t.id == id)
+    }
+
+    /// Total duration in samples across all tracks (max clip end position).
+    pub fn total_duration_samples(&self) -> u64 {
+        self.tracks
+            .iter()
+            .flat_map(|t| t.clips.iter())
+            .map(|c| c.position.saturating_add(c.duration))
+            .max()
+            .unwrap_or(0)
     }
 }

--- a/crates/vibez-ui/src/state.rs
+++ b/crates/vibez-ui/src/state.rs
@@ -48,6 +48,12 @@ impl UiTrack {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Workspace {
+    Arrange,
+    Mix,
+}
+
 pub struct AppState {
     // Transport
     pub playing: bool,
@@ -64,6 +70,7 @@ pub struct AppState {
 
     // UI
     pub status_text: String,
+    pub workspace: Workspace,
 
     // Multi-track
     pub tracks: Vec<UiTrack>,
@@ -81,7 +88,8 @@ impl Default for AppState {
             bpm_text: format!("{DEFAULT_BPM:.0}"),
             peak_l: 0.0,
             peak_r: 0.0,
-            status_text: "Ready — Open a file or add a track".to_string(),
+            status_text: "Ready — Add a track to get started".to_string(),
+            workspace: Workspace::Arrange,
             tracks: Vec::new(),
             selected_track: None,
             next_track_number: 1,

--- a/crates/vibez-ui/src/state.rs
+++ b/crates/vibez-ui/src/state.rs
@@ -49,10 +49,6 @@ impl UiTrack {
 }
 
 pub struct AppState {
-    // Audio data (legacy single-file)
-    pub audio: Option<Arc<DecodedAudio>>,
-    pub file_name: Option<String>,
-
     // Transport
     pub playing: bool,
     pub position_samples: u64,
@@ -67,7 +63,6 @@ pub struct AppState {
     pub peak_r: f32,
 
     // UI
-    pub loading: bool,
     pub status_text: String,
 
     // Multi-track
@@ -79,8 +74,6 @@ pub struct AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            audio: None,
-            file_name: None,
             playing: false,
             position_samples: 0,
             sample_rate: 44_100,
@@ -88,7 +81,6 @@ impl Default for AppState {
             bpm_text: format!("{DEFAULT_BPM:.0}"),
             peak_l: 0.0,
             peak_r: 0.0,
-            loading: false,
             status_text: "Ready — Open a file or add a track".to_string(),
             tracks: Vec::new(),
             selected_track: None,
@@ -103,12 +95,11 @@ impl AppState {
     }
 
     pub fn duration_seconds(&self) -> f64 {
-        // Prefer multi-track duration if tracks exist
-        let track_dur = self.total_duration_samples();
-        if track_dur > 0 {
-            track_dur as f64 / self.sample_rate as f64
+        let samples = self.total_duration_samples();
+        if samples > 0 {
+            samples as f64 / self.sample_rate as f64
         } else {
-            self.audio.as_ref().map_or(0.0, |a| a.duration_seconds())
+            0.0
         }
     }
 

--- a/crates/vibez-ui/src/theme.rs
+++ b/crates/vibez-ui/src/theme.rs
@@ -97,6 +97,112 @@ pub const METER_RED: Color = Color {
     a: 1.0,
 };
 
+// -- Phase 2 colors --
+
+/// Track lane background
+pub const TRACK_BG: Color = Color {
+    r: 0.118,
+    g: 0.118,
+    b: 0.200,
+    a: 1.0,
+};
+
+/// Selected track background
+pub const TRACK_BG_SELECTED: Color = Color {
+    r: 0.160,
+    g: 0.160,
+    b: 0.260,
+    a: 1.0,
+};
+
+/// Clip body color
+pub const CLIP_BODY: Color = Color {
+    r: 0.300,
+    g: 0.480,
+    b: 0.900,
+    a: 0.6,
+};
+
+/// Clip border color
+pub const CLIP_BORDER: Color = Color {
+    r: 0.380,
+    g: 0.565,
+    b: 1.0,
+    a: 0.9,
+};
+
+/// Fader track color
+pub const FADER_TRACK: Color = Color {
+    r: 0.180,
+    g: 0.180,
+    b: 0.280,
+    a: 1.0,
+};
+
+/// Fader handle color
+pub const FADER_HANDLE: Color = Color {
+    r: 0.700,
+    g: 0.700,
+    b: 0.800,
+    a: 1.0,
+};
+
+/// Knob background
+pub const KNOB_BG: Color = Color {
+    r: 0.160,
+    g: 0.160,
+    b: 0.250,
+    a: 1.0,
+};
+
+/// Knob arc color
+pub const KNOB_ARC: Color = Color {
+    r: 0.380,
+    g: 0.565,
+    b: 1.0,
+    a: 1.0,
+};
+
+/// Mute button active color
+pub const MUTE_ACTIVE: Color = Color {
+    r: 0.973,
+    g: 0.443,
+    b: 0.443,
+    a: 1.0,
+};
+
+/// Solo button active color
+pub const SOLO_ACTIVE: Color = Color {
+    r: 1.0,
+    g: 0.843,
+    b: 0.0,
+    a: 1.0,
+};
+
+/// Time ruler background
+pub const RULER_BG: Color = Color {
+    r: 0.110,
+    g: 0.110,
+    b: 0.190,
+    a: 1.0,
+};
+
+/// Time ruler text
+pub const RULER_TEXT: Color = Color {
+    r: 0.533,
+    g: 0.533,
+    b: 0.667,
+    a: 1.0,
+};
+
+/// Time ruler line
+pub const RULER_LINE: Color = Color {
+    r: 0.300,
+    g: 0.300,
+    b: 0.420,
+    a: 0.5,
+};
+
 pub fn vibez_theme() -> Theme {
     Theme::custom(
         "Vibez".to_string(),

--- a/crates/vibez-ui/src/widgets/fader.rs
+++ b/crates/vibez-ui/src/widgets/fader.rs
@@ -1,0 +1,152 @@
+use iced::mouse;
+use iced::widget::canvas;
+use iced::{Rectangle, Renderer, Theme};
+
+use crate::message::Message;
+use crate::theme;
+use vibez_core::id::TrackId;
+
+/// Vertical fader widget for track gain control.
+pub struct FaderWidget {
+    pub track_id: TrackId,
+    /// Current gain value (0.0..2.0).
+    pub value: f32,
+}
+
+impl FaderWidget {
+    pub fn new(track_id: TrackId, value: f32) -> Self {
+        Self { track_id, value }
+    }
+}
+
+/// State for mouse dragging.
+#[derive(Debug, Default)]
+pub struct FaderState {
+    dragging: bool,
+    last_y: f32,
+}
+
+impl canvas::Program<Message> for FaderWidget {
+    type State = FaderState;
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let w = bounds.width;
+        let h = bounds.height;
+
+        // Fader track
+        let track_w = 6.0;
+        let track_x = (w - track_w) / 2.0;
+        let track_top = 4.0;
+        let track_h = h - 8.0;
+
+        frame.fill_rectangle(
+            iced::Point::new(track_x, track_top),
+            iced::Size::new(track_w, track_h),
+            theme::FADER_TRACK,
+        );
+
+        // Unity gain mark (at 0.5 of the track = gain 1.0)
+        let unity_y = track_top + track_h * 0.5;
+        let unity_line = canvas::Path::line(
+            iced::Point::new(track_x - 2.0, unity_y),
+            iced::Point::new(track_x + track_w + 2.0, unity_y),
+        );
+        frame.stroke(
+            &unity_line,
+            canvas::Stroke::default()
+                .with_color(theme::TEXT_DIM)
+                .with_width(1.0),
+        );
+
+        // Handle position: gain 0.0 = bottom, gain 2.0 = top
+        let normalized = (self.value / 2.0).clamp(0.0, 1.0);
+        let handle_y = track_top + track_h * (1.0 - normalized);
+        let handle_h = 10.0;
+        let handle_w = w - 4.0;
+        let handle_x = 2.0;
+
+        // Filled portion (from bottom to handle)
+        let fill_h = track_top + track_h - handle_y;
+        if fill_h > 0.0 {
+            frame.fill_rectangle(
+                iced::Point::new(track_x, handle_y),
+                iced::Size::new(track_w, fill_h),
+                theme::ACCENT,
+            );
+        }
+
+        // Handle
+        frame.fill_rectangle(
+            iced::Point::new(handle_x, handle_y - handle_h / 2.0),
+            iced::Size::new(handle_w, handle_h),
+            theme::FADER_HANDLE,
+        );
+
+        vec![frame.into_geometry()]
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if state.dragging || cursor.is_over(bounds) {
+            mouse::Interaction::ResizingVertically
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: canvas::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<Message>) {
+        match event {
+            canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
+                if let Some(pos) = cursor.position_in(bounds) {
+                    state.dragging = true;
+                    state.last_y = pos.y;
+                    return (canvas::event::Status::Captured, None);
+                }
+            }
+            canvas::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
+                if state.dragging {
+                    state.dragging = false;
+                    return (canvas::event::Status::Captured, None);
+                }
+            }
+            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { .. }) => {
+                if state.dragging {
+                    if let Some(pos) = cursor.position_in(bounds) {
+                        let delta = state.last_y - pos.y;
+                        state.last_y = pos.y;
+
+                        let track_h = bounds.height - 8.0;
+                        let gain_delta = delta / track_h * 2.0;
+                        let new_gain = (self.value + gain_delta).clamp(0.0, 2.0);
+
+                        return (
+                            canvas::event::Status::Captured,
+                            Some(Message::SetTrackGain(self.track_id, new_gain)),
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        (canvas::event::Status::Ignored, None)
+    }
+}

--- a/crates/vibez-ui/src/widgets/fader.rs
+++ b/crates/vibez-ui/src/widgets/fader.rs
@@ -6,6 +6,151 @@ use crate::message::Message;
 use crate::theme;
 use vibez_core::id::TrackId;
 
+/// Horizontal fader widget for track gain control (arrangement track headers).
+pub struct HorizontalFaderWidget {
+    pub track_id: TrackId,
+    /// Current gain value (0.0..2.0).
+    pub value: f32,
+}
+
+impl HorizontalFaderWidget {
+    pub fn new(track_id: TrackId, value: f32) -> Self {
+        Self { track_id, value }
+    }
+}
+
+/// State for horizontal fader mouse dragging.
+#[derive(Debug, Default)]
+pub struct HorizontalFaderState {
+    dragging: bool,
+    last_x: f32,
+}
+
+impl canvas::Program<Message> for HorizontalFaderWidget {
+    type State = HorizontalFaderState;
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let w = bounds.width;
+        let h = bounds.height;
+
+        // Fader track (horizontal)
+        let track_h = 4.0;
+        let track_y = (h - track_h) / 2.0;
+        let track_left = 4.0;
+        let track_w = w - 8.0;
+
+        frame.fill_rectangle(
+            iced::Point::new(track_left, track_y),
+            iced::Size::new(track_w, track_h),
+            theme::FADER_TRACK,
+        );
+
+        // Unity gain mark (at 0.5 of the track = gain 1.0)
+        let unity_x = track_left + track_w * 0.5;
+        let unity_line = canvas::Path::line(
+            iced::Point::new(unity_x, track_y - 2.0),
+            iced::Point::new(unity_x, track_y + track_h + 2.0),
+        );
+        frame.stroke(
+            &unity_line,
+            canvas::Stroke::default()
+                .with_color(theme::TEXT_DIM)
+                .with_width(1.0),
+        );
+
+        // Handle position: gain 0.0 = left, gain 2.0 = right
+        let normalized = (self.value / 2.0).clamp(0.0, 1.0);
+        let handle_x = track_left + track_w * normalized;
+        let handle_w = 8.0;
+        let handle_h = h - 4.0;
+        let handle_y = 2.0;
+
+        // Filled portion (from left to handle)
+        let fill_w = handle_x - track_left;
+        if fill_w > 0.0 {
+            frame.fill_rectangle(
+                iced::Point::new(track_left, track_y),
+                iced::Size::new(fill_w, track_h),
+                theme::ACCENT,
+            );
+        }
+
+        // Handle
+        frame.fill_rectangle(
+            iced::Point::new(handle_x - handle_w / 2.0, handle_y),
+            iced::Size::new(handle_w, handle_h),
+            theme::FADER_HANDLE,
+        );
+
+        vec![frame.into_geometry()]
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if state.dragging || cursor.is_over(bounds) {
+            mouse::Interaction::ResizingHorizontally
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: canvas::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<Message>) {
+        match event {
+            canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
+                if let Some(pos) = cursor.position_in(bounds) {
+                    state.dragging = true;
+                    state.last_x = pos.x;
+                    return (canvas::event::Status::Captured, None);
+                }
+            }
+            canvas::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
+                if state.dragging {
+                    state.dragging = false;
+                    return (canvas::event::Status::Captured, None);
+                }
+            }
+            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { .. }) => {
+                if state.dragging {
+                    if let Some(pos) = cursor.position_in(bounds) {
+                        let delta = pos.x - state.last_x;
+                        state.last_x = pos.x;
+
+                        let track_w = bounds.width - 8.0;
+                        let gain_delta = delta / track_w * 2.0;
+                        let new_gain = (self.value + gain_delta).clamp(0.0, 2.0);
+
+                        return (
+                            canvas::event::Status::Captured,
+                            Some(Message::SetTrackGain(self.track_id, new_gain)),
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        (canvas::event::Status::Ignored, None)
+    }
+}
+
 /// Vertical fader widget for track gain control.
 pub struct FaderWidget {
     pub track_id: TrackId,

--- a/crates/vibez-ui/src/widgets/knob.rs
+++ b/crates/vibez-ui/src/widgets/knob.rs
@@ -1,3 +1,6 @@
+use std::time::Instant;
+
+use iced::keyboard;
 use iced::mouse;
 use iced::widget::canvas;
 use iced::{Rectangle, Renderer, Theme};
@@ -5,6 +8,21 @@ use iced::{Rectangle, Renderer, Theme};
 use crate::message::Message;
 use crate::theme;
 use vibez_core::id::TrackId;
+
+/// 270° arc sweep matching DAW standards.
+/// Start at 135° (bottom-left), end at 405° (bottom-right).
+const ARC_START: f32 = std::f32::consts::FRAC_PI_4 * 3.0; // 135° = 3π/4
+const ARC_END: f32 = ARC_START + std::f32::consts::FRAC_PI_2 * 3.0; // 135° + 270° = 405° = 9π/4
+const ARC_CENTER: f32 = (ARC_START + ARC_END) / 2.0; // 270° = 3π/2
+
+/// Sensitivity: full 0→1 range over ~150px of vertical drag.
+const BASE_SENSITIVITY: f32 = 1.0 / 150.0;
+/// Shift modifier makes it 5x finer.
+const FINE_DIVISOR: f32 = 5.0;
+/// Scroll step per line tick.
+const SCROLL_STEP: f32 = 0.02;
+/// Double-click window in milliseconds.
+const DOUBLE_CLICK_MS: u64 = 300;
 
 /// Rotary knob widget for track pan control.
 pub struct KnobWidget {
@@ -19,11 +37,24 @@ impl KnobWidget {
     }
 }
 
-/// State for mouse dragging.
-#[derive(Debug, Default)]
+/// State for mouse interaction.
+#[derive(Debug)]
 pub struct KnobState {
     dragging: bool,
     last_y: f32,
+    shift_held: bool,
+    last_click: Option<Instant>,
+}
+
+impl Default for KnobState {
+    fn default() -> Self {
+        Self {
+            dragging: false,
+            last_y: 0.0,
+            shift_held: false,
+            last_click: None,
+        }
+    }
 }
 
 impl canvas::Program<Message> for KnobWidget {
@@ -47,57 +78,65 @@ impl canvas::Program<Message> for KnobWidget {
         let bg_circle = canvas::Path::circle(center, radius);
         frame.fill(&bg_circle, theme::KNOB_BG);
 
-        // Arc showing the value
-        // Range: from ~225° (left) through 270° (bottom/center) to ~315° (right)
-        // Using standard math angles: 225° = 5π/4 (start), 315° = 7π/4 (end)
-        let start_angle = std::f32::consts::FRAC_PI_4 * 5.0; // 225°
-        let end_angle = std::f32::consts::FRAC_PI_4 * 7.0; // 315°
-        let value_angle = start_angle + self.value * (end_angle - start_angle);
-
-        // Draw the arc as line segments
         let arc_radius = radius - 2.0;
-        let segments = 32;
+        let segments = 40;
 
-        // Background arc (full range)
-        let bg_arc = build_arc(center, arc_radius, start_angle, end_angle, segments);
+        // Background arc (full 270° range)
+        let bg_arc = build_arc(center, arc_radius, ARC_START, ARC_END, segments);
         frame.stroke(
             &bg_arc,
             canvas::Stroke::default()
                 .with_color(theme::FADER_TRACK)
-                .with_width(2.5),
+                .with_width(3.0),
         );
 
-        // Value arc
-        let value_arc = build_arc(center, arc_radius, start_angle, value_angle, segments);
+        // Value arc (filled portion)
+        let value_angle = ARC_START + self.value * (ARC_END - ARC_START);
+        if self.value > 0.005 {
+            let value_arc = build_arc(center, arc_radius, ARC_START, value_angle, segments);
+            frame.stroke(
+                &value_arc,
+                canvas::Stroke::default()
+                    .with_color(theme::KNOB_ARC)
+                    .with_width(3.0),
+            );
+        }
+
+        // Pointer line from center toward current value angle
+        let pointer_inner = radius * 0.25;
+        let pointer_outer = radius - 3.0;
+        let pointer = canvas::Path::line(
+            iced::Point::new(
+                center.x + pointer_inner * value_angle.cos(),
+                center.y + pointer_inner * value_angle.sin(),
+            ),
+            iced::Point::new(
+                center.x + pointer_outer * value_angle.cos(),
+                center.y + pointer_outer * value_angle.sin(),
+            ),
+        );
         frame.stroke(
-            &value_arc,
+            &pointer,
             canvas::Stroke::default()
-                .with_color(theme::KNOB_ARC)
-                .with_width(2.5),
+                .with_color(theme::TEXT)
+                .with_width(2.0),
         );
 
-        // Indicator dot at the value position
-        let dot_x = center.x + arc_radius * value_angle.cos();
-        let dot_y = center.y + arc_radius * value_angle.sin();
-        let dot = canvas::Path::circle(iced::Point::new(dot_x, dot_y), 2.5);
-        frame.fill(&dot, theme::TEXT);
-
-        // Center marker line
-        let center_angle = (start_angle + end_angle) / 2.0;
-        let mark_inner = radius - 6.0;
-        let mark_outer = radius - 1.0;
-        let mark = canvas::Path::line(
+        // Center tick mark at bottom (270° / 3π/2)
+        let tick_inner = radius - 1.0;
+        let tick_outer = radius + 2.0;
+        let tick = canvas::Path::line(
             iced::Point::new(
-                center.x + mark_inner * center_angle.cos(),
-                center.y + mark_inner * center_angle.sin(),
+                center.x + tick_inner * ARC_CENTER.cos(),
+                center.y + tick_inner * ARC_CENTER.sin(),
             ),
             iced::Point::new(
-                center.x + mark_outer * center_angle.cos(),
-                center.y + mark_outer * center_angle.sin(),
+                center.x + tick_outer * ARC_CENTER.cos(),
+                center.y + tick_outer * ARC_CENTER.sin(),
             ),
         );
         frame.stroke(
-            &mark,
+            &tick,
             canvas::Stroke::default()
                 .with_color(theme::TEXT_DIM)
                 .with_width(1.0),
@@ -112,8 +151,10 @@ impl canvas::Program<Message> for KnobWidget {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> mouse::Interaction {
-        if state.dragging || cursor.is_over(bounds) {
-            mouse::Interaction::ResizingVertically
+        if state.dragging {
+            mouse::Interaction::Grabbing
+        } else if cursor.is_over(bounds) {
+            mouse::Interaction::Grab
         } else {
             mouse::Interaction::default()
         }
@@ -127,28 +168,59 @@ impl canvas::Program<Message> for KnobWidget {
         cursor: mouse::Cursor,
     ) -> (canvas::event::Status, Option<Message>) {
         match event {
-            canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
+            // Track modifier keys
+            canvas::Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
+                state.shift_held = modifiers.shift();
+                return (canvas::event::Status::Ignored, None);
+            }
+
+            // Click: start drag or double-click to reset
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 if cursor.is_over(bounds) {
+                    let now = Instant::now();
+
+                    // Double-click detection
+                    if let Some(last) = state.last_click {
+                        if now.duration_since(last).as_millis() < DOUBLE_CLICK_MS as u128 {
+                            state.last_click = None;
+                            return (
+                                canvas::event::Status::Captured,
+                                Some(Message::SetTrackPan(self.track_id, 0.5)),
+                            );
+                        }
+                    }
+                    state.last_click = Some(now);
+
                     state.dragging = true;
-                    if let Some(pos) = cursor.position_in(bounds) {
+                    if let Some(pos) = cursor.position() {
                         state.last_y = pos.y;
                     }
                     return (canvas::event::Status::Captured, None);
                 }
             }
-            canvas::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
+
+            // Release
+            canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 if state.dragging {
                     state.dragging = false;
                     return (canvas::event::Status::Captured, None);
                 }
             }
-            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { .. }) => {
+
+            // Drag: vertical movement adjusts value (use absolute position
+            // so dragging outside the small knob bounds still tracks)
+            canvas::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
                 if state.dragging {
-                    if let Some(pos) = cursor.position_in(bounds) {
-                        let delta = state.last_y - pos.y;
+                    if let Some(pos) = cursor.position() {
+                        let delta = state.last_y - pos.y; // up = positive
                         state.last_y = pos.y;
 
-                        let sensitivity = 0.005;
+                        let sensitivity = if state.shift_held {
+                            BASE_SENSITIVITY / FINE_DIVISOR
+                        } else {
+                            BASE_SENSITIVITY
+                        };
+
                         let new_pan = (self.value + delta * sensitivity).clamp(0.0, 1.0);
 
                         return (
@@ -158,6 +230,30 @@ impl canvas::Program<Message> for KnobWidget {
                     }
                 }
             }
+
+            // Scroll wheel
+            canvas::Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if cursor.is_over(bounds) {
+                    let scroll_y = match delta {
+                        mouse::ScrollDelta::Lines { y, .. } => y,
+                        mouse::ScrollDelta::Pixels { y, .. } => y / 20.0,
+                    };
+
+                    let step = if state.shift_held {
+                        SCROLL_STEP / FINE_DIVISOR
+                    } else {
+                        SCROLL_STEP
+                    };
+
+                    let new_pan = (self.value + scroll_y * step).clamp(0.0, 1.0);
+
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::SetTrackPan(self.track_id, new_pan)),
+                    );
+                }
+            }
+
             _ => {}
         }
 

--- a/crates/vibez-ui/src/widgets/knob.rs
+++ b/crates/vibez-ui/src/widgets/knob.rs
@@ -1,0 +1,190 @@
+use iced::mouse;
+use iced::widget::canvas;
+use iced::{Rectangle, Renderer, Theme};
+
+use crate::message::Message;
+use crate::theme;
+use vibez_core::id::TrackId;
+
+/// Rotary knob widget for track pan control.
+pub struct KnobWidget {
+    pub track_id: TrackId,
+    /// Current pan value (0.0 = left, 0.5 = center, 1.0 = right).
+    pub value: f32,
+}
+
+impl KnobWidget {
+    pub fn new(track_id: TrackId, value: f32) -> Self {
+        Self { track_id, value }
+    }
+}
+
+/// State for mouse dragging.
+#[derive(Debug, Default)]
+pub struct KnobState {
+    dragging: bool,
+    last_y: f32,
+}
+
+impl canvas::Program<Message> for KnobWidget {
+    type State = KnobState;
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let w = bounds.width;
+        let h = bounds.height;
+        let center = iced::Point::new(w / 2.0, h / 2.0);
+        let radius = (w.min(h) / 2.0 - 3.0).max(4.0);
+
+        // Background circle
+        let bg_circle = canvas::Path::circle(center, radius);
+        frame.fill(&bg_circle, theme::KNOB_BG);
+
+        // Arc showing the value
+        // Range: from ~225° (left) through 270° (bottom/center) to ~315° (right)
+        // Using standard math angles: 225° = 5π/4 (start), 315° = 7π/4 (end)
+        let start_angle = std::f32::consts::FRAC_PI_4 * 5.0; // 225°
+        let end_angle = std::f32::consts::FRAC_PI_4 * 7.0; // 315°
+        let value_angle = start_angle + self.value * (end_angle - start_angle);
+
+        // Draw the arc as line segments
+        let arc_radius = radius - 2.0;
+        let segments = 32;
+
+        // Background arc (full range)
+        let bg_arc = build_arc(center, arc_radius, start_angle, end_angle, segments);
+        frame.stroke(
+            &bg_arc,
+            canvas::Stroke::default()
+                .with_color(theme::FADER_TRACK)
+                .with_width(2.5),
+        );
+
+        // Value arc
+        let value_arc = build_arc(center, arc_radius, start_angle, value_angle, segments);
+        frame.stroke(
+            &value_arc,
+            canvas::Stroke::default()
+                .with_color(theme::KNOB_ARC)
+                .with_width(2.5),
+        );
+
+        // Indicator dot at the value position
+        let dot_x = center.x + arc_radius * value_angle.cos();
+        let dot_y = center.y + arc_radius * value_angle.sin();
+        let dot = canvas::Path::circle(iced::Point::new(dot_x, dot_y), 2.5);
+        frame.fill(&dot, theme::TEXT);
+
+        // Center marker line
+        let center_angle = (start_angle + end_angle) / 2.0;
+        let mark_inner = radius - 6.0;
+        let mark_outer = radius - 1.0;
+        let mark = canvas::Path::line(
+            iced::Point::new(
+                center.x + mark_inner * center_angle.cos(),
+                center.y + mark_inner * center_angle.sin(),
+            ),
+            iced::Point::new(
+                center.x + mark_outer * center_angle.cos(),
+                center.y + mark_outer * center_angle.sin(),
+            ),
+        );
+        frame.stroke(
+            &mark,
+            canvas::Stroke::default()
+                .with_color(theme::TEXT_DIM)
+                .with_width(1.0),
+        );
+
+        vec![frame.into_geometry()]
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if state.dragging || cursor.is_over(bounds) {
+            mouse::Interaction::ResizingVertically
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: canvas::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<Message>) {
+        match event {
+            canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
+                if cursor.is_over(bounds) {
+                    state.dragging = true;
+                    if let Some(pos) = cursor.position_in(bounds) {
+                        state.last_y = pos.y;
+                    }
+                    return (canvas::event::Status::Captured, None);
+                }
+            }
+            canvas::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
+                if state.dragging {
+                    state.dragging = false;
+                    return (canvas::event::Status::Captured, None);
+                }
+            }
+            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { .. }) => {
+                if state.dragging {
+                    if let Some(pos) = cursor.position_in(bounds) {
+                        let delta = state.last_y - pos.y;
+                        state.last_y = pos.y;
+
+                        let sensitivity = 0.005;
+                        let new_pan = (self.value + delta * sensitivity).clamp(0.0, 1.0);
+
+                        return (
+                            canvas::event::Status::Captured,
+                            Some(Message::SetTrackPan(self.track_id, new_pan)),
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        (canvas::event::Status::Ignored, None)
+    }
+}
+
+fn build_arc(
+    center: iced::Point,
+    radius: f32,
+    start: f32,
+    end: f32,
+    segments: usize,
+) -> canvas::Path {
+    canvas::Path::new(|builder| {
+        let step = (end - start) / segments as f32;
+        for i in 0..=segments {
+            let angle = start + step * i as f32;
+            let point = iced::Point::new(
+                center.x + radius * angle.cos(),
+                center.y + radius * angle.sin(),
+            );
+            if i == 0 {
+                builder.move_to(point);
+            } else {
+                builder.line_to(point);
+            }
+        }
+    })
+}

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -9,7 +9,7 @@ use crate::widgets::knob::KnobWidget;
 use crate::widgets::vu_meter::VuMeterWidget;
 
 /// Render a single mixer channel strip for a track.
-pub fn view_mixer_strip(track: &UiTrack) -> Element<Message> {
+pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
     // Track name
     let name = text(&track.name)
         .size(11)

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -1,0 +1,127 @@
+use iced::widget::{button, canvas, column, container, row, text};
+use iced::{Element, Length, Theme};
+
+use crate::message::Message;
+use crate::state::UiTrack;
+use crate::theme as vibez_theme;
+use crate::widgets::fader::FaderWidget;
+use crate::widgets::knob::KnobWidget;
+use crate::widgets::vu_meter::VuMeterWidget;
+
+/// Render a single mixer channel strip for a track.
+pub fn view_mixer_strip(track: &UiTrack) -> Element<Message> {
+    // Track name
+    let name = text(&track.name)
+        .size(11)
+        .color(vibez_theme::TEXT)
+        .width(Length::Fill);
+
+    // Pan knob
+    let knob = KnobWidget::new(track.id, track.pan);
+    let knob_canvas: Element<Message> = canvas(knob)
+        .width(Length::Fixed(32.0))
+        .height(Length::Fixed(32.0))
+        .into();
+
+    let pan_label = text(format_pan(track.pan))
+        .size(9)
+        .color(vibez_theme::TEXT_DIM);
+
+    // Fader
+    let fader = FaderWidget::new(track.id, track.gain);
+    let fader_canvas: Element<Message> = canvas(fader)
+        .width(Length::Fixed(28.0))
+        .height(Length::Fixed(100.0))
+        .into();
+
+    let gain_label = text(format_gain_db(track.gain))
+        .size(9)
+        .color(vibez_theme::TEXT_DIM);
+
+    // VU meter for this track
+    let meter = VuMeterWidget {
+        peak_l: track.peak_l,
+        peak_r: track.peak_r,
+    };
+    let meter_canvas: Element<Message> = canvas(meter)
+        .width(Length::Fixed(20.0))
+        .height(Length::Fixed(100.0))
+        .into();
+
+    // Mute button
+    let mute_btn = if track.mute {
+        button(text("M").size(11).color(vibez_theme::MUTE_ACTIVE))
+            .on_press(Message::SetTrackMute(track.id))
+            .padding([4, 8])
+    } else {
+        button(text("M").size(11).color(vibez_theme::TEXT_DIM))
+            .on_press(Message::SetTrackMute(track.id))
+            .padding([4, 8])
+    };
+
+    // Solo button
+    let solo_btn = if track.solo {
+        button(text("S").size(11).color(vibez_theme::SOLO_ACTIVE))
+            .on_press(Message::SetTrackSolo(track.id))
+            .padding([4, 8])
+    } else {
+        button(text("S").size(11).color(vibez_theme::TEXT_DIM))
+            .on_press(Message::SetTrackSolo(track.id))
+            .padding([4, 8])
+    };
+
+    let mute_solo_row = row![mute_btn, solo_btn].spacing(2);
+
+    // Add clip button
+    let add_clip_btn = button(text("+").size(11))
+        .on_press(Message::AddClipToTrack(track.id))
+        .padding([2, 6]);
+
+    // Fader + meter side by side
+    let fader_meter = row![fader_canvas, meter_canvas].spacing(2);
+
+    let strip = column![
+        name,
+        knob_canvas,
+        pan_label,
+        fader_meter,
+        gain_label,
+        mute_solo_row,
+        add_clip_btn,
+    ]
+    .spacing(4)
+    .padding(6)
+    .width(Length::Fixed(72.0))
+    .align_x(iced::Alignment::Center);
+
+    container(strip)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(vibez_theme::BG_SURFACE.into()),
+            border: iced::Border {
+                color: vibez_theme::TEXT_DIM,
+                width: 0.5,
+                radius: 2.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
+}
+
+fn format_pan(pan: f32) -> String {
+    if (pan - 0.5).abs() < 0.01 {
+        "C".to_string()
+    } else if pan < 0.5 {
+        format!("L{:.0}", (0.5 - pan) * 200.0)
+    } else {
+        format!("R{:.0}", (pan - 0.5) * 200.0)
+    }
+}
+
+fn format_gain_db(gain: f32) -> String {
+    if gain <= 0.001 {
+        "-inf".to_string()
+    } else {
+        let db = 20.0 * gain.log10();
+        format!("{db:+.1}")
+    }
+}

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -31,7 +31,7 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<Message> {
     let fader = FaderWidget::new(track.id, track.gain);
     let fader_canvas: Element<Message> = canvas(fader)
         .width(Length::Fixed(28.0))
-        .height(Length::Fixed(100.0))
+        .height(Length::Fill)
         .into();
 
     let gain_label = text(format_gain_db(track.gain))
@@ -45,7 +45,7 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<Message> {
     };
     let meter_canvas: Element<Message> = canvas(meter)
         .width(Length::Fixed(20.0))
-        .height(Length::Fixed(100.0))
+        .height(Length::Fill)
         .into();
 
     // Mute button
@@ -72,13 +72,10 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<Message> {
 
     let mute_solo_row = row![mute_btn, solo_btn].spacing(2);
 
-    // Add clip button
-    let add_clip_btn = button(text("+").size(11))
-        .on_press(Message::AddClipToTrack(track.id))
-        .padding([2, 6]);
-
     // Fader + meter side by side
-    let fader_meter = row![fader_canvas, meter_canvas].spacing(2);
+    let fader_meter = row![fader_canvas, meter_canvas]
+        .spacing(2)
+        .height(Length::Fill);
 
     let strip = column![
         name,
@@ -87,14 +84,15 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<Message> {
         fader_meter,
         gain_label,
         mute_solo_row,
-        add_clip_btn,
     ]
     .spacing(4)
     .padding(6)
     .width(Length::Fixed(72.0))
+    .height(Length::Fill)
     .align_x(iced::Alignment::Center);
 
     container(strip)
+        .height(Length::Fill)
         .style(|_theme: &Theme| container::Style {
             background: Some(vibez_theme::BG_SURFACE.into()),
             border: iced::Border {

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -1,2 +1,6 @@
+pub mod fader;
+pub mod knob;
+pub mod mixer_strip;
+pub mod timeline;
 pub mod vu_meter;
 pub mod waveform;

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -2,5 +2,6 @@ pub mod fader;
 pub mod knob;
 pub mod mixer_strip;
 pub mod timeline;
+pub mod track_header;
 pub mod vu_meter;
 pub mod waveform;

--- a/crates/vibez-ui/src/widgets/timeline.rs
+++ b/crates/vibez-ui/src/widgets/timeline.rs
@@ -6,33 +6,7 @@ use crate::message::Message;
 use crate::state::UiTrack;
 use crate::theme;
 
-/// Height of each track lane in pixels.
-const TRACK_LANE_HEIGHT: f32 = 80.0;
-/// Width of the track header area.
-const TRACK_HEADER_WIDTH: f32 = 120.0;
-/// Height of the time ruler at the top.
-const TIME_RULER_HEIGHT: f32 = 24.0;
-
-pub struct TimelineWidget {
-    /// Snapshot of track data for rendering.
-    pub tracks: Vec<TimelineTrack>,
-    /// Playhead position 0.0..1.0.
-    pub playhead_position: f64,
-    /// Total duration in seconds (for ruler).
-    pub duration_seconds: f64,
-    /// Currently selected track index.
-    pub selected_track_idx: Option<usize>,
-    pub sample_rate: u32,
-    pub cache: canvas::Cache,
-}
-
-/// Lightweight copy of track data for rendering.
-pub struct TimelineTrack {
-    pub name: String,
-    pub clips: Vec<TimelineClip>,
-    pub mute: bool,
-    pub solo: bool,
-}
+// ── Lightweight data types for rendering ──
 
 /// Lightweight copy of clip data for rendering.
 pub struct TimelineClip {
@@ -43,99 +17,38 @@ pub struct TimelineClip {
     pub peaks: Vec<(f32, f32)>,
 }
 
-impl Default for TimelineWidget {
-    fn default() -> Self {
-        Self {
-            tracks: Vec::new(),
-            playhead_position: 0.0,
-            duration_seconds: 0.0,
-            selected_track_idx: None,
-            sample_rate: 44_100,
-            cache: canvas::Cache::new(),
-        }
-    }
+/// Compute waveform peaks for a clip.
+pub fn compute_clip_peaks(clip: &crate::state::UiClip) -> Vec<(f32, f32)> {
+    let num_peaks = (clip.duration as usize / 100).clamp(1, 1000);
+    (0..num_peaks)
+        .map(|i| {
+            let start = clip.source_offset as usize + i * clip.duration as usize / num_peaks;
+            let end = clip.source_offset as usize + (i + 1) * clip.duration as usize / num_peaks;
+            let channels = clip.audio.num_channels();
+            if channels == 0 {
+                return (0.0, 0.0);
+            }
+            let mut min_val = 0.0f32;
+            let mut max_val = 0.0f32;
+            for ch in 0..channels {
+                let (ch_min, ch_max) = clip.audio.peak_in_range(ch, start, end);
+                min_val += ch_min;
+                max_val += ch_max;
+            }
+            (min_val / channels as f32, max_val / channels as f32)
+        })
+        .collect()
 }
 
-impl TimelineWidget {
-    pub fn new() -> Self {
-        Self::default()
-    }
+// ── RulerWidget ──
 
-    /// Update the timeline from UI state.
-    pub fn sync_from_tracks(
-        &mut self,
-        tracks: &[UiTrack],
-        selected_idx: Option<usize>,
-        duration_seconds: f64,
-        sample_rate: u32,
-    ) {
-        self.selected_track_idx = selected_idx;
-        self.duration_seconds = duration_seconds;
-        self.sample_rate = sample_rate;
-
-        // Only rebuild if track/clip structure changed
-        let needs_rebuild = self.tracks.len() != tracks.len()
-            || self
-                .tracks
-                .iter()
-                .zip(tracks.iter())
-                .any(|(old, new)| old.clips.len() != new.clips.len() || old.name != new.name);
-
-        if needs_rebuild {
-            self.tracks = tracks
-                .iter()
-                .map(|t| TimelineTrack {
-                    name: t.name.clone(),
-                    clips: t
-                        .clips
-                        .iter()
-                        .map(|c| {
-                            // Compute mini-waveform peaks (simplified: 1 peak per ~100 samples)
-                            let num_peaks = (c.duration as usize / 100).clamp(1, 1000);
-                            let peaks: Vec<(f32, f32)> = (0..num_peaks)
-                                .map(|i| {
-                                    let start = c.source_offset as usize
-                                        + i * c.duration as usize / num_peaks;
-                                    let end = c.source_offset as usize
-                                        + (i + 1) * c.duration as usize / num_peaks;
-                                    let channels = c.audio.num_channels();
-                                    if channels == 0 {
-                                        return (0.0, 0.0);
-                                    }
-                                    let mut min_val = 0.0f32;
-                                    let mut max_val = 0.0f32;
-                                    for ch in 0..channels {
-                                        let (ch_min, ch_max) =
-                                            c.audio.peak_in_range(ch, start, end);
-                                        min_val += ch_min;
-                                        max_val += ch_max;
-                                    }
-                                    (min_val / channels as f32, max_val / channels as f32)
-                                })
-                                .collect();
-
-                            TimelineClip {
-                                position: c.position,
-                                duration: c.duration,
-                                name: c.name.clone(),
-                                peaks,
-                            }
-                        })
-                        .collect(),
-                    mute: t.mute,
-                    solo: t.solo,
-                })
-                .collect();
-            self.cache.clear();
-        }
-    }
-
-    pub fn set_playhead(&mut self, pos: f64) {
-        self.playhead_position = pos;
-    }
+/// Canvas widget that draws the time ruler ticks/labels + playhead line.
+pub struct RulerWidget {
+    pub playhead_position: f64,
+    pub duration_seconds: f64,
 }
 
-impl canvas::Program<Message> for TimelineWidget {
+impl canvas::Program<Message> for RulerWidget {
     type State = ();
 
     fn draw(
@@ -146,242 +59,217 @@ impl canvas::Program<Message> for TimelineWidget {
         bounds: Rectangle,
         _cursor: mouse::Cursor,
     ) -> Vec<canvas::Geometry> {
-        let bg = self.cache.draw(renderer, bounds.size(), |frame| {
-            let w = bounds.width;
-            let h = bounds.height;
-            let content_w = w - TRACK_HEADER_WIDTH;
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let w = bounds.width;
+        let h = bounds.height;
 
-            // Background
-            frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::BG_DARK);
+        // Background
+        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::RULER_BG);
 
-            // Time ruler
-            frame.fill_rectangle(
-                iced::Point::new(TRACK_HEADER_WIDTH, 0.0),
-                iced::Size::new(content_w, TIME_RULER_HEIGHT),
-                theme::RULER_BG,
-            );
+        // Ruler tick marks and labels
+        if self.duration_seconds > 0.0 {
+            let seconds_per_pixel = self.duration_seconds / w as f64;
+            let tick_interval = tick_interval_for_duration(self.duration_seconds);
 
-            // Ruler tick marks and labels
-            if self.duration_seconds > 0.0 {
-                let seconds_per_pixel = self.duration_seconds / content_w as f64;
-                let tick_interval = tick_interval_for_duration(self.duration_seconds);
-
-                let mut t = 0.0;
-                while t <= self.duration_seconds {
-                    let x =
-                        TRACK_HEADER_WIDTH + (t / self.duration_seconds * content_w as f64) as f32;
-                    let tick = canvas::Path::line(
-                        iced::Point::new(x, 0.0),
-                        iced::Point::new(x, TIME_RULER_HEIGHT),
-                    );
-                    frame.stroke(
-                        &tick,
-                        canvas::Stroke::default()
-                            .with_color(theme::RULER_LINE)
-                            .with_width(1.0),
-                    );
-
-                    // Label
-                    let label = format_ruler_time(t);
-                    frame.fill_text(canvas::Text {
-                        content: label,
-                        position: iced::Point::new(x + 3.0, 4.0),
-                        color: theme::RULER_TEXT,
-                        size: iced::Pixels(10.0),
-                        ..Default::default()
-                    });
-
-                    t += tick_interval;
-                    // Safety: prevent infinite loop for very small intervals
-                    if seconds_per_pixel > 1000.0 {
-                        break;
-                    }
-                }
-            }
-
-            // Draw track lanes
-            for (i, track) in self.tracks.iter().enumerate() {
-                let lane_y = TIME_RULER_HEIGHT + i as f32 * TRACK_LANE_HEIGHT;
-
-                if lane_y > h {
-                    break;
-                }
-
-                // Track lane background
-                let bg_color = if self.selected_track_idx == Some(i) {
-                    theme::TRACK_BG_SELECTED
-                } else {
-                    theme::TRACK_BG
-                };
-                frame.fill_rectangle(
-                    iced::Point::new(0.0, lane_y),
-                    iced::Size::new(w, TRACK_LANE_HEIGHT),
-                    bg_color,
-                );
-
-                // Lane separator line
-                let sep = canvas::Path::line(
-                    iced::Point::new(0.0, lane_y + TRACK_LANE_HEIGHT),
-                    iced::Point::new(w, lane_y + TRACK_LANE_HEIGHT),
-                );
+            let mut t = 0.0;
+            while t <= self.duration_seconds {
+                let x = (t / self.duration_seconds * w as f64) as f32;
+                let tick = canvas::Path::line(iced::Point::new(x, 0.0), iced::Point::new(x, h));
                 frame.stroke(
-                    &sep,
+                    &tick,
                     canvas::Stroke::default()
-                        .with_color(Color {
-                            a: 0.3,
-                            ..theme::TEXT_DIM
-                        })
+                        .with_color(theme::RULER_LINE)
                         .with_width(1.0),
                 );
 
-                // Track header
-                frame.fill_rectangle(
-                    iced::Point::new(0.0, lane_y),
-                    iced::Size::new(TRACK_HEADER_WIDTH, TRACK_LANE_HEIGHT),
-                    theme::BG_SURFACE,
-                );
-
-                // Track name
-                let name_color = if track.mute {
-                    theme::TEXT_DIM
-                } else {
-                    theme::TEXT
-                };
+                let label = format_ruler_time(t);
                 frame.fill_text(canvas::Text {
-                    content: track.name.clone(),
-                    position: iced::Point::new(8.0, lane_y + 8.0),
-                    color: name_color,
-                    size: iced::Pixels(12.0),
+                    content: label,
+                    position: iced::Point::new(x + 3.0, 4.0),
+                    color: theme::RULER_TEXT,
+                    size: iced::Pixels(10.0),
                     ..Default::default()
                 });
 
-                // Mute/Solo indicators
-                if track.mute {
-                    frame.fill_text(canvas::Text {
-                        content: "M".to_string(),
-                        position: iced::Point::new(8.0, lane_y + 28.0),
-                        color: theme::MUTE_ACTIVE,
-                        size: iced::Pixels(11.0),
-                        ..Default::default()
-                    });
+                t += tick_interval;
+                if seconds_per_pixel > 1000.0 {
+                    break;
                 }
-                if track.solo {
-                    frame.fill_text(canvas::Text {
-                        content: "S".to_string(),
-                        position: iced::Point::new(22.0, lane_y + 28.0),
-                        color: theme::SOLO_ACTIVE,
-                        size: iced::Pixels(11.0),
-                        ..Default::default()
-                    });
-                }
+            }
+        }
 
-                // Draw clips
-                if self.duration_seconds > 0.0 {
-                    let total_samples = self.duration_seconds * self.sample_rate as f64;
+        // Playhead
+        if self.duration_seconds > 0.0 {
+            let x = (self.playhead_position as f32) * w;
+            let playhead_line =
+                canvas::Path::line(iced::Point::new(x, 0.0), iced::Point::new(x, h));
+            frame.stroke(
+                &playhead_line,
+                canvas::Stroke::default()
+                    .with_color(theme::PLAYHEAD)
+                    .with_width(1.5),
+            );
+        }
 
-                    for clip in &track.clips {
-                        let clip_x = TRACK_HEADER_WIDTH
-                            + (clip.position as f64 / total_samples * content_w as f64) as f32;
-                        let clip_w =
-                            (clip.duration as f64 / total_samples * content_w as f64) as f32;
-                        let clip_y = lane_y + 4.0;
-                        let clip_h = TRACK_LANE_HEIGHT - 8.0;
+        vec![frame.into_geometry()]
+    }
+}
 
-                        // Clip body
+// ── TrackClipCanvas ──
+
+/// Canvas for ONE track's clip area (waveforms, borders, names, playhead overlay).
+pub struct TrackClipCanvas {
+    pub clips: Vec<TimelineClip>,
+    pub playhead_position: f64,
+    pub duration_seconds: f64,
+    pub sample_rate: u32,
+    pub selected: bool,
+}
+
+impl TrackClipCanvas {
+    pub fn from_track(
+        track: &UiTrack,
+        playhead_position: f64,
+        duration_seconds: f64,
+        sample_rate: u32,
+        selected: bool,
+    ) -> Self {
+        let clips = track
+            .clips
+            .iter()
+            .map(|c| TimelineClip {
+                position: c.position,
+                duration: c.duration,
+                name: c.name.clone(),
+                peaks: compute_clip_peaks(c),
+            })
+            .collect();
+        Self {
+            clips,
+            playhead_position,
+            duration_seconds,
+            sample_rate,
+            selected,
+        }
+    }
+}
+
+impl canvas::Program<Message> for TrackClipCanvas {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let w = bounds.width;
+        let h = bounds.height;
+
+        // Background
+        let bg_color = if self.selected {
+            theme::TRACK_BG_SELECTED
+        } else {
+            theme::TRACK_BG
+        };
+        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), bg_color);
+
+        // Draw clips
+        if self.duration_seconds > 0.0 {
+            let total_samples = self.duration_seconds * self.sample_rate as f64;
+
+            for clip in &self.clips {
+                let clip_x = (clip.position as f64 / total_samples * w as f64) as f32;
+                let clip_w = (clip.duration as f64 / total_samples * w as f64) as f32;
+                let clip_y = 4.0;
+                let clip_h = h - 8.0;
+
+                // Clip body
+                frame.fill_rectangle(
+                    iced::Point::new(clip_x, clip_y),
+                    iced::Size::new(clip_w.max(2.0), clip_h),
+                    theme::CLIP_BODY,
+                );
+
+                // Mini waveform
+                if !clip.peaks.is_empty() && clip_w > 4.0 {
+                    let center_y = clip_y + clip_h / 2.0;
+                    let half_h = clip_h / 2.0 - 2.0;
+                    let pixels = clip_w as usize;
+                    for px in 0..pixels {
+                        let peak_idx = px * clip.peaks.len() / pixels.max(1);
+                        if peak_idx >= clip.peaks.len() {
+                            break;
+                        }
+                        let (min_val, max_val) = clip.peaks[peak_idx];
+                        let y_top = center_y - (max_val * half_h);
+                        let y_bottom = center_y - (min_val * half_h);
+                        let height = (y_bottom - y_top).max(1.0);
                         frame.fill_rectangle(
-                            iced::Point::new(clip_x, clip_y),
-                            iced::Size::new(clip_w.max(2.0), clip_h),
-                            theme::CLIP_BODY,
+                            iced::Point::new(clip_x + px as f32, y_top),
+                            iced::Size::new(1.0, height),
+                            Color {
+                                a: 0.7,
+                                ..theme::WAVEFORM
+                            },
                         );
-
-                        // Mini waveform
-                        if !clip.peaks.is_empty() && clip_w > 4.0 {
-                            let center_y = clip_y + clip_h / 2.0;
-                            let half_h = clip_h / 2.0 - 2.0;
-                            let pixels = clip_w as usize;
-                            for px in 0..pixels {
-                                let peak_idx = px * clip.peaks.len() / pixels.max(1);
-                                if peak_idx >= clip.peaks.len() {
-                                    break;
-                                }
-                                let (min_val, max_val) = clip.peaks[peak_idx];
-                                let y_top = center_y - (max_val * half_h);
-                                let y_bottom = center_y - (min_val * half_h);
-                                let height = (y_bottom - y_top).max(1.0);
-                                frame.fill_rectangle(
-                                    iced::Point::new(clip_x + px as f32, y_top),
-                                    iced::Size::new(1.0, height),
-                                    Color {
-                                        a: 0.7,
-                                        ..theme::WAVEFORM
-                                    },
-                                );
-                            }
-                        }
-
-                        // Clip border
-                        let border = canvas::Path::rectangle(
-                            iced::Point::new(clip_x, clip_y),
-                            iced::Size::new(clip_w.max(2.0), clip_h),
-                        );
-                        frame.stroke(
-                            &border,
-                            canvas::Stroke::default()
-                                .with_color(theme::CLIP_BORDER)
-                                .with_width(1.0),
-                        );
-
-                        // Clip name label
-                        if clip_w > 40.0 {
-                            frame.fill_text(canvas::Text {
-                                content: clip.name.clone(),
-                                position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
-                                color: theme::TEXT,
-                                size: iced::Pixels(10.0),
-                                ..Default::default()
-                            });
-                        }
                     }
                 }
-            }
 
-            // Header/content separator
-            let header_sep = canvas::Path::line(
-                iced::Point::new(TRACK_HEADER_WIDTH, 0.0),
-                iced::Point::new(TRACK_HEADER_WIDTH, h),
-            );
-            frame.stroke(
-                &header_sep,
-                canvas::Stroke::default()
-                    .with_color(Color {
-                        a: 0.4,
-                        ..theme::TEXT_DIM
-                    })
-                    .with_width(1.0),
-            );
-        });
-
-        // Playhead (drawn every frame, not cached)
-        let playhead = {
-            let mut frame = canvas::Frame::new(renderer, bounds.size());
-            let content_w = bounds.width - TRACK_HEADER_WIDTH;
-            if self.duration_seconds > 0.0 {
-                let x = TRACK_HEADER_WIDTH + (self.playhead_position as f32) * content_w;
-                let playhead_line = canvas::Path::line(
-                    iced::Point::new(x, 0.0),
-                    iced::Point::new(x, bounds.height),
+                // Clip border
+                let border = canvas::Path::rectangle(
+                    iced::Point::new(clip_x, clip_y),
+                    iced::Size::new(clip_w.max(2.0), clip_h),
                 );
                 frame.stroke(
-                    &playhead_line,
+                    &border,
                     canvas::Stroke::default()
-                        .with_color(theme::PLAYHEAD)
-                        .with_width(1.5),
+                        .with_color(theme::CLIP_BORDER)
+                        .with_width(1.0),
                 );
-            }
-            frame.into_geometry()
-        };
 
-        vec![bg, playhead]
+                // Clip name label
+                if clip_w > 40.0 {
+                    frame.fill_text(canvas::Text {
+                        content: clip.name.clone(),
+                        position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
+                        color: theme::TEXT,
+                        size: iced::Pixels(10.0),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
+        // Playhead overlay
+        if self.duration_seconds > 0.0 {
+            let x = (self.playhead_position as f32) * w;
+            let playhead_line =
+                canvas::Path::line(iced::Point::new(x, 0.0), iced::Point::new(x, h));
+            frame.stroke(
+                &playhead_line,
+                canvas::Stroke::default()
+                    .with_color(theme::PLAYHEAD)
+                    .with_width(1.5),
+            );
+        }
+
+        // Bottom separator
+        let sep = canvas::Path::line(iced::Point::new(0.0, h - 1.0), iced::Point::new(w, h - 1.0));
+        frame.stroke(
+            &sep,
+            canvas::Stroke::default()
+                .with_color(Color {
+                    a: 0.3,
+                    ..theme::TEXT_DIM
+                })
+                .with_width(1.0),
+        );
+
+        vec![frame.into_geometry()]
     }
 
     fn mouse_interaction(
@@ -390,12 +278,11 @@ impl canvas::Program<Message> for TimelineWidget {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> mouse::Interaction {
-        if let Some(pos) = cursor.position_in(bounds) {
-            if pos.x > TRACK_HEADER_WIDTH && pos.y > TIME_RULER_HEIGHT {
-                return mouse::Interaction::Pointer;
-            }
+        if cursor.is_over(bounds) {
+            mouse::Interaction::Pointer
+        } else {
+            mouse::Interaction::default()
         }
-        mouse::Interaction::default()
     }
 
     fn update(
@@ -409,25 +296,12 @@ impl canvas::Program<Message> for TimelineWidget {
             event
         {
             if let Some(pos) = cursor.position_in(bounds) {
-                let content_w = bounds.width - TRACK_HEADER_WIDTH;
-
-                // Click on timeline content area → seek
-                if pos.x > TRACK_HEADER_WIDTH && pos.y > TIME_RULER_HEIGHT && content_w > 0.0 {
-                    let normalized = ((pos.x - TRACK_HEADER_WIDTH) / content_w) as f64;
+                if bounds.width > 0.0 {
+                    let normalized = (pos.x / bounds.width) as f64;
                     return (
                         canvas::event::Status::Captured,
                         Some(Message::Seek(normalized.clamp(0.0, 1.0))),
                     );
-                }
-
-                // Click on track header → select track
-                if pos.x <= TRACK_HEADER_WIDTH && pos.y > TIME_RULER_HEIGHT {
-                    let track_idx = ((pos.y - TIME_RULER_HEIGHT) / TRACK_LANE_HEIGHT) as usize;
-                    if track_idx < self.tracks.len() {
-                        // We need the TrackId but we don't store it here.
-                        // This is handled by mapping the index in the app.
-                        // For now, return None and let the app handle clicks via container.
-                    }
                 }
             }
         }

--- a/crates/vibez-ui/src/widgets/timeline.rs
+++ b/crates/vibez-ui/src/widgets/timeline.rs
@@ -1,0 +1,463 @@
+use iced::mouse;
+use iced::widget::canvas;
+use iced::{Color, Rectangle, Renderer, Theme};
+
+use crate::message::Message;
+use crate::state::UiTrack;
+use crate::theme;
+
+/// Height of each track lane in pixels.
+const TRACK_LANE_HEIGHT: f32 = 80.0;
+/// Width of the track header area.
+const TRACK_HEADER_WIDTH: f32 = 120.0;
+/// Height of the time ruler at the top.
+const TIME_RULER_HEIGHT: f32 = 24.0;
+
+pub struct TimelineWidget {
+    /// Snapshot of track data for rendering.
+    pub tracks: Vec<TimelineTrack>,
+    /// Playhead position 0.0..1.0.
+    pub playhead_position: f64,
+    /// Total duration in seconds (for ruler).
+    pub duration_seconds: f64,
+    /// Currently selected track index.
+    pub selected_track_idx: Option<usize>,
+    pub sample_rate: u32,
+    pub cache: canvas::Cache,
+}
+
+/// Lightweight copy of track data for rendering.
+pub struct TimelineTrack {
+    pub name: String,
+    pub clips: Vec<TimelineClip>,
+    pub mute: bool,
+    pub solo: bool,
+}
+
+/// Lightweight copy of clip data for rendering.
+pub struct TimelineClip {
+    pub position: u64,
+    pub duration: u64,
+    pub name: String,
+    /// Pre-computed waveform peaks for mini display (per pixel column).
+    pub peaks: Vec<(f32, f32)>,
+}
+
+impl Default for TimelineWidget {
+    fn default() -> Self {
+        Self {
+            tracks: Vec::new(),
+            playhead_position: 0.0,
+            duration_seconds: 0.0,
+            selected_track_idx: None,
+            sample_rate: 44_100,
+            cache: canvas::Cache::new(),
+        }
+    }
+}
+
+impl TimelineWidget {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Update the timeline from UI state.
+    pub fn sync_from_tracks(
+        &mut self,
+        tracks: &[UiTrack],
+        selected_idx: Option<usize>,
+        duration_seconds: f64,
+        sample_rate: u32,
+    ) {
+        self.selected_track_idx = selected_idx;
+        self.duration_seconds = duration_seconds;
+        self.sample_rate = sample_rate;
+
+        // Only rebuild if track/clip structure changed
+        let needs_rebuild = self.tracks.len() != tracks.len()
+            || self
+                .tracks
+                .iter()
+                .zip(tracks.iter())
+                .any(|(old, new)| old.clips.len() != new.clips.len() || old.name != new.name);
+
+        if needs_rebuild {
+            self.tracks = tracks
+                .iter()
+                .map(|t| TimelineTrack {
+                    name: t.name.clone(),
+                    clips: t
+                        .clips
+                        .iter()
+                        .map(|c| {
+                            // Compute mini-waveform peaks (simplified: 1 peak per ~100 samples)
+                            let num_peaks = (c.duration as usize / 100).clamp(1, 1000);
+                            let peaks: Vec<(f32, f32)> = (0..num_peaks)
+                                .map(|i| {
+                                    let start = c.source_offset as usize
+                                        + i * c.duration as usize / num_peaks;
+                                    let end = c.source_offset as usize
+                                        + (i + 1) * c.duration as usize / num_peaks;
+                                    let channels = c.audio.num_channels();
+                                    if channels == 0 {
+                                        return (0.0, 0.0);
+                                    }
+                                    let mut min_val = 0.0f32;
+                                    let mut max_val = 0.0f32;
+                                    for ch in 0..channels {
+                                        let (ch_min, ch_max) =
+                                            c.audio.peak_in_range(ch, start, end);
+                                        min_val += ch_min;
+                                        max_val += ch_max;
+                                    }
+                                    (min_val / channels as f32, max_val / channels as f32)
+                                })
+                                .collect();
+
+                            TimelineClip {
+                                position: c.position,
+                                duration: c.duration,
+                                name: c.name.clone(),
+                                peaks,
+                            }
+                        })
+                        .collect(),
+                    mute: t.mute,
+                    solo: t.solo,
+                })
+                .collect();
+            self.cache.clear();
+        }
+    }
+
+    pub fn set_playhead(&mut self, pos: f64) {
+        self.playhead_position = pos;
+    }
+}
+
+impl canvas::Program<Message> for TimelineWidget {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let bg = self.cache.draw(renderer, bounds.size(), |frame| {
+            let w = bounds.width;
+            let h = bounds.height;
+            let content_w = w - TRACK_HEADER_WIDTH;
+
+            // Background
+            frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::BG_DARK);
+
+            // Time ruler
+            frame.fill_rectangle(
+                iced::Point::new(TRACK_HEADER_WIDTH, 0.0),
+                iced::Size::new(content_w, TIME_RULER_HEIGHT),
+                theme::RULER_BG,
+            );
+
+            // Ruler tick marks and labels
+            if self.duration_seconds > 0.0 {
+                let seconds_per_pixel = self.duration_seconds / content_w as f64;
+                let tick_interval = tick_interval_for_duration(self.duration_seconds);
+
+                let mut t = 0.0;
+                while t <= self.duration_seconds {
+                    let x =
+                        TRACK_HEADER_WIDTH + (t / self.duration_seconds * content_w as f64) as f32;
+                    let tick = canvas::Path::line(
+                        iced::Point::new(x, 0.0),
+                        iced::Point::new(x, TIME_RULER_HEIGHT),
+                    );
+                    frame.stroke(
+                        &tick,
+                        canvas::Stroke::default()
+                            .with_color(theme::RULER_LINE)
+                            .with_width(1.0),
+                    );
+
+                    // Label
+                    let label = format_ruler_time(t);
+                    frame.fill_text(canvas::Text {
+                        content: label,
+                        position: iced::Point::new(x + 3.0, 4.0),
+                        color: theme::RULER_TEXT,
+                        size: iced::Pixels(10.0),
+                        ..Default::default()
+                    });
+
+                    t += tick_interval;
+                    // Safety: prevent infinite loop for very small intervals
+                    if seconds_per_pixel > 1000.0 {
+                        break;
+                    }
+                }
+            }
+
+            // Draw track lanes
+            for (i, track) in self.tracks.iter().enumerate() {
+                let lane_y = TIME_RULER_HEIGHT + i as f32 * TRACK_LANE_HEIGHT;
+
+                if lane_y > h {
+                    break;
+                }
+
+                // Track lane background
+                let bg_color = if self.selected_track_idx == Some(i) {
+                    theme::TRACK_BG_SELECTED
+                } else {
+                    theme::TRACK_BG
+                };
+                frame.fill_rectangle(
+                    iced::Point::new(0.0, lane_y),
+                    iced::Size::new(w, TRACK_LANE_HEIGHT),
+                    bg_color,
+                );
+
+                // Lane separator line
+                let sep = canvas::Path::line(
+                    iced::Point::new(0.0, lane_y + TRACK_LANE_HEIGHT),
+                    iced::Point::new(w, lane_y + TRACK_LANE_HEIGHT),
+                );
+                frame.stroke(
+                    &sep,
+                    canvas::Stroke::default()
+                        .with_color(Color {
+                            a: 0.3,
+                            ..theme::TEXT_DIM
+                        })
+                        .with_width(1.0),
+                );
+
+                // Track header
+                frame.fill_rectangle(
+                    iced::Point::new(0.0, lane_y),
+                    iced::Size::new(TRACK_HEADER_WIDTH, TRACK_LANE_HEIGHT),
+                    theme::BG_SURFACE,
+                );
+
+                // Track name
+                let name_color = if track.mute {
+                    theme::TEXT_DIM
+                } else {
+                    theme::TEXT
+                };
+                frame.fill_text(canvas::Text {
+                    content: track.name.clone(),
+                    position: iced::Point::new(8.0, lane_y + 8.0),
+                    color: name_color,
+                    size: iced::Pixels(12.0),
+                    ..Default::default()
+                });
+
+                // Mute/Solo indicators
+                if track.mute {
+                    frame.fill_text(canvas::Text {
+                        content: "M".to_string(),
+                        position: iced::Point::new(8.0, lane_y + 28.0),
+                        color: theme::MUTE_ACTIVE,
+                        size: iced::Pixels(11.0),
+                        ..Default::default()
+                    });
+                }
+                if track.solo {
+                    frame.fill_text(canvas::Text {
+                        content: "S".to_string(),
+                        position: iced::Point::new(22.0, lane_y + 28.0),
+                        color: theme::SOLO_ACTIVE,
+                        size: iced::Pixels(11.0),
+                        ..Default::default()
+                    });
+                }
+
+                // Draw clips
+                if self.duration_seconds > 0.0 {
+                    let total_samples = self.duration_seconds * self.sample_rate as f64;
+
+                    for clip in &track.clips {
+                        let clip_x = TRACK_HEADER_WIDTH
+                            + (clip.position as f64 / total_samples * content_w as f64) as f32;
+                        let clip_w =
+                            (clip.duration as f64 / total_samples * content_w as f64) as f32;
+                        let clip_y = lane_y + 4.0;
+                        let clip_h = TRACK_LANE_HEIGHT - 8.0;
+
+                        // Clip body
+                        frame.fill_rectangle(
+                            iced::Point::new(clip_x, clip_y),
+                            iced::Size::new(clip_w.max(2.0), clip_h),
+                            theme::CLIP_BODY,
+                        );
+
+                        // Mini waveform
+                        if !clip.peaks.is_empty() && clip_w > 4.0 {
+                            let center_y = clip_y + clip_h / 2.0;
+                            let half_h = clip_h / 2.0 - 2.0;
+                            let pixels = clip_w as usize;
+                            for px in 0..pixels {
+                                let peak_idx = px * clip.peaks.len() / pixels.max(1);
+                                if peak_idx >= clip.peaks.len() {
+                                    break;
+                                }
+                                let (min_val, max_val) = clip.peaks[peak_idx];
+                                let y_top = center_y - (max_val * half_h);
+                                let y_bottom = center_y - (min_val * half_h);
+                                let height = (y_bottom - y_top).max(1.0);
+                                frame.fill_rectangle(
+                                    iced::Point::new(clip_x + px as f32, y_top),
+                                    iced::Size::new(1.0, height),
+                                    Color {
+                                        a: 0.7,
+                                        ..theme::WAVEFORM
+                                    },
+                                );
+                            }
+                        }
+
+                        // Clip border
+                        let border = canvas::Path::rectangle(
+                            iced::Point::new(clip_x, clip_y),
+                            iced::Size::new(clip_w.max(2.0), clip_h),
+                        );
+                        frame.stroke(
+                            &border,
+                            canvas::Stroke::default()
+                                .with_color(theme::CLIP_BORDER)
+                                .with_width(1.0),
+                        );
+
+                        // Clip name label
+                        if clip_w > 40.0 {
+                            frame.fill_text(canvas::Text {
+                                content: clip.name.clone(),
+                                position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
+                                color: theme::TEXT,
+                                size: iced::Pixels(10.0),
+                                ..Default::default()
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Header/content separator
+            let header_sep = canvas::Path::line(
+                iced::Point::new(TRACK_HEADER_WIDTH, 0.0),
+                iced::Point::new(TRACK_HEADER_WIDTH, h),
+            );
+            frame.stroke(
+                &header_sep,
+                canvas::Stroke::default()
+                    .with_color(Color {
+                        a: 0.4,
+                        ..theme::TEXT_DIM
+                    })
+                    .with_width(1.0),
+            );
+        });
+
+        // Playhead (drawn every frame, not cached)
+        let playhead = {
+            let mut frame = canvas::Frame::new(renderer, bounds.size());
+            let content_w = bounds.width - TRACK_HEADER_WIDTH;
+            if self.duration_seconds > 0.0 {
+                let x = TRACK_HEADER_WIDTH + (self.playhead_position as f32) * content_w;
+                let playhead_line = canvas::Path::line(
+                    iced::Point::new(x, 0.0),
+                    iced::Point::new(x, bounds.height),
+                );
+                frame.stroke(
+                    &playhead_line,
+                    canvas::Stroke::default()
+                        .with_color(theme::PLAYHEAD)
+                        .with_width(1.5),
+                );
+            }
+            frame.into_geometry()
+        };
+
+        vec![bg, playhead]
+    }
+
+    fn mouse_interaction(
+        &self,
+        _state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if let Some(pos) = cursor.position_in(bounds) {
+            if pos.x > TRACK_HEADER_WIDTH && pos.y > TIME_RULER_HEIGHT {
+                return mouse::Interaction::Pointer;
+            }
+        }
+        mouse::Interaction::default()
+    }
+
+    fn update(
+        &self,
+        _state: &mut Self::State,
+        event: canvas::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<Message>) {
+        if let canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) =
+            event
+        {
+            if let Some(pos) = cursor.position_in(bounds) {
+                let content_w = bounds.width - TRACK_HEADER_WIDTH;
+
+                // Click on timeline content area → seek
+                if pos.x > TRACK_HEADER_WIDTH && pos.y > TIME_RULER_HEIGHT && content_w > 0.0 {
+                    let normalized = ((pos.x - TRACK_HEADER_WIDTH) / content_w) as f64;
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::Seek(normalized.clamp(0.0, 1.0))),
+                    );
+                }
+
+                // Click on track header → select track
+                if pos.x <= TRACK_HEADER_WIDTH && pos.y > TIME_RULER_HEIGHT {
+                    let track_idx = ((pos.y - TIME_RULER_HEIGHT) / TRACK_LANE_HEIGHT) as usize;
+                    if track_idx < self.tracks.len() {
+                        // We need the TrackId but we don't store it here.
+                        // This is handled by mapping the index in the app.
+                        // For now, return None and let the app handle clicks via container.
+                    }
+                }
+            }
+        }
+
+        (canvas::event::Status::Ignored, None)
+    }
+}
+
+/// Choose an appropriate tick interval based on total duration.
+fn tick_interval_for_duration(duration: f64) -> f64 {
+    if duration <= 5.0 {
+        0.5
+    } else if duration <= 15.0 {
+        1.0
+    } else if duration <= 60.0 {
+        5.0
+    } else if duration <= 300.0 {
+        15.0
+    } else {
+        60.0
+    }
+}
+
+/// Format time for ruler labels.
+fn format_ruler_time(seconds: f64) -> String {
+    let mins = (seconds / 60.0) as u32;
+    let secs = seconds % 60.0;
+    if mins > 0 {
+        format!("{mins}:{secs:04.1}")
+    } else {
+        format!("{secs:.1}s")
+    }
+}

--- a/crates/vibez-ui/src/widgets/track_header.rs
+++ b/crates/vibez-ui/src/widgets/track_header.rs
@@ -12,7 +12,7 @@ pub const TRACK_HEADER_WIDTH: f32 = 180.0;
 
 /// Render the track header for the arrangement view.
 /// Compact layout: name + "+" | [M] [S] | horizontal gain fader + VU meter.
-pub fn view_track_header(track: &UiTrack) -> Element<Message> {
+pub fn view_track_header(track: &UiTrack) -> Element<'_, Message> {
     // Row 1: Track name + "+" add clip button
     let name = text(&track.name).size(12).color(if track.mute {
         vibez_theme::TEXT_DIM

--- a/crates/vibez-ui/src/widgets/track_header.rs
+++ b/crates/vibez-ui/src/widgets/track_header.rs
@@ -1,0 +1,82 @@
+use iced::widget::{button, canvas, column, container, row, text};
+use iced::{Element, Length, Theme};
+
+use crate::message::Message;
+use crate::state::UiTrack;
+use crate::theme as vibez_theme;
+use crate::widgets::fader::HorizontalFaderWidget;
+use crate::widgets::vu_meter::HorizontalVuMeterWidget;
+
+/// Width of the track header panel in the arrangement view.
+pub const TRACK_HEADER_WIDTH: f32 = 180.0;
+
+/// Render the track header for the arrangement view.
+/// Compact layout: name + "+" | [M] [S] | horizontal gain fader + VU meter.
+pub fn view_track_header(track: &UiTrack) -> Element<Message> {
+    // Row 1: Track name + "+" add clip button
+    let name = text(&track.name).size(12).color(if track.mute {
+        vibez_theme::TEXT_DIM
+    } else {
+        vibez_theme::TEXT
+    });
+
+    let add_clip_btn = button(text("+").size(11))
+        .on_press(Message::AddClipToTrack(track.id))
+        .padding([2, 6]);
+
+    let name_row = row![name, add_clip_btn]
+        .spacing(4)
+        .align_y(iced::Alignment::Center);
+
+    // Row 2: Mute/Solo buttons
+    let mute_btn = if track.mute {
+        button(text("M").size(10).color(vibez_theme::MUTE_ACTIVE))
+            .on_press(Message::SetTrackMute(track.id))
+            .padding([2, 6])
+    } else {
+        button(text("M").size(10).color(vibez_theme::TEXT_DIM))
+            .on_press(Message::SetTrackMute(track.id))
+            .padding([2, 6])
+    };
+
+    let solo_btn = if track.solo {
+        button(text("S").size(10).color(vibez_theme::SOLO_ACTIVE))
+            .on_press(Message::SetTrackSolo(track.id))
+            .padding([2, 6])
+    } else {
+        button(text("S").size(10).color(vibez_theme::TEXT_DIM))
+            .on_press(Message::SetTrackSolo(track.id))
+            .padding([2, 6])
+    };
+
+    let mute_solo_row = row![mute_btn, solo_btn].spacing(2);
+
+    // Row 3: Horizontal gain fader (spans width)
+    let fader = HorizontalFaderWidget::new(track.id, track.gain);
+    let fader_canvas: Element<Message> = canvas(fader)
+        .width(Length::Fill)
+        .height(Length::Fixed(14.0))
+        .into();
+
+    // Row 4: Horizontal VU meter (spans width)
+    let meter = HorizontalVuMeterWidget {
+        peak_l: track.peak_l,
+        peak_r: track.peak_r,
+    };
+    let meter_canvas: Element<Message> = canvas(meter)
+        .width(Length::Fill)
+        .height(Length::Fixed(8.0))
+        .into();
+
+    let header = column![name_row, mute_solo_row, fader_canvas, meter_canvas]
+        .spacing(2)
+        .padding(6)
+        .width(Length::Fixed(TRACK_HEADER_WIDTH));
+
+    container(header)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(vibez_theme::BG_SURFACE.into()),
+            ..Default::default()
+        })
+        .into()
+}

--- a/crates/vibez-ui/src/widgets/vu_meter.rs
+++ b/crates/vibez-ui/src/widgets/vu_meter.rs
@@ -117,3 +117,84 @@ impl canvas::Program<crate::message::Message> for VuMeterWidget {
         vec![frame.into_geometry()]
     }
 }
+
+/// Horizontal VU meter for arrangement track headers.
+/// Two bars stacked vertically (L on top, R below), growing left to right.
+pub struct HorizontalVuMeterWidget {
+    pub peak_l: f32,
+    pub peak_r: f32,
+}
+
+impl canvas::Program<crate::message::Message> for HorizontalVuMeterWidget {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let w = bounds.width;
+        let h = bounds.height;
+
+        // Background
+        frame.fill_rectangle(
+            iced::Point::ORIGIN,
+            iced::Size::new(w, h),
+            theme::BG_SURFACE,
+        );
+
+        let padding = 1.0;
+        let bar_height = (h / 2.0 - padding * 1.5).max(2.0);
+        let max_width = w - padding * 2.0;
+
+        let draw_bar = |frame: &mut canvas::Frame, y: f32, level: f32| {
+            let green_threshold = 0.6;
+            let yellow_threshold = 0.85;
+
+            if level > 0.0 {
+                // Green portion (0..0.6)
+                let green_w = (level.min(green_threshold) * max_width).max(0.0);
+                frame.fill_rectangle(
+                    iced::Point::new(padding, y),
+                    iced::Size::new(green_w, bar_height),
+                    theme::METER_GREEN,
+                );
+
+                // Yellow portion (0.6..0.85)
+                if level > green_threshold {
+                    let green_end = green_threshold * max_width;
+                    let yellow_w =
+                        ((level.min(yellow_threshold) - green_threshold) * max_width).max(0.0);
+                    frame.fill_rectangle(
+                        iced::Point::new(padding + green_end, y),
+                        iced::Size::new(yellow_w, bar_height),
+                        theme::METER_YELLOW,
+                    );
+                }
+
+                // Red portion (0.85..1.0)
+                if level > yellow_threshold {
+                    let yellow_end = yellow_threshold * max_width;
+                    let red_w = ((level.min(1.0) - yellow_threshold) * max_width).max(0.0);
+                    frame.fill_rectangle(
+                        iced::Point::new(padding + yellow_end, y),
+                        iced::Size::new(red_w, bar_height),
+                        theme::METER_RED,
+                    );
+                }
+            }
+        };
+
+        let top_y = padding;
+        let bottom_y = h / 2.0 + padding * 0.5;
+
+        draw_bar(&mut frame, top_y, self.peak_l);
+        draw_bar(&mut frame, bottom_y, self.peak_r);
+
+        vec![frame.into_geometry()]
+    }
+}


### PR DESCRIPTION
## Summary

- **Workspace views**: Arrange/Mix tabs in header bar, one view active at a time
- **Arrangement view**: Per-track rows with widget-based headers (name, +, M/S, horizontal fader, horizontal VU) and individual clip canvases
- **Mixer view**: Full-height channel strips with master pinned to far right, top area reserved for future effects/instruments
- **Global detail panel**: Shows selected track's effects/instruments context below both views (Ableton-style)
- **Knob rewrite**: 270° arc, vertical drag with absolute cursor tracking, shift for fine-tune, double-click to reset, scroll wheel support
- **New widgets**: HorizontalFaderWidget, HorizontalVuMeterWidget, RulerWidget, TrackClipCanvas, track_header module
- Removed legacy "Open File" button — clips added via "+" on track headers

## Test plan

- [x] `cargo test --workspace` — 109 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Verify Arrange/Mix tab switching
- [ ] Verify knob drag up = clockwise, drag down = counterclockwise
- [ ] Verify shift+drag fine adjustment on knobs
- [ ] Verify double-click knob resets to center
- [ ] Verify master strip pinned to far right in mixer view
- [ ] Verify detail panel updates when selecting tracks in both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)