### PR TITLE
fix(plugins): sandboxed scanning, VST3 ModuleEntry + IID fixes, usable plugin menu

### DIFF
--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -220,6 +220,31 @@ Three distinct issues observed:
   scrollable capped at 320 px, and menu x/y clamped to the window via
   new window-size tracking (WindowResized message).
 
+### 14. VST3 GUI fails for dual-component plugins (FIXED in PR #6)
+- Found 2026-07-05 right after #11 made VST3s load at all: ZL loads
+  and processes but its GUI won't open. Log: "queryInterface(
+  IEditController) failed (hr=1)".
+- Root cause: VST3 dual-component architecture. Single-component
+  plugins (DPF: Dragonfly, Surge) expose IEditController on the
+  component object, which is all vibez asked for. JUCE plugins (ZL,
+  Vital) ship processor and controller as separate factory classes;
+  the host must call IComponent::getControllerClassId, create the
+  controller from the factory, initialize it, and wire the two via
+  IConnectionPoint.
+- Fix: Vst3PluginInstance resolves the controller at load time (QI
+  first, factory fallback + connection wiring), owns its lifetime,
+  and hands the GUI layer a ready IEditController pointer.
+- TODO left in code: sync component state to a freshly created
+  controller (needs an IBStream impl); editors currently open with
+  default values until a param is touched.
+
+### 15. Plugin popup: 4-column grid (dogfood feedback 2026-07-05)
+- Single 220 px column wasted the popup and pushed the menu far from
+  the click point (fixed-height clamping). Now: plugins tab is a
+  4-column grid (~630 px wide), sorted by name, name + format/type
+  per cell, scrollable at 380 px cap, and the popup clamps by its
+  ESTIMATED content height so small lists stay at the click point.
+
 ## Fix status
 
 - Bugs #7 and #8: root-caused and fixed in PR #3

--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -162,6 +162,29 @@ Three distinct issues observed:
       detected onsets (we already have an onset detector).
    c. Rubberband bindings (LGPL, native dep) for melodic material.
 
+### 10. Plugin scan crashes the whole DAW (FIXED in PR #6)
+- Found 2026-07-04: scanning ~/Music/plugins killed vibez.
+- Root cause 1 (crash containment): scanning dlopen'd plugin bundles
+  IN-PROCESS, so any misbehaving bundle takes the app down. Fixed with
+  per-bundle sandbox subprocess (vibez-plugin-scan helper, JSON over
+  stdout, 30 s hang timeout); crashing bundles are skipped and reported
+  in the scan status line.
+- Root cause 2 (why Dragonfly crashed at all): OUR BUG, not theirs.
+  The VST3 spec requires calling the module entry export (Linux:
+  `ModuleEntry(dlopen handle)`, Windows: `InitDll()`) after loading
+  the shared object and before `GetPluginFactory`. Both the scanner
+  and the instance load path skipped it. DPF-based plugins (all
+  Dragonfly Reverbs) rely on ModuleEntry for internal init and
+  segfault in `getClassInfo` without it; JUCE-based plugins (ZL, LSP,
+  Dexed) happen to tolerate the omission, which hid the bug.
+  Proven with a C probe: same factory walk segfaults without
+  ModuleEntry, succeeds with it. Fixed: `vst3_module_init`/`_exit` in
+  vst3_host/scanner.rs, called from scan and load paths (load path
+  matters most: without it, ADDING a Dragonfly to a track would have
+  crashed the DAW even with sandboxed scanning).
+- Verified after both fixes: 206 plugins found from ~/Music/plugins,
+  0 skipped, all 4 Dragonfly VST3s + 4 CLAPs scan clean.
+
 ## Fix status
 
 - Bugs #7 and #8: root-caused and fixed in PR #3

--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -185,6 +185,41 @@ Three distinct issues observed:
 - Verified after both fixes: 206 plugins found from ~/Music/plugins,
   0 skipped, all 4 Dragonfly VST3s + 4 CLAPs scan clean.
 
+### 11. NO VST3 plugin ever loaded: IAudioProcessor IID typo (FIXED in PR #6)
+- Found 2026-07-04 while chasing "dragonfly not loading": ZL failed the
+  same way. Log line: "Plugin load error: Component does not implement
+  IAudioProcessor" for every VST3 (Dragonfly, ZL). Only CLAP loads ever
+  worked.
+- Root cause: hand-written IAUDIOPROCESSOR_IID in vst3_host/instance.rs
+  ended 0x3F; the real Steinberg IID {42043F99-B7DA-453C-A569-
+  E79D9AAEC33D} ends 0x3D. One wrong byte = every plugin correctly
+  rejects queryInterface. Proven with a C probe against Dragonfly (DPF)
+  and ZL (JUCE): both return the processor with 0x3D, both refuse 0x3F.
+- Fix: corrected byte + regression tests asserting all hand-written
+  IIDs (IComponent, IAudioProcessor, IEditController) byte-equal the
+  SDK-generated constants in the vst3 crate.
+
+### 12. Project persistence does not save plugins on tracks (OPEN)
+- Reported 2026-07-04. vibez-project has zero plugin serialization:
+  plugin devices on tracks are simply not part of the project schema.
+- Full fix needs: (a) serialize plugin id/path/order per track,
+  (b) plugin STATE via VST3 IComponent::getState / CLAP state ext —
+  note our clap host currently answers host_get_extension(clap.state)
+  with null, so state support must be added on the host side too,
+  (c) reload path: re-instantiate plugin, setState, rebuild GUI keys.
+- Sizable feature, own PR. Without (b) a first cut could persist just
+  the plugin list and default state.
+
+### 13. Plugin device menu unusable without search (FIXED in PR #6)
+- Screenshot: ~/Pictures/"Screenshot from 2026-07-04 23-45-03.png".
+- The right-click device menu rendered all 212 cached plugins in an
+  uncapped column positioned at the click point; the devices panel is
+  at the bottom of the window, so the whole list rendered off-screen
+  and the menu looked empty until a search shrank it.
+- Fix: list sorted by vendor with dim vendor header rows, wrapped in a
+  scrollable capped at 320 px, and menu x/y clamped to the window via
+  new window-size tracking (WindowResized message).
+
 ## Fix status
 
 - Bugs #7 and #8: root-caused and fixed in PR #3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4738,6 +4738,7 @@ version = "0.1.0"
 dependencies = [
  "iced",
  "libloading 0.8.9",
+ "vibez-plugin-host",
  "vibez-ui",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ license.workspace = true
 
 [dependencies]
 vibez-ui = { workspace = true }
+vibez-plugin-host = { workspace = true }
 iced = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/vibez-plugin-host/examples/scan_dir.rs
+++ b/crates/vibez-plugin-host/examples/scan_dir.rs
@@ -1,0 +1,75 @@
+//! Scan a plugin directory, printing each candidate before it loads
+//! so a crashing plugin identifies itself in the output.
+//!
+//!   cargo run -p vibez-plugin-host --example scan_dir -- <dir>            # in-process (crashy)
+//!   cargo run -p vibez-plugin-host --example scan_dir -- --sandboxed <dir> # via subprocess helper
+
+use std::path::PathBuf;
+
+use vibez_plugin_host::scanner;
+use vibez_plugin_host::settings::PluginSettings;
+
+fn main() {
+    let mut args: Vec<String> = std::env::args().skip(1).collect();
+    let sandboxed = args.iter().any(|a| a == "--sandboxed");
+    args.retain(|a| a != "--sandboxed");
+    let dir = args
+        .first()
+        .map(PathBuf::from)
+        .expect("usage: scan_dir [--sandboxed] <plugin directory>");
+
+    let settings = PluginSettings {
+        extra_scan_paths: vec![dir],
+        scan_default_paths: false,
+        cache: Vec::new(),
+    };
+
+    if sandboxed {
+        let report = scanner::scan_plugins_sandboxed(&settings);
+        println!("{} plugins found", report.plugins.len());
+        for info in &report.plugins {
+            println!("  OK: {}", info.name);
+        }
+        for (path, reason) in &report.failed {
+            println!("  SKIPPED: {} ({reason})", path.display());
+        }
+        println!("--- sandboxed scan completed without crashing ---");
+        return;
+    }
+
+    let candidates = scanner::collect_plugin_paths(&settings);
+    println!("{} candidates:", candidates.len());
+    for (path, format) in &candidates {
+        println!("  [{format:?}] {}", path.display());
+    }
+
+    println!("--- loading one by one ---");
+    for (path, format) in &candidates {
+        println!("LOADING [{format:?}] {} ...", path.display());
+        let single = PluginSettings {
+            extra_scan_paths: vec![path.clone()],
+            scan_default_paths: false,
+            cache: Vec::new(),
+        };
+        // scan_plugins only walks directories, so scan the parent dir
+        // trick doesn't isolate; call the per-format scanners directly.
+        let _ = single;
+        let result = match format {
+            vibez_plugin_host::format::PluginFormat::Clap => {
+                vibez_plugin_host::clap_host::scanner::scan_clap(path)
+            }
+            vibez_plugin_host::format::PluginFormat::Vst3 => {
+                vibez_plugin_host::vst3_host::scanner::scan_vst3(path)
+            }
+        };
+        match result {
+            Ok(infos) => {
+                for info in infos {
+                    println!("  OK: {} ({:?})", info.name, info.id);
+                }
+            }
+            Err(e) => println!("  ERR: {e}"),
+        }
+    }
+    println!("--- scan completed without crashing ---");
+}

--- a/crates/vibez-plugin-host/src/bin/vibez-plugin-scan.rs
+++ b/crates/vibez-plugin-host/src/bin/vibez-plugin-scan.rs
@@ -1,0 +1,48 @@
+//! Out-of-process plugin scan helper.
+//!
+//! Loads ONE plugin bundle in this throwaway process and prints its
+//! `Vec<PluginInfo>` as JSON on stdout. Plugins execute arbitrary
+//! native code the moment they are dlopen'd, and a misbehaving one
+//! (e.g. a segfaulting VST3 factory) must kill this process, not the
+//! DAW. The parent treats a non-zero / signal exit as "plugin is bad,
+//! skip it" and keeps scanning.
+//!
+//!   vibez-plugin-scan <clap|vst3> <path>
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    let (Some(format), Some(path)) = (args.next(), args.next()) else {
+        eprintln!("usage: vibez-plugin-scan <clap|vst3> <path>");
+        return ExitCode::from(2);
+    };
+    let path = PathBuf::from(path);
+
+    let result = match format.as_str() {
+        "clap" => vibez_plugin_host::clap_host::scanner::scan_clap(&path),
+        "vst3" => vibez_plugin_host::vst3_host::scanner::scan_vst3(&path),
+        other => {
+            eprintln!("unknown plugin format: {other}");
+            return ExitCode::from(2);
+        }
+    };
+
+    match result {
+        Ok(infos) => match serde_json::to_string(&infos) {
+            Ok(json) => {
+                println!("{json}");
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("failed to serialize scan result: {e}");
+                ExitCode::FAILURE
+            }
+        },
+        Err(e) => {
+            eprintln!("{e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/vibez-plugin-host/src/gui.rs
+++ b/crates/vibez-plugin-host/src/gui.rs
@@ -429,3 +429,17 @@ impl Drop for Vst3GuiHandle {
         }
     }
 }
+
+#[cfg(test)]
+mod iid_tests {
+    /// See vst3_host::instance::tests — hand-written IIDs must match
+    /// the SDK-generated constants or plugins reject queryInterface.
+    #[test]
+    fn ieditcontroller_iid_matches_sdk() {
+        let sdk: Vec<u8> = vst3::Steinberg::Vst::IEditController_iid
+            .iter()
+            .map(|b| *b as u8)
+            .collect();
+        assert_eq!(super::IEDIT_CONTROLLER_IID.as_slice(), sdk.as_slice());
+    }
+}

--- a/crates/vibez-plugin-host/src/gui.rs
+++ b/crates/vibez-plugin-host/src/gui.rs
@@ -225,7 +225,7 @@ impl ClapGuiHandle {
 // ── VST3 GUI Handle ──
 
 /// VST3 IEditController IID: {DCD7BBE3-7742-448D-A874-AACC979C759E}
-const IEDIT_CONTROLLER_IID: [u8; 16] = [
+pub(crate) const IEDIT_CONTROLLER_IID: [u8; 16] = [
     0xDC, 0xD7, 0xBB, 0xE3, 0x77, 0x42, 0x44, 0x8D, 0xA8, 0x74, 0xAA, 0xCC, 0x97, 0x9C, 0x75, 0x9E,
 ];
 
@@ -240,35 +240,26 @@ pub struct Vst3GuiHandle {
 unsafe impl Send for Vst3GuiHandle {}
 
 impl Vst3GuiHandle {
-    /// Extract an IEditController from a VST3 component via queryInterface.
+    /// Wrap the IEditController resolved at plugin load time
+    /// (`Vst3PluginInstance::controller_ptr`). Dual-component plugins
+    /// (JUCE) keep the controller as a separate object, so the GUI can
+    /// no longer be reached by querying the component; the instance
+    /// owns the resolution logic and hands the pointer here.
     ///
     /// # Safety
-    /// `component` must be a valid IComponent COM pointer.
-    pub unsafe fn new(component: *mut c_void) -> Option<Self> {
-        if component.is_null() {
-            eprintln!("vibez: Vst3GuiHandle::new — component is null");
+    /// `edit_controller` must be a valid IEditController COM pointer
+    /// (or null, which returns None). Takes its own reference.
+    pub unsafe fn new(edit_controller: *mut c_void) -> Option<Self> {
+        if edit_controller.is_null() {
+            eprintln!("vibez: Vst3GuiHandle::new — no edit controller (GUI unavailable)");
             return None;
         }
-        // FUnknown::queryInterface(iid, &mut obj) - vtable[0]
-        type QueryInterfaceFn =
-            unsafe extern "system" fn(*mut c_void, *const u8, *mut *mut c_void) -> i32;
-        let vtbl = *(component as *const *const *const c_void);
-        let query_interface: QueryInterfaceFn = std::mem::transmute(*vtbl.add(0));
-
-        let mut edit_controller: *mut c_void = std::ptr::null_mut();
-        let hr = query_interface(
-            component,
-            IEDIT_CONTROLLER_IID.as_ptr(),
-            &mut edit_controller,
-        );
-        if hr != 0 || edit_controller.is_null() {
-            eprintln!(
-                "vibez: Vst3GuiHandle::new — queryInterface(IEditController) failed (hr={hr})"
-            );
-            return None;
-        }
-        eprintln!("vibez: Vst3GuiHandle::new — got IEditController OK");
-        // edit_controller now has its own refcount from queryInterface
+        // FUnknown::addRef - vtable[1]: hold our own reference; the
+        // plugin instance keeps its own and releases it independently.
+        type AddRefFn = unsafe extern "system" fn(*mut c_void) -> u32;
+        let vtbl = *(edit_controller as *const *const *const c_void);
+        let add_ref: AddRefFn = std::mem::transmute(*vtbl.add(1));
+        add_ref(edit_controller);
         Some(Self {
             edit_controller,
             plug_view: std::ptr::null_mut(),

--- a/crates/vibez-plugin-host/src/lib.rs
+++ b/crates/vibez-plugin-host/src/lib.rs
@@ -5,6 +5,7 @@ pub mod gui;
 pub mod info;
 pub mod instance;
 pub mod paths;
+pub mod scan_helper;
 pub mod scanner;
 pub mod settings;
 pub mod vst3_host;

--- a/crates/vibez-plugin-host/src/lib.rs
+++ b/crates/vibez-plugin-host/src/lib.rs
@@ -15,7 +15,7 @@ pub use format::{PluginCategory, PluginFormat, PluginId};
 pub use gui::{PluginGuiHandle, PluginGuiKey};
 pub use info::PluginInfo;
 pub use instance::PluginInstance;
-pub use scanner::scan_plugins;
+pub use scanner::{scan_plugins, scan_plugins_sandboxed, ScanReport};
 pub use settings::PluginSettings;
 pub use wrappers::effect::PluginEffectWrapper;
 pub use wrappers::instrument::PluginInstrumentWrapper;

--- a/crates/vibez-plugin-host/src/scan_helper.rs
+++ b/crates/vibez-plugin-host/src/scan_helper.rs
@@ -1,0 +1,55 @@
+//! Out-of-process plugin scan helper entry point.
+//!
+//! Loads ONE plugin bundle in a throwaway process and prints its
+//! `Vec<PluginInfo>` as JSON on stdout. Plugins execute arbitrary
+//! native code the moment they are dlopen'd, and a misbehaving one
+//! (e.g. a segfaulting VST3 factory) must kill that process, not the
+//! DAW. The parent treats a non-zero / signal exit as "plugin is bad,
+//! skip it" and keeps scanning.
+//!
+//! Shared by two identical `vibez-plugin-scan` binaries: one in this
+//! crate (for `cargo run -p vibez-plugin-host` workflows) and one in
+//! the root `vibez` package, which exists so a plain `cargo build`
+//! of the app also puts the helper next to the `vibez` executable.
+//! Without it the sandboxed scan silently falls back to in-process.
+//!
+//!   vibez-plugin-scan <clap|vst3> <path>
+
+use std::path::PathBuf;
+
+/// Run the helper; returns the process exit code
+/// (0 = ok, 1 = scan failed, 2 = bad usage).
+pub fn run() -> u8 {
+    let mut args = std::env::args().skip(1);
+    let (Some(format), Some(path)) = (args.next(), args.next()) else {
+        eprintln!("usage: vibez-plugin-scan <clap|vst3> <path>");
+        return 2;
+    };
+    let path = PathBuf::from(path);
+
+    let result = match format.as_str() {
+        "clap" => crate::clap_host::scanner::scan_clap(&path),
+        "vst3" => crate::vst3_host::scanner::scan_vst3(&path),
+        other => {
+            eprintln!("unknown plugin format: {other}");
+            return 2;
+        }
+    };
+
+    match result {
+        Ok(infos) => match serde_json::to_string(&infos) {
+            Ok(json) => {
+                println!("{json}");
+                0
+            }
+            Err(e) => {
+                eprintln!("failed to serialize scan result: {e}");
+                1
+            }
+        },
+        Err(e) => {
+            eprintln!("{e}");
+            1
+        }
+    }
+}

--- a/crates/vibez-plugin-host/src/scanner.rs
+++ b/crates/vibez-plugin-host/src/scanner.rs
@@ -73,6 +73,145 @@ fn scan_vst3_bundle(path: &Path, results: &mut Vec<PluginInfo>) {
     }
 }
 
+/// Result of a sandboxed scan: everything found, plus the bundles
+/// that could not be scanned (crashed, timed out, or errored).
+#[derive(Debug, Clone, Default)]
+pub struct ScanReport {
+    pub plugins: Vec<PluginInfo>,
+    pub failed: Vec<(PathBuf, String)>,
+}
+
+/// How long a single plugin bundle gets in the scan subprocess before
+/// it is presumed hung. Generous because one .clap can contain a
+/// whole suite (LSP ships 100+ plugins in one file).
+const SCAN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Scan for plugins, loading each bundle in a throwaway subprocess so
+/// a crashing or hanging plugin cannot take the DAW down with it. A
+/// bundle that dies is recorded in `ScanReport::failed` and skipped.
+///
+/// Falls back to the in-process scan if the `vibez-plugin-scan`
+/// helper binary is not next to the current executable (e.g. ad-hoc
+/// cargo invocations of a single crate).
+pub fn scan_plugins_sandboxed(settings: &PluginSettings) -> ScanReport {
+    let Some(helper) = helper_binary() else {
+        log::warn!("vibez-plugin-scan helper not found; scanning in-process (unsafe)");
+        return ScanReport {
+            plugins: scan_plugins(settings),
+            failed: Vec::new(),
+        };
+    };
+
+    let mut report = ScanReport::default();
+    for (path, format) in collect_plugin_paths(settings) {
+        let format_arg = match format {
+            PluginFormat::Clap => "clap",
+            PluginFormat::Vst3 => "vst3",
+        };
+        match scan_in_subprocess(&helper, format_arg, &path) {
+            Ok(infos) => report.plugins.extend(infos),
+            Err(reason) => {
+                log::warn!("plugin scan failed for {path:?}: {reason}");
+                report.failed.push((path, reason));
+            }
+        }
+    }
+    report
+}
+
+fn helper_binary() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    // Same directory as the app binary; one level up covers cargo's
+    // target/<profile>/examples/ layout.
+    [dir, dir.parent()?]
+        .iter()
+        .map(|d| d.join("vibez-plugin-scan"))
+        .find(|p| p.is_file())
+}
+
+fn scan_in_subprocess(
+    helper: &Path,
+    format_arg: &str,
+    path: &Path,
+) -> Result<Vec<PluginInfo>, String> {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new(helper)
+        .arg(format_arg)
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to spawn scan helper: {e}"))?;
+
+    // Drain stdout/stderr on threads so a chatty plugin cannot fill
+    // the pipe and deadlock against our timeout polling.
+    let mut stdout = child.stdout.take().expect("stdout piped");
+    let mut stderr = child.stderr.take().expect("stderr piped");
+    let out_thread = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stdout.read_to_string(&mut buf);
+        buf
+    });
+    let err_thread = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stderr.read_to_string(&mut buf);
+        buf
+    });
+
+    let deadline = std::time::Instant::now() + SCAN_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(format!(
+                        "timed out after {}s (presumed hung)",
+                        SCAN_TIMEOUT.as_secs()
+                    ));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(e) => return Err(format!("failed to wait for scan helper: {e}")),
+        }
+    };
+
+    let stdout = out_thread.join().unwrap_or_default();
+    let stderr = err_thread.join().unwrap_or_default();
+
+    if !status.success() {
+        let detail = stderr.lines().next().unwrap_or("").trim();
+        return Err(match status.code() {
+            // A signal death (no exit code on Unix) is the crash case
+            // this whole subprocess dance exists for.
+            None => format!("crashed during scan ({})", describe_signal(&status)),
+            Some(code) if detail.is_empty() => format!("scan helper exited with code {code}"),
+            Some(_) => detail.to_string(),
+        });
+    }
+
+    serde_json::from_str(stdout.trim()).map_err(|e| format!("unparseable scan helper output: {e}"))
+}
+
+#[cfg(unix)]
+fn describe_signal(status: &std::process::ExitStatus) -> String {
+    use std::os::unix::process::ExitStatusExt;
+    match status.signal() {
+        Some(sig) => format!("signal {sig}"),
+        None => "unknown signal".to_string(),
+    }
+}
+
+#[cfg(not(unix))]
+fn describe_signal(_status: &std::process::ExitStatus) -> String {
+    "abnormal termination".to_string()
+}
+
 /// Collect all plugin file paths from scan directories without loading them.
 pub fn collect_plugin_paths(settings: &PluginSettings) -> Vec<(PathBuf, PluginFormat)> {
     let mut paths_out = Vec::new();

--- a/crates/vibez-plugin-host/src/vst3_host/instance.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/instance.rs
@@ -17,6 +17,13 @@ pub struct Vst3PluginInstance {
     component: *mut std::ffi::c_void,
     /// Raw COM pointer to IAudioProcessor
     processor: *mut std::ffi::c_void,
+    /// Raw COM pointer to IEditController. For single-component
+    /// plugins (DPF) this is the component itself; for dual-component
+    /// plugins (JUCE) it is a separate object created from the factory.
+    controller: *mut std::ffi::c_void,
+    /// True when `controller` is a separate object that we created and
+    /// initialized, and therefore must terminate on drop.
+    controller_is_separate: bool,
     param_descriptors: Vec<ParamDescriptor>,
     param_values: Vec<f32>,
     buffer_adapter: AudioBufferAdapter,
@@ -42,6 +49,11 @@ const ICOMPONENT_IID: [u8; 16] = [
 // VST3 IAudioProcessor IID: {42043F99-B7DA-453C-A569-E79D9AAEC33D}
 const IAUDIOPROCESSOR_IID: [u8; 16] = [
     0x42, 0x04, 0x3F, 0x99, 0xB7, 0xDA, 0x45, 0x3C, 0xA5, 0x69, 0xE7, 0x9D, 0x9A, 0xAE, 0xC3, 0x3D,
+];
+
+// VST3 IConnectionPoint IID: {70A4156F-6E6E-4026-9891-48BFAA60D8D1}
+const ICONNECTIONPOINT_IID: [u8; 16] = [
+    0x70, 0xA4, 0x15, 0x6F, 0x6E, 0x6E, 0x40, 0x26, 0x98, 0x91, 0x48, 0xBF, 0xAA, 0x60, 0xD8, 0xD1,
 ];
 
 /// Raw ProcessSetup matching VST3 C layout.
@@ -89,10 +101,16 @@ impl Vst3PluginInstance {
         self.component
     }
 
+    /// Raw IEditController pointer resolved at load time, or null when
+    /// the plugin exposed none (GUI unavailable).
+    pub fn controller_ptr(&self) -> *mut std::ffi::c_void {
+        self.controller
+    }
+
     /// Extract a GUI handle (IEditController) from this instance.
     /// Must be called on the main thread before wrapping for the audio thread.
     pub fn extract_gui_handle(&self) -> Option<crate::gui::Vst3GuiHandle> {
-        unsafe { crate::gui::Vst3GuiHandle::new(self.component) }
+        unsafe { crate::gui::Vst3GuiHandle::new(self.controller) }
     }
 
     /// Load and instantiate a VST3 plugin by its class ID from a `.vst3` bundle.
@@ -187,8 +205,63 @@ impl Vst3PluginInstance {
             return Err("Component does not implement IAudioProcessor".into());
         }
 
+        // Resolve the edit controller while the factory is still alive.
+        // Single-component plugins (DPF: Dragonfly, Surge) expose it on
+        // the component; dual-component plugins (JUCE: ZL, Vital) hand
+        // out a separate class id that must be instantiated from the
+        // factory, initialized, and connected to the component.
+        let mut controller: *mut std::ffi::c_void = std::ptr::null_mut();
+        let mut controller_is_separate = false;
+        let hr = unsafe {
+            query_interface(
+                component,
+                crate::gui::IEDIT_CONTROLLER_IID.as_ptr(),
+                &mut controller,
+            )
+        };
+        if hr != 0 || controller.is_null() {
+            controller = std::ptr::null_mut();
+            // IComponent::getControllerClassId(&mut TUID) - vtable [5]
+            type GetControllerClassIdFn =
+                unsafe extern "system" fn(*mut std::ffi::c_void, *mut u8) -> i32;
+            let get_ctrl_cid: GetControllerClassIdFn =
+                unsafe { std::mem::transmute(*comp_vtbl.add(5)) };
+            let mut ctrl_cid = [0u8; 16];
+            if unsafe { get_ctrl_cid(component, ctrl_cid.as_mut_ptr()) } == 0 {
+                let hr = unsafe {
+                    create_instance(
+                        factory_ptr,
+                        ctrl_cid.as_ptr(),
+                        crate::gui::IEDIT_CONTROLLER_IID.as_ptr(),
+                        &mut controller,
+                    )
+                };
+                if hr == 0 && !controller.is_null() {
+                    let ctrl_vtbl = unsafe { vtbl(controller) };
+                    let ctrl_init: InitializeFn = unsafe { std::mem::transmute(*ctrl_vtbl.add(3)) };
+                    if unsafe { ctrl_init(controller, std::ptr::null_mut()) } == 0 {
+                        controller_is_separate = true;
+                        unsafe { connect_component_and_controller(component, controller) };
+                        // TODO: sync state (component getState ->
+                        // controller setComponentState) once we have an
+                        // IBStream implementation.
+                    } else {
+                        type ReleaseFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> u32;
+                        let release: ReleaseFn = unsafe { std::mem::transmute(*ctrl_vtbl.add(2)) };
+                        unsafe { release(controller) };
+                        controller = std::ptr::null_mut();
+                    }
+                } else {
+                    controller = std::ptr::null_mut();
+                }
+            }
+        }
+
         // Get name
         let name = get_class_name_raw(factory_ptr, &cid_bytes);
+        if controller.is_null() {
+            eprintln!("vibez: no IEditController for {name}: plugin GUI unavailable");
+        }
 
         // Release factory
         type ReleaseFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> u32;
@@ -203,6 +276,8 @@ impl Vst3PluginInstance {
             _lib: lib,
             component,
             processor,
+            controller,
+            controller_is_separate,
             param_descriptors: Vec::new(),
             param_values: Vec::new(),
             buffer_adapter,
@@ -444,6 +519,18 @@ impl Drop for Vst3PluginInstance {
         if self.active {
             self.deactivate();
         }
+        if !self.controller.is_null() {
+            let ctrl_vtbl = unsafe { vtbl(self.controller) };
+            if self.controller_is_separate {
+                // IPluginBase::terminate - vtable [4]
+                type TerminateFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> i32;
+                let terminate: TerminateFn = unsafe { std::mem::transmute(*ctrl_vtbl.add(4)) };
+                unsafe { terminate(self.controller) };
+            }
+            type ReleaseFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> u32;
+            let release: ReleaseFn = unsafe { std::mem::transmute(*ctrl_vtbl.add(2)) };
+            unsafe { release(self.controller) };
+        }
         if !self.component.is_null() {
             // IPluginBase::terminate - vtable [4]
             type TerminateFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> i32;
@@ -466,6 +553,50 @@ impl Drop for Vst3PluginInstance {
     }
 }
 
+/// Best-effort IConnectionPoint wiring between a dual-component
+/// plugin's processor and controller. JUCE plugins use this channel to
+/// keep the editor in sync with the processor; opening the GUI works
+/// without it, but parameter changes would not propagate.
+///
+/// # Safety
+/// Both pointers must be valid COM objects.
+unsafe fn connect_component_and_controller(
+    component: *mut std::ffi::c_void,
+    controller: *mut std::ffi::c_void,
+) {
+    type QueryInterfaceFn = unsafe extern "system" fn(
+        *mut std::ffi::c_void,
+        *const u8,
+        *mut *mut std::ffi::c_void,
+    ) -> i32;
+    type ReleaseFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> u32;
+    // IConnectionPoint::connect(other) - vtable [3]
+    type ConnectFn = unsafe extern "system" fn(*mut std::ffi::c_void, *mut std::ffi::c_void) -> i32;
+
+    let get_cp = |obj: *mut std::ffi::c_void| -> Option<*mut std::ffi::c_void> {
+        let v = vtbl(obj);
+        let qi: QueryInterfaceFn = std::mem::transmute(*v.add(0));
+        let mut cp: *mut std::ffi::c_void = std::ptr::null_mut();
+        if qi(obj, ICONNECTIONPOINT_IID.as_ptr(), &mut cp) == 0 && !cp.is_null() {
+            Some(cp)
+        } else {
+            None
+        }
+    };
+
+    let (Some(comp_cp), Some(ctrl_cp)) = (get_cp(component), get_cp(controller)) else {
+        return;
+    };
+    let comp_connect: ConnectFn = std::mem::transmute(*vtbl(comp_cp).add(3));
+    let ctrl_connect: ConnectFn = std::mem::transmute(*vtbl(ctrl_cp).add(3));
+    comp_connect(comp_cp, ctrl_cp);
+    ctrl_connect(ctrl_cp, comp_cp);
+    let release_comp: ReleaseFn = std::mem::transmute(*vtbl(comp_cp).add(2));
+    let release_ctrl: ReleaseFn = std::mem::transmute(*vtbl(ctrl_cp).add(2));
+    release_comp(comp_cp);
+    release_ctrl(ctrl_cp);
+}
+
 #[cfg(test)]
 mod tests {
     /// Hand-written IIDs must match the SDK-generated constants in the
@@ -480,6 +611,14 @@ mod tests {
     #[test]
     fn icomponent_iid_matches_sdk() {
         assert_iid(super::ICOMPONENT_IID, vst3::Steinberg::Vst::IComponent_iid);
+    }
+
+    #[test]
+    fn iconnectionpoint_iid_matches_sdk() {
+        assert_iid(
+            super::ICONNECTIONPOINT_IID,
+            vst3::Steinberg::Vst::IConnectionPoint_iid,
+        );
     }
 
     #[test]

--- a/crates/vibez-plugin-host/src/vst3_host/instance.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/instance.rs
@@ -109,6 +109,7 @@ impl Vst3PluginInstance {
             libloading::Library::new(&module_path)
                 .map_err(|e| format!("Failed to load VST3 module: {e}"))?
         };
+        let lib = super::scanner::vst3_module_init(lib)?;
 
         type GetFactoryFn = unsafe extern "system" fn() -> *mut std::ffi::c_void;
 
@@ -461,5 +462,6 @@ impl Drop for Vst3PluginInstance {
             let release: ReleaseFn = unsafe { std::mem::transmute(*proc_vtbl.add(2)) };
             unsafe { release(self.processor) };
         }
+        super::scanner::vst3_module_exit(&self._lib);
     }
 }

--- a/crates/vibez-plugin-host/src/vst3_host/instance.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/instance.rs
@@ -39,9 +39,9 @@ const ICOMPONENT_IID: [u8; 16] = [
     0xE8, 0x31, 0xFF, 0x31, 0xF2, 0xD5, 0x43, 0x01, 0x92, 0x8E, 0xBB, 0xEE, 0x25, 0x69, 0x78, 0x02,
 ];
 
-// VST3 IAudioProcessor IID: {42043F99-B7DA-453C-A569-E79D9AAEC33F}
+// VST3 IAudioProcessor IID: {42043F99-B7DA-453C-A569-E79D9AAEC33D}
 const IAUDIOPROCESSOR_IID: [u8; 16] = [
-    0x42, 0x04, 0x3F, 0x99, 0xB7, 0xDA, 0x45, 0x3C, 0xA5, 0x69, 0xE7, 0x9D, 0x9A, 0xAE, 0xC3, 0x3F,
+    0x42, 0x04, 0x3F, 0x99, 0xB7, 0xDA, 0x45, 0x3C, 0xA5, 0x69, 0xE7, 0x9D, 0x9A, 0xAE, 0xC3, 0x3D,
 ];
 
 /// Raw ProcessSetup matching VST3 C layout.
@@ -463,5 +463,30 @@ impl Drop for Vst3PluginInstance {
             unsafe { release(self.processor) };
         }
         super::scanner::vst3_module_exit(&self._lib);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Hand-written IIDs must match the SDK-generated constants in the
+    /// vst3 crate. A single wrong byte makes every plugin reject the
+    /// queryInterface call (a 0x3F-for-0x3D typo in IAudioProcessor
+    /// once broke loading of ALL VST3 plugins).
+    fn assert_iid(ours: [u8; 16], sdk: [::std::os::raw::c_char; 16]) {
+        let sdk_bytes: Vec<u8> = sdk.iter().map(|b| *b as u8).collect();
+        assert_eq!(ours.as_slice(), sdk_bytes.as_slice());
+    }
+
+    #[test]
+    fn icomponent_iid_matches_sdk() {
+        assert_iid(super::ICOMPONENT_IID, vst3::Steinberg::Vst::IComponent_iid);
+    }
+
+    #[test]
+    fn iaudioprocessor_iid_matches_sdk() {
+        assert_iid(
+            super::IAUDIOPROCESSOR_IID,
+            vst3::Steinberg::Vst::IAudioProcessor_iid,
+        );
     }
 }

--- a/crates/vibez-plugin-host/src/vst3_host/scanner.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/scanner.rs
@@ -12,6 +12,49 @@ pub fn scan_vst3(path: &Path) -> Result<Vec<PluginInfo>, String> {
     }
 }
 
+/// Run the platform-specific VST3 module entry export. The VST3 spec
+/// requires this before `GetPluginFactory` (Linux: `ModuleEntry(handle)`,
+/// Windows: `InitDll()`); DPF-based plugins such as Dragonfly Reverb
+/// segfault inside the factory if it is skipped. Takes the library by
+/// value because extracting the raw handle on unix consumes the wrapper.
+pub(crate) fn vst3_module_init(lib: libloading::Library) -> Result<libloading::Library, String> {
+    #[cfg(unix)]
+    {
+        use libloading::os::unix::Library as UnixLibrary;
+        let handle = UnixLibrary::from(lib).into_raw();
+        let lib = libloading::Library::from(unsafe { UnixLibrary::from_raw(handle) });
+        type ModuleEntryFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> bool;
+        if let Ok(entry) = unsafe { lib.get::<ModuleEntryFn>(b"ModuleEntry\0") } {
+            if !unsafe { entry(handle) } {
+                return Err("ModuleEntry returned false".into());
+            }
+        }
+        Ok(lib)
+    }
+    #[cfg(windows)]
+    {
+        type InitDllFn = unsafe extern "system" fn() -> bool;
+        if let Ok(entry) = unsafe { lib.get::<InitDllFn>(b"InitDll\0") } {
+            if !unsafe { entry() } {
+                return Err("InitDll returned false".into());
+            }
+        }
+        Ok(lib)
+    }
+}
+
+/// Counterpart to [`vst3_module_init`]; call before the library is dropped.
+pub(crate) fn vst3_module_exit(lib: &libloading::Library) {
+    #[cfg(unix)]
+    const NAME: &[u8] = b"ModuleExit\0";
+    #[cfg(windows)]
+    const NAME: &[u8] = b"ExitDll\0";
+    type ExitFn = unsafe extern "system" fn() -> bool;
+    if let Ok(exit) = unsafe { lib.get::<ExitFn>(NAME) } {
+        unsafe { exit() };
+    }
+}
+
 fn scan_vst3_inner(path: &Path) -> Result<Vec<PluginInfo>, String> {
     let module_path = find_vst3_module(path)?;
 
@@ -19,6 +62,7 @@ fn scan_vst3_inner(path: &Path) -> Result<Vec<PluginInfo>, String> {
         libloading::Library::new(&module_path)
             .map_err(|e| format!("Failed to load VST3 module: {e}"))?
     };
+    let lib = vst3_module_init(lib)?;
 
     // GetPluginFactory returns a raw COM pointer to IPluginFactory.
     // We call through the vtable directly since the vst3 crate's traits require smart pointers.
@@ -102,6 +146,7 @@ fn scan_vst3_inner(path: &Path) -> Result<Vec<PluginInfo>, String> {
 
     // Drop the library so the OS fully unloads it and resets all statics.
     // Leaking via mem::forget can poison plugins that use one-shot init guards.
+    vst3_module_exit(&lib);
     drop(lib);
 
     Ok(results)

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -1728,6 +1728,7 @@ impl App {
                     | Message::CreateNoteClipFromSelection(_)
                     | Message::EditNameText(_)
                     | Message::CursorMoved(_, _)
+                    | Message::WindowResized(_, _)
                     | Message::MouseReleased
                     | Message::NewProject
                     | Message::OpenProject
@@ -3718,6 +3719,10 @@ impl App {
             Message::CursorMoved(x, y) => {
                 self.state.cursor_x = x;
                 self.state.cursor_y = y;
+            }
+            Message::WindowResized(w, h) => {
+                self.state.window_width = w;
+                self.state.window_height = h;
             }
             Message::MouseReleased => {
                 self.state.drag_resize_active = false;
@@ -8718,13 +8723,31 @@ impl App {
                             .color(th::TEXT_DIM),
                     );
                 } else {
-                    for plugin in &self.state.plugin_settings.cache {
+                    let mut sorted: Vec<&vibez_plugin_host::PluginInfo> =
+                        self.state.plugin_settings.cache.iter().collect();
+                    sorted.sort_by(|a, b| {
+                        a.vendor
+                            .to_lowercase()
+                            .cmp(&b.vendor.to_lowercase())
+                            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+                    });
+                    let mut last_vendor: Option<&str> = None;
+                    for plugin in sorted {
                         let name = &plugin.name;
                         if !search_lower.is_empty()
                             && !name.to_lowercase().contains(&search_lower)
                             && !plugin.vendor.to_lowercase().contains(&search_lower)
                         {
                             continue;
+                        }
+                        if last_vendor != Some(plugin.vendor.as_str()) {
+                            last_vendor = Some(plugin.vendor.as_str());
+                            items_col = items_col.push(
+                                text(plugin.vendor.clone())
+                                    .size(10)
+                                    .color(th::TEXT_DIM)
+                                    .width(Length::Fill),
+                            );
                         }
                         let format_badge = match plugin.format {
                             PluginFormat::Clap => "CLAP",
@@ -8788,7 +8811,18 @@ impl App {
             }
         }
 
-        let menu_content = column![tabs_row, search_input, items_col]
+        // Cap the list height and scroll it: a full plugin library is
+        // hundreds of rows, which would otherwise render past the
+        // bottom of the window and look like an empty menu.
+        const MENU_LIST_MAX_H: f32 = 320.0;
+        let items_scroll = container(scrollable(items_col).width(Length::Fill).direction(
+            scrollable::Direction::Vertical(
+                scrollable::Scrollbar::new().width(6).scroller_width(6),
+            ),
+        ))
+        .max_height(MENU_LIST_MAX_H);
+
+        let menu_content = column![tabs_row, search_input, items_scroll]
             .spacing(6)
             .padding(8)
             .width(Length::Fixed(220.0));
@@ -8803,13 +8837,16 @@ impl App {
             ..Default::default()
         });
 
-        // Position the menu near where it was triggered
+        // Position the menu near where it was triggered, clamped so it
+        // stays on-screen when opened near the window edges (the
+        // devices panel lives at the bottom of the window).
+        const MENU_EST_H: f32 = MENU_LIST_MAX_H + 90.0;
+        const MENU_W: f32 = 236.0;
+        let menu_y = menu.y.min(self.state.window_height - MENU_EST_H).max(0.0);
+        let menu_x = menu.x.min(self.state.window_width - MENU_W).max(0.0);
         let padded = column![
-            vertical_space().height(Length::Fixed(menu.y.max(0.0))),
-            row![
-                horizontal_space().width(Length::Fixed(menu.x.max(0.0))),
-                menu_card,
-            ]
+            vertical_space().height(Length::Fixed(menu_y)),
+            row![horizontal_space().width(Length::Fixed(menu_x)), menu_card,]
         ];
 
         mouse_area(container(padded).width(Length::Fill).height(Length::Fill))
@@ -9442,6 +9479,9 @@ impl App {
                 iced::Event::Mouse(iced::mouse::Event::ButtonReleased(
                     iced::mouse::Button::Left,
                 )) => Some(Message::MouseReleased),
+                iced::Event::Window(iced::window::Event::Resized(size)) => {
+                    Some(Message::WindowResized(size.width, size.height))
+                }
                 _ => None,
             }),
         ])

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -4697,7 +4697,7 @@ impl App {
                     return Task::perform(
                         async move {
                             tokio::task::spawn_blocking(move || {
-                                vibez_plugin_host::scan_plugins(&settings)
+                                vibez_plugin_host::scan_plugins_sandboxed(&settings)
                             })
                             .await
                             .unwrap_or_default()
@@ -4706,11 +4706,28 @@ impl App {
                     );
                 }
             }
-            Message::ScanPluginsComplete(plugins) => {
-                let count = plugins.len();
-                self.state.plugin_settings.cache = plugins;
+            Message::ScanPluginsComplete(report) => {
+                let count = report.plugins.len();
+                self.state.plugin_settings.cache = report.plugins;
                 self.state.plugin_scan_in_progress = false;
-                self.state.plugin_scan_status = format!("Found {count} plugins");
+                self.state.plugin_scan_status = if report.failed.is_empty() {
+                    format!("Found {count} plugins")
+                } else {
+                    for (path, reason) in &report.failed {
+                        eprintln!("vibez: plugin skipped: {path:?}: {reason}");
+                    }
+                    let names: Vec<String> = report
+                        .failed
+                        .iter()
+                        .filter_map(|(p, _)| p.file_name())
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .collect();
+                    format!(
+                        "Found {count} plugins ({} skipped: {})",
+                        report.failed.len(),
+                        names.join(", ")
+                    )
+                };
                 let _ = self.state.plugin_settings.save();
             }
             Message::AddPluginScanPath => {

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8684,8 +8684,13 @@ impl App {
             .width(Length::Fill);
 
         // Items list
+        const PLUGIN_GRID_COLS: usize = 4;
+        const PLUGIN_GRID_COL_W: f32 = 150.0;
         let mut items_col = column![].spacing(2);
         let search_lower = menu.search.to_lowercase();
+        // Estimated visible rows, used to size and clamp the popup.
+        let mut est_rows: usize = 0;
+        let mut is_grid = false;
 
         match menu.category {
             Some(DeviceMenuCategory::Instruments) => {
@@ -8713,72 +8718,78 @@ impl App {
                             }
                         });
                     items_col = items_col.push(btn);
+                    est_rows += 1;
                 }
             }
             Some(DeviceMenuCategory::Plugins) => {
+                is_grid = true;
                 if self.state.plugin_settings.cache.is_empty() {
                     items_col = items_col.push(
                         text("No plugins scanned yet.\nUse File → Settings to scan.")
                             .size(11)
                             .color(th::TEXT_DIM),
                     );
+                    est_rows = 2;
                 } else {
-                    let mut sorted: Vec<&vibez_plugin_host::PluginInfo> =
-                        self.state.plugin_settings.cache.iter().collect();
-                    sorted.sort_by(|a, b| {
-                        a.vendor
-                            .to_lowercase()
-                            .cmp(&b.vendor.to_lowercase())
-                            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
-                    });
-                    let mut last_vendor: Option<&str> = None;
-                    for plugin in sorted {
-                        let name = &plugin.name;
-                        if !search_lower.is_empty()
-                            && !name.to_lowercase().contains(&search_lower)
-                            && !plugin.vendor.to_lowercase().contains(&search_lower)
-                        {
-                            continue;
-                        }
-                        if last_vendor != Some(plugin.vendor.as_str()) {
-                            last_vendor = Some(plugin.vendor.as_str());
-                            items_col = items_col.push(
-                                text(plugin.vendor.clone())
-                                    .size(10)
-                                    .color(th::TEXT_DIM)
-                                    .width(Length::Fill),
-                            );
-                        }
-                        let format_badge = match plugin.format {
-                            PluginFormat::Clap => "CLAP",
-                            PluginFormat::Vst3 => "VST3",
-                        };
-                        let cat_label = match plugin.category {
-                            PluginCategory::Effect => "fx",
-                            PluginCategory::Instrument => "inst",
-                            PluginCategory::Both => "fx+inst",
-                        };
-                        let label_text = format!("{name}  [{format_badge}] {cat_label}");
-                        let plugin_id = plugin.id.clone();
-                        let btn = button(text(label_text).size(11).color(th::TEXT))
-                            .on_press(Message::AddPluginToTrack(track_id, plugin_id))
-                            .padding([6, 10])
-                            .width(Length::Fill)
-                            .style(|_theme: &Theme, status| {
-                                let bg = match status {
-                                    button::Status::Hovered | button::Status::Pressed => {
-                                        Some(th::BG_HOVER.into())
+                    let mut filtered: Vec<&vibez_plugin_host::PluginInfo> = self
+                        .state
+                        .plugin_settings
+                        .cache
+                        .iter()
+                        .filter(|p| {
+                            search_lower.is_empty()
+                                || p.name.to_lowercase().contains(&search_lower)
+                                || p.vendor.to_lowercase().contains(&search_lower)
+                        })
+                        .collect();
+                    filtered.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+                    est_rows = filtered.len().div_ceil(PLUGIN_GRID_COLS);
+                    for chunk in filtered.chunks(PLUGIN_GRID_COLS) {
+                        let mut grid_row = row![].spacing(2);
+                        for plugin in chunk {
+                            let format_badge = match plugin.format {
+                                PluginFormat::Clap => "CLAP",
+                                PluginFormat::Vst3 => "VST3",
+                            };
+                            let cat_label = match plugin.category {
+                                PluginCategory::Effect => "fx",
+                                PluginCategory::Instrument => "inst",
+                                PluginCategory::Both => "fx+inst",
+                            };
+                            let display: String = if plugin.name.chars().count() > 20 {
+                                format!("{}...", plugin.name.chars().take(18).collect::<String>())
+                            } else {
+                                plugin.name.clone()
+                            };
+                            let plugin_id = plugin.id.clone();
+                            let cell = column![
+                                text(display).size(11).color(th::TEXT),
+                                text(format!("{format_badge} {cat_label}"))
+                                    .size(9)
+                                    .color(th::TEXT_DIM),
+                            ]
+                            .spacing(1);
+                            let btn = button(cell)
+                                .on_press(Message::AddPluginToTrack(track_id, plugin_id))
+                                .padding([4, 8])
+                                .width(Length::Fixed(PLUGIN_GRID_COL_W))
+                                .style(|_theme: &Theme, status| {
+                                    let bg = match status {
+                                        button::Status::Hovered | button::Status::Pressed => {
+                                            Some(th::BG_HOVER.into())
+                                        }
+                                        _ => None,
+                                    };
+                                    button::Style {
+                                        background: bg,
+                                        text_color: th::TEXT,
+                                        border: iced::Border::default(),
+                                        ..Default::default()
                                     }
-                                    _ => None,
-                                };
-                                button::Style {
-                                    background: bg,
-                                    text_color: th::TEXT,
-                                    border: iced::Border::default(),
-                                    ..Default::default()
-                                }
-                            });
-                        items_col = items_col.push(btn);
+                                });
+                            grid_row = grid_row.push(btn);
+                        }
+                        items_col = items_col.push(grid_row);
                     }
                 }
             }
@@ -8807,14 +8818,23 @@ impl App {
                             }
                         });
                     items_col = items_col.push(btn);
+                    est_rows += 1;
                 }
             }
         }
 
         // Cap the list height and scroll it: a full plugin library is
-        // hundreds of rows, which would otherwise render past the
-        // bottom of the window and look like an empty menu.
-        const MENU_LIST_MAX_H: f32 = 320.0;
+        // hundreds of entries, which would otherwise render past the
+        // bottom of the window and look like an empty menu. The
+        // plugins tab uses a 4-column grid to spend the space on
+        // breadth instead of one skinny endless column.
+        const MENU_LIST_MAX_H: f32 = 380.0;
+        let (menu_w, row_h) = if is_grid {
+            (PLUGIN_GRID_COL_W * PLUGIN_GRID_COLS as f32 + 30.0, 38.0)
+        } else {
+            (220.0, 29.0)
+        };
+        let est_list_h = (est_rows.max(1) as f32 * row_h).min(MENU_LIST_MAX_H);
         let items_scroll = container(scrollable(items_col).width(Length::Fill).direction(
             scrollable::Direction::Vertical(
                 scrollable::Scrollbar::new().width(6).scroller_width(6),
@@ -8825,7 +8845,7 @@ impl App {
         let menu_content = column![tabs_row, search_input, items_scroll]
             .spacing(6)
             .padding(8)
-            .width(Length::Fixed(220.0));
+            .width(Length::Fixed(menu_w));
 
         let menu_card = container(menu_content).style(|_theme: &Theme| container::Style {
             background: Some(th::BG_SURFACE.into()),
@@ -8837,13 +8857,12 @@ impl App {
             ..Default::default()
         });
 
-        // Position the menu near where it was triggered, clamped so it
-        // stays on-screen when opened near the window edges (the
+        // Position the menu near where it was triggered, clamped just
+        // enough that the estimated content stays on-screen (the
         // devices panel lives at the bottom of the window).
-        const MENU_EST_H: f32 = MENU_LIST_MAX_H + 90.0;
-        const MENU_W: f32 = 236.0;
-        let menu_y = menu.y.min(self.state.window_height - MENU_EST_H).max(0.0);
-        let menu_x = menu.x.min(self.state.window_width - MENU_W).max(0.0);
+        let est_h = est_list_h + 90.0;
+        let menu_y = menu.y.min(self.state.window_height - est_h).max(0.0);
+        let menu_x = menu.x.min(self.state.window_width - menu_w - 16.0).max(0.0);
         let padded = column![
             vertical_space().height(Length::Fixed(menu_y)),
             row![horizontal_space().width(Length::Fixed(menu_x)), menu_card,]
@@ -9517,7 +9536,14 @@ fn load_plugin_effect_bg(info: &PluginInfo, sample_rate: f64) -> Result<PluginLo
                 sample_rate,
                 4096,
             )?;
-            let gui_raw_ptr = Some(PluginRawPtr::Vst3(vst3_inst.component_ptr()));
+            let gui_raw_ptr = {
+                let ctrl = vst3_inst.controller_ptr();
+                if ctrl.is_null() {
+                    None
+                } else {
+                    Some(PluginRawPtr::Vst3(ctrl))
+                }
+            };
             let name = vst3_inst.name().to_string();
             let wrapper = vibez_plugin_host::PluginEffectWrapper::new(Box::new(vst3_inst));
             Ok(PluginLoadResult {
@@ -9562,7 +9588,14 @@ fn load_plugin_instrument_bg(
                 sample_rate,
                 4096,
             )?;
-            let gui_raw_ptr = Some(PluginRawPtr::Vst3(vst3_inst.component_ptr()));
+            let gui_raw_ptr = {
+                let ctrl = vst3_inst.controller_ptr();
+                if ctrl.is_null() {
+                    None
+                } else {
+                    Some(PluginRawPtr::Vst3(ctrl))
+                }
+            };
             let name = vst3_inst.name().to_string();
             let wrapper = vibez_plugin_host::PluginInstrumentWrapper::new(Box::new(vst3_inst));
             Ok(PluginInstrumentLoadResult {

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -8,7 +8,7 @@ use vibez_core::midi::{InstrumentKind, MidiNote};
 use vibez_core::track::{ClipInfo, DrumPadState, MediaSourceRef};
 use vibez_dropbox::{AccountInfo, DropboxEntry, Tokens as DropboxTokens};
 use vibez_plugin_host::gui::PluginGuiKey;
-use vibez_plugin_host::{PluginId, PluginInfo};
+use vibez_plugin_host::PluginId;
 use vibez_project::Project;
 
 use crate::state::{

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -479,7 +479,7 @@ pub enum Message {
 
     // Plugin scanning
     ScanPlugins,
-    ScanPluginsComplete(Vec<PluginInfo>),
+    ScanPluginsComplete(vibez_plugin_host::ScanReport),
     AddPluginScanPath,
     PluginScanPathSelected(Option<PathBuf>),
     RemovePluginScanPath(usize),

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -396,6 +396,7 @@ pub enum Message {
 
     // Cursor tracking
     CursorMoved(f32, f32),
+    WindowResized(f32, f32),
     MouseReleased,
 
     // File menu

--- a/crates/vibez-ui/src/state.rs
+++ b/crates/vibez-ui/src/state.rs
@@ -518,6 +518,10 @@ pub struct AppState {
     pub cursor_x: f32,
     pub cursor_y: f32,
 
+    // Last known window size, for clamping popup menus on-screen
+    pub window_width: f32,
+    pub window_height: f32,
+
     // Arrangement drag auto-scroll: tracks active resize/move for tick-driven edge scrolling
     pub drag_resize_active: bool,
 
@@ -609,6 +613,8 @@ impl Default for AppState {
             context_menu: None,
             cursor_x: 0.0,
             cursor_y: 0.0,
+            window_width: 1400.0,
+            window_height: 900.0,
             drag_resize_active: false,
             editing_track_name: None,
             editing_clip_name: None,

--- a/src/bin/vibez-plugin-scan.rs
+++ b/src/bin/vibez-plugin-scan.rs
@@ -1,4 +1,6 @@
 //! See `vibez_plugin_host::scan_helper` for what this binary is for.
+//! It lives in the root package so a plain `cargo build` puts the
+//! helper next to the `vibez` executable.
 
 use std::process::ExitCode;
 


### PR DESCRIPTION
Started as "scanning crashes the DAW" and grew into four related plugin-host fixes as testing peeled the onion:

**1. Sandboxed scanning (crash containment).** Each candidate bundle is loaded in a throwaway `vibez-plugin-scan` subprocess (JSON over stdout, 30 s hang timeout). A crashing bundle is recorded and skipped; the scan continues and the status line reports skips.

**2. Missing VST3 ModuleEntry (why Dragonfly crashed the scan).** The VST3 module API requires the platform entry export (Linux `ModuleEntry(handle)`, Windows `InitDll()`) after dlopen and before `GetPluginFactory`. Both scan and load paths skipped it. DPF-based plugins (Dragonfly) segfault in `getClassInfo` without it; JUCE-based plugins tolerate it, which hid the bug. `vst3_module_init`/`vst3_module_exit` now bracket both paths.

**3. Scan helper missing from normal builds.** A plain `cargo build --release` only builds the root package, so the helper bin never landed next to the app and sandboxed scanning silently fell back to in-process. The helper logic moved into the library and a thin duplicate bin in the root package guarantees it ships.

**4. IAudioProcessor IID typo (why NO VST3 plugin ever loaded).** The hand-written IID ended `0x3F` instead of `0x3D`, so every VST3 plugin correctly rejected our `queryInterface` and only CLAP plugins ever loaded. Proven with a C probe against both DPF (Dragonfly) and JUCE (ZL) builds. Fixed, plus regression tests asserting all hand-written IIDs byte-equal the SDK-generated constants from the `vst3` crate.

Also included: the right-click device menu rendered the full plugin cache (212 rows) in an uncapped column at the click position, which put the whole list off-screen; it is now vendor-grouped, scrollable (320 px cap), and clamped to the window edges.

Verified against ~/Music/plugins (LSP suite, Dexed, ZL, Dragonfly): 206 plugins found, 0 skipped; Dragonfly and ZL VST3s pass the IAudioProcessor query.

Repro/debug tool: `cargo run -p vibez-plugin-host --example scan_dir -- [--sandboxed] <dir>`.
