### PR TITLE
fix(warp): idempotent re-warp geometry + re-apply warp on project load

### DIFF
--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -1,0 +1,119 @@
+# Dogfood Session 1: 2026-07-03
+
+Goal: one 2-minute track sketch, start to finish, no mid-session fixes.
+Every bug/friction point below, in the order encountered.
+
+## Bug list
+
+### 1. Subtractive synth: parameter edits do not change the sound
+- Context: trying to make a sub bass with the subtractive synth.
+- Expected: tweaking oscillator/filter/envelope params audibly changes the patch.
+- Actual: the synth only ever produces one sound regardless of parameter edits.
+- Suspicion: UI param changes may not be reaching the engine voice (message
+  plumbing), or the synth reads params only at note-on/init.
+- Severity: blocker for any bass/lead sound design. Workaround: none within
+  the synth; use samples instead.
+
+### 2. Knobs feel bad globally (vs Ableton reference)
+- Context: all knob widgets across the app.
+- Complaint: "they just dont feel like ableton knobs."
+- Ableton knob behavior for reference: click + vertical drag, Ctrl/Cmd for
+  fine adjustment, double-click resets to default, value readout while
+  dragging, pointer stays put (no jump).
+- TODO: pin down which of these is missing/wrong (sensitivity curve? drag
+  axis? no fine mode? no reset? value jump on grab?).
+- Severity: friction, global. Touches every device.
+
+### 3. Clip loop button places the loop end marker in the wrong place
+- Context: clicking the loop button on a MIDI clip ("Pattern 1", Pos 0.0,
+  Dur 8.0, on MIDI 9) in the arrangement.
+- Expected: loop region defaults to exactly the clip's length (loop end at
+  the end of the clip), so the clip repeats seamlessly.
+- Actual: the red loop line lands somewhere else, not at the end of the
+  bar/clip. Intermittent: "sometimes it loops fine with midi," which smells
+  like the loop end is computed from a default/stale length that only
+  coincidentally matches some clips, or a beats-vs-bars unit mixup.
+- Screenshot: ~/Pictures/"Screenshot from 2026-07-03 19-31-10.png". Ruler
+  shows the loop bracket spanning ~bars 1-5 with the marker near bar 3 while
+  the selected 8-beat (2-bar) clip ends at bar 3; brown loop overlay bleeds
+  across bars 3-5 on multiple tracks.
+- Feature request attached: loop end should be user-draggable, but default
+  to clip end.
+- Severity: near showstopper for loop-based composition; workaround is
+  duplicating clips manually instead of looping.
+
+### 4. Drum rack: pad-to-note mapping is invisible
+- Context: sequencing drum rack hits in the piano roll.
+- Problem: no way to see which MIDI note a pad responds to. User has to
+  hunt-and-peck keys in the piano roll to find each pad's note.
+- Ask: show the note name (e.g. C1, D#1) on each drum pad, and ideally
+  mirror pad/sample names on the piano roll's key lane when editing a clip
+  on a drum rack track (Ableton shows sample names instead of piano keys).
+- Reference: standard drum rack layout starts at C1 (MIDI 36), chromatic
+  upward per pad.
+- Severity: friction, but hits the core drum workflow on every beat made.
+
+### 5. Cannot delete notes in a MIDI clip
+- Context: editing notes in the piano roll.
+- Expected: select a note, press Delete or Backspace, note is removed.
+- Actual: no keyboard path to delete a selected note at all.
+- Note: commit 21b2d0b ("backspace no longer deletes clips while editing
+  text inputs") shows backspace handling exists for clips; the guard may
+  have eaten the piano-roll note case, or note deletion was never wired.
+- Severity: major friction; MIDI editing is add-only right now.
+
+### 6. Stuck notes during MIDI clip playback (note held way too long)
+- Context: playing back a MIDI clip.
+- Actual: sometimes a note sustains far past its written length, as if the
+  key is being held down. Intermittent.
+- Suspicion: missing/lost note-off. Classic causes: (a) note-off scheduled
+  after the loop boundary gets skipped when playback wraps (would tie this
+  directly to bug #3's loop-region weirdness), (b) note-off events dropped
+  when the event buffer fills, (c) voice stealing without note-off cleanup.
+- User verdict: "basically making midi programming unusable."
+- Severity: showstopper for MIDI workflow. Likely same subsystem as #3;
+  fixing the loop/event scheduling path may kill both.
+
+### 7. Project reload: everything loads completely out of sync
+- Context: closed vibez, reopened the saved project (persistence test).
+- Actual: on reload the project plays badly out of sync and "not sounding
+  like how it did at all."
+- Prime suspect: warp/tempo-match state is applied at import time via
+  runtime audio replacement (WSOLA stretch + ReplaceClipAudio, commits
+  d045923/67b75c0), but on load the project likely re-reads the ORIGINAL
+  file audio without re-running the warp. Result: clips that were
+  tempo-matched in-session come back at their raw tempo/length = global
+  desync.
+- Also check on load: clip start offsets, nominal BPM fields, per-clip
+  warp metadata actually round-tripping through the project file.
+- This is likely the remembered "synchronisation of audio clips" bug.
+- Severity: SHOWSTOPPER. Projects cannot be trusted to reopen; kills the
+  entire save/resume workflow, makes finishing a track across sessions
+  impossible.
+
+### 8. Tempo-match/warp sounds completely wrong (128 BPM loop into 120 project)
+- Context: drum loop with nominal 128 BPM, warped/quantized to a 120 BPM
+  project.
+- Expected (Ableton behavior): loop plays in time at 120, transients on the
+  grid, same musical content just slower.
+- Actual: "completely sounds off."
+- Suspects, in order:
+  (a) stretch ratio direction: 128 -> 120 must LENGTHEN audio by 128/120
+      (~6.7%). Commit 70b46f3 already fixed one ratio inversion; the
+      slower-project direction may still be wrong or was re-broken.
+  (b) whole-bar snapping (9dd06dc) forcing the warped duration to a bar
+      count that doesn't match the loop's true length, smearing the grid.
+  (c) wrong/misdetected source BPM feeding the ratio (BPM detector floor
+      changes in b443e2a).
+  (d) WSOLA artifacts, but "completely off" sounds like timing math, not
+      stretch quality.
+- Quick disambiguation: does the warped loop play at the wrong SPEED (ratio
+  bug) or right speed but wrong FEEL/grid (snap/quality bug)?
+- Severity: showstopper for the sample-first thesis; tempo-matching library
+  loops is the core workflow.
+
+## Not yet exercised
+- resample/bounce
+- phrase variation
+- genre templates
+- audio clip sync / looping (the remembered core bugs)

--- a/crates/vibez-audio-io/src/midi_input.rs
+++ b/crates/vibez-audio-io/src/midi_input.rs
@@ -28,9 +28,17 @@ pub enum MidiEvent {
     /// Note pressed. Velocity 1..=127 — velocity 0 is normalised to
     /// `NoteOff` by the parser because that is how most hardware
     /// encodes note-off.
-    NoteOn { pitch: u8, velocity: u8 },
-    NoteOff { pitch: u8 },
-    ControlChange { cc: u8, value: u8 },
+    NoteOn {
+        pitch: u8,
+        velocity: u8,
+    },
+    NoteOff {
+        pitch: u8,
+    },
+    ControlChange {
+        cc: u8,
+        value: u8,
+    },
 }
 
 /// Active MIDI input connection. Dropping this closes the port and
@@ -78,7 +86,9 @@ pub fn open_midi_input(target_name: &str) -> Result<MidiInputHandle, String> {
         })
         .ok_or_else(|| format!("MIDI port not found: {target_name}"))?;
 
-    let resolved_name = input.port_name(&port).unwrap_or_else(|_| target_name.to_string());
+    let resolved_name = input
+        .port_name(&port)
+        .unwrap_or_else(|_| target_name.to_string());
     let (tx, rx) = mpsc::channel::<MidiEvent>();
 
     let conn = input

--- a/crates/vibez-core/src/onset.rs
+++ b/crates/vibez-core/src/onset.rs
@@ -469,10 +469,12 @@ mod tests {
         let onsets = detect_onsets(&audio, 1.2);
         assert!(!onsets.is_empty());
         for exp in expected.iter() {
-            let found = onsets
-                .iter()
-                .any(|&o| (o as i64 - *exp as i64).abs() < 512);
-            assert!(found, "no onset within 512 samples of {}: {:?}", exp, onsets);
+            let found = onsets.iter().any(|&o| (o as i64 - *exp as i64).abs() < 512);
+            assert!(
+                found,
+                "no onset within 512 samples of {}: {:?}",
+                exp, onsets
+            );
         }
     }
 

--- a/crates/vibez-core/src/phrase_variation.rs
+++ b/crates/vibez-core/src/phrase_variation.rs
@@ -175,14 +175,17 @@ pub fn generate_variants(
     let mutators = preset.mutators();
     (0..count)
         .map(|i| {
-            let seed = seed_base
-                .wrapping_add((i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+            let seed = seed_base.wrapping_add((i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
             let mut rng = Rng::new(seed);
             let mut notes = base.notes.clone();
             for mutator in mutators {
                 notes = mutator.apply(notes, base.duration_beats, &mut rng);
             }
-            notes.sort_by(|a, b| a.start_beat.partial_cmp(&b.start_beat).unwrap_or(std::cmp::Ordering::Equal));
+            notes.sort_by(|a, b| {
+                a.start_beat
+                    .partial_cmp(&b.start_beat)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             NoteClipInfo {
                 id: ClipId::new(),
                 track_id: base.track_id,
@@ -219,10 +222,7 @@ fn apply_swing(mut notes: Vec<MidiNote>, amount: f32) -> Vec<MidiNote> {
 
 fn apply_thin(notes: Vec<MidiNote>, probability: f32, rng: &mut Rng) -> Vec<MidiNote> {
     let p = probability.clamp(0.0, 1.0);
-    notes
-        .into_iter()
-        .filter(|_| !rng.chance(p))
-        .collect()
+    notes.into_iter().filter(|_| !rng.chance(p)).collect()
 }
 
 fn apply_densify(
@@ -280,11 +280,7 @@ fn is_backbeat(beat: f64) -> bool {
     on_beat && (integer.rem_euclid(4) == 1 || integer.rem_euclid(4) == 3)
 }
 
-fn apply_end_fill(
-    mut notes: Vec<MidiNote>,
-    phrase_beats: f64,
-    rng: &mut Rng,
-) -> Vec<MidiNote> {
+fn apply_end_fill(mut notes: Vec<MidiNote>, phrase_beats: f64, rng: &mut Rng) -> Vec<MidiNote> {
     if phrase_beats < 2.0 {
         return notes;
     }

--- a/crates/vibez-dropbox/src/api.rs
+++ b/crates/vibez-dropbox/src/api.rs
@@ -164,11 +164,7 @@ impl DropboxClient {
 
     // -- internal helpers ------------------------------------------------
 
-    async fn post_json<T>(
-        &self,
-        url: &str,
-        body: &serde_json::Value,
-    ) -> DropboxResult<T>
+    async fn post_json<T>(&self, url: &str, body: &serde_json::Value) -> DropboxResult<T>
     where
         T: for<'de> Deserialize<'de>,
     {

--- a/crates/vibez-dropbox/src/cache.rs
+++ b/crates/vibez-dropbox/src/cache.rs
@@ -131,9 +131,7 @@ mod tests {
     fn write_round_trips() {
         let dir = TempDir::new().unwrap();
         let cache = DropboxCache::with_root(dir.path().to_path_buf());
-        let path = cache
-            .write("/kick.wav", Some("abc"), b"hello")
-            .unwrap();
+        let path = cache.write("/kick.wav", Some("abc"), b"hello").unwrap();
         assert!(path.is_file());
         assert!(cache.is_cached("/kick.wav", Some("abc")));
         assert!(!cache.is_cached("/kick.wav", Some("different")));

--- a/crates/vibez-dropbox/src/oauth.rs
+++ b/crates/vibez-dropbox/src/oauth.rs
@@ -37,10 +37,7 @@ impl BrowserOpener for SystemBrowserOpener {
 }
 
 /// Run the full PKCE flow and return fresh tokens.
-pub async fn run_flow(
-    app_key: &str,
-    opener: Arc<dyn BrowserOpener>,
-) -> DropboxResult<Tokens> {
+pub async fn run_flow(app_key: &str, opener: Arc<dyn BrowserOpener>) -> DropboxResult<Tokens> {
     let verifier = random_url_safe_string(64);
     let challenge = code_challenge(&verifier);
     let state = random_url_safe_string(32);
@@ -74,9 +71,9 @@ pub async fn run_flow(
             "Dropbox returned authorisation error: {err}"
         )));
     }
-    let code = callback.code.ok_or_else(|| {
-        DropboxError::Oauth("no `code` parameter in callback URL".into())
-    })?;
+    let code = callback
+        .code
+        .ok_or_else(|| DropboxError::Oauth("no `code` parameter in callback URL".into()))?;
 
     exchange_code_for_tokens(app_key, &verifier, &code, &redirect_uri).await
 }
@@ -84,10 +81,7 @@ pub async fn run_flow(
 /// Exchange a long-lived refresh token for a new access token.
 /// Dropbox may or may not return a new refresh token; preserve the
 /// existing one if absent.
-pub async fn refresh_access_token(
-    app_key: &str,
-    existing_refresh: &str,
-) -> DropboxResult<Tokens> {
+pub async fn refresh_access_token(app_key: &str, existing_refresh: &str) -> DropboxResult<Tokens> {
     let client = reqwest::Client::new();
     let response = client
         .post("https://api.dropboxapi.com/oauth2/token")
@@ -143,8 +137,7 @@ async fn exchange_code_for_tokens(
     let parsed: TokenResponse = response.json().await?;
     let refresh = parsed.refresh_token.clone().ok_or_else(|| {
         DropboxError::Oauth(
-            "Dropbox did not return a refresh_token; is `token_access_type=offline` set?"
-                .into(),
+            "Dropbox did not return a refresh_token; is `token_access_type=offline` set?".into(),
         )
     })?;
     Ok(tokens_from_response(parsed, &refresh))
@@ -157,7 +150,9 @@ fn tokens_from_response(resp: TokenResponse, fallback_refresh: &str) -> Tokens {
         .unwrap_or(0);
     Tokens {
         access_token: resp.access_token,
-        refresh_token: resp.refresh_token.unwrap_or_else(|| fallback_refresh.to_string()),
+        refresh_token: resp
+            .refresh_token
+            .unwrap_or_else(|| fallback_refresh.to_string()),
         expires_at_secs: now_secs.saturating_add(resp.expires_in),
     }
 }
@@ -182,12 +177,7 @@ async fn bind_loopback() -> DropboxResult<(TcpListener, u16)> {
     )))
 }
 
-fn build_authorize_url(
-    app_key: &str,
-    challenge: &str,
-    state: &str,
-    redirect_uri: &str,
-) -> String {
+fn build_authorize_url(app_key: &str, challenge: &str, state: &str, redirect_uri: &str) -> String {
     let mut url = "https://www.dropbox.com/oauth2/authorize?".to_string();
     let mut append = |key: &str, value: &str| {
         url.push_str(key);
@@ -292,12 +282,7 @@ mod tests {
 
     #[test]
     fn authorize_url_includes_required_params() {
-        let url = build_authorize_url(
-            "abc",
-            "CHALLENGE",
-            "STATE",
-            "http://127.0.0.1:53682",
-        );
+        let url = build_authorize_url("abc", "CHALLENGE", "STATE", "http://127.0.0.1:53682");
         assert!(url.contains("client_id=abc"));
         assert!(url.contains("response_type=code"));
         assert!(url.contains("code_challenge=CHALLENGE"));

--- a/crates/vibez-dropbox/src/types.rs
+++ b/crates/vibez-dropbox/src/types.rs
@@ -44,9 +44,7 @@ pub struct DropboxEntry {
 
 impl DropboxEntry {
     pub fn file_extension(&self) -> Option<&str> {
-        self.name
-            .rsplit_once('.')
-            .map(|(_, ext)| ext)
+        self.name.rsplit_once('.').map(|(_, ext)| ext)
     }
 
     /// True if the file extension is one vibez recognises as audio.

--- a/crates/vibez-dsp/src/phaser.rs
+++ b/crates/vibez-dsp/src/phaser.rs
@@ -122,7 +122,10 @@ impl AudioEffect for PhaserEffect {
             let lfo = 0.5 + 0.5 * self.phase.sin();
             let ratio = 8.0_f32.powf(self.depth * lfo);
             let break_hz = CENTER_HZ * ratio;
-            let a = Self::a1(break_hz.clamp(20.0, self.sample_rate * 0.45), self.sample_rate);
+            let a = Self::a1(
+                break_hz.clamp(20.0, self.sample_rate * 0.45),
+                self.sample_rate,
+            );
 
             for c in 0..ch {
                 let idx = frame * ch + c;

--- a/crates/vibez-dsp/src/time_stretch.rs
+++ b/crates/vibez-dsp/src/time_stretch.rs
@@ -253,11 +253,7 @@ fn wsola_synthesize(input: &[f32], target_len: usize, deltas: &[isize]) -> Vec<f
     for (i, out_sample) in out.iter_mut().enumerate() {
         let src_idx = i + pad;
         let w = out_win[src_idx];
-        *out_sample = if w > 1e-6 {
-            out_sum[src_idx] / w
-        } else {
-            0.0
-        };
+        *out_sample = if w > 1e-6 { out_sum[src_idx] / w } else { 0.0 };
     }
     out
 }
@@ -565,10 +561,7 @@ mod tests {
         }
         assert!(rms_values.len() > 4);
         let max = rms_values.iter().cloned().fold(0.0_f32, f32::max);
-        let min = rms_values
-            .iter()
-            .cloned()
-            .fold(f32::INFINITY, f32::min);
+        let min = rms_values.iter().cloned().fold(f32::INFINITY, f32::min);
         // 0.3 dB ≈ ratio 1.035. WSOLA with per-sample gain
         // normalisation should sit well inside that.
         let ratio_db = 20.0 * (max / min.max(1e-6)).log10();

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -220,7 +220,10 @@ pub enum EngineCommand {
         velocity: u8,
     },
     /// Route a live note-off from an external MIDI source.
-    ExternalNoteOff { track_id: TrackId, pitch: u8 },
+    ExternalNoteOff {
+        track_id: TrackId,
+        pitch: u8,
+    },
 
     // -- External plugins --
     /// Add a pre-loaded external plugin effect to a track.

--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -147,7 +147,11 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
             });
         }
 
-        for clip in req.audio_clips.iter().filter(|c| c.track_id == track_info.id) {
+        for clip in req
+            .audio_clips
+            .iter()
+            .filter(|c| c.track_id == track_info.id)
+        {
             if !clip_included_for_mode(clip.id, req.mode, false) {
                 continue;
             }
@@ -162,14 +166,15 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
                     loop_start: clip.loop_start,
                     loop_end: clip.loop_end,
                 }),
-                None => warnings.push(format!(
-                    "Clip '{}' audio missing, skipped",
-                    clip.name
-                )),
+                None => warnings.push(format!("Clip '{}' audio missing, skipped", clip.name)),
             }
         }
 
-        for nc in req.note_clips.iter().filter(|c| c.track_id == track_info.id) {
+        for nc in req
+            .note_clips
+            .iter()
+            .filter(|c| c.track_id == track_info.id)
+        {
             if !clip_included_for_mode(nc.id, req.mode, true) {
                 continue;
             }
@@ -516,9 +521,7 @@ mod tests {
             kind: TrackKind::Instrument(InstrumentKind::SubtractiveSynth),
             color_index: 0,
             instrument: Some(InstrumentKind::SubtractiveSynth),
-            native_instrument: Some(InstrumentStateInfo::SubtractiveSynth {
-                params: Vec::new(),
-            }),
+            native_instrument: Some(InstrumentStateInfo::SubtractiveSynth { params: Vec::new() }),
         };
         let note_clip = NoteClipInfo {
             id: cid,

--- a/crates/vibez-project/src/templates.rs
+++ b/crates/vibez-project/src/templates.rs
@@ -93,9 +93,7 @@ fn drum_track(name: &str, color: u8) -> TrackInfo {
     let mut t = TrackInfo::new(name);
     t.kind = TrackKind::Instrument(InstrumentKind::DrumRack);
     t.instrument = Some(InstrumentKind::DrumRack);
-    t.native_instrument = Some(InstrumentStateInfo::DrumRack {
-        pads: empty_pads(),
-    });
+    t.native_instrument = Some(InstrumentStateInfo::DrumRack { pads: empty_pads() });
     t.color_index = color;
     t
 }

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -16,13 +16,12 @@ use vibez_core::effect::EffectType;
 use vibez_core::id::{ClipId, EffectId, TrackId};
 use vibez_core::midi::{InstrumentKind, MidiNote, TrackKind};
 use vibez_core::track::{ClipInfo, InstrumentStateInfo, MediaSourceRef, TrackInfo};
+use vibez_dropbox::{
+    load_app_key_with_env_override, DropboxCache, DropboxClient, DropboxEntry, DropboxSettings,
+};
 use vibez_engine::commands::EngineCommand;
 use vibez_engine::engine::AudioEngine;
 use vibez_engine::events::EngineEvent;
-use vibez_dropbox::{
-    load_app_key_with_env_override, DropboxCache, DropboxClient, DropboxEntry,
-    DropboxSettings,
-};
 use vibez_plugin_host::gui::PluginGuiKey;
 use vibez_plugin_host::{PluginCategory, PluginFormat, PluginInfo, PluginInstance};
 use vibez_project::Project;
@@ -76,10 +75,8 @@ struct PluginInstrumentLoadResult {
 
 struct BounceAssets {
     clips: std::collections::HashMap<ClipId, Arc<vibez_core::audio_buffer::DecodedAudio>>,
-    samplers: std::collections::HashMap<
-        TrackId,
-        (Arc<vibez_core::audio_buffer::DecodedAudio>, String),
-    >,
+    samplers:
+        std::collections::HashMap<TrackId, (Arc<vibez_core::audio_buffer::DecodedAudio>, String)>,
     pads: std::collections::HashMap<
         (TrackId, usize),
         (Arc<vibez_core::audio_buffer::DecodedAudio>, String),
@@ -185,8 +182,7 @@ impl App {
         // matches one currently visible, else to the first available
         // port. Silent on failure: the user can still work without
         // MIDI, and Settings → Audio lets them pick manually later.
-        let midi_input =
-            auto_open_midi_input(ui_settings.preferred_midi_input.as_deref());
+        let midi_input = auto_open_midi_input(ui_settings.preferred_midi_input.as_deref());
 
         let mut app = Self {
             state,
@@ -333,8 +329,7 @@ impl App {
                         }
                     }
                     InstrumentStateInfo::DrumRack { pads } => {
-                        ui_track.drum_rack_pads =
-                            pads.iter().map(UiDrumPad::from_state).collect();
+                        ui_track.drum_rack_pads = pads.iter().map(UiDrumPad::from_state).collect();
                         for (i, pad) in pads.iter().cloned().enumerate() {
                             self.send_command(EngineCommand::SetDrumRackPadState {
                                 track_id: track_info.id,
@@ -363,10 +358,7 @@ impl App {
             sample_browser_open: self.state.sample_browser_open,
             auto_warp_on_import: self.state.auto_warp_on_import,
             warp_confidence_threshold: self.state.warp_confidence_threshold,
-            preferred_midi_input: self
-                .midi_input
-                .as_ref()
-                .map(|h| h.port_name.clone()),
+            preferred_midi_input: self.midi_input.as_ref().map(|h| h.port_name.clone()),
         };
         if let Err(err) = settings.save() {
             self.state.status_text = format!("UI settings save error: {err}");
@@ -570,8 +562,7 @@ impl App {
             BrowserImportTarget::ArrangementClipAt {
                 track_id,
                 position_samples,
-            } => self
-                .add_audio_clip_to_track_at(track_id, position_samples, audio, name, source),
+            } => self.add_audio_clip_to_track_at(track_id, position_samples, audio, name, source),
             BrowserImportTarget::Sampler(track_id) => {
                 self.apply_sampler_sample_loaded(track_id, audio, name, source);
                 Task::none()
@@ -607,8 +598,7 @@ impl App {
                 return Task::none();
             }
             None => {
-                self.state.status_text =
-                    "Drop target not found; drag cancelled".to_string();
+                self.state.status_text = "Drop target not found; drag cancelled".to_string();
                 return Task::none();
             }
         };
@@ -692,8 +682,7 @@ impl App {
                 rev,
             } => {
                 let Some(client) = self.dropbox_client.clone() else {
-                    self.state.status_text =
-                        "Not connected to Dropbox for this drop".to_string();
+                    self.state.status_text = "Not connected to Dropbox for this drop".to_string();
                     return Task::none();
                 };
                 let cache = self.dropbox_cache.clone();
@@ -713,14 +702,12 @@ impl App {
                 Task::perform(
                     fetch_dropbox_sample_async(client, cache, entry),
                     move |result| match result {
-                        Ok((audio, decoded_name, source)) => {
-                            Message::BrowserSampleDecoded(
-                                target.clone(),
-                                audio,
-                                decoded_name,
-                                source,
-                            )
-                        }
+                        Ok((audio, decoded_name, source)) => Message::BrowserSampleDecoded(
+                            target.clone(),
+                            audio,
+                            decoded_name,
+                            source,
+                        ),
                         Err(err) => Message::BrowserSampleDecodeError(err),
                     },
                 )
@@ -1002,7 +989,7 @@ impl App {
                     original_bpm: loaded_clip.info.original_bpm,
                     warped: loaded_clip.info.warped,
                     warped_to_bpm: loaded_clip.info.warped_to_bpm,
-                    original_audio: None,
+                    original_audio: loaded_clip.original_audio,
                 });
             }
         }
@@ -1260,8 +1247,7 @@ impl App {
 
     fn apply_snapshot(&mut self, snapshot: crate::state::ProjectSnapshot) {
         // Tear down the engine side.
-        let existing_track_ids: Vec<TrackId> =
-            self.state.tracks.iter().map(|t| t.id).collect();
+        let existing_track_ids: Vec<TrackId> = self.state.tracks.iter().map(|t| t.id).collect();
         for track_id in existing_track_ids {
             self.send_command(EngineCommand::RemoveTrack(track_id));
         }
@@ -1297,10 +1283,7 @@ impl App {
                 self.send_command(EngineCommand::AddTrack(track.id, track.name.clone()));
             }
             TrackKind::Midi | TrackKind::Instrument(_) => {
-                self.send_command(EngineCommand::AddMidiTrack(
-                    track.id,
-                    track.name.clone(),
-                ));
+                self.send_command(EngineCommand::AddMidiTrack(track.id, track.name.clone()));
             }
         }
         self.send_command(EngineCommand::SetTrackGain(track.id, track.gain));
@@ -1458,14 +1441,13 @@ impl App {
         };
 
         self.state.status_text = format!("Quantizing {}...", input.original_name);
-        Task::perform(
-            quantize_audio_clip_async(input),
-            move |result| Message::AudioQuantizeReady {
+        Task::perform(quantize_audio_clip_async(input), move |result| {
+            Message::AudioQuantizeReady {
                 track_id,
                 old_clip_id: clip_id,
                 result,
-            },
-        )
+            }
+        })
     }
 
     fn apply_audio_quantize_success(
@@ -1522,19 +1504,14 @@ impl App {
                 clip_id: success.new_clip_id,
             });
 
-        let duration_seconds =
-            success.new_duration as f64 / self.state.sample_rate as f64;
+        let duration_seconds = success.new_duration as f64 / self.state.sample_rate as f64;
         self.state.status_text = format!(
             "Quantized {} slice(s) to {} ({:.1}s)",
             success.slice_count, success.grid_label, duration_seconds
         );
     }
 
-    fn dispatch_detect_clip_bpm(
-        &mut self,
-        track_id: TrackId,
-        clip_id: ClipId,
-    ) -> Task<Message> {
+    fn dispatch_detect_clip_bpm(&mut self, track_id: TrackId, clip_id: ClipId) -> Task<Message> {
         let Some(track) = self.state.find_track(track_id) else {
             self.state.status_text = "Track not found".to_string();
             return Task::none();
@@ -1551,15 +1528,14 @@ impl App {
             .unwrap_or_else(|| Arc::clone(&clip.audio));
         let sample_rate = self.state.sample_rate;
         self.state.status_text = format!("Detecting BPM for {}...", clip.name);
-        Task::perform(
-            detect_clip_bpm_async(audio, sample_rate),
-            move |estimate| Message::ClipBpmDetected {
+        Task::perform(detect_clip_bpm_async(audio, sample_rate), move |estimate| {
+            Message::ClipBpmDetected {
                 track_id,
                 clip_id,
                 bpm: estimate.map(|e| e.bpm),
                 confidence: estimate.map(|e| e.confidence).unwrap_or(0.0),
-            },
-        )
+            }
+        })
     }
 
     fn dispatch_warp_clip_to_project(
@@ -1582,8 +1558,7 @@ impl App {
             return Task::none();
         };
         let Some(clip_bpm) = clip.original_bpm else {
-            self.state.status_text =
-                "Set or detect the clip's BPM before warping".to_string();
+            self.state.status_text = "Set or detect the clip's BPM before warping".to_string();
             return Task::none();
         };
         if clip_bpm <= 0.0 {
@@ -1592,13 +1567,17 @@ impl App {
         }
         // If the clip was already warped once, warp the retained
         // original_audio. Otherwise the current `audio` is itself the
-        // original.
+        // original. Either way the clip's geometry fields are in
+        // samples of the CURRENT buffer, so `fields_frames` must be
+        // the current buffer's frame count for the rescale to be
+        // idempotent across repeated warps.
         let source_audio = clip
             .original_audio
             .clone()
             .unwrap_or_else(|| Arc::clone(&clip.audio));
-        let input = WarpClipInput {
+        let input = crate::warp::WarpClipInput {
             audio: source_audio,
+            fields_frames: clip.audio.num_frames() as u64,
             source_offset: clip.source_offset,
             duration: clip.duration,
             loop_start: clip.loop_start,
@@ -1608,14 +1587,13 @@ impl App {
         };
         let _ = sample_rate;
         self.state.status_text = format!("Warping to {project_bpm:.0} BPM...");
-        Task::perform(
-            warp_clip_async(input),
-            move |result| Message::ClipWarpReady {
+        Task::perform(crate::warp::warp_clip_async(input), move |result| {
+            Message::ClipWarpReady {
                 track_id,
                 clip_id,
                 result,
-            },
-        )
+            }
+        })
     }
 
     fn apply_clip_warp_success(
@@ -1662,10 +1640,7 @@ impl App {
         clip_id: ClipId,
         audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
     ) -> Task<Message> {
-        if !self.state.auto_warp_on_import
-            || self.state.bpm <= 0.0
-            || self.state.sample_rate == 0
-        {
+        if !self.state.auto_warp_on_import || self.state.bpm <= 0.0 || self.state.sample_rate == 0 {
             return Task::none();
         }
         let input = AutoWarpInput {
@@ -1674,14 +1649,13 @@ impl App {
             project_bpm: self.state.bpm,
             confidence_threshold: self.state.warp_confidence_threshold,
         };
-        Task::perform(
-            auto_warp_clip_async(input),
-            move |outcome| Message::ClipAutoWarpReady {
+        Task::perform(auto_warp_clip_async(input), move |outcome| {
+            Message::ClipAutoWarpReady {
                 track_id,
                 clip_id,
                 outcome,
-            },
-        )
+            }
+        })
     }
 
     fn apply_auto_warp_outcome(
@@ -1783,10 +1757,7 @@ impl App {
             });
         }
         self.mark_project_dirty();
-        self.state.status_text = format!(
-            "Quantized {count} note(s) to {}",
-            grid.label()
-        );
+        self.state.status_text = format!("Quantized {count} note(s) to {}", grid.label());
     }
 
     fn generate_phrase_variations(&mut self, track_id: TrackId, clip_id: ClipId) {
@@ -1818,12 +1789,8 @@ impl App {
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
         let count = 3usize;
-        let variants = vibez_core::phrase_variation::generate_variants(
-            &source_info,
-            preset,
-            seed,
-            count,
-        );
+        let variants =
+            vibez_core::phrase_variation::generate_variants(&source_info, preset, seed, count);
 
         let phrase_length = source_info.duration_beats.max(1.0);
         let base_position = source_info.position_beats + phrase_length;
@@ -4400,15 +4367,12 @@ impl App {
                 match vibez_audio_io::midi_input::list_midi_input_ports() {
                     Ok(ports) => {
                         self.midi_input_ports = ports;
-                        self.state.status_text = format!(
-                            "Found {} MIDI input port(s)",
-                            self.midi_input_ports.len()
-                        );
+                        self.state.status_text =
+                            format!("Found {} MIDI input port(s)", self.midi_input_ports.len());
                     }
                     Err(err) => {
                         self.midi_input_ports.clear();
-                        self.state.status_text =
-                            format!("MIDI scan error: {err}");
+                        self.state.status_text = format!("MIDI scan error: {err}");
                     }
                 }
             }
@@ -4444,8 +4408,7 @@ impl App {
                     })
                     .collect();
                 if targets.is_empty() {
-                    self.state.status_text =
-                        "Re-warp all: no warped clips to re-warp".to_string();
+                    self.state.status_text = "Re-warp all: no warped clips to re-warp".to_string();
                     return Task::none();
                 }
                 let count = targets.len();
@@ -4595,8 +4558,7 @@ impl App {
             }
             // -- Drag-and-drop from sample browser --
             Message::StartDragSample { source, label } => {
-                self.state.status_text =
-                    format!("Dragging {label} - drop on a lane or drum pad");
+                self.state.status_text = format!("Dragging {label} - drop on a lane or drum pad");
                 self.state.drag_source = Some(source);
                 self.state.drag_label = Some(label);
                 self.state.drag_hover_track = None;
@@ -4645,7 +4607,10 @@ impl App {
                         self.state.drag_label = None;
                         return self.dispatch_drop_for_target(
                             source,
-                            BrowserImportTarget::DrumRackPad { track_id, pad_index },
+                            BrowserImportTarget::DrumRackPad {
+                                track_id,
+                                pad_index,
+                            },
                         );
                     }
                     None => {
@@ -4669,8 +4634,7 @@ impl App {
                             });
                         if let Some((audio, name)) = audition {
                             self.send_command(EngineCommand::StartPreview(audio));
-                            self.state.status_text =
-                                format!("Pad {}: {}", pad_index + 1, name);
+                            self.state.status_text = format!("Pad {}: {}", pad_index + 1, name);
                         }
                         return self.update(Message::SelectDrumRackPad(track_id, pad_index));
                     }
@@ -4681,10 +4645,8 @@ impl App {
                     return Task::none();
                 };
                 self.state.drag_label = None;
-                return self.dispatch_drop_for_target(
-                    source,
-                    BrowserImportTarget::Sampler(track_id),
-                );
+                return self
+                    .dispatch_drop_for_target(source, BrowserImportTarget::Sampler(track_id));
             }
             Message::LocalSamplePreviewReady(Ok(audio)) => {
                 self.send_command(EngineCommand::StartPreview(audio));
@@ -5061,7 +5023,9 @@ impl App {
                     self.state.status_text = "No time selection active".to_string();
                     return Task::none();
                 }
-                let start = self.state.beats_to_samples(self.state.selection_start_beats);
+                let start = self
+                    .state
+                    .beats_to_samples(self.state.selection_start_beats);
                 let end = self.state.beats_to_samples(self.state.selection_end_beats);
                 return self.dispatch_bounce(
                     vibez_engine::render::BounceMode::Master,
@@ -5082,8 +5046,7 @@ impl App {
                 let (range, insert_pos, name) = if is_note_clip {
                     let spb = self.state.sample_rate as f64 * 60.0 / self.state.bpm;
                     let track_opt = self.state.find_track(track_id);
-                    let nc = track_opt
-                        .and_then(|t| t.note_clips.iter().find(|c| c.id == clip_id));
+                    let nc = track_opt.and_then(|t| t.note_clips.iter().find(|c| c.id == clip_id));
                     match nc {
                         Some(nc) => {
                             let start = (nc.position_beats * spb) as u64;
@@ -5282,8 +5245,7 @@ impl App {
                 }
                 let total = self.state.total_duration_samples();
                 if total == 0 {
-                    self.state.status_text =
-                        "Nothing to export: project is empty".to_string();
+                    self.state.status_text = "Nothing to export: project is empty".to_string();
                     return Task::none();
                 }
                 let assets = self.collect_bounce_assets();
@@ -5330,11 +5292,7 @@ impl App {
             }
             Message::SaveDropboxAppKey => {
                 let value = self.state.dropbox.app_key_input.trim().to_string();
-                self.dropbox_settings.app_key = if value.is_empty() {
-                    None
-                } else {
-                    Some(value)
-                };
+                self.dropbox_settings.app_key = if value.is_empty() { None } else { Some(value) };
                 if let Err(err) = self.dropbox_settings.save() {
                     self.state.dropbox.last_error = Some(format!("save settings: {err}"));
                 }
@@ -5343,8 +5301,7 @@ impl App {
                 self.state.status_text = "Dropbox app key saved".to_string();
             }
             Message::ConnectDropbox => {
-                let Some(app_key) = load_app_key_with_env_override(&self.dropbox_settings)
-                else {
+                let Some(app_key) = load_app_key_with_env_override(&self.dropbox_settings) else {
                     self.state.dropbox.last_error = Some(
                         "No Dropbox app key set. Register an app at dropbox.com/developers/apps \
                         and paste the App key above."
@@ -5366,9 +5323,7 @@ impl App {
             }
             Message::DropboxConnected(Ok(outcome)) => {
                 self.state.dropbox.auth_in_progress = false;
-                if let Some(app_key) =
-                    load_app_key_with_env_override(&self.dropbox_settings)
-                {
+                if let Some(app_key) = load_app_key_with_env_override(&self.dropbox_settings) {
                     let client = DropboxClient::new(app_key, outcome.tokens.clone());
                     self.dropbox_client = Some(Arc::new(client));
                 }
@@ -5379,8 +5334,7 @@ impl App {
                 }
                 self.state.dropbox.connected = true;
                 self.state.dropbox.account_email = Some(outcome.info.email.clone());
-                self.state.status_text =
-                    format!("Dropbox connected: {}", outcome.info.email);
+                self.state.status_text = format!("Dropbox connected: {}", outcome.info.email);
             }
             Message::DropboxConnected(Err(err)) => {
                 self.state.dropbox.auth_in_progress = false;
@@ -5406,8 +5360,7 @@ impl App {
                     return Task::none();
                 }
                 let Some(client) = self.dropbox_client.clone() else {
-                    self.state.dropbox.last_error =
-                        Some("Not connected to Dropbox".into());
+                    self.state.dropbox.last_error = Some("Not connected to Dropbox".into());
                     return Task::none();
                 };
                 self.state.dropbox.listing_in_progress.insert(path.clone());
@@ -5450,17 +5403,15 @@ impl App {
             }
             Message::DropboxPreview(entry) => {
                 let Some(client) = self.dropbox_client.clone() else {
-                    self.state.dropbox.last_error =
-                        Some("Not connected to Dropbox".into());
+                    self.state.dropbox.last_error = Some("Not connected to Dropbox".into());
                     return Task::none();
                 };
                 let cache = self.dropbox_cache.clone();
                 self.state.dropbox.preview_in_progress = true;
                 self.state.status_text = format!("Fetching preview: {}", entry.name);
-                return Task::perform(
-                    fetch_dropbox_sample_async(client, cache, entry),
-                    |result| Message::DropboxPreviewReady(result.map(|(audio, _, _)| audio)),
-                );
+                return Task::perform(fetch_dropbox_sample_async(client, cache, entry), |result| {
+                    Message::DropboxPreviewReady(result.map(|(audio, _, _)| audio))
+                });
             }
             Message::DropboxPreviewReady(Ok(audio)) => {
                 self.state.dropbox.preview_in_progress = false;
@@ -5474,8 +5425,7 @@ impl App {
             }
             Message::DropboxImportToArrangement(entry) => {
                 let Some(client) = self.dropbox_client.clone() else {
-                    self.state.dropbox.last_error =
-                        Some("Not connected to Dropbox".into());
+                    self.state.dropbox.last_error = Some("Not connected to Dropbox".into());
                     return Task::none();
                 };
                 let cache = self.dropbox_cache.clone();
@@ -5493,13 +5443,11 @@ impl App {
             }
             Message::DropboxImportToDevice(entry) => {
                 let Some(client) = self.dropbox_client.clone() else {
-                    self.state.dropbox.last_error =
-                        Some("Not connected to Dropbox".into());
+                    self.state.dropbox.last_error = Some("Not connected to Dropbox".into());
                     return Task::none();
                 };
                 let Some(target) = self.selected_browser_device_target() else {
-                    self.state.status_text =
-                        "Select a Sampler or Drum Pad track first".into();
+                    self.state.status_text = "Select a Sampler or Drum Pad track first".into();
                     return Task::none();
                 };
                 let cache = self.dropbox_cache.clone();
@@ -6333,10 +6281,7 @@ impl App {
                 .size(12)
                 .color(th::ACCENT)
                 .into(),
-            None => text("Not connected")
-                .size(12)
-                .color(th::TEXT_DIM)
-                .into(),
+            None => text("Not connected").size(12).color(th::TEXT_DIM).into(),
         };
 
         let rescan_btn = button(text("Rescan ports").size(11).color(th::TEXT))
@@ -6344,9 +6289,7 @@ impl App {
             .padding([4, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::BG_HOVER.into())
-                    }
+                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
                     _ => None,
                 };
                 button::Style {
@@ -6366,9 +6309,7 @@ impl App {
             .padding([4, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::BG_HOVER.into())
-                    }
+                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
                     _ => None,
                 };
                 button::Style {
@@ -6422,7 +6363,11 @@ impl App {
                     background: bg,
                     text_color: if is_current { th::ACCENT } else { th::TEXT },
                     border: iced::Border {
-                        color: if is_current { th::ACCENT_DIM } else { th::BORDER },
+                        color: if is_current {
+                            th::ACCENT_DIM
+                        } else {
+                            th::BORDER
+                        },
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -6616,9 +6561,7 @@ impl App {
             .padding([6, 12])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::BG_HOVER.into())
-                    }
+                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
                     _ => None,
                 };
                 button::Style {
@@ -6657,8 +6600,7 @@ impl App {
             text("Not connected").size(12).color(th::TEXT_DIM).into()
         };
 
-        let can_connect =
-            self.state.dropbox.has_app_key && !self.state.dropbox.auth_in_progress;
+        let can_connect = self.state.dropbox.has_app_key && !self.state.dropbox.auth_in_progress;
         let connect_label = if self.state.dropbox.auth_in_progress {
             "Connecting..."
         } else if self.state.dropbox.connected {
@@ -6673,9 +6615,7 @@ impl App {
             }
             btn.padding([6, 12]).style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::BG_HOVER.into())
-                    }
+                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
                     _ => None,
                 };
                 button::Style {
@@ -7178,7 +7118,11 @@ impl App {
                 })
             };
             row![
-                tab_btn("Local", local_active, crate::state::SampleBrowserMode::Local),
+                tab_btn(
+                    "Local",
+                    local_active,
+                    crate::state::SampleBrowserMode::Local
+                ),
                 tab_btn(
                     "Dropbox",
                     dropbox_active,
@@ -7258,27 +7202,29 @@ impl App {
         .color(th::TEXT_DIM);
         let conf_slider = slider(0.0..=1.0, conf, Message::SetWarpConfidenceThreshold).step(0.05);
 
-        let rewarp_btn = button(text("Re-warp all clips to project tempo").size(12).color(th::TEXT))
-            .on_press(Message::RewarpAllClips)
-            .padding([6, 12])
-            .style(|_theme: &Theme, status| {
-                let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::BG_HOVER.into())
-                    }
-                    _ => None,
-                };
-                button::Style {
-                    background: bg,
-                    text_color: th::TEXT,
-                    border: iced::Border {
-                        color: th::ACCENT_DIM,
-                        width: 1.0,
-                        radius: 4.0.into(),
-                    },
-                    ..Default::default()
-                }
-            });
+        let rewarp_btn = button(
+            text("Re-warp all clips to project tempo")
+                .size(12)
+                .color(th::TEXT),
+        )
+        .on_press(Message::RewarpAllClips)
+        .padding([6, 12])
+        .style(|_theme: &Theme, status| {
+            let bg = match status {
+                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                _ => None,
+            };
+            button::Style {
+                background: bg,
+                text_color: th::TEXT,
+                border: iced::Border {
+                    color: th::ACCENT_DIM,
+                    width: 1.0,
+                    radius: 4.0.into(),
+                },
+                ..Default::default()
+            }
+        });
 
         column![
             title,
@@ -7706,17 +7652,8 @@ impl App {
                 .into();
         }
 
-        let account = self
-            .state
-            .dropbox
-            .account_email
-            .clone()
-            .unwrap_or_default();
-        let header = column![
-            title,
-            text(account).size(11).color(th::TEXT_DIM),
-        ]
-        .spacing(2);
+        let account = self.state.dropbox.account_email.clone().unwrap_or_default();
+        let header = column![title, text(account).size(11).color(th::TEXT_DIM),].spacing(2);
 
         let mut rows: Vec<Element<'_, Message>> = Vec::new();
         self.render_dropbox_tree(String::new(), 0, &mut rows);
@@ -7763,10 +7700,7 @@ impl App {
                         ..Default::default()
                     }
                 });
-            if let Some(entry) = selected_entry
-                .as_ref()
-                .filter(|e| e.is_supported_audio())
-            {
+            if let Some(entry) = selected_entry.as_ref().filter(|e| e.is_supported_audio()) {
                 btn = btn.on_press(Message::DropboxImportToArrangement(entry.clone()));
             }
             btn.into()
@@ -7794,9 +7728,7 @@ impl App {
                     }
                 });
             if let (Some(entry), Some(_)) = (
-                selected_entry
-                    .as_ref()
-                    .filter(|e| e.is_supported_audio()),
+                selected_entry.as_ref().filter(|e| e.is_supported_audio()),
                 self.selected_browser_device_target(),
             ) {
                 btn = btn.on_press(Message::DropboxImportToDevice(entry.clone()));
@@ -7842,17 +7774,11 @@ impl App {
         };
         let mut sorted: Vec<&DropboxEntry> = entries.iter().collect();
         sorted.sort_by(|a, b| {
-            (!a.is_folder, a.name.to_lowercase())
-                .cmp(&(!b.is_folder, b.name.to_lowercase()))
+            (!a.is_folder, a.name.to_lowercase()).cmp(&(!b.is_folder, b.name.to_lowercase()))
         });
         for entry in sorted {
-            let expanded = self
-                .state
-                .dropbox
-                .expanded
-                .contains(&entry.path_lower);
-            let selected =
-                self.state.dropbox.selected_path.as_deref() == Some(&entry.path_lower);
+            let expanded = self.state.dropbox.expanded.contains(&entry.path_lower);
+            let selected = self.state.dropbox.selected_path.as_deref() == Some(&entry.path_lower);
 
             let prefix = if entry.is_folder {
                 if expanded {
@@ -8752,14 +8678,7 @@ impl App {
                 .padding([8, 6])
                 .width(Length::Fixed(60.0))
                 .style(move |_theme: &Theme| container::Style {
-                    background: Some(
-                        if active {
-                            th::ACCENT_DIM
-                        } else {
-                            th::BG_DARK
-                        }
-                        .into(),
-                    ),
+                    background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
                     text_color: Some(if active { th::ACCENT } else { th::TEXT }),
                     border: iced::Border {
                         color: if active { th::ACCENT_DIM } else { th::BORDER },
@@ -9430,11 +9349,7 @@ impl App {
             .into()
     }
 
-    fn view_audio_warp_row(
-        &self,
-        track_id: TrackId,
-        clip: &UiClip,
-    ) -> Element<'_, Message> {
+    fn view_audio_warp_row(&self, track_id: TrackId, clip: &UiClip) -> Element<'_, Message> {
         let clip_id = clip.id;
         let label = text("Warp").size(11).color(th::TEXT_DIM);
 
@@ -9516,11 +9431,7 @@ impl App {
         row_widgets.into()
     }
 
-    fn view_audio_quantize_row(
-        &self,
-        track_id: TrackId,
-        clip_id: ClipId,
-    ) -> Element<'_, Message> {
+    fn view_audio_quantize_row(&self, track_id: TrackId, clip_id: ClipId) -> Element<'_, Message> {
         let label = text("Quantize").size(11).color(th::TEXT_DIM);
         let grid_btn = |grid: crate::state::SnapGrid| -> Element<'_, Message> {
             button(text(grid.label()).size(11).color(th::TEXT))
@@ -9955,24 +9866,6 @@ async fn detect_clip_bpm_async(
         .unwrap_or(None)
 }
 
-struct WarpClipInput {
-    audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
-    source_offset: u64,
-    duration: u64,
-    loop_start: u64,
-    loop_end: u64,
-    clip_bpm: f64,
-    project_bpm: f64,
-}
-
-async fn warp_clip_async(
-    input: WarpClipInput,
-) -> Result<crate::message::ClipWarpSuccess, String> {
-    tokio::task::spawn_blocking(move || compute_warp(input))
-        .await
-        .map_err(|e| format!("warp task failed: {e}"))?
-}
-
 struct AutoWarpInput {
     audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
     sample_rate: u32,
@@ -9999,8 +9892,9 @@ async fn auto_warp_clip_async(input: AutoWarpInput) -> crate::message::AutoWarpO
         };
     }
     let num_frames = input.audio.num_frames();
-    let warp_input = WarpClipInput {
+    let warp_input = crate::warp::WarpClipInput {
         audio: input.audio,
+        fields_frames: num_frames as u64,
         source_offset: 0,
         duration: num_frames as u64,
         loop_start: 0,
@@ -10008,7 +9902,7 @@ async fn auto_warp_clip_async(input: AutoWarpInput) -> crate::message::AutoWarpO
         clip_bpm: est.bpm,
         project_bpm: input.project_bpm,
     };
-    match warp_clip_async(warp_input).await {
+    match crate::warp::warp_clip_async(warp_input).await {
         Ok(success) => AutoWarpOutcome::Warped {
             confidence: est.confidence,
             success,
@@ -10019,80 +9913,6 @@ async fn auto_warp_clip_async(input: AutoWarpInput) -> crate::message::AutoWarpO
         },
     }
 }
-
-fn compute_warp(input: WarpClipInput) -> Result<crate::message::ClipWarpSuccess, String> {
-    if input.clip_bpm <= 0.0 || input.project_bpm <= 0.0 {
-        return Err("Invalid BPM".into());
-    }
-    let source_frames = input.audio.num_frames();
-    if source_frames == 0 {
-        return Err("Empty audio".into());
-    }
-    let sample_rate = input.audio.sample_rate as f64;
-    if sample_rate <= 0.0 {
-        return Err("Invalid sample rate".into());
-    }
-    // Naive warp ratio derived from the "same number of beats at a
-    // different tempo" identity:
-    //
-    //   source_frames = beats * 60 / clip_bpm * sample_rate
-    //   target_frames = beats * 60 / project_bpm * sample_rate
-    //   => target / source = clip_bpm / project_bpm
-    let naive_ratio = input.clip_bpm / input.project_bpm;
-    let naive_target = source_frames as f64 * naive_ratio;
-
-    // Snap the warped length to the nearest whole bar at the project
-    // tempo when the naive result lands close to an integer bar
-    // count. Real drum loops almost always carry a trailing pickup
-    // (the "and" before beat 1 of the next bar) for crossfade
-    // purposes. A naive proportional warp preserves that pickup,
-    // which then leaks past the arrangement loop boundary and
-    // sounds like a double beat. Snapping to the nearest bar
-    // trims / extends the clip so a "1 bar" loop plays as exactly
-    // one bar at the project tempo.
-    //
-    // The 0.25-bar guard means we only snap when the source is
-    // plausibly "about N bars"; a 1.5-bar clip stays at 1.5 bars
-    // rather than being aggressively remapped.
-    let bar_samples = 4.0 * 60.0 * sample_rate / input.project_bpm;
-    let target_total = if bar_samples >= 1.0 {
-        let naive_bars = naive_target / bar_samples;
-        if naive_bars >= 0.5 {
-            let rounded = naive_bars.round();
-            if (naive_bars - rounded).abs() < 0.25 {
-                (rounded * bar_samples).round() as usize
-            } else {
-                naive_target as usize
-            }
-        } else {
-            naive_target as usize
-        }
-    } else {
-        naive_target as usize
-    };
-
-    if target_total == 0 {
-        return Err("Target length collapsed to zero".into());
-    }
-
-    let stretched =
-        vibez_dsp::time_stretch::pitch_preserving_stretch(&input.audio, target_total);
-    // Effective ratio after snap so source_offset / loop bounds
-    // scale consistently with the actual stretched length.
-    let effective_ratio = target_total as f64 / source_frames as f64;
-    let scale = |x: u64| -> u64 { (x as f64 * effective_ratio) as u64 };
-    Ok(crate::message::ClipWarpSuccess {
-        audio: Arc::new(stretched),
-        original_audio: input.audio,
-        new_duration: scale(input.duration),
-        new_source_offset: scale(input.source_offset),
-        new_loop_start: scale(input.loop_start),
-        new_loop_end: scale(input.loop_end),
-        detected_bpm: input.clip_bpm,
-        warped_to_bpm: input.project_bpm,
-    })
-}
-
 
 fn compute_audio_quantize(
     input: QuantizeInput,
@@ -10137,7 +9957,9 @@ fn compute_audio_quantize(
     let mut target_positions: Vec<u64> = Vec::with_capacity(source_bounds.len());
     for &b in &source_bounds {
         let original_timeline_pos = clip_position.saturating_add(b - clip_source_offset);
-        let snapped_beats = grid.snap_beat(samples_to_beats(original_timeline_pos)).max(0.0);
+        let snapped_beats = grid
+            .snap_beat(samples_to_beats(original_timeline_pos))
+            .max(0.0);
         target_positions.push(beats_to_samples(snapped_beats));
     }
     for i in 1..target_positions.len() {
@@ -10147,8 +9969,7 @@ fn compute_audio_quantize(
     }
 
     let channel_count = audio.channels.len().max(1);
-    let mut output_channels: Vec<Vec<f32>> =
-        (0..channel_count).map(|_| Vec::new()).collect();
+    let mut output_channels: Vec<Vec<f32>> = (0..channel_count).map(|_| Vec::new()).collect();
     let mut total_out_len: usize = 0;
     let mut stretched_slices = 0usize;
 
@@ -10156,8 +9977,7 @@ fn compute_audio_quantize(
         let src_start = source_bounds[i] as usize;
         let src_end = source_bounds[i + 1] as usize;
         let src_len = src_end.saturating_sub(src_start);
-        let target_len =
-            target_positions[i + 1].saturating_sub(target_positions[i]) as usize;
+        let target_len = target_positions[i + 1].saturating_sub(target_positions[i]) as usize;
         if src_len < MIN_SLICE_FRAMES || target_len == 0 {
             continue;
         }
@@ -10245,7 +10065,14 @@ async fn fetch_dropbox_sample_async(
     client: Arc<DropboxClient>,
     cache: DropboxCache,
     entry: DropboxEntry,
-) -> Result<(Arc<vibez_core::audio_buffer::DecodedAudio>, String, MediaSourceRef), String> {
+) -> Result<
+    (
+        Arc<vibez_core::audio_buffer::DecodedAudio>,
+        String,
+        MediaSourceRef,
+    ),
+    String,
+> {
     let local = client
         .download_to_cache(&entry, &cache)
         .await
@@ -10302,6 +10129,41 @@ async fn bounce_async(
     .map_err(|err| format!("bounce task failed: {err}"))?
 }
 
+/// Finish a decoded clip for project load. The project file stores
+/// the raw source reference, but a warped clip's geometry (duration /
+/// offsets / loop bounds) is saved in warped-sample units, so the
+/// deterministic stretch is re-applied here; otherwise every warped
+/// clip reloads at its raw tempo and the whole project plays out of
+/// sync. The stretch runs on a blocking thread (WSOLA over a whole
+/// clip is CPU-heavy).
+async fn finish_loaded_clip(
+    info: ClipInfo,
+    raw: Arc<vibez_core::audio_buffer::DecodedAudio>,
+) -> LoadedClipData {
+    if info.warped {
+        if let (Some(clip_bpm), Some(warped_to_bpm)) = (info.original_bpm, info.warped_to_bpm) {
+            let stretch_src = Arc::clone(&raw);
+            let warped = tokio::task::spawn_blocking(move || {
+                crate::warp::rewarp_for_load(&stretch_src, clip_bpm, warped_to_bpm)
+            })
+            .await
+            .unwrap_or(None);
+            if let Some(warped) = warped {
+                return LoadedClipData {
+                    info,
+                    audio: warped,
+                    original_audio: Some(raw),
+                };
+            }
+        }
+    }
+    LoadedClipData {
+        info,
+        audio: raw,
+        original_audio: None,
+    }
+}
+
 async fn load_project_async(
     path: PathBuf,
     dropbox: Option<(Arc<DropboxClient>, DropboxCache)>,
@@ -10322,19 +10184,17 @@ async fn load_project_async(
         match clip.resolved_source().cloned() {
             Some(MediaSourceRef::LocalFile { path: clip_path }) => {
                 match decode_blocking(clip_path).await {
-                    Ok(audio) => clips.push(LoadedClipData {
-                        info: clip.clone(),
-                        audio: Arc::new(audio),
-                    }),
+                    Ok(audio) => {
+                        clips.push(finish_loaded_clip(clip.clone(), Arc::new(audio)).await)
+                    }
                     Err(err) => warnings.push(format!("Skipped clip '{}' ({})", clip.name, err)),
                 }
             }
             Some(source @ MediaSourceRef::DropboxFile { .. }) => {
                 match hydrate_dropbox_source(dropbox.as_ref(), &source, &clip.name).await {
-                    Ok(audio) => clips.push(LoadedClipData {
-                        info: clip.clone(),
-                        audio: Arc::new(audio),
-                    }),
+                    Ok(audio) => {
+                        clips.push(finish_loaded_clip(clip.clone(), Arc::new(audio)).await)
+                    }
                     Err(err) => warnings.push(err),
                 }
             }
@@ -10366,29 +10226,24 @@ async fn load_project_async(
                             )),
                         }
                     }
-                    MediaSourceRef::DropboxFile { .. } => match hydrate_dropbox_source(
-                        dropbox.as_ref(),
-                        source,
-                        &track.name,
-                    )
-                    .await
-                    {
-                        Ok(audio) => sampler_samples.push(LoadedSamplerData {
-                            track_id: track.id,
-                            source: source.clone(),
-                            audio: Arc::new(audio),
-                            name: source.display_name(),
-                        }),
-                        Err(err) => warnings.push(err),
-                    },
+                    MediaSourceRef::DropboxFile { .. } => {
+                        match hydrate_dropbox_source(dropbox.as_ref(), source, &track.name).await {
+                            Ok(audio) => sampler_samples.push(LoadedSamplerData {
+                                track_id: track.id,
+                                source: source.clone(),
+                                audio: Arc::new(audio),
+                                name: source.display_name(),
+                            }),
+                            Err(err) => warnings.push(err),
+                        }
+                    }
                 },
                 InstrumentStateInfo::DrumRack { pads } => {
                     for (pad_index, pad) in pads.iter().enumerate() {
                         let Some(source) = &pad.source else {
                             continue;
                         };
-                        let label =
-                            format!("drum pad {} on '{}'", pad_index + 1, track.name);
+                        let label = format!("drum pad {} on '{}'", pad_index + 1, track.name);
                         match source {
                             MediaSourceRef::LocalFile { path: sample_path } => {
                                 match decode_blocking(sample_path.clone()).await {
@@ -10402,18 +10257,11 @@ async fn load_project_async(
                                             state: pad.clone(),
                                         })
                                     }
-                                    Err(err) => {
-                                        warnings.push(format!("Skipped {label} ({err})"))
-                                    }
+                                    Err(err) => warnings.push(format!("Skipped {label} ({err})")),
                                 }
                             }
                             MediaSourceRef::DropboxFile { .. } => {
-                                match hydrate_dropbox_source(
-                                    dropbox.as_ref(),
-                                    source,
-                                    &label,
-                                )
-                                .await
+                                match hydrate_dropbox_source(dropbox.as_ref(), source, &label).await
                                 {
                                     Ok(audio) => {
                                         drum_rack_pad_samples.push(LoadedDrumRackPadData {
@@ -10446,9 +10294,7 @@ async fn load_project_async(
     })
 }
 
-async fn decode_blocking(
-    path: PathBuf,
-) -> Result<vibez_core::audio_buffer::DecodedAudio, String> {
+async fn decode_blocking(path: PathBuf) -> Result<vibez_core::audio_buffer::DecodedAudio, String> {
     tokio::task::spawn_blocking(move || {
         file_io::decode_audio_file(&path).map_err(|e| e.to_string())
     })

--- a/crates/vibez-ui/src/lib.rs
+++ b/crates/vibez-ui/src/lib.rs
@@ -5,6 +5,7 @@ pub mod plugin_window;
 mod state;
 mod theme;
 mod ui_settings;
+mod warp;
 pub mod widgets;
 
 pub fn run() -> iced::Result {

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -19,7 +19,12 @@ use crate::state::{
 #[derive(Debug, Clone)]
 pub struct LoadedClipData {
     pub info: ClipInfo,
+    /// Audio the clip's geometry fields refer to. For warped clips
+    /// this is the re-stretched buffer, not the raw file contents.
     pub audio: Arc<DecodedAudio>,
+    /// Raw un-warped audio, retained when `info.warped` so later
+    /// re-warps stretch from the original.
+    pub original_audio: Option<Arc<DecodedAudio>>,
 }
 
 #[derive(Debug, Clone)]
@@ -116,7 +121,10 @@ pub enum BrowserImportTarget {
         position_samples: u64,
     },
     Sampler(TrackId),
-    DrumRackPad { track_id: TrackId, pad_index: usize },
+    DrumRackPad {
+        track_id: TrackId,
+        pad_index: usize,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/crates/vibez-ui/src/warp.rs
+++ b/crates/vibez-ui/src/warp.rs
@@ -1,0 +1,319 @@
+//! Clip warp math: tempo-matching a clip's audio to the project BPM.
+//!
+//! The stretch itself lives in `vibez_dsp::time_stretch`. This module
+//! owns the surrounding arithmetic, which has two invariants that were
+//! violated by earlier revisions (dogfood session 2026-07-03, bugs #7
+//! and #8 in `.notes/dogfood-2026-07-03.md`):
+//!
+//! 1. **Re-warp must be idempotent.** A clip's geometry fields
+//!    (`duration`, `source_offset`, `loop_start`, `loop_end`) are
+//!    expressed in samples of whatever buffer the clip currently
+//!    references. When re-warping we stretch from the retained
+//!    *original* audio, so geometry must be rescaled by
+//!    `new_target / fields_frames` (the buffer the fields refer to),
+//!    NOT by `new_target / original_frames`. Scaling by the latter
+//!    compounds the ratio on every warp and drifts the clip
+//!    boundaries off the audio content.
+//!
+//! 2. **The warp is deterministic.** `warp_target_frames` is a pure
+//!    function of (source frames, sample rate, clip BPM, project BPM),
+//!    so project load can regenerate the exact stretched buffer the
+//!    saved geometry refers to by re-running it with the persisted
+//!    `original_bpm` / `warped_to_bpm` pair.
+
+use std::sync::Arc;
+
+use vibez_core::audio_buffer::DecodedAudio;
+
+use crate::message::ClipWarpSuccess;
+
+pub struct WarpClipInput {
+    /// The un-warped source audio to stretch.
+    pub audio: Arc<DecodedAudio>,
+    /// Frame count of the buffer the clip's geometry fields currently
+    /// reference. Equal to `audio.num_frames()` on a first warp;
+    /// equal to the current (already-warped) buffer's frame count on
+    /// a re-warp.
+    pub fields_frames: u64,
+    pub source_offset: u64,
+    pub duration: u64,
+    pub loop_start: u64,
+    pub loop_end: u64,
+    pub clip_bpm: f64,
+    pub project_bpm: f64,
+}
+
+/// Deterministic warped length for a clip: the naive proportional
+/// length snapped to the nearest whole bar at the project tempo when
+/// the naive result lands close to an integer bar count.
+///
+/// Real drum loops almost always carry a trailing pickup (the "and"
+/// before beat 1 of the next bar) for crossfade purposes. A naive
+/// proportional warp preserves that pickup, which then leaks past the
+/// arrangement loop boundary and sounds like a double beat. Snapping
+/// to the nearest bar trims / extends the clip so a "1 bar" loop
+/// plays as exactly one bar at the project tempo.
+///
+/// The 0.25-bar guard means we only snap when the source is plausibly
+/// "about N bars"; a 1.5-bar clip stays at 1.5 bars rather than being
+/// aggressively remapped.
+pub fn warp_target_frames(
+    source_frames: usize,
+    sample_rate: f64,
+    clip_bpm: f64,
+    project_bpm: f64,
+) -> usize {
+    // Same number of beats at a different tempo:
+    //   source_frames = beats * 60 / clip_bpm * sample_rate
+    //   target_frames = beats * 60 / project_bpm * sample_rate
+    //   => target / source = clip_bpm / project_bpm
+    let naive_ratio = clip_bpm / project_bpm;
+    let naive_target = source_frames as f64 * naive_ratio;
+
+    let bar_samples = 4.0 * 60.0 * sample_rate / project_bpm;
+    if bar_samples >= 1.0 {
+        let naive_bars = naive_target / bar_samples;
+        if naive_bars >= 0.5 {
+            let rounded = naive_bars.round();
+            if (naive_bars - rounded).abs() < 0.25 {
+                return (rounded * bar_samples).round() as usize;
+            }
+        }
+    }
+    naive_target as usize
+}
+
+pub fn compute_warp(input: WarpClipInput) -> Result<ClipWarpSuccess, String> {
+    if input.clip_bpm <= 0.0 || input.project_bpm <= 0.0 {
+        return Err("Invalid BPM".into());
+    }
+    let source_frames = input.audio.num_frames();
+    if source_frames == 0 {
+        return Err("Empty audio".into());
+    }
+    if input.fields_frames == 0 {
+        return Err("Empty clip geometry reference".into());
+    }
+    let sample_rate = input.audio.sample_rate as f64;
+    if sample_rate <= 0.0 {
+        return Err("Invalid sample rate".into());
+    }
+
+    let target_total = warp_target_frames(
+        source_frames,
+        sample_rate,
+        input.clip_bpm,
+        input.project_bpm,
+    );
+    if target_total == 0 {
+        return Err("Target length collapsed to zero".into());
+    }
+
+    let stretched = vibez_dsp::time_stretch::pitch_preserving_stretch(&input.audio, target_total);
+    // Geometry fields are rescaled relative to the buffer they
+    // currently reference, so warping an already-warped clip to the
+    // same tempo is a no-op on geometry and warping to a new tempo
+    // lands exactly where a fresh warp from the original would.
+    let field_ratio = target_total as f64 / input.fields_frames as f64;
+    let scale = |x: u64| -> u64 { (x as f64 * field_ratio).round() as u64 };
+    Ok(ClipWarpSuccess {
+        audio: Arc::new(stretched),
+        original_audio: input.audio,
+        new_duration: scale(input.duration),
+        new_source_offset: scale(input.source_offset),
+        new_loop_start: scale(input.loop_start),
+        new_loop_end: scale(input.loop_end),
+        detected_bpm: input.clip_bpm,
+        warped_to_bpm: input.project_bpm,
+    })
+}
+
+pub async fn warp_clip_async(input: WarpClipInput) -> Result<ClipWarpSuccess, String> {
+    tokio::task::spawn_blocking(move || compute_warp(input))
+        .await
+        .map_err(|e| format!("warp task failed: {e}"))?
+}
+
+/// Regenerate the stretched audio a saved warped clip's geometry
+/// refers to. Used on project load: the project file stores the raw
+/// source reference plus geometry in warped-sample units, so the
+/// stretch has to be re-applied before the clip is handed to the
+/// engine. Deterministic: same inputs as the original warp produce
+/// the same target length.
+pub fn rewarp_for_load(
+    raw: &Arc<DecodedAudio>,
+    clip_bpm: f64,
+    warped_to_bpm: f64,
+) -> Option<Arc<DecodedAudio>> {
+    if clip_bpm <= 0.0 || warped_to_bpm <= 0.0 {
+        return None;
+    }
+    let source_frames = raw.num_frames();
+    if source_frames == 0 {
+        return None;
+    }
+    let sample_rate = raw.sample_rate as f64;
+    if sample_rate <= 0.0 {
+        return None;
+    }
+    let target = warp_target_frames(source_frames, sample_rate, clip_bpm, warped_to_bpm);
+    if target == 0 {
+        return None;
+    }
+    Some(Arc::new(vibez_dsp::time_stretch::pitch_preserving_stretch(
+        raw, target,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SR: u32 = 44_100;
+
+    /// A synthetic loop that is exactly `bars` bars long at `bpm`.
+    fn exact_loop(bars: f64, bpm: f64) -> Arc<DecodedAudio> {
+        let frames = (bars * 4.0 * 60.0 / bpm * SR as f64).round() as usize;
+        Arc::new(DecodedAudio {
+            channels: vec![vec![0.25; frames]],
+            sample_rate: SR,
+        })
+    }
+
+    fn first_warp_input(
+        audio: &Arc<DecodedAudio>,
+        clip_bpm: f64,
+        project_bpm: f64,
+    ) -> WarpClipInput {
+        let frames = audio.num_frames() as u64;
+        WarpClipInput {
+            audio: Arc::clone(audio),
+            fields_frames: frames,
+            source_offset: 0,
+            duration: frames,
+            loop_start: 0,
+            loop_end: frames,
+            clip_bpm,
+            project_bpm,
+        }
+    }
+
+    #[test]
+    fn warp_128_to_120_lengthens_to_exact_bars() {
+        // 2-bar loop at 128 warped into a 120 project must come out
+        // exactly 2 bars long at 120: 2 * 4 * 60/120 * 44100 = 176400.
+        let audio = exact_loop(2.0, 128.0);
+        let target = warp_target_frames(audio.num_frames(), SR as f64, 128.0, 120.0);
+        assert_eq!(target, 176_400);
+    }
+
+    #[test]
+    fn warp_direction_slower_project_lengthens_faster_project_shortens() {
+        let audio = exact_loop(2.0, 128.0);
+        let src = audio.num_frames();
+        let slower = warp_target_frames(src, SR as f64, 128.0, 120.0);
+        let faster = warp_target_frames(src, SR as f64, 128.0, 140.0);
+        assert!(slower > src, "128->120 must lengthen: {src} -> {slower}");
+        assert!(faster < src, "128->140 must shorten: {src} -> {faster}");
+    }
+
+    #[test]
+    fn bar_snap_leaves_non_integer_bar_sources_alone() {
+        // A 1.5-bar source is not "about N bars"; the naive
+        // proportional length must be preserved.
+        let audio = exact_loop(1.5, 128.0);
+        let src = audio.num_frames();
+        let target = warp_target_frames(src, SR as f64, 128.0, 120.0);
+        let naive = (src as f64 * 128.0 / 120.0) as usize;
+        assert_eq!(target, naive);
+    }
+
+    #[test]
+    fn first_warp_scales_geometry_by_ratio() {
+        let audio = exact_loop(2.0, 128.0);
+        let out = compute_warp(first_warp_input(&audio, 128.0, 120.0)).unwrap();
+        assert_eq!(out.audio.num_frames(), 176_400);
+        assert_eq!(out.new_duration, 176_400);
+        assert_eq!(out.new_loop_end, 176_400);
+        assert_eq!(out.new_source_offset, 0);
+    }
+
+    /// Regression: dogfood 2026-07-03 bug #8. Re-warping to the SAME
+    /// tempo must not move the clip geometry. The old code rescaled
+    /// warped-unit fields by the full original->target ratio again,
+    /// compounding ~6.7% per warp at 128->120.
+    #[test]
+    fn rewarp_to_same_tempo_is_idempotent() {
+        let audio = exact_loop(2.0, 128.0);
+        let first = compute_warp(first_warp_input(&audio, 128.0, 120.0)).unwrap();
+
+        let second = compute_warp(WarpClipInput {
+            audio: Arc::clone(&first.original_audio),
+            fields_frames: first.audio.num_frames() as u64,
+            source_offset: first.new_source_offset,
+            duration: first.new_duration,
+            loop_start: first.new_loop_start,
+            loop_end: first.new_loop_end,
+            clip_bpm: 128.0,
+            project_bpm: 120.0,
+        })
+        .unwrap();
+
+        assert_eq!(second.new_duration, first.new_duration);
+        assert_eq!(second.new_loop_end, first.new_loop_end);
+        assert_eq!(second.audio.num_frames(), first.audio.num_frames());
+        // Geometry must match the audio it plays.
+        assert_eq!(second.new_duration as usize, second.audio.num_frames());
+    }
+
+    /// Regression: re-warping to a NEW tempo must land exactly where
+    /// a fresh warp from the original would, with geometry matching
+    /// the stretched audio.
+    #[test]
+    fn rewarp_to_new_tempo_matches_fresh_warp() {
+        let audio = exact_loop(2.0, 128.0);
+        let first = compute_warp(first_warp_input(&audio, 128.0, 120.0)).unwrap();
+
+        let rewarped = compute_warp(WarpClipInput {
+            audio: Arc::clone(&first.original_audio),
+            fields_frames: first.audio.num_frames() as u64,
+            source_offset: first.new_source_offset,
+            duration: first.new_duration,
+            loop_start: first.new_loop_start,
+            loop_end: first.new_loop_end,
+            clip_bpm: 128.0,
+            project_bpm: 135.0,
+        })
+        .unwrap();
+
+        let fresh = compute_warp(first_warp_input(&audio, 128.0, 135.0)).unwrap();
+        assert_eq!(rewarped.audio.num_frames(), fresh.audio.num_frames());
+        assert_eq!(rewarped.new_duration, fresh.new_duration);
+        assert_eq!(rewarped.new_loop_end, fresh.new_loop_end);
+    }
+
+    /// Regression: dogfood 2026-07-03 bug #7. Project load must be
+    /// able to regenerate a stretched buffer whose length matches the
+    /// warped-unit geometry that was saved.
+    #[test]
+    fn load_rewarp_reproduces_saved_geometry_length() {
+        let audio = exact_loop(2.0, 128.0);
+        let saved = compute_warp(first_warp_input(&audio, 128.0, 120.0)).unwrap();
+
+        // Simulate reload: raw audio decoded from disk + persisted BPM pair.
+        let reloaded = rewarp_for_load(&saved.original_audio, 128.0, 120.0).unwrap();
+        assert_eq!(reloaded.num_frames() as u64, saved.new_duration);
+    }
+
+    #[test]
+    fn load_rewarp_rejects_bad_inputs() {
+        let audio = exact_loop(2.0, 128.0);
+        assert!(rewarp_for_load(&audio, 0.0, 120.0).is_none());
+        assert!(rewarp_for_load(&audio, 128.0, 0.0).is_none());
+        let empty = Arc::new(DecodedAudio {
+            channels: vec![Vec::new()],
+            sample_rate: SR,
+        });
+        assert!(rewarp_for_load(&empty, 128.0, 120.0).is_none());
+    }
+}

--- a/crates/vibez-ui/src/widgets/timeline.rs
+++ b/crates/vibez-ui/src/widgets/timeline.rs
@@ -882,8 +882,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
 
         // True when a sample drag is active and the cursor is hovering this
         // lane. Used to paint a drop indicator.
-        let drop_hover =
-            self.sample_drop_active && cursor.position_in(bounds).is_some();
+        let drop_hover = self.sample_drop_active && cursor.position_in(bounds).is_some();
 
         // Background
         let bg_color = if drop_hover {
@@ -1763,11 +1762,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                         // matches the indicator drawn in `draw`.
                         let beat = self.x_to_beat(pos.x).max(0.0).round();
                         let spb = self.spb();
-                        let position_samples = if spb > 0.0 {
-                            (beat * spb) as u64
-                        } else {
-                            0
-                        };
+                        let position_samples = if spb > 0.0 { (beat * spb) as u64 } else { 0 };
                         state.drag = None;
                         return (
                             canvas::event::Status::Captured,


### PR DESCRIPTION
Fixes bugs #7 and #8 from the 2026-07-03 dogfood session (`.notes/dogfood-2026-07-03.md`): warped projects reloading completely out of sync, and warp/tempo-match sounding completely off after repeated warps.

## Root causes

**1. Re-warp double-scaled clip geometry.** `compute_warp` stretched the retained *original* audio (correct) but rescaled the clip's `duration`/`source_offset`/`loop_start`/`loop_end`, which are already in warped-sample units, by the full original-to-target ratio again. Every warp compounded clip geometry by another ratio factor (~6.7% per warp at 128 to 120) while the audio stayed the correct length, so clip boundaries drifted off the audio content. This fired constantly in practice: auto-warp on import runs first, so any manual warp or tempo-change re-warp afterward was a re-warp.

**2. Project load never re-applied the warp.** `load_project_async` decoded the raw file from disk and paired it with clip geometry saved in warped-sample units. The stretch was never re-run, so every warped clip reloaded at its raw tempo and the whole project played out of sync. Warped projects mathematically could not reload correctly.

## Fix

- Warp math extracted from `app.rs` into a new `vibez-ui/src/warp.rs` module.
- `WarpClipInput` gains `fields_frames`: the frame count of the buffer the clip's geometry currently references. Geometry is rescaled by `target / fields_frames`, making re-warp to the same tempo a geometric no-op and re-warp to a new tempo land exactly where a fresh warp from the original would.
- On project load, the deterministic stretch (`warp_target_frames`, same bar-snap math) is re-run from the persisted `original_bpm`/`warped_to_bpm` pair, off the async executor via `spawn_blocking`. The raw decode is retained as `original_audio` so later re-warps still stretch from the source.

## Tests

8 new regression tests in `warp.rs` covering ratio direction, bar snapping, re-warp idempotence, re-warp-to-new-tempo equivalence, and load-time regeneration matching saved geometry. The two idempotence tests were verified to fail against the old scaling logic. Full workspace test suite passes; clippy warnings are pre-existing (verified against the base branch).

Second commit is `cargo fmt` drift across the workspace, kept separate for reviewability.