### PR TITLE
feat(plugins): plugin persistence + working VST3 hosting (run loop, thread affinity, host context)

### DIFF
--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -199,7 +199,7 @@ Three distinct issues observed:
   IIDs (IComponent, IAudioProcessor, IEditController) byte-equal the
   SDK-generated constants in the vst3 crate.
 
-### 12. Project persistence does not save plugins on tracks (OPEN)
+### 12. Project persistence does not save plugins on tracks (FIXED in PR #7)
 - Reported 2026-07-04. vibez-project has zero plugin serialization:
   plugin devices on tracks are simply not part of the project schema.
 - Full fix needs: (a) serialize plugin id/path/order per track,
@@ -207,8 +207,20 @@ Three distinct issues observed:
   note our clap host currently answers host_get_extension(clap.state)
   with null, so state support must be added on the host side too,
   (c) reload path: re-instantiate plugin, setState, rebuild GUI keys.
-- Sizable feature, own PR. Without (b) a first cut could persist just
-  the plugin list and default state.
+- Fixed 2026-07-05 (fix/plugin-persistence): EffectInfo gained an
+  optional PluginDeviceInfo (format/uid/path/name/state_b64);
+  TrackInfo gained plugin_instrument. State capture happens on the
+  UI thread at save time through PluginStatePtr raw pointers stashed
+  at load (same pattern as the GUI pointers), since the engine owns
+  the instance exclusively. CLAP state via clap.state ext with host
+  ostream/istream; VST3 via IComponent getState/setState + controller
+  setComponentState through a hand-built in-memory IBStream. Reload
+  spawns one background thread loading persisted plugins in file
+  order so chain positions restore deterministically; saved state is
+  applied before the device is handed to the engine. Old project
+  files load unchanged (serde defaults, regression test).
+- Also fixed: clear_project_runtime never dropped plugin_gui_raw_ptrs,
+  leaving dangling raw pointers after switching projects.
 
 ### 13. Plugin device menu unusable without search (FIXED in PR #6)
 - Screenshot: ~/Pictures/"Screenshot from 2026-07-04 23-45-03.png".

--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -299,6 +299,32 @@ Three distinct issues observed:
   ever full the device leaks instead of being destroyed in the
   callback.
 
+### 19. VST3: missing IHostApplication broke GUI-DSP link + more (FIXED in PR #7)
+- Found 2026-07-05 via headless probe (examples/vst3_probe.rs) after
+  user reported ZL "controllable but not processing" and Dragonfly
+  GUI failing to open.
+- Probe findings: Dragonfly DSP actually worked (reverb tail decays);
+  ZL process() ran and was bit-transparent (flat EQ), so the real
+  breakage was the GUI-to-DSP link, not the audio path.
+- Root cause: we passed NULL as the host context everywhere. JUCE
+  links editor to processor by allocating an IMessage from the
+  host's IHostApplication and sending it over the connection points;
+  with no context the editor binds to an orphaned processor (knobs
+  move, sound never changes, analyzer dead). DPF createView
+  outright requires a host application and returned null.
+- Fix: full IHostApplication + IMessage + IAttributeList COM
+  implementation (vst3_host/host_context.rs), passed to
+  IPluginFactory3::setHostContext and both component and controller
+  initialize.
+- Also from the probe: buses were never activated (activateBus now
+  called for main audio + event buses at init); process() now
+  presents one AudioBusBuffers per reported bus (ZL has a sidechain)
+  with separate output buffers (VST3 is out-of-place); stub
+  IParameterChanges + IParamValueQueue satisfy DPF's asserts;
+  teardown releases the processor before terminating the component.
+- vst3_probe verifies both plugins end to end: processing altered
+  audio, reverb tail, createView non-null, clean teardown.
+
 ## Fix status
 
 - Bugs #7 and #8: root-caused and fixed in PR #3

--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -338,6 +338,10 @@ Three distinct issues observed:
   check: warp the same clip repeatedly / change tempo and re-warp all,
   confirm clip boundaries stay on the audio.
 - Bugs #1-#6: still open.
+- Bugs #12, #16, #18, #19 (plugin persistence + full VST3 hosting
+  chain): FIXED in PR #7, user-verified 2026-07-05 ("Perfect works
+  now!"): ZL processes audibly with live analyzer, Dragonfly GUI
+  opens, removal instant, state round-trips.
 
 ## Not yet exercised
 - resample/bounce

--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -257,6 +257,27 @@ Three distinct issues observed:
   per cell, scrollable at 380 px cap, and the popup clamps by its
   ESTIMATED content height so small lists stay at the click point.
 
+### 16. VST3 GUIs frozen: missing Linux IRunLoop (FIXED in PR #7)
+- Found 2026-07-05 testing PR #7: ZL Equalizer's editor opens (after
+  #14) but paints once, partially, and ignores all input.
+- Root cause: on Linux the VST3 GUI contract requires the host to
+  pass an IPlugFrame to IPlugView::setFrame, from which the plugin
+  queries IRunLoop and registers timers + fd handlers. JUCE editors
+  repaint and dispatch input ONLY from those callbacks. We never
+  called setFrame. The CLAP host already implements the equivalent
+  (timer-support / posix-fd-support), which is why LSP GUIs worked.
+- Fix: hand-built dual-interface COM object (IPlugFrame + IRunLoop
+  subobject) in vst3_host/runloop.rs; handlers land in a registry the
+  plugin window manager services every poll tick. Frame lives from
+  setFrame (before attached) until after removed().
+- resizeView currently just echoes onSize; real host-window resize is
+  still bug #9.
+
+### 17. Plugin grid truncated names (FIXED in PR #7)
+- "..." truncation made the LSP suite indistinguishable (dozens of
+  "Graphic Equalizer x..."). Full names now wrap inside fixed-width
+  grid cells.
+
 ## Fix status
 
 - Bugs #7 and #8: root-caused and fixed in PR #3

--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -278,6 +278,27 @@ Three distinct issues observed:
   "Graphic Equalizer x..."). Full names now wrap inside fixed-width
   grid cells.
 
+### 18. VST3 GUIs still dead + remove hangs: JUCE thread affinity (FIXED in PR #7)
+- Found 2026-07-05 after #16: ZL editor still frozen even with the
+  run loop, and removing the plugin hung the whole DAW.
+- Root cause 1: VST3 plugins were fully instantiated on a background
+  loader thread. JUCE binds its MessageManager to the instantiating
+  thread, so every GUI callback fired from the UI thread was
+  wrong-thread and teardown blocked forever. The CLAP path solved
+  this long ago with two-phase loading; VST3 skipped it on the
+  assumption it was immune (comment written before any VST3 loaded).
+  Fix: identical two-phase split for VST3 (dlopen in background,
+  ModuleEntry/factory/instantiate/activate in phase 2 on the UI
+  thread), saved state applied after phase 2.
+- Root cause 2: the engine dropped removed devices IN THE AUDIO
+  CALLBACK (RemoveEffect retain, RemoveTrack, instrument replace).
+  Plugin destructors run dlclose, COM release, and JUCE teardown:
+  RT-hostile and wrong-thread. Fix: removed devices are sent back
+  over the event ring (EngineEvent::DisposeEffect/DisposeInstrument
+  in a DisposalCell) and dropped on the UI thread. If the ring is
+  ever full the device leaks instead of being destroyed in the
+  callback.
+
 ## Fix status
 
 - Bugs #7 and #8: root-caused and fixed in PR #3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,6 +4812,7 @@ version = "0.1.0"
 dependencies = [
  "clap-sys",
  "dirs 5.0.1",
+ "libc",
  "libloading 0.8.9",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4836,6 +4836,7 @@ dependencies = [
 name = "vibez-ui"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "dirs 5.0.1",
  "iced",
  "rfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ iced = { version = "0.13", features = ["canvas", "tokio"] }
 
 # Shared
 serde = { version = "1", features = ["derive"] }
+base64 = "0.22"
 serde_json = "1"
 
 [package]

--- a/crates/vibez-core/src/effect.rs
+++ b/crates/vibez-core/src/effect.rs
@@ -66,6 +66,25 @@ pub struct EffectInfo {
     pub effect_type: EffectType,
     pub bypass: bool,
     pub params: Vec<f32>,
+    /// Present when this chain slot is a third-party plugin rather
+    /// than a built-in effect. `effect_type`/`params` are ignored for
+    /// plugin slots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin: Option<PluginDeviceInfo>,
+}
+
+/// Identity and state of a third-party plugin device, as persisted in
+/// a project file. `format` is "clap" or "vst3"; `state_b64` is the
+/// plugin's opaque state blob (CLAP state ext / VST3 IComponent
+/// getState), base64-encoded for JSON.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PluginDeviceInfo {
+    pub format: String,
+    pub uid: String,
+    pub path: std::path::PathBuf,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_b64: Option<String>,
 }
 
 #[cfg(test)]
@@ -93,6 +112,7 @@ mod tests {
             effect_type: EffectType::Delay,
             bypass: false,
             params: vec![500.0, 0.5, 0.3],
+            plugin: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         let loaded: EffectInfo = serde_json::from_str(&json).unwrap();

--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -85,6 +85,9 @@ pub struct TrackInfo {
     pub instrument: Option<InstrumentKind>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub native_instrument: Option<InstrumentStateInfo>,
+    /// Third-party plugin instrument on this track, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin_instrument: Option<crate::effect::PluginDeviceInfo>,
 }
 
 impl TrackInfo {
@@ -101,6 +104,7 @@ impl TrackInfo {
             color_index: 0,
             instrument: None,
             native_instrument: None,
+            plugin_instrument: None,
         }
     }
 }

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -348,7 +348,15 @@ impl AudioEngine {
                     self.recalculate_audio_length();
                 }
                 EngineCommand::RemoveTrack(id) => {
-                    self.tracks.retain(|t| t.id != id);
+                    if let Some(pos) = self.tracks.iter().position(|t| t.id == id) {
+                        let mut track = self.tracks.remove(pos);
+                        for slot in track.effects.drain(..) {
+                            self.dispose_effect(slot.effect);
+                        }
+                        if let Some(instrument) = track.instrument.take() {
+                            self.dispose_instrument(instrument);
+                        }
+                    }
                     self.recalculate_audio_length();
                 }
                 EngineCommand::ReorderTracks(order) => {
@@ -472,7 +480,10 @@ impl AudioEngine {
                 }
                 EngineCommand::RemoveEffect(track_id, effect_id) => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        track.effects.retain(|e| e.id != effect_id);
+                        if let Some(pos) = track.effects.iter().position(|e| e.id == effect_id) {
+                            let slot = track.effects.remove(pos);
+                            self.dispose_effect(slot.effect);
+                        }
                     }
                 }
                 EngineCommand::SetEffectParam {
@@ -526,12 +537,19 @@ impl AudioEngine {
                 }
                 EngineCommand::SetTrackInstrument(track_id, kind) => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        track.instrument = Some(create_instrument(kind, self.sample_rate as f32));
+                        let old = track
+                            .instrument
+                            .replace(create_instrument(kind, self.sample_rate as f32));
+                        if let Some(old) = old {
+                            self.dispose_instrument(old);
+                        }
                     }
                 }
                 EngineCommand::RemoveTrackInstrument(track_id) => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        track.instrument = None;
+                        if let Some(instrument) = track.instrument.take() {
+                            self.dispose_instrument(instrument);
+                        }
                     }
                 }
                 EngineCommand::SetNoteClipDuration {
@@ -768,7 +786,9 @@ impl AudioEngine {
                     instrument,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        track.instrument = Some(instrument);
+                        if let Some(old) = track.instrument.replace(instrument) {
+                            self.dispose_instrument(old);
+                        }
                     }
                 }
             }
@@ -776,6 +796,33 @@ impl AudioEngine {
     }
 
     /// Recalculate transport audio length from all track clips.
+    /// Hand a removed device back to the UI thread for teardown. If
+    /// the event ring is full (should never happen for these rare
+    /// events) the device is leaked rather than destroyed here:
+    /// plugin destructors are wildly RT-unsafe (dlclose, COM, JUCE).
+    fn dispose_effect(&mut self, effect: Box<dyn vibez_dsp::effect::AudioEffect>) {
+        if let Err(rtrb::PushError::Full(item)) =
+            self.event_tx
+                .push(crate::events::EngineEvent::DisposeEffect(
+                    crate::events::DisposalCell::new(effect),
+                ))
+        {
+            std::mem::forget(item);
+        }
+    }
+
+    /// See [`Self::dispose_effect`].
+    fn dispose_instrument(&mut self, instrument: Box<dyn vibez_instruments::Instrument>) {
+        if let Err(rtrb::PushError::Full(item)) =
+            self.event_tx
+                .push(crate::events::EngineEvent::DisposeInstrument(
+                    crate::events::DisposalCell::new(instrument),
+                ))
+        {
+            std::mem::forget(item);
+        }
+    }
+
     fn recalculate_audio_length(&mut self) {
         let total = calculate_total_length(&self.tracks);
         if total > 0 {

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -6,8 +6,52 @@ use vibez_core::id::TrackId;
 /// consumed on the UI thread to update the interface.  Because they are
 /// produced in the audio callback, every variant must be trivially cheap to
 /// construct (no allocations, no locks).
+/// Opaque, shareable holder carrying a boxed device across the event
+/// ring for disposal. Exists so `EngineEvent` can keep deriving
+/// Debug/Clone/PartialEq: clones share the same cell, equality is
+/// cell identity, and whichever holder takes the box first drops it.
+pub struct DisposalCell<T: ?Sized>(std::sync::Arc<std::sync::Mutex<Option<Box<T>>>>);
+
+impl<T: ?Sized> DisposalCell<T> {
+    pub fn new(device: Box<T>) -> Self {
+        Self(std::sync::Arc::new(std::sync::Mutex::new(Some(device))))
+    }
+
+    /// Take the device out for dropping; None if already taken.
+    pub fn take(&self) -> Option<Box<T>> {
+        self.0.lock().ok().and_then(|mut guard| guard.take())
+    }
+}
+
+impl<T: ?Sized> Clone for DisposalCell<T> {
+    fn clone(&self) -> Self {
+        Self(std::sync::Arc::clone(&self.0))
+    }
+}
+
+impl<T: ?Sized> PartialEq for DisposalCell<T> {
+    fn eq(&self, other: &Self) -> bool {
+        std::sync::Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl<T: ?Sized> std::fmt::Debug for DisposalCell<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("DisposalCell")
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum EngineEvent {
+    /// A device removed from the audio graph, handed back so the UI
+    /// thread performs the teardown. Plugin destructors run dlclose
+    /// and COM/JUCE teardown, which must never happen in the audio
+    /// callback (RT-unsafe) or off the plugin's main thread (JUCE
+    /// MessageManager affinity: deadlocks).
+    DisposeEffect(DisposalCell<dyn vibez_dsp::effect::AudioEffect>),
+    /// See [`EngineEvent::DisposeEffect`].
+    DisposeInstrument(DisposalCell<dyn vibez_instruments::Instrument>),
+
     /// The current playback position expressed as an absolute sample offset.
     PlaybackPosition(u64),
 

--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -305,6 +305,7 @@ mod tests {
             color_index: 0,
             instrument: None,
             native_instrument: None,
+            plugin_instrument: None,
         }
     }
 
@@ -522,6 +523,7 @@ mod tests {
             color_index: 0,
             instrument: Some(InstrumentKind::SubtractiveSynth),
             native_instrument: Some(InstrumentStateInfo::SubtractiveSynth { params: Vec::new() }),
+            plugin_instrument: None,
         };
         let note_clip = NoteClipInfo {
             id: cid,
@@ -570,6 +572,7 @@ mod tests {
             color_index: 0,
             instrument: None,
             native_instrument: None,
+            plugin_instrument: None,
         };
         let req = BounceRequest {
             tracks: vec![track],
@@ -599,6 +602,7 @@ mod tests {
             effect_type: EffectType::Gain,
             bypass: false,
             params: vec![0.5],
+            plugin: None,
         });
         let audio = audio_of(100, 1.0);
         let clip = ClipInfo {

--- a/crates/vibez-plugin-host/Cargo.toml
+++ b/crates/vibez-plugin-host/Cargo.toml
@@ -13,5 +13,6 @@ serde_json = { workspace = true }
 clap-sys = "0.5"
 vst3 = "0.3"
 libloading = "0.8"
+libc = "0.2"
 dirs = "5"
 log = "0.4"

--- a/crates/vibez-plugin-host/examples/vst3_probe.rs
+++ b/crates/vibez-plugin-host/examples/vst3_probe.rs
@@ -1,0 +1,97 @@
+//! Headless VST3 host probe: loads a plugin, reports its buses,
+//! pushes audio through process_audio, and checks whether the plugin
+//! actually processes (output differs from input / reverb tail decays)
+//! plus whether createView works. Everything runs on the main thread,
+//! matching the DAW's post-two-phase thread model.
+//!
+//!   cargo run -p vibez-plugin-host --example vst3_probe -- <bundle.vst3> [uid]
+
+use std::path::PathBuf;
+
+use vibez_plugin_host::vst3_host::instance::Vst3PluginInstance;
+use vibez_plugin_host::PluginInstance;
+
+fn rms(buf: &[f32]) -> f32 {
+    (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt()
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = PathBuf::from(args.next().expect("usage: vst3_probe <bundle.vst3> [uid]"));
+    let uid = args.next();
+
+    // Discover class uid via the scanner if not given.
+    let uid = uid.unwrap_or_else(|| {
+        let infos = vibez_plugin_host::vst3_host::scanner::scan_vst3(&path).expect("scan failed");
+        let info = infos.first().expect("no audio classes in bundle");
+        println!("class: {} uid={}", info.name, info.id.uid);
+        info.id.uid.clone()
+    });
+
+    let mut inst =
+        Vst3PluginInstance::load(&path, &uid, false, 48_000.0, 512).expect("load failed");
+    println!("loaded: {}", inst.name());
+
+    // ── audio probe ──
+    const FRAMES: usize = 512;
+    const CH: usize = 2;
+    let mut had_tail = false;
+    let mut altered = false;
+    for block in 0..12 {
+        let mut buf = vec![0.0f32; FRAMES * CH];
+        let feeding = block < 6;
+        if feeding {
+            for (i, frame) in buf.chunks_mut(CH).enumerate() {
+                let t = (block * FRAMES + i) as f32 / 48_000.0;
+                let s = (t * 440.0 * std::f32::consts::TAU).sin() * 0.5;
+                frame[0] = s;
+                frame[1] = s;
+            }
+        }
+        let input_rms = rms(&buf);
+        let input_copy = buf.clone();
+        inst.process_audio(&mut buf, CH);
+        let output_rms = rms(&buf);
+        if buf != input_copy {
+            altered = true;
+        }
+        if !feeding && output_rms > 1e-6 {
+            had_tail = true;
+        }
+        println!(
+            "block {block:2} {} in_rms={input_rms:.4} out_rms={output_rms:.4}{}",
+            if feeding { "feed   " } else { "silence" },
+            if buf == input_copy {
+                "  (passthrough)"
+            } else {
+                ""
+            },
+        );
+    }
+    println!("processing altered audio: {altered}");
+    println!("tail after input stopped: {had_tail}");
+
+    // ── createView probe ──
+    let ctrl = inst.controller_ptr();
+    if ctrl.is_null() {
+        println!("createView: NO CONTROLLER");
+    } else {
+        type CreateViewFn =
+            unsafe extern "system" fn(*mut std::ffi::c_void, *const u8) -> *mut std::ffi::c_void;
+        unsafe {
+            let vtbl = *(ctrl as *const *const *const std::ffi::c_void);
+            let create_view: CreateViewFn = std::mem::transmute(*vtbl.add(17));
+            let view = create_view(ctrl, b"editor\0".as_ptr());
+            println!("createView(\"editor\") -> {view:p}");
+            if !view.is_null() {
+                type ReleaseFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> u32;
+                let vvtbl = *(view as *const *const *const std::ffi::c_void);
+                let release: ReleaseFn = std::mem::transmute(*vvtbl.add(2));
+                release(view);
+            }
+        }
+    }
+
+    drop(inst);
+    println!("clean teardown OK");
+}

--- a/crates/vibez-plugin-host/src/clap_host/instance.rs
+++ b/crates/vibez-plugin-host/src/clap_host/instance.rs
@@ -285,6 +285,14 @@ impl PluginInstance for ClapPluginInstance {
         &self.name
     }
 
+    fn save_state(&mut self) -> Option<Vec<u8>> {
+        unsafe { crate::state::clap_save_state(self.plugin_ptr) }
+    }
+
+    fn load_state(&mut self, data: &[u8]) -> bool {
+        unsafe { crate::state::clap_load_state(self.plugin_ptr, data) }
+    }
+
     fn param_count(&self) -> usize {
         self.param_descriptors.len()
     }

--- a/crates/vibez-plugin-host/src/gui.rs
+++ b/crates/vibez-plugin-host/src/gui.rs
@@ -31,6 +31,14 @@ pub enum PluginGuiHandle {
 unsafe impl Send for PluginGuiHandle {}
 
 impl PluginGuiHandle {
+    /// Pump per-view host services (VST3 Linux IRunLoop). No-op for
+    /// CLAP, whose timer/fd extensions are pumped by the CLAP host.
+    pub fn service_runloop(&self) {
+        if let PluginGuiHandle::Vst3(h) = self {
+            h.service_runloop();
+        }
+    }
+
     /// Whether the plugin actually supports a GUI.
     pub fn has_gui(&self) -> bool {
         match self {
@@ -234,6 +242,10 @@ pub struct Vst3GuiHandle {
     edit_controller: *mut c_void,
     /// IPlugView COM pointer (created on open, destroyed on close).
     plug_view: *mut c_void,
+    /// Host IPlugFrame + Linux IRunLoop for this view. Alive from
+    /// setFrame until after removed(); the window manager services
+    /// its timers/fds every poll tick.
+    frame: Option<crate::vst3_host::runloop::HostPlugFrame>,
     pub open: bool,
 }
 
@@ -263,8 +275,17 @@ impl Vst3GuiHandle {
         Some(Self {
             edit_controller,
             plug_view: std::ptr::null_mut(),
+            frame: None,
             open: false,
         })
+    }
+
+    /// Pump this view's run loop (timers + fd handlers). JUCE editors
+    /// paint and dispatch input exclusively from these callbacks.
+    pub fn service_runloop(&self) {
+        if let Some(frame) = &self.frame {
+            frame.service();
+        }
     }
 
     fn get_size(&self) -> Option<(u32, u32)> {
@@ -341,6 +362,9 @@ impl Vst3GuiHandle {
             unsafe { release(self.plug_view) };
             self.plug_view = std::ptr::null_mut();
         }
+        // Frame outlives removed(): plugins unregister their handlers
+        // in removed() and need the run loop alive to do it.
+        self.frame = None;
         self.open = false;
     }
 
@@ -389,6 +413,19 @@ impl Vst3GuiHandle {
             self.plug_view = std::ptr::null_mut();
             return false;
         }
+
+        // Provide IPlugFrame/IRunLoop before attaching: JUCE queries
+        // the run loop during attached() and a null frame leaves the
+        // editor frozen (no repaints, no input).
+        let frame = crate::vst3_host::runloop::HostPlugFrame::new();
+        // IPlugView::setFrame(frame) - vtable[12]
+        type SetFrameFn = unsafe extern "system" fn(*mut c_void, *mut c_void) -> i32;
+        let set_frame: SetFrameFn = unsafe { std::mem::transmute(*view_vtbl.add(12)) };
+        let hr = unsafe { set_frame(self.plug_view, frame.as_iplugframe()) };
+        if hr != 0 {
+            eprintln!("vibez: open_view — setFrame returned {hr} (continuing)");
+        }
+        self.frame = Some(frame);
 
         // Attach to X11 window
         eprintln!("vibez: open_view — attaching to X11 window {window_id}");

--- a/crates/vibez-plugin-host/src/instance.rs
+++ b/crates/vibez-plugin-host/src/instance.rs
@@ -23,6 +23,15 @@ pub trait PluginInstance: Send {
         self.note_off(pitch);
     }
     fn reset(&mut self);
+    /// Capture the plugin's opaque state blob (project persistence).
+    /// Main-thread class in both CLAP and VST3. Default: unsupported.
+    fn save_state(&mut self) -> Option<Vec<u8>> {
+        None
+    }
+    /// Restore a previously captured state blob. Default: unsupported.
+    fn load_state(&mut self, _data: &[u8]) -> bool {
+        false
+    }
     fn is_instrument(&self) -> bool;
     fn prepare(&mut self, sample_rate: f64, max_buffer_size: u32);
     fn activate(&mut self) -> bool;

--- a/crates/vibez-plugin-host/src/lib.rs
+++ b/crates/vibez-plugin-host/src/lib.rs
@@ -8,6 +8,7 @@ pub mod paths;
 pub mod scan_helper;
 pub mod scanner;
 pub mod settings;
+pub mod state;
 pub mod vst3_host;
 pub mod wrappers;
 
@@ -18,5 +19,6 @@ pub use info::PluginInfo;
 pub use instance::PluginInstance;
 pub use scanner::{scan_plugins, scan_plugins_sandboxed, ScanReport};
 pub use settings::PluginSettings;
+pub use state::{capture_plugin_state, PluginStatePtr};
 pub use wrappers::effect::PluginEffectWrapper;
 pub use wrappers::instrument::PluginInstrumentWrapper;

--- a/crates/vibez-plugin-host/src/state.rs
+++ b/crates/vibez-plugin-host/src/state.rs
@@ -1,0 +1,195 @@
+//! Plugin state capture and restore.
+//!
+//! CLAP: the `clap.state` extension with host-provided
+//! `clap_ostream`/`clap_istream` callbacks writing into a Vec.
+//! VST3: `IComponent::getState`/`setState` (plus
+//! `IEditController::setComponentState` for dual-component plugins)
+//! through the in-memory IBStream in `vst3_host::bstream`.
+//!
+//! Capture must happen while the plugin object is alive inside the
+//! engine, so the UI keeps a [`PluginStatePtr`] per device (the same
+//! pattern the GUI layer uses with its raw pointers) and calls
+//! [`capture_plugin_state`] on the UI thread at save time. State
+//! functions are main-thread class in both plugin APIs; plugins
+//! synchronize internally against their audio thread.
+
+use std::ffi::c_void;
+
+use clap_sys::ext::state::{clap_plugin_state, CLAP_EXT_STATE};
+use clap_sys::plugin::clap_plugin;
+use clap_sys::stream::{clap_istream, clap_ostream};
+
+/// Raw pointer needed to capture a live plugin's state from the UI
+/// thread after the instance itself has moved into the engine.
+#[derive(Debug, Clone, Copy)]
+pub enum PluginStatePtr {
+    /// `*const clap_plugin`
+    Clap(*const c_void),
+    /// VST3 IComponent pointer (getState/setState live there).
+    Vst3Component(*mut c_void),
+}
+
+// Safety: the pointers are only dereferenced on the UI thread; the
+// enum is Send so it can live in UI state alongside PluginRawPtr.
+unsafe impl Send for PluginStatePtr {}
+
+/// Capture the plugin's current state as an opaque blob.
+///
+/// # Safety
+/// The pointer must refer to a still-loaded plugin instance (the
+/// device must not have been removed from the engine). UI thread only.
+pub unsafe fn capture_plugin_state(ptr: &PluginStatePtr) -> Option<Vec<u8>> {
+    match ptr {
+        PluginStatePtr::Clap(p) => clap_save_state(*p as *const clap_plugin),
+        PluginStatePtr::Vst3Component(p) => vst3_component_get_state(*p),
+    }
+}
+
+// ── CLAP ──
+
+unsafe extern "C" fn ostream_write(
+    stream: *const clap_ostream,
+    buffer: *const c_void,
+    size: u64,
+) -> i64 {
+    let out = &mut *((*stream).ctx as *mut Vec<u8>);
+    let n = size as usize;
+    out.extend_from_slice(std::slice::from_raw_parts(buffer as *const u8, n));
+    n as i64
+}
+
+struct IstreamCtx<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+unsafe extern "C" fn istream_read(
+    stream: *const clap_istream,
+    buffer: *mut c_void,
+    size: u64,
+) -> i64 {
+    let ctx = &mut *((*stream).ctx as *mut IstreamCtx);
+    let available = ctx.data.len().saturating_sub(ctx.pos);
+    let n = (size as usize).min(available);
+    if n > 0 {
+        std::ptr::copy_nonoverlapping(ctx.data.as_ptr().add(ctx.pos), buffer as *mut u8, n);
+        ctx.pos += n;
+    }
+    n as i64
+}
+
+unsafe fn clap_state_ext(plugin: *const clap_plugin) -> Option<*const clap_plugin_state> {
+    if plugin.is_null() {
+        return None;
+    }
+    let get_extension = (*plugin).get_extension?;
+    let ext = get_extension(plugin, CLAP_EXT_STATE.as_ptr()) as *const clap_plugin_state;
+    if ext.is_null() {
+        None
+    } else {
+        Some(ext)
+    }
+}
+
+/// Save a CLAP plugin's state via the `clap.state` extension.
+///
+/// # Safety
+/// `plugin` must be a valid, initialized clap_plugin. Main thread.
+pub(crate) unsafe fn clap_save_state(plugin: *const clap_plugin) -> Option<Vec<u8>> {
+    let ext = clap_state_ext(plugin)?;
+    let save = (*ext).save?;
+    let mut out: Vec<u8> = Vec::new();
+    let stream = clap_ostream {
+        ctx: &mut out as *mut Vec<u8> as *mut c_void,
+        write: Some(ostream_write),
+    };
+    if save(plugin, &stream) {
+        Some(out)
+    } else {
+        None
+    }
+}
+
+/// Load previously saved state into a CLAP plugin.
+///
+/// # Safety
+/// `plugin` must be a valid, initialized clap_plugin. Main thread.
+pub(crate) unsafe fn clap_load_state(plugin: *const clap_plugin, data: &[u8]) -> bool {
+    let Some(ext) = clap_state_ext(plugin) else {
+        return false;
+    };
+    let Some(load) = (*ext).load else {
+        return false;
+    };
+    let mut ctx = IstreamCtx { data, pos: 0 };
+    let stream = clap_istream {
+        ctx: &mut ctx as *mut IstreamCtx as *mut c_void,
+        read: Some(istream_read),
+    };
+    load(plugin, &stream)
+}
+
+// ── VST3 ──
+
+/// IComponent vtable: FUnknown[0..2], IPluginBase[3..4], then
+/// getControllerClassId[5], setIoMode[6], getBusCount[7],
+/// getBusInfo[8], getRoutingInfo[9], activateBus[10], setActive[11],
+/// setState[12], getState[13].
+const VST3_COMPONENT_SET_STATE: usize = 12;
+const VST3_COMPONENT_GET_STATE: usize = 13;
+/// IEditController vtable: FUnknown[0..2], IPluginBase[3..4], then
+/// setComponentState[5].
+const VST3_CONTROLLER_SET_COMPONENT_STATE: usize = 5;
+
+type StateFn = unsafe extern "system" fn(*mut c_void, *mut c_void) -> i32;
+
+unsafe fn vst3_state_call(obj: *mut c_void, slot: usize, stream: *mut c_void) -> i32 {
+    let vtbl = *(obj as *const *const *const c_void);
+    let f: StateFn = std::mem::transmute(*vtbl.add(slot));
+    f(obj, stream)
+}
+
+/// # Safety
+/// `component` must be a valid IComponent pointer. Main thread.
+pub(crate) unsafe fn vst3_component_get_state(component: *mut c_void) -> Option<Vec<u8>> {
+    if component.is_null() {
+        return None;
+    }
+    let stream = crate::vst3_host::bstream::MemoryStream::for_writing();
+    let hr = vst3_state_call(component, VST3_COMPONENT_GET_STATE, stream.as_ibstream());
+    if hr == 0 {
+        Some(stream.data())
+    } else {
+        None
+    }
+}
+
+/// Restore component state, mirroring it into the controller when one
+/// exists (dual-component plugins keep an independent copy).
+///
+/// # Safety
+/// Pointers must be valid (controller may be null). Main thread.
+pub(crate) unsafe fn vst3_set_state(
+    component: *mut c_void,
+    controller: *mut c_void,
+    data: &[u8],
+) -> bool {
+    if component.is_null() {
+        return false;
+    }
+    let stream = crate::vst3_host::bstream::MemoryStream::with_data(data.to_vec());
+    let hr = vst3_state_call(component, VST3_COMPONENT_SET_STATE, stream.as_ibstream());
+    if hr != 0 {
+        return false;
+    }
+    if !controller.is_null() && controller != component {
+        // Fresh stream so the controller reads from position 0.
+        let stream = crate::vst3_host::bstream::MemoryStream::with_data(data.to_vec());
+        vst3_state_call(
+            controller,
+            VST3_CONTROLLER_SET_COMPONENT_STATE,
+            stream.as_ibstream(),
+        );
+    }
+    true
+}

--- a/crates/vibez-plugin-host/src/vst3_host/bstream.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/bstream.rs
@@ -32,8 +32,7 @@ const K_IB_SEEK_END: i32 = 2;
 #[repr(C)]
 struct Vtbl {
     // FUnknown
-    query_interface:
-        unsafe extern "system" fn(*mut Stream, *const u8, *mut *mut c_void) -> i32,
+    query_interface: unsafe extern "system" fn(*mut Stream, *const u8, *mut *mut c_void) -> i32,
     add_ref: unsafe extern "system" fn(*mut Stream) -> u32,
     release: unsafe extern "system" fn(*mut Stream) -> u32,
     // IBStream

--- a/crates/vibez-plugin-host/src/vst3_host/bstream.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/bstream.rs
@@ -1,0 +1,270 @@
+//! Minimal in-memory IBStream COM object, required by
+//! IComponent::getState / setState and
+//! IEditController::setComponentState for plugin state persistence.
+//!
+//! VST3 hosts must hand plugins a host-implemented stream; there is
+//! nothing to borrow from the plugin side, so this builds the COM
+//! object by hand: a #[repr(C)] struct whose first field points at a
+//! static vtable of extern "system" fns.
+
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+// FUnknown IID: {00000000-0000-0000-C000-000000000046}
+const FUNKNOWN_IID: [u8; 16] = [
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
+];
+
+// IBStream IID: {C3BF6EA2-3099-4752-9B6B-F9901EE33E9B}
+const IBSTREAM_IID: [u8; 16] = [
+    0xC3, 0xBF, 0x6E, 0xA2, 0x30, 0x99, 0x47, 0x52, 0x9B, 0x6B, 0xF9, 0x90, 0x1E, 0xE3, 0x3E, 0x9B,
+];
+
+const K_RESULT_OK: i32 = 0;
+const K_NO_INTERFACE: i32 = -1;
+const K_INVALID_ARGUMENT: i32 = 2;
+
+// IBStream::seek modes
+const K_IB_SEEK_SET: i32 = 0;
+const K_IB_SEEK_CUR: i32 = 1;
+const K_IB_SEEK_END: i32 = 2;
+
+#[repr(C)]
+struct Vtbl {
+    // FUnknown
+    query_interface:
+        unsafe extern "system" fn(*mut Stream, *const u8, *mut *mut c_void) -> i32,
+    add_ref: unsafe extern "system" fn(*mut Stream) -> u32,
+    release: unsafe extern "system" fn(*mut Stream) -> u32,
+    // IBStream
+    read: unsafe extern "system" fn(*mut Stream, *mut c_void, i32, *mut i32) -> i32,
+    write: unsafe extern "system" fn(*mut Stream, *mut c_void, i32, *mut i32) -> i32,
+    seek: unsafe extern "system" fn(*mut Stream, i64, i32, *mut i64) -> i32,
+    tell: unsafe extern "system" fn(*mut Stream, *mut i64) -> i32,
+}
+
+static VTBL: Vtbl = Vtbl {
+    query_interface,
+    add_ref,
+    release,
+    read,
+    write,
+    seek,
+    tell,
+};
+
+#[repr(C)]
+struct Stream {
+    vtbl: *const Vtbl,
+    refcount: AtomicU32,
+    data: Vec<u8>,
+    pos: usize,
+}
+
+unsafe extern "system" fn query_interface(
+    this: *mut Stream,
+    iid: *const u8,
+    obj: *mut *mut c_void,
+) -> i32 {
+    let iid = std::slice::from_raw_parts(iid, 16);
+    if iid == FUNKNOWN_IID || iid == IBSTREAM_IID {
+        add_ref(this);
+        *obj = this as *mut c_void;
+        K_RESULT_OK
+    } else {
+        *obj = std::ptr::null_mut();
+        K_NO_INTERFACE
+    }
+}
+
+unsafe extern "system" fn add_ref(this: *mut Stream) -> u32 {
+    (*this).refcount.fetch_add(1, Ordering::AcqRel) + 1
+}
+
+unsafe extern "system" fn release(this: *mut Stream) -> u32 {
+    let remaining = (*this).refcount.fetch_sub(1, Ordering::AcqRel) - 1;
+    if remaining == 0 {
+        drop(Box::from_raw(this));
+    }
+    remaining
+}
+
+unsafe extern "system" fn read(
+    this: *mut Stream,
+    buffer: *mut c_void,
+    num_bytes: i32,
+    num_read: *mut i32,
+) -> i32 {
+    let s = &mut *this;
+    let want = num_bytes.max(0) as usize;
+    let available = s.data.len().saturating_sub(s.pos);
+    let n = want.min(available);
+    if n > 0 {
+        std::ptr::copy_nonoverlapping(s.data.as_ptr().add(s.pos), buffer as *mut u8, n);
+        s.pos += n;
+    }
+    if !num_read.is_null() {
+        *num_read = n as i32;
+    }
+    K_RESULT_OK
+}
+
+unsafe extern "system" fn write(
+    this: *mut Stream,
+    buffer: *mut c_void,
+    num_bytes: i32,
+    num_written: *mut i32,
+) -> i32 {
+    let s = &mut *this;
+    let n = num_bytes.max(0) as usize;
+    if n > 0 {
+        let src = std::slice::from_raw_parts(buffer as *const u8, n);
+        if s.pos + n > s.data.len() {
+            s.data.resize(s.pos + n, 0);
+        }
+        s.data[s.pos..s.pos + n].copy_from_slice(src);
+        s.pos += n;
+    }
+    if !num_written.is_null() {
+        *num_written = n as i32;
+    }
+    K_RESULT_OK
+}
+
+unsafe extern "system" fn seek(this: *mut Stream, pos: i64, mode: i32, result: *mut i64) -> i32 {
+    let s = &mut *this;
+    let base: i64 = match mode {
+        K_IB_SEEK_SET => 0,
+        K_IB_SEEK_CUR => s.pos as i64,
+        K_IB_SEEK_END => s.data.len() as i64,
+        _ => return K_INVALID_ARGUMENT,
+    };
+    let new_pos = base + pos;
+    if new_pos < 0 {
+        return K_INVALID_ARGUMENT;
+    }
+    s.pos = new_pos as usize;
+    if !result.is_null() {
+        *result = new_pos;
+    }
+    K_RESULT_OK
+}
+
+unsafe extern "system" fn tell(this: *mut Stream, pos: *mut i64) -> i32 {
+    if pos.is_null() {
+        return K_INVALID_ARGUMENT;
+    }
+    *pos = (*this).pos as i64;
+    K_RESULT_OK
+}
+
+/// Owned in-memory IBStream. Hand `as_ibstream()` to plugin calls;
+/// the object stays alive until this wrapper drops (plugins may
+/// addRef/release around their use, the wrapper holds its own ref).
+pub(crate) struct MemoryStream {
+    ptr: *mut Stream,
+}
+
+impl MemoryStream {
+    /// Empty stream for the plugin to write into (getState).
+    pub(crate) fn for_writing() -> Self {
+        Self::with_data(Vec::new())
+    }
+
+    /// Stream pre-filled with saved state for the plugin to read
+    /// (setState / setComponentState). Position starts at 0.
+    pub(crate) fn with_data(data: Vec<u8>) -> Self {
+        let boxed = Box::new(Stream {
+            vtbl: &VTBL,
+            refcount: AtomicU32::new(1),
+            data,
+            pos: 0,
+        });
+        Self {
+            ptr: Box::into_raw(boxed),
+        }
+    }
+
+    pub(crate) fn as_ibstream(&self) -> *mut c_void {
+        self.ptr as *mut c_void
+    }
+
+    /// Copy out everything written so far.
+    pub(crate) fn data(&self) -> Vec<u8> {
+        unsafe { (*self.ptr).data.clone() }
+    }
+}
+
+impl Drop for MemoryStream {
+    fn drop(&mut self) {
+        unsafe { release(self.ptr) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ibstream_iid_matches_sdk() {
+        let sdk: Vec<u8> = vst3::Steinberg::IBStream_iid
+            .iter()
+            .map(|b| *b as u8)
+            .collect();
+        assert_eq!(IBSTREAM_IID.as_slice(), sdk.as_slice());
+    }
+
+    #[test]
+    fn write_read_roundtrip_via_vtable() {
+        let stream = MemoryStream::for_writing();
+        let ptr = stream.as_ibstream() as *mut Stream;
+        let payload = b"vibez state";
+        unsafe {
+            let mut written = 0i32;
+            assert_eq!(
+                write(
+                    ptr,
+                    payload.as_ptr() as *mut c_void,
+                    payload.len() as i32,
+                    &mut written
+                ),
+                K_RESULT_OK
+            );
+            assert_eq!(written as usize, payload.len());
+
+            let mut result = 0i64;
+            assert_eq!(seek(ptr, 0, K_IB_SEEK_SET, &mut result), K_RESULT_OK);
+
+            let mut buf = [0u8; 32];
+            let mut read_n = 0i32;
+            assert_eq!(
+                read(ptr, buf.as_mut_ptr() as *mut c_void, 32, &mut read_n),
+                K_RESULT_OK
+            );
+            assert_eq!(&buf[..read_n as usize], payload);
+        }
+        assert_eq!(stream.data(), payload);
+    }
+
+    #[test]
+    fn query_interface_and_refcount() {
+        let stream = MemoryStream::for_writing();
+        let ptr = stream.as_ibstream() as *mut Stream;
+        unsafe {
+            let mut obj: *mut c_void = std::ptr::null_mut();
+            assert_eq!(
+                query_interface(ptr, IBSTREAM_IID.as_ptr(), &mut obj),
+                K_RESULT_OK
+            );
+            assert!(!obj.is_null());
+            assert_eq!(release(ptr), 1); // back to the wrapper's ref
+
+            let mut obj: *mut c_void = std::ptr::null_mut();
+            let bogus = [0xABu8; 16];
+            assert_eq!(
+                query_interface(ptr, bogus.as_ptr(), &mut obj),
+                K_NO_INTERFACE
+            );
+        }
+    }
+}

--- a/crates/vibez-plugin-host/src/vst3_host/host_context.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/host_context.rs
@@ -1,0 +1,560 @@
+//! Host-side IHostApplication with IMessage / IAttributeList support.
+//!
+//! Plugins receive this as the `context` argument of
+//! `IPluginBase::initialize` (component AND controller) and via
+//! `IPluginFactory3::setHostContext`. It matters far beyond
+//! politeness: dual-component plugins link their controller to their
+//! processor by allocating an IMessage from the host application and
+//! sending it over the connection points. With a null context, JUCE
+//! plugins silently leave the editor bound to an orphaned processor
+//! (GUI moves, sound never changes) and DPF refuses to create a view
+//! at all.
+
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+// FUnknown IID: {00000000-0000-0000-C000-000000000046}
+const FUNKNOWN_IID: [u8; 16] = [
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
+];
+// IHostApplication IID: {58E595CC-DB2D-4969-8B6A-AF8C36A664E5}
+pub(crate) const IHOSTAPPLICATION_IID: [u8; 16] = [
+    0x58, 0xE5, 0x95, 0xCC, 0xDB, 0x2D, 0x49, 0x69, 0x8B, 0x6A, 0xAF, 0x8C, 0x36, 0xA6, 0x64, 0xE5,
+];
+// IMessage IID: {936F033B-C6C0-47DB-BB08-82F813C1E613}
+pub(crate) const IMESSAGE_IID: [u8; 16] = [
+    0x93, 0x6F, 0x03, 0x3B, 0xC6, 0xC0, 0x47, 0xDB, 0xBB, 0x08, 0x82, 0xF8, 0x13, 0xC1, 0xE6, 0x13,
+];
+// IAttributeList IID: {1E5F0AEB-CC7F-4533-A254-401138AD5EE4}
+pub(crate) const IATTRIBUTELIST_IID: [u8; 16] = [
+    0x1E, 0x5F, 0x0A, 0xEB, 0xCC, 0x7F, 0x45, 0x33, 0xA2, 0x54, 0x40, 0x11, 0x38, 0xAD, 0x5E, 0xE4,
+];
+// IPluginFactory3 IID: {4555A2AB-C123-4E57-9B12-291036878931}
+pub(crate) const IPLUGINFACTORY3_IID: [u8; 16] = [
+    0x45, 0x55, 0xA2, 0xAB, 0xC1, 0x23, 0x4E, 0x57, 0x9B, 0x12, 0x29, 0x10, 0x36, 0x87, 0x89, 0x31,
+];
+
+const K_RESULT_OK: i32 = 0;
+const K_RESULT_FALSE: i32 = 1;
+const K_NO_INTERFACE: i32 = -1;
+const K_INVALID_ARGUMENT: i32 = 2;
+
+unsafe fn iid_slice(iid: *const u8) -> &'static [u8] {
+    std::slice::from_raw_parts(iid, 16)
+}
+
+// ── IAttributeList ──
+
+enum AttrValue {
+    Int(i64),
+    Float(f64),
+    Str(Vec<u16>),
+    Bin(Vec<u8>),
+}
+
+#[repr(C)]
+struct AttrListVtbl {
+    query_interface: unsafe extern "system" fn(*mut AttrList, *const u8, *mut *mut c_void) -> i32,
+    add_ref: unsafe extern "system" fn(*mut AttrList) -> u32,
+    release: unsafe extern "system" fn(*mut AttrList) -> u32,
+    set_int: unsafe extern "system" fn(*mut AttrList, *const i8, i64) -> i32,
+    get_int: unsafe extern "system" fn(*mut AttrList, *const i8, *mut i64) -> i32,
+    set_float: unsafe extern "system" fn(*mut AttrList, *const i8, f64) -> i32,
+    get_float: unsafe extern "system" fn(*mut AttrList, *const i8, *mut f64) -> i32,
+    set_string: unsafe extern "system" fn(*mut AttrList, *const i8, *const u16) -> i32,
+    get_string: unsafe extern "system" fn(*mut AttrList, *const i8, *mut u16, u32) -> i32,
+    set_binary: unsafe extern "system" fn(*mut AttrList, *const i8, *const c_void, u32) -> i32,
+    get_binary:
+        unsafe extern "system" fn(*mut AttrList, *const i8, *mut *const c_void, *mut u32) -> i32,
+}
+
+static ATTR_VTBL: AttrListVtbl = AttrListVtbl {
+    query_interface: attr_query_interface,
+    add_ref: attr_add_ref,
+    release: attr_release,
+    set_int,
+    get_int,
+    set_float,
+    get_float,
+    set_string,
+    get_string,
+    set_binary,
+    get_binary,
+};
+
+#[repr(C)]
+struct AttrList {
+    vtbl: *const AttrListVtbl,
+    refcount: AtomicU32,
+    values: Mutex<HashMap<String, AttrValue>>,
+}
+
+fn new_attr_list() -> *mut AttrList {
+    Box::into_raw(Box::new(AttrList {
+        vtbl: &ATTR_VTBL,
+        refcount: AtomicU32::new(1),
+        values: Mutex::new(HashMap::new()),
+    }))
+}
+
+unsafe fn attr_key(id: *const i8) -> Option<String> {
+    if id.is_null() {
+        return None;
+    }
+    Some(
+        std::ffi::CStr::from_ptr(id as *const std::os::raw::c_char)
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+unsafe extern "system" fn attr_query_interface(
+    this: *mut AttrList,
+    iid: *const u8,
+    obj: *mut *mut c_void,
+) -> i32 {
+    let iid = iid_slice(iid);
+    if iid == FUNKNOWN_IID || iid == IATTRIBUTELIST_IID {
+        attr_add_ref(this);
+        *obj = this as *mut c_void;
+        K_RESULT_OK
+    } else {
+        *obj = std::ptr::null_mut();
+        K_NO_INTERFACE
+    }
+}
+
+unsafe extern "system" fn attr_add_ref(this: *mut AttrList) -> u32 {
+    (*this).refcount.fetch_add(1, Ordering::AcqRel) + 1
+}
+
+unsafe extern "system" fn attr_release(this: *mut AttrList) -> u32 {
+    let remaining = (*this).refcount.fetch_sub(1, Ordering::AcqRel) - 1;
+    if remaining == 0 {
+        drop(Box::from_raw(this));
+    }
+    remaining
+}
+
+unsafe extern "system" fn set_int(this: *mut AttrList, id: *const i8, value: i64) -> i32 {
+    let Some(key) = attr_key(id) else {
+        return K_INVALID_ARGUMENT;
+    };
+    (*this)
+        .values
+        .lock()
+        .map(|mut v| {
+            v.insert(key, AttrValue::Int(value));
+            K_RESULT_OK
+        })
+        .unwrap_or(K_INVALID_ARGUMENT)
+}
+
+unsafe extern "system" fn get_int(this: *mut AttrList, id: *const i8, out: *mut i64) -> i32 {
+    let Some(key) = attr_key(id) else {
+        return K_INVALID_ARGUMENT;
+    };
+    match (*this).values.lock() {
+        Ok(v) => match v.get(&key) {
+            Some(AttrValue::Int(value)) => {
+                *out = *value;
+                K_RESULT_OK
+            }
+            _ => K_RESULT_FALSE,
+        },
+        Err(_) => K_INVALID_ARGUMENT,
+    }
+}
+
+unsafe extern "system" fn set_float(this: *mut AttrList, id: *const i8, value: f64) -> i32 {
+    let Some(key) = attr_key(id) else {
+        return K_INVALID_ARGUMENT;
+    };
+    (*this)
+        .values
+        .lock()
+        .map(|mut v| {
+            v.insert(key, AttrValue::Float(value));
+            K_RESULT_OK
+        })
+        .unwrap_or(K_INVALID_ARGUMENT)
+}
+
+unsafe extern "system" fn get_float(this: *mut AttrList, id: *const i8, out: *mut f64) -> i32 {
+    let Some(key) = attr_key(id) else {
+        return K_INVALID_ARGUMENT;
+    };
+    match (*this).values.lock() {
+        Ok(v) => match v.get(&key) {
+            Some(AttrValue::Float(value)) => {
+                *out = *value;
+                K_RESULT_OK
+            }
+            _ => K_RESULT_FALSE,
+        },
+        Err(_) => K_INVALID_ARGUMENT,
+    }
+}
+
+unsafe extern "system" fn set_string(this: *mut AttrList, id: *const i8, value: *const u16) -> i32 {
+    let Some(key) = attr_key(id) else {
+        return K_INVALID_ARGUMENT;
+    };
+    if value.is_null() {
+        return K_INVALID_ARGUMENT;
+    }
+    let mut buf = Vec::new();
+    let mut p = value;
+    while *p != 0 {
+        buf.push(*p);
+        p = p.add(1);
+    }
+    buf.push(0);
+    (*this)
+        .values
+        .lock()
+        .map(|mut v| {
+            v.insert(key, AttrValue::Str(buf));
+            K_RESULT_OK
+        })
+        .unwrap_or(K_INVALID_ARGUMENT)
+}
+
+unsafe extern "system" fn get_string(
+    this: *mut AttrList,
+    id: *const i8,
+    out: *mut u16,
+    size_bytes: u32,
+) -> i32 {
+    let Some(key) = attr_key(id) else {
+        return K_INVALID_ARGUMENT;
+    };
+    match (*this).values.lock() {
+        Ok(v) => match v.get(&key) {
+            Some(AttrValue::Str(value)) => {
+                let cap = (size_bytes as usize / 2).min(value.len());
+                if cap == 0 {
+                    return K_RESULT_FALSE;
+                }
+                std::ptr::copy_nonoverlapping(value.as_ptr(), out, cap);
+                // Ensure termination even when truncated.
+                *out.add(cap - 1) = 0;
+                K_RESULT_OK
+            }
+            _ => K_RESULT_FALSE,
+        },
+        Err(_) => K_INVALID_ARGUMENT,
+    }
+}
+
+unsafe extern "system" fn set_binary(
+    this: *mut AttrList,
+    id: *const i8,
+    data: *const c_void,
+    size: u32,
+) -> i32 {
+    let Some(key) = attr_key(id) else {
+        return K_INVALID_ARGUMENT;
+    };
+    let bytes = if data.is_null() || size == 0 {
+        Vec::new()
+    } else {
+        std::slice::from_raw_parts(data as *const u8, size as usize).to_vec()
+    };
+    (*this)
+        .values
+        .lock()
+        .map(|mut v| {
+            v.insert(key, AttrValue::Bin(bytes));
+            K_RESULT_OK
+        })
+        .unwrap_or(K_INVALID_ARGUMENT)
+}
+
+unsafe extern "system" fn get_binary(
+    this: *mut AttrList,
+    id: *const i8,
+    data: *mut *const c_void,
+    size: *mut u32,
+) -> i32 {
+    let Some(key) = attr_key(id) else {
+        return K_INVALID_ARGUMENT;
+    };
+    match (*this).values.lock() {
+        Ok(v) => match v.get(&key) {
+            Some(AttrValue::Bin(value)) => {
+                // Pointer stays valid while the attribute list lives
+                // and the value is not overwritten, matching host
+                // implementations in the wild.
+                *data = value.as_ptr() as *const c_void;
+                *size = value.len() as u32;
+                K_RESULT_OK
+            }
+            _ => K_RESULT_FALSE,
+        },
+        Err(_) => K_INVALID_ARGUMENT,
+    }
+}
+
+// ── IMessage ──
+
+#[repr(C)]
+struct MessageVtbl {
+    query_interface: unsafe extern "system" fn(*mut Message, *const u8, *mut *mut c_void) -> i32,
+    add_ref: unsafe extern "system" fn(*mut Message) -> u32,
+    release: unsafe extern "system" fn(*mut Message) -> u32,
+    get_message_id: unsafe extern "system" fn(*mut Message) -> *const i8,
+    set_message_id: unsafe extern "system" fn(*mut Message, *const i8),
+    get_attributes: unsafe extern "system" fn(*mut Message) -> *mut AttrList,
+}
+
+static MESSAGE_VTBL: MessageVtbl = MessageVtbl {
+    query_interface: msg_query_interface,
+    add_ref: msg_add_ref,
+    release: msg_release,
+    get_message_id,
+    set_message_id,
+    get_attributes,
+};
+
+#[repr(C)]
+struct Message {
+    vtbl: *const MessageVtbl,
+    refcount: AtomicU32,
+    /// NUL-terminated message id, owned.
+    id: Mutex<Vec<u8>>,
+    attributes: *mut AttrList,
+}
+
+unsafe extern "system" fn msg_query_interface(
+    this: *mut Message,
+    iid: *const u8,
+    obj: *mut *mut c_void,
+) -> i32 {
+    let iid = iid_slice(iid);
+    if iid == FUNKNOWN_IID || iid == IMESSAGE_IID {
+        msg_add_ref(this);
+        *obj = this as *mut c_void;
+        K_RESULT_OK
+    } else {
+        *obj = std::ptr::null_mut();
+        K_NO_INTERFACE
+    }
+}
+
+unsafe extern "system" fn msg_add_ref(this: *mut Message) -> u32 {
+    (*this).refcount.fetch_add(1, Ordering::AcqRel) + 1
+}
+
+unsafe extern "system" fn msg_release(this: *mut Message) -> u32 {
+    let remaining = (*this).refcount.fetch_sub(1, Ordering::AcqRel) - 1;
+    if remaining == 0 {
+        attr_release((*this).attributes);
+        drop(Box::from_raw(this));
+    }
+    remaining
+}
+
+unsafe extern "system" fn get_message_id(this: *mut Message) -> *const i8 {
+    match (*this).id.lock() {
+        Ok(id) if !id.is_empty() => id.as_ptr() as *const i8,
+        _ => std::ptr::null(),
+    }
+}
+
+unsafe extern "system" fn set_message_id(this: *mut Message, id: *const i8) {
+    let new_id = if id.is_null() {
+        Vec::new()
+    } else {
+        let mut bytes = std::ffi::CStr::from_ptr(id as *const std::os::raw::c_char)
+            .to_bytes()
+            .to_vec();
+        bytes.push(0);
+        bytes
+    };
+    if let Ok(mut slot) = (*this).id.lock() {
+        *slot = new_id;
+    }
+}
+
+unsafe extern "system" fn get_attributes(this: *mut Message) -> *mut AttrList {
+    // Per COM convention the caller does not own this reference; the
+    // list lives as long as the message.
+    (*this).attributes
+}
+
+fn new_message() -> *mut Message {
+    Box::into_raw(Box::new(Message {
+        vtbl: &MESSAGE_VTBL,
+        refcount: AtomicU32::new(1),
+        id: Mutex::new(Vec::new()),
+        attributes: new_attr_list(),
+    }))
+}
+
+// ── IHostApplication ──
+
+#[repr(C)]
+struct HostAppVtbl {
+    query_interface: unsafe extern "system" fn(*mut HostApp, *const u8, *mut *mut c_void) -> i32,
+    add_ref: unsafe extern "system" fn(*mut HostApp) -> u32,
+    release: unsafe extern "system" fn(*mut HostApp) -> u32,
+    get_name: unsafe extern "system" fn(*mut HostApp, *mut u16) -> i32,
+    create_instance:
+        unsafe extern "system" fn(*mut HostApp, *const u8, *const u8, *mut *mut c_void) -> i32,
+}
+
+static HOST_APP_VTBL: HostAppVtbl = HostAppVtbl {
+    query_interface: host_query_interface,
+    add_ref: host_add_ref,
+    release: host_release,
+    get_name: host_get_name,
+    create_instance: host_create_instance,
+};
+
+#[repr(C)]
+struct HostApp {
+    vtbl: *const HostAppVtbl,
+}
+unsafe impl Sync for HostApp {}
+
+static HOST_APP: HostApp = HostApp {
+    vtbl: &HOST_APP_VTBL,
+};
+
+unsafe extern "system" fn host_query_interface(
+    this: *mut HostApp,
+    iid: *const u8,
+    obj: *mut *mut c_void,
+) -> i32 {
+    let iid = iid_slice(iid);
+    if iid == FUNKNOWN_IID || iid == IHOSTAPPLICATION_IID {
+        *obj = this as *mut c_void;
+        K_RESULT_OK
+    } else {
+        *obj = std::ptr::null_mut();
+        K_NO_INTERFACE
+    }
+}
+
+// Process-lifetime static: refcounting is a no-op.
+unsafe extern "system" fn host_add_ref(_this: *mut HostApp) -> u32 {
+    1
+}
+unsafe extern "system" fn host_release(_this: *mut HostApp) -> u32 {
+    1
+}
+
+unsafe extern "system" fn host_get_name(_this: *mut HostApp, name: *mut u16) -> i32 {
+    if name.is_null() {
+        return K_INVALID_ARGUMENT;
+    }
+    // String128: UTF-16, 128 code units max including terminator.
+    for (i, ch) in "vibez".encode_utf16().enumerate() {
+        *name.add(i) = ch;
+    }
+    *name.add(5) = 0;
+    K_RESULT_OK
+}
+
+unsafe extern "system" fn host_create_instance(
+    _this: *mut HostApp,
+    cid: *const u8,
+    iid: *const u8,
+    obj: *mut *mut c_void,
+) -> i32 {
+    let cid = iid_slice(cid);
+    let iid = iid_slice(iid);
+    if cid == IMESSAGE_IID && (iid == IMESSAGE_IID || iid == FUNKNOWN_IID) {
+        *obj = new_message() as *mut c_void;
+        return K_RESULT_OK;
+    }
+    if cid == IATTRIBUTELIST_IID && (iid == IATTRIBUTELIST_IID || iid == FUNKNOWN_IID) {
+        *obj = new_attr_list() as *mut c_void;
+        return K_RESULT_OK;
+    }
+    *obj = std::ptr::null_mut();
+    K_NO_INTERFACE
+}
+
+/// Process-wide IHostApplication pointer, valid forever. Pass as the
+/// `context` to IPluginBase::initialize and IPluginFactory3::
+/// setHostContext.
+pub(crate) fn host_application() -> *mut c_void {
+    static PTR: OnceLock<usize> = OnceLock::new();
+    *PTR.get_or_init(|| &HOST_APP as *const HostApp as usize) as *mut c_void
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sdk_bytes(tuid: [::std::os::raw::c_char; 16]) -> Vec<u8> {
+        tuid.iter().map(|b| *b as u8).collect()
+    }
+
+    #[test]
+    fn iids_match_sdk() {
+        assert_eq!(
+            IHOSTAPPLICATION_IID.as_slice(),
+            sdk_bytes(vst3::Steinberg::Vst::IHostApplication_iid).as_slice()
+        );
+        assert_eq!(
+            IMESSAGE_IID.as_slice(),
+            sdk_bytes(vst3::Steinberg::Vst::IMessage_iid).as_slice()
+        );
+        assert_eq!(
+            IATTRIBUTELIST_IID.as_slice(),
+            sdk_bytes(vst3::Steinberg::Vst::IAttributeList_iid).as_slice()
+        );
+        assert_eq!(
+            IPLUGINFACTORY3_IID.as_slice(),
+            sdk_bytes(vst3::Steinberg::IPluginFactory3_iid).as_slice()
+        );
+    }
+
+    #[test]
+    fn message_roundtrip_via_vtable() {
+        unsafe {
+            let app = host_application() as *mut HostApp;
+            let mut obj: *mut c_void = std::ptr::null_mut();
+            let hr =
+                host_create_instance(app, IMESSAGE_IID.as_ptr(), IMESSAGE_IID.as_ptr(), &mut obj);
+            assert_eq!(hr, K_RESULT_OK);
+            let msg = obj as *mut Message;
+
+            set_message_id(msg, c"JuceVST3EditController".as_ptr() as *const i8);
+            let id = get_message_id(msg);
+            assert_eq!(
+                std::ffi::CStr::from_ptr(id as *const std::os::raw::c_char)
+                    .to_str()
+                    .unwrap(),
+                "JuceVST3EditController"
+            );
+
+            let attrs = get_attributes(msg);
+            assert!(!attrs.is_null());
+            let key = c"JuceVST3EditController".as_ptr() as *const i8;
+            assert_eq!(set_int(attrs, key, 0x1234), K_RESULT_OK);
+            let mut out = 0i64;
+            assert_eq!(get_int(attrs, key, &mut out), K_RESULT_OK);
+            assert_eq!(out, 0x1234);
+
+            // Binary roundtrip
+            let payload = [1u8, 2, 3, 4];
+            assert_eq!(
+                set_binary(attrs, key, payload.as_ptr() as *const c_void, 4),
+                K_RESULT_OK
+            );
+            let mut data: *const c_void = std::ptr::null();
+            let mut size = 0u32;
+            assert_eq!(get_binary(attrs, key, &mut data, &mut size), K_RESULT_OK);
+            assert_eq!(size, 4);
+            assert_eq!(std::slice::from_raw_parts(data as *const u8, 4), &payload);
+
+            msg_release(msg);
+        }
+    }
+}

--- a/crates/vibez-plugin-host/src/vst3_host/instance.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/instance.rs
@@ -336,6 +336,14 @@ impl PluginInstance for Vst3PluginInstance {
         &self.name
     }
 
+    fn save_state(&mut self) -> Option<Vec<u8>> {
+        unsafe { crate::state::vst3_component_get_state(self.component) }
+    }
+
+    fn load_state(&mut self, data: &[u8]) -> bool {
+        unsafe { crate::state::vst3_set_state(self.component, self.controller, data) }
+    }
+
     fn param_count(&self) -> usize {
         self.param_descriptors.len()
     }

--- a/crates/vibez-plugin-host/src/vst3_host/instance.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/instance.rs
@@ -27,12 +27,167 @@ pub struct Vst3PluginInstance {
     param_descriptors: Vec<ParamDescriptor>,
     param_values: Vec<f32>,
     buffer_adapter: AudioBufferAdapter,
+    /// Separate output buffers: VST3 process() is out-of-place by
+    /// default and JUCE plugins do not reliably write in-place.
+    out_adapter: AudioBufferAdapter,
+    /// Audio bus counts reported by the component; process() must
+    /// present an AudioBusBuffers entry per bus, active or not.
+    audio_in_buses: i32,
+    audio_out_buses: i32,
+    /// One-shot latch so a failing process() logs once, not per block.
+    process_error_logged: bool,
     note_events: Vec<NoteEvent>,
     sample_rate: f64,
     active: bool,
 }
 
 unsafe impl Send for Vst3PluginInstance {}
+
+// ── Stub IParameterChanges ──
+// DPF-based plugins assert on null input/outputParameterChanges and
+// JUCE tolerates but prefers them. This is a stateless, static COM
+// object: no parameters in, additions rejected.
+
+#[repr(C)]
+struct ParamChangesVtbl {
+    query_interface: unsafe extern "system" fn(
+        *mut std::ffi::c_void,
+        *const u8,
+        *mut *mut std::ffi::c_void,
+    ) -> i32,
+    add_ref: unsafe extern "system" fn(*mut std::ffi::c_void) -> u32,
+    release: unsafe extern "system" fn(*mut std::ffi::c_void) -> u32,
+    get_parameter_count: unsafe extern "system" fn(*mut std::ffi::c_void) -> i32,
+    get_parameter_data:
+        unsafe extern "system" fn(*mut std::ffi::c_void, i32) -> *mut std::ffi::c_void,
+    add_parameter_data: unsafe extern "system" fn(
+        *mut std::ffi::c_void,
+        *const u32,
+        *mut i32,
+    ) -> *mut std::ffi::c_void,
+}
+
+unsafe extern "system" fn pc_query_interface(
+    this: *mut std::ffi::c_void,
+    _iid: *const u8,
+    obj: *mut *mut std::ffi::c_void,
+) -> i32 {
+    // Static object: answer everything with ourselves; refcounting is
+    // a no-op so over-answering is harmless.
+    unsafe { *obj = this };
+    0
+}
+unsafe extern "system" fn pc_add_ref(_this: *mut std::ffi::c_void) -> u32 {
+    1
+}
+unsafe extern "system" fn pc_release(_this: *mut std::ffi::c_void) -> u32 {
+    1
+}
+unsafe extern "system" fn pc_count(_this: *mut std::ffi::c_void) -> i32 {
+    0
+}
+unsafe extern "system" fn pc_get_data(
+    _this: *mut std::ffi::c_void,
+    _index: i32,
+) -> *mut std::ffi::c_void {
+    std::ptr::null_mut()
+}
+unsafe extern "system" fn pc_add_data(
+    _this: *mut std::ffi::c_void,
+    _id: *const u32,
+    index: *mut i32,
+) -> *mut std::ffi::c_void {
+    // Hand back a discard-queue: DPF asserts on a null return and
+    // then writes its output points into whatever it gets.
+    if !index.is_null() {
+        unsafe { *index = 0 };
+    }
+    &PARAM_QUEUE_STUB as *const ParamQueueStub as *mut std::ffi::c_void
+}
+
+// IParamValueQueue stub: identifies as parameter 0, holds no points,
+// accepts (and discards) added points.
+#[repr(C)]
+struct ParamQueueVtbl {
+    query_interface: unsafe extern "system" fn(
+        *mut std::ffi::c_void,
+        *const u8,
+        *mut *mut std::ffi::c_void,
+    ) -> i32,
+    add_ref: unsafe extern "system" fn(*mut std::ffi::c_void) -> u32,
+    release: unsafe extern "system" fn(*mut std::ffi::c_void) -> u32,
+    get_parameter_id: unsafe extern "system" fn(*mut std::ffi::c_void) -> u32,
+    get_point_count: unsafe extern "system" fn(*mut std::ffi::c_void) -> i32,
+    get_point: unsafe extern "system" fn(*mut std::ffi::c_void, i32, *mut i32, *mut f64) -> i32,
+    add_point: unsafe extern "system" fn(*mut std::ffi::c_void, i32, f64, *mut i32) -> i32,
+}
+
+unsafe extern "system" fn pq_parameter_id(_this: *mut std::ffi::c_void) -> u32 {
+    0
+}
+unsafe extern "system" fn pq_point_count(_this: *mut std::ffi::c_void) -> i32 {
+    0
+}
+unsafe extern "system" fn pq_get_point(
+    _this: *mut std::ffi::c_void,
+    _index: i32,
+    _offset: *mut i32,
+    _value: *mut f64,
+) -> i32 {
+    1 // kResultFalse
+}
+unsafe extern "system" fn pq_add_point(
+    _this: *mut std::ffi::c_void,
+    _offset: i32,
+    _value: f64,
+    index: *mut i32,
+) -> i32 {
+    if !index.is_null() {
+        unsafe { *index = 0 };
+    }
+    0
+}
+
+static PARAM_QUEUE_VTBL: ParamQueueVtbl = ParamQueueVtbl {
+    query_interface: pc_query_interface,
+    add_ref: pc_add_ref,
+    release: pc_release,
+    get_parameter_id: pq_parameter_id,
+    get_point_count: pq_point_count,
+    get_point: pq_get_point,
+    add_point: pq_add_point,
+};
+
+#[repr(C)]
+struct ParamQueueStub {
+    vtbl: *const ParamQueueVtbl,
+}
+unsafe impl Sync for ParamQueueStub {}
+static PARAM_QUEUE_STUB: ParamQueueStub = ParamQueueStub {
+    vtbl: &PARAM_QUEUE_VTBL,
+};
+
+static PARAM_CHANGES_VTBL: ParamChangesVtbl = ParamChangesVtbl {
+    query_interface: pc_query_interface,
+    add_ref: pc_add_ref,
+    release: pc_release,
+    get_parameter_count: pc_count,
+    get_parameter_data: pc_get_data,
+    add_parameter_data: pc_add_data,
+};
+
+#[repr(C)]
+struct ParamChangesStub {
+    vtbl: *const ParamChangesVtbl,
+}
+unsafe impl Sync for ParamChangesStub {}
+static PARAM_CHANGES_STUB: ParamChangesStub = ParamChangesStub {
+    vtbl: &PARAM_CHANGES_VTBL,
+};
+
+fn param_changes_stub() -> *mut std::ffi::c_void {
+    &PARAM_CHANGES_STUB as *const ParamChangesStub as *mut std::ffi::c_void
+}
 
 /// Output of [`Vst3PluginInstance::load_partial`]: a dlopen'd module
 /// with no plugin code executed yet.
@@ -187,6 +342,40 @@ impl Vst3PluginInstance {
             return Err("GetPluginFactory returned null".into());
         }
 
+        // Give the factory our IHostApplication (IPluginFactory3).
+        // DPF-based plugins fall back to this context when initialize
+        // received none; best effort, older factories lack it.
+        unsafe {
+            type QueryInterfaceFn = unsafe extern "system" fn(
+                *mut std::ffi::c_void,
+                *const u8,
+                *mut *mut std::ffi::c_void,
+            ) -> i32;
+            let qi: QueryInterfaceFn =
+                std::mem::transmute(**(factory_ptr as *const *const *const std::ffi::c_void));
+            let mut f3: *mut std::ffi::c_void = std::ptr::null_mut();
+            if qi(
+                factory_ptr,
+                super::host_context::IPLUGINFACTORY3_IID.as_ptr(),
+                &mut f3,
+            ) == 0
+                && !f3.is_null()
+            {
+                // IPluginFactory3::setHostContext - vtable [10]
+                // (FUnknown 0-2, IPluginFactory 3-6, IPluginFactory2
+                // getClassInfo2 [7], IPluginFactory3
+                // getClassInfoUnicode [8]... setHostContext [9]).
+                type SetHostContextFn =
+                    unsafe extern "system" fn(*mut std::ffi::c_void, *mut std::ffi::c_void) -> i32;
+                let f3_vtbl = vtbl(f3);
+                let set_host_context: SetHostContextFn = std::mem::transmute(*f3_vtbl.add(9));
+                set_host_context(f3, super::host_context::host_application());
+                type ReleaseFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> u32;
+                let release: ReleaseFn = std::mem::transmute(*f3_vtbl.add(2));
+                release(f3);
+            }
+        }
+
         let cid_bytes = parse_uid(class_uid)?;
 
         // IPluginFactory::createInstance(cid, iid, &mut obj)
@@ -220,7 +409,7 @@ impl Vst3PluginInstance {
             unsafe extern "system" fn(*mut std::ffi::c_void, *mut std::ffi::c_void) -> i32;
         let comp_vtbl = unsafe { vtbl(component) };
         let initialize: InitializeFn = unsafe { std::mem::transmute(*comp_vtbl.add(3)) };
-        let hr = unsafe { initialize(component, std::ptr::null_mut()) };
+        let hr = unsafe { initialize(component, super::host_context::host_application()) };
         if hr != 0 {
             return Err(format!("Component initialize failed (hr={hr})"));
         }
@@ -315,6 +504,39 @@ impl Vst3PluginInstance {
         unsafe { release(factory_ptr) };
 
         let buffer_adapter = AudioBufferAdapter::new(2, max_buffer_size as usize);
+        let out_adapter = AudioBufferAdapter::new(2, max_buffer_size as usize);
+
+        // Discover audio buses and activate the main ones. JUCE
+        // plugins skip processing entirely while their buses are
+        // inactive, and process() must present one AudioBusBuffers
+        // per reported bus (aux/sidechain entries stay empty).
+        // IComponent: getBusCount [7], activateBus [10].
+        type GetBusCountFn = unsafe extern "system" fn(*mut std::ffi::c_void, i32, i32) -> i32;
+        type ActivateBusFn =
+            unsafe extern "system" fn(*mut std::ffi::c_void, i32, i32, i32, u8) -> i32;
+        const K_AUDIO: i32 = 0;
+        const K_EVENT: i32 = 1;
+        const K_INPUT: i32 = 0;
+        const K_OUTPUT: i32 = 1;
+        let get_bus_count: GetBusCountFn = unsafe { std::mem::transmute(*comp_vtbl.add(7)) };
+        let activate_bus: ActivateBusFn = unsafe { std::mem::transmute(*comp_vtbl.add(10)) };
+        let audio_in_buses = unsafe { get_bus_count(component, K_AUDIO, K_INPUT) };
+        let audio_out_buses = unsafe { get_bus_count(component, K_AUDIO, K_OUTPUT) };
+        unsafe {
+            if audio_in_buses > 0 {
+                activate_bus(component, K_AUDIO, K_INPUT, 0, 1);
+            }
+            if audio_out_buses > 0 {
+                activate_bus(component, K_AUDIO, K_OUTPUT, 0, 1);
+            }
+            // Event buses (MIDI in/out for instruments).
+            if get_bus_count(component, K_EVENT, K_INPUT) > 0 {
+                activate_bus(component, K_EVENT, K_INPUT, 0, 1);
+            }
+            if get_bus_count(component, K_EVENT, K_OUTPUT) > 0 {
+                activate_bus(component, K_EVENT, K_OUTPUT, 0, 1);
+            }
+        }
 
         let mut instance = Self {
             name,
@@ -327,6 +549,10 @@ impl Vst3PluginInstance {
             param_descriptors: Vec::new(),
             param_values: Vec::new(),
             buffer_adapter,
+            out_adapter,
+            audio_in_buses,
+            audio_out_buses,
+            process_error_logged: false,
             note_events: Vec::new(),
             sample_rate,
             active: false,
@@ -422,32 +648,74 @@ impl PluginInstance for Vst3PluginInstance {
         }
 
         self.buffer_adapter.deinterleave(buffer, frames);
+        for out in self.out_adapter.channel_buffers_mut() {
+            out[..frames].fill(0.0);
+        }
 
-        let bufs = self.buffer_adapter.channel_buffers_mut();
-        let mut data_ptrs: Vec<*mut f32> = bufs.iter_mut().map(|b| b.as_mut_ptr()).collect();
+        let mut in_ptrs: Vec<*mut f32> = self
+            .buffer_adapter
+            .channel_buffers_mut()
+            .iter_mut()
+            .map(|b| b.as_mut_ptr())
+            .collect();
+        let mut out_ptrs: Vec<*mut f32> = self
+            .out_adapter
+            .channel_buffers_mut()
+            .iter_mut()
+            .map(|b| b.as_mut_ptr())
+            .collect();
 
-        let mut input_bus = AudioBusBuffersRaw {
-            num_channels: channels as i32,
-            silence_flags: 0,
-            channel_buffers32: data_ptrs.as_mut_ptr(),
+        // One AudioBusBuffers entry per reported bus. Bus 0 carries
+        // the real audio; aux/sidechain buses are present but empty
+        // (inactive, zero channels), which JUCE maps to silence.
+        let empty_bus = || AudioBusBuffersRaw {
+            num_channels: 0,
+            silence_flags: u64::MAX,
+            channel_buffers32: std::ptr::null_mut(),
         };
-
-        let mut output_bus = AudioBusBuffersRaw {
-            num_channels: channels as i32,
-            silence_flags: 0,
-            channel_buffers32: data_ptrs.as_mut_ptr(),
+        let num_inputs = if self.is_instrument {
+            self.audio_in_buses.max(0)
+        } else {
+            self.audio_in_buses.max(1)
         };
+        let num_outputs = self.audio_out_buses.max(1);
+        let mut input_buses: Vec<AudioBusBuffersRaw> = (0..num_inputs)
+            .map(|i| {
+                if i == 0 && !self.is_instrument {
+                    AudioBusBuffersRaw {
+                        num_channels: channels as i32,
+                        silence_flags: 0,
+                        channel_buffers32: in_ptrs.as_mut_ptr(),
+                    }
+                } else {
+                    empty_bus()
+                }
+            })
+            .collect();
+        let mut output_buses: Vec<AudioBusBuffersRaw> = (0..num_outputs)
+            .map(|i| {
+                if i == 0 {
+                    AudioBusBuffersRaw {
+                        num_channels: channels as i32,
+                        silence_flags: 0,
+                        channel_buffers32: out_ptrs.as_mut_ptr(),
+                    }
+                } else {
+                    empty_bus()
+                }
+            })
+            .collect();
 
         let mut process_data = ProcessDataRaw {
             process_mode: 0,
             symbolic_sample_size: 0,
             num_samples: frames as i32,
-            num_inputs: if self.is_instrument { 0 } else { 1 },
-            num_outputs: 1,
-            inputs: &mut input_bus,
-            outputs: &mut output_bus,
-            input_parameter_changes: std::ptr::null_mut(),
-            output_parameter_changes: std::ptr::null_mut(),
+            num_inputs,
+            num_outputs,
+            inputs: input_buses.as_mut_ptr(),
+            outputs: output_buses.as_mut_ptr(),
+            input_parameter_changes: param_changes_stub(),
+            output_parameter_changes: param_changes_stub(),
             input_events: std::ptr::null_mut(),
             output_events: std::ptr::null_mut(),
             process_context: std::ptr::null_mut(),
@@ -466,9 +734,15 @@ impl PluginInstance for Vst3PluginInstance {
             unsafe extern "system" fn(*mut std::ffi::c_void, *mut ProcessDataRaw) -> i32;
         let proc_vtbl = unsafe { vtbl(self.processor) };
         let process: ProcessFn = unsafe { std::mem::transmute(*proc_vtbl.add(9)) };
-        let _hr = unsafe { process(self.processor, &mut process_data) };
+        let hr = unsafe { process(self.processor, &mut process_data) };
 
-        self.buffer_adapter.interleave(buffer, frames);
+        if hr == 0 {
+            self.out_adapter.interleave(buffer, frames);
+        } else if !self.process_error_logged {
+            self.process_error_logged = true;
+            eprintln!("vibez: {}: process() failed (hr={hr})", self.name);
+        }
+        // On failure the interleaved buffer keeps the dry signal.
         self.note_events.clear();
     }
 
@@ -511,7 +785,10 @@ impl PluginInstance for Vst3PluginInstance {
             let proc_vtbl = unsafe { vtbl(self.processor) };
             let setup_processing: SetupProcessingFn =
                 unsafe { std::mem::transmute(*proc_vtbl.add(7)) };
-            unsafe { setup_processing(self.processor, &mut setup) };
+            let hr = unsafe { setup_processing(self.processor, &mut setup) };
+            if hr != 0 {
+                eprintln!("vibez: {}: setupProcessing failed (hr={hr})", self.name);
+            }
         }
     }
 
@@ -532,6 +809,9 @@ impl PluginInstance for Vst3PluginInstance {
         let comp_vtbl = unsafe { vtbl(self.component) };
         let set_active: SetActiveFn = unsafe { std::mem::transmute(*comp_vtbl.add(11)) };
         let hr = unsafe { set_active(self.component, 1) };
+        if hr != 0 {
+            eprintln!("vibez: {}: setActive(1) failed (hr={hr})", self.name);
+        }
         if hr == 0 {
             if !self.processor.is_null() {
                 // IAudioProcessor::setProcessing - vtable [8]
@@ -585,6 +865,15 @@ impl Drop for Vst3PluginInstance {
             let release: ReleaseFn = unsafe { std::mem::transmute(*ctrl_vtbl.add(2)) };
             unsafe { release(self.controller) };
         }
+        // Release the processor interface before terminating the
+        // component: DPF warns (and may misbehave) if the audio
+        // processor ref is still held at component teardown.
+        if !self.processor.is_null() {
+            type ReleaseFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> u32;
+            let proc_vtbl = unsafe { vtbl(self.processor) };
+            let release: ReleaseFn = unsafe { std::mem::transmute(*proc_vtbl.add(2)) };
+            unsafe { release(self.processor) };
+        }
         if !self.component.is_null() {
             // IPluginBase::terminate - vtable [4]
             type TerminateFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> i32;
@@ -596,12 +885,6 @@ impl Drop for Vst3PluginInstance {
             type ReleaseFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> u32;
             let release: ReleaseFn = unsafe { std::mem::transmute(*comp_vtbl.add(2)) };
             unsafe { release(self.component) };
-        }
-        if !self.processor.is_null() {
-            type ReleaseFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> u32;
-            let proc_vtbl = unsafe { vtbl(self.processor) };
-            let release: ReleaseFn = unsafe { std::mem::transmute(*proc_vtbl.add(2)) };
-            unsafe { release(self.processor) };
         }
         super::scanner::vst3_module_exit(&self._lib);
     }

--- a/crates/vibez-plugin-host/src/vst3_host/instance.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/instance.rs
@@ -34,6 +34,14 @@ pub struct Vst3PluginInstance {
 
 unsafe impl Send for Vst3PluginInstance {}
 
+/// Output of [`Vst3PluginInstance::load_partial`]: a dlopen'd module
+/// with no plugin code executed yet.
+pub struct PartialVst3Plugin {
+    lib: libloading::Library,
+    class_uid: String,
+    is_instrument: bool,
+}
+
 #[allow(dead_code)]
 struct NoteEvent {
     is_on: bool,
@@ -114,6 +122,11 @@ impl Vst3PluginInstance {
     }
 
     /// Load and instantiate a VST3 plugin by its class ID from a `.vst3` bundle.
+    ///
+    /// Everything after the dlopen runs plugin code that may pin
+    /// itself to the calling thread (JUCE creates its MessageManager
+    /// on the instantiating thread); call this on the UI thread, or
+    /// use [`Self::load_partial`] + [`Self::init_on_main_thread`].
     pub fn load(
         path: &Path,
         class_uid: &str,
@@ -121,12 +134,45 @@ impl Vst3PluginInstance {
         sample_rate: f64,
         max_buffer_size: u32,
     ) -> Result<Self, String> {
-        let module_path = super::scanner::find_vst3_module(path)?;
+        let partial = Self::load_partial(path, class_uid, is_instrument)?;
+        Self::init_on_main_thread(partial, sample_rate, max_buffer_size)
+    }
 
+    /// Phase 1: locate and dlopen the module. Safe on a background
+    /// thread; runs no VST3 API calls (mirrors the CLAP two-phase
+    /// load that exists for JUCE MessageManager thread affinity).
+    pub fn load_partial(
+        path: &Path,
+        class_uid: &str,
+        is_instrument: bool,
+    ) -> Result<PartialVst3Plugin, String> {
+        let module_path = super::scanner::find_vst3_module(path)?;
         let lib = unsafe {
             libloading::Library::new(&module_path)
                 .map_err(|e| format!("Failed to load VST3 module: {e}"))?
         };
+        Ok(PartialVst3Plugin {
+            lib,
+            class_uid: class_uid.to_string(),
+            is_instrument,
+        })
+    }
+
+    /// Phase 2: run module init, factory, instantiation, and
+    /// activation. MUST run on the UI thread: JUCE plugins bind their
+    /// MessageManager to this thread, and the GUI plus teardown must
+    /// happen on the same one.
+    pub fn init_on_main_thread(
+        partial: PartialVst3Plugin,
+        sample_rate: f64,
+        max_buffer_size: u32,
+    ) -> Result<Self, String> {
+        let PartialVst3Plugin {
+            lib,
+            class_uid,
+            is_instrument,
+        } = partial;
+        let class_uid = class_uid.as_str();
         let lib = super::scanner::vst3_module_init(lib)?;
 
         type GetFactoryFn = unsafe extern "system" fn() -> *mut std::ffi::c_void;

--- a/crates/vibez-plugin-host/src/vst3_host/mod.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod bstream;
+pub(crate) mod host_context;
 pub mod host_impl;
 pub mod instance;
 pub mod runloop;

--- a/crates/vibez-plugin-host/src/vst3_host/mod.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod bstream;
 pub mod host_impl;
 pub mod instance;
+pub mod runloop;
 pub mod scanner;

--- a/crates/vibez-plugin-host/src/vst3_host/mod.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod bstream;
 pub mod host_impl;
 pub mod instance;
 pub mod scanner;

--- a/crates/vibez-plugin-host/src/vst3_host/runloop.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/runloop.rs
@@ -1,0 +1,469 @@
+//! Host-side IPlugFrame + Linux IRunLoop for VST3 plugin GUIs.
+//!
+//! On Linux the VST3 GUI contract requires the host to provide an
+//! event-loop service: plugins register file-descriptor handlers and
+//! timers with the IRunLoop they query from the IPlugFrame passed to
+//! IPlugView::setFrame. JUCE-based editors (ZL, Vital) do all their
+//! repainting and input dispatch from those callbacks; without a run
+//! loop the editor draws once and never responds.
+//!
+//! One COM object implements both interfaces: IPlugFrame at offset 0
+//! and IRunLoop as an embedded subobject one pointer in. Registered
+//! handlers land in a shared registry which the plugin window manager
+//! services from its UI-thread poll tick.
+
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+// FUnknown IID: {00000000-0000-0000-C000-000000000046}
+const FUNKNOWN_IID: [u8; 16] = [
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
+];
+
+// IPlugFrame IID: {367FAF01-AFA9-4693-8D4D-A2A0ED0882A3}
+pub(crate) const IPLUGFRAME_IID: [u8; 16] = [
+    0x36, 0x7F, 0xAF, 0x01, 0xAF, 0xA9, 0x46, 0x93, 0x8D, 0x4D, 0xA2, 0xA0, 0xED, 0x08, 0x82, 0xA3,
+];
+
+// Linux IRunLoop IID: {18C35366-9776-4F1A-9C5B-83857A871389}
+pub(crate) const IRUNLOOP_IID: [u8; 16] = [
+    0x18, 0xC3, 0x53, 0x66, 0x97, 0x76, 0x4F, 0x1A, 0x9C, 0x5B, 0x83, 0x85, 0x7A, 0x87, 0x13, 0x89,
+];
+
+const K_RESULT_OK: i32 = 0;
+const K_NO_INTERFACE: i32 = -1;
+const K_INVALID_ARGUMENT: i32 = 2;
+
+/// FUnknown vtable slots shared by plugin-side handler objects.
+type HandlerReleaseFn = unsafe extern "system" fn(*mut c_void) -> u32;
+type HandlerAddRefFn = unsafe extern "system" fn(*mut c_void) -> u32;
+/// IEventHandler::onFDIsSet(fd) / ITimerHandler::onTimer() - vtable [3]
+type OnFdIsSetFn = unsafe extern "system" fn(*mut c_void, i32);
+type OnTimerFn = unsafe extern "system" fn(*mut c_void);
+
+unsafe fn handler_vtbl_slot(obj: *mut c_void, slot: usize) -> *const c_void {
+    let vtbl = *(obj as *const *const *const c_void);
+    *vtbl.add(slot)
+}
+
+unsafe fn handler_add_ref(obj: *mut c_void) {
+    let f: HandlerAddRefFn = std::mem::transmute(handler_vtbl_slot(obj, 1));
+    f(obj);
+}
+
+unsafe fn handler_release(obj: *mut c_void) {
+    let f: HandlerReleaseFn = std::mem::transmute(handler_vtbl_slot(obj, 2));
+    f(obj);
+}
+
+struct EventHandlerEntry {
+    handler: *mut c_void,
+    fd: i32,
+}
+
+struct TimerEntry {
+    handler: *mut c_void,
+    interval: Duration,
+    next_fire: Instant,
+}
+
+// Safety: handlers are registered and serviced on the UI thread only;
+// Send is required because the registry travels inside Arc<Mutex<..>>.
+unsafe impl Send for EventHandlerEntry {}
+unsafe impl Send for TimerEntry {}
+
+/// Handlers a plugin registered with our run loop.
+#[derive(Default)]
+pub struct RunLoopRegistry {
+    event_handlers: Vec<EventHandlerEntry>,
+    timers: Vec<TimerEntry>,
+}
+
+impl RunLoopRegistry {
+    /// Fire due timers and ready file descriptors. UI thread only.
+    fn service(&mut self) {
+        let now = Instant::now();
+        // Collect first: a callback may re-enter register/unregister
+        // through the same mutex if invoked while iterating.
+        let due_timers: Vec<*mut c_void> = self
+            .timers
+            .iter_mut()
+            .filter(|t| now >= t.next_fire)
+            .map(|t| {
+                t.next_fire = now + t.interval;
+                t.handler
+            })
+            .collect();
+
+        let mut ready_fds: Vec<(*mut c_void, i32)> = Vec::new();
+        if !self.event_handlers.is_empty() {
+            let mut pollfds: Vec<libc::pollfd> = self
+                .event_handlers
+                .iter()
+                .map(|e| libc::pollfd {
+                    fd: e.fd,
+                    events: libc::POLLIN,
+                    revents: 0,
+                })
+                .collect();
+            let rc = unsafe { libc::poll(pollfds.as_mut_ptr(), pollfds.len() as u64, 0) };
+            if rc > 0 {
+                for (entry, pfd) in self.event_handlers.iter().zip(&pollfds) {
+                    if pfd.revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR) != 0 {
+                        ready_fds.push((entry.handler, entry.fd));
+                    }
+                }
+            }
+        }
+
+        for handler in due_timers {
+            unsafe {
+                let on_timer: OnTimerFn = std::mem::transmute(handler_vtbl_slot(handler, 3));
+                on_timer(handler);
+            }
+        }
+        for (handler, fd) in ready_fds {
+            unsafe {
+                let on_fd: OnFdIsSetFn = std::mem::transmute(handler_vtbl_slot(handler, 3));
+                on_fd(handler, fd);
+            }
+        }
+    }
+}
+
+/// Service a registry outside the lock held during callbacks:
+/// take the work under the lock, run callbacks after releasing it.
+pub fn service_registry(registry: &Mutex<RunLoopRegistry>) {
+    // Callbacks (JUCE paint/input) may call back into
+    // register/unregister; a held lock would deadlock. Swap the
+    // registry out, service it, merge re-registrations back.
+    let mut taken = {
+        let Ok(mut guard) = registry.lock() else {
+            return;
+        };
+        std::mem::take(&mut *guard)
+    };
+    taken.service();
+    if let Ok(mut guard) = registry.lock() {
+        // Anything the callbacks registered while we serviced.
+        let added = std::mem::take(&mut *guard);
+        *guard = taken;
+        guard.event_handlers.extend(added.event_handlers);
+        guard.timers.extend(added.timers);
+    }
+}
+
+#[repr(C)]
+struct FrameVtbl {
+    query_interface: unsafe extern "system" fn(*mut Frame, *const u8, *mut *mut c_void) -> i32,
+    add_ref: unsafe extern "system" fn(*mut Frame) -> u32,
+    release: unsafe extern "system" fn(*mut Frame) -> u32,
+    /// IPlugFrame::resizeView(view, newSize)
+    resize_view: unsafe extern "system" fn(*mut Frame, *mut c_void, *mut c_void) -> i32,
+}
+
+#[repr(C)]
+struct RunLoopVtbl {
+    query_interface: unsafe extern "system" fn(*mut c_void, *const u8, *mut *mut c_void) -> i32,
+    add_ref: unsafe extern "system" fn(*mut c_void) -> u32,
+    release: unsafe extern "system" fn(*mut c_void) -> u32,
+    register_event_handler: unsafe extern "system" fn(*mut c_void, *mut c_void, i32) -> i32,
+    unregister_event_handler: unsafe extern "system" fn(*mut c_void, *mut c_void) -> i32,
+    register_timer: unsafe extern "system" fn(*mut c_void, *mut c_void, u64) -> i32,
+    unregister_timer: unsafe extern "system" fn(*mut c_void, *mut c_void) -> i32,
+}
+
+static FRAME_VTBL: FrameVtbl = FrameVtbl {
+    query_interface: frame_query_interface,
+    add_ref: frame_add_ref,
+    release: frame_release,
+    resize_view,
+};
+
+static RUNLOOP_VTBL: RunLoopVtbl = RunLoopVtbl {
+    query_interface: rl_query_interface,
+    add_ref: rl_add_ref,
+    release: rl_release,
+    register_event_handler,
+    unregister_event_handler,
+    register_timer,
+    unregister_timer,
+};
+
+#[repr(C)]
+struct Frame {
+    frame_vtbl: *const FrameVtbl,
+    /// IRunLoop subobject: a pointer-sized slot whose address is the
+    /// COM pointer handed out for IRunLoop queries.
+    runloop_vtbl: *const RunLoopVtbl,
+    refcount: AtomicU32,
+    registry: *const Mutex<RunLoopRegistry>,
+}
+
+const RUNLOOP_OFFSET: usize = std::mem::size_of::<*const c_void>();
+
+unsafe fn frame_from_runloop(this: *mut c_void) -> *mut Frame {
+    (this as *mut u8).sub(RUNLOOP_OFFSET) as *mut Frame
+}
+
+unsafe fn qi_common(frame: *mut Frame, iid: *const u8, obj: *mut *mut c_void) -> i32 {
+    let iid = std::slice::from_raw_parts(iid, 16);
+    if iid == FUNKNOWN_IID || iid == IPLUGFRAME_IID {
+        frame_add_ref(frame);
+        *obj = frame as *mut c_void;
+        K_RESULT_OK
+    } else if iid == IRUNLOOP_IID {
+        frame_add_ref(frame);
+        *obj = (frame as *mut u8).add(RUNLOOP_OFFSET) as *mut c_void;
+        K_RESULT_OK
+    } else {
+        *obj = std::ptr::null_mut();
+        K_NO_INTERFACE
+    }
+}
+
+unsafe extern "system" fn frame_query_interface(
+    this: *mut Frame,
+    iid: *const u8,
+    obj: *mut *mut c_void,
+) -> i32 {
+    qi_common(this, iid, obj)
+}
+
+unsafe extern "system" fn frame_add_ref(this: *mut Frame) -> u32 {
+    (*this).refcount.fetch_add(1, Ordering::AcqRel) + 1
+}
+
+unsafe extern "system" fn frame_release(this: *mut Frame) -> u32 {
+    let remaining = (*this).refcount.fetch_sub(1, Ordering::AcqRel) - 1;
+    if remaining == 0 {
+        // Release any handlers the plugin failed to unregister, then
+        // drop our Arc reference to the registry.
+        let registry = Arc::from_raw((*this).registry);
+        if let Ok(mut reg) = registry.lock() {
+            for e in reg.event_handlers.drain(..) {
+                handler_release(e.handler);
+            }
+            for t in reg.timers.drain(..) {
+                handler_release(t.handler);
+            }
+        }
+        drop(registry);
+        drop(Box::from_raw(this));
+    }
+    remaining
+}
+
+unsafe extern "system" fn resize_view(
+    _this: *mut Frame,
+    view: *mut c_void,
+    rect: *mut c_void,
+) -> i32 {
+    if view.is_null() || rect.is_null() {
+        return K_INVALID_ARGUMENT;
+    }
+    // Accept the request and echo it back via IPlugView::onSize
+    // (vtable [10]). Resizing the host X11 window itself is bug #9
+    // territory; this keeps plugin-initiated resizes consistent.
+    type OnSizeFn = unsafe extern "system" fn(*mut c_void, *mut c_void) -> i32;
+    let vtbl = *(view as *const *const *const c_void);
+    let on_size: OnSizeFn = std::mem::transmute(*vtbl.add(10));
+    on_size(view, rect)
+}
+
+unsafe extern "system" fn rl_query_interface(
+    this: *mut c_void,
+    iid: *const u8,
+    obj: *mut *mut c_void,
+) -> i32 {
+    qi_common(frame_from_runloop(this), iid, obj)
+}
+
+unsafe extern "system" fn rl_add_ref(this: *mut c_void) -> u32 {
+    frame_add_ref(frame_from_runloop(this))
+}
+
+unsafe extern "system" fn rl_release(this: *mut c_void) -> u32 {
+    frame_release(frame_from_runloop(this))
+}
+
+unsafe fn with_registry(this: *mut c_void, f: impl FnOnce(&mut RunLoopRegistry)) -> i32 {
+    let frame = frame_from_runloop(this);
+    match (*(*frame).registry).lock() {
+        Ok(mut reg) => {
+            f(&mut reg);
+            K_RESULT_OK
+        }
+        Err(_) => K_INVALID_ARGUMENT,
+    }
+}
+
+unsafe extern "system" fn register_event_handler(
+    this: *mut c_void,
+    handler: *mut c_void,
+    fd: i32,
+) -> i32 {
+    if handler.is_null() {
+        return K_INVALID_ARGUMENT;
+    }
+    handler_add_ref(handler);
+    with_registry(this, |reg| {
+        reg.event_handlers.push(EventHandlerEntry { handler, fd });
+    })
+}
+
+unsafe extern "system" fn unregister_event_handler(this: *mut c_void, handler: *mut c_void) -> i32 {
+    let mut removed: Vec<*mut c_void> = Vec::new();
+    let rc = with_registry(this, |reg| {
+        reg.event_handlers.retain(|e| {
+            if e.handler == handler {
+                removed.push(e.handler);
+                false
+            } else {
+                true
+            }
+        });
+    });
+    for h in removed {
+        handler_release(h);
+    }
+    rc
+}
+
+unsafe extern "system" fn register_timer(
+    this: *mut c_void,
+    handler: *mut c_void,
+    milliseconds: u64,
+) -> i32 {
+    if handler.is_null() {
+        return K_INVALID_ARGUMENT;
+    }
+    handler_add_ref(handler);
+    let interval = Duration::from_millis(milliseconds.max(1));
+    with_registry(this, |reg| {
+        reg.timers.push(TimerEntry {
+            handler,
+            interval,
+            next_fire: Instant::now() + interval,
+        });
+    })
+}
+
+unsafe extern "system" fn unregister_timer(this: *mut c_void, handler: *mut c_void) -> i32 {
+    let mut removed: Vec<*mut c_void> = Vec::new();
+    let rc = with_registry(this, |reg| {
+        reg.timers.retain(|t| {
+            if t.handler == handler {
+                removed.push(t.handler);
+                false
+            } else {
+                true
+            }
+        });
+    });
+    for h in removed {
+        handler_release(h);
+    }
+    rc
+}
+
+/// Owned IPlugFrame/IRunLoop pair for one plugin view. Keep it alive
+/// from before `IPlugView::setFrame` until after `IPlugView::removed`.
+pub struct HostPlugFrame {
+    ptr: *mut Frame,
+    registry: Arc<Mutex<RunLoopRegistry>>,
+}
+
+// Safety: the frame is created and used on the UI thread; Send lets
+// it live inside UI-side structs that iced requires to be Send.
+unsafe impl Send for HostPlugFrame {}
+
+impl HostPlugFrame {
+    pub fn new() -> Self {
+        let registry = Arc::new(Mutex::new(RunLoopRegistry::default()));
+        let boxed = Box::new(Frame {
+            frame_vtbl: &FRAME_VTBL,
+            runloop_vtbl: &RUNLOOP_VTBL,
+            refcount: AtomicU32::new(1),
+            registry: Arc::into_raw(Arc::clone(&registry)),
+        });
+        Self {
+            ptr: Box::into_raw(boxed),
+            registry,
+        }
+    }
+
+    pub fn as_iplugframe(&self) -> *mut c_void {
+        self.ptr as *mut c_void
+    }
+
+    /// Fire due timers and ready fds for this view's plugin.
+    pub fn service(&self) {
+        service_registry(&self.registry);
+    }
+}
+
+impl Default for HostPlugFrame {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for HostPlugFrame {
+    fn drop(&mut self) {
+        unsafe { frame_release(self.ptr) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sdk_bytes(tuid: [::std::os::raw::c_char; 16]) -> Vec<u8> {
+        tuid.iter().map(|b| *b as u8).collect()
+    }
+
+    #[test]
+    fn iplugframe_iid_matches_sdk() {
+        assert_eq!(
+            IPLUGFRAME_IID.as_slice(),
+            sdk_bytes(vst3::Steinberg::IPlugFrame_iid).as_slice()
+        );
+    }
+
+    #[test]
+    fn irunloop_iid_matches_sdk() {
+        assert_eq!(
+            IRUNLOOP_IID.as_slice(),
+            sdk_bytes(vst3::Steinberg::Linux::IRunLoop_iid).as_slice()
+        );
+    }
+
+    #[test]
+    fn qi_runloop_subobject_roundtrip() {
+        let frame = HostPlugFrame::new();
+        unsafe {
+            let mut rl: *mut c_void = std::ptr::null_mut();
+            let hr = frame_query_interface(
+                frame.as_iplugframe() as *mut Frame,
+                IRUNLOOP_IID.as_ptr(),
+                &mut rl,
+            );
+            assert_eq!(hr, K_RESULT_OK);
+            assert!(!rl.is_null());
+            assert_ne!(rl, frame.as_iplugframe());
+
+            // QI back from the subobject to the frame.
+            let mut back: *mut c_void = std::ptr::null_mut();
+            let hr = rl_query_interface(rl, IPLUGFRAME_IID.as_ptr(), &mut back);
+            assert_eq!(hr, K_RESULT_OK);
+            assert_eq!(back, frame.as_iplugframe());
+
+            // Drop the two refs QI added.
+            rl_release(rl);
+            rl_release(rl);
+        }
+    }
+}

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -92,6 +92,65 @@ mod tests {
     use vibez_core::track::{InstrumentStateInfo, MediaSourceRef};
 
     #[test]
+    fn plugin_devices_roundtrip() {
+        use vibez_core::effect::{EffectInfo, EffectType, PluginDeviceInfo};
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugins.vibez");
+
+        let dev = PluginDeviceInfo {
+            format: "vst3".to_string(),
+            uid: "ABCD1234-0000-0000-0000-000000000000".to_string(),
+            path: PathBuf::from("/plugins/ZL Equalizer 2.vst3"),
+            name: "ZL Equalizer 2".to_string(),
+            state_b64: Some("dmliZXogc3RhdGU=".to_string()),
+        };
+        let mut track = TrackInfo::new("FX");
+        track.effects.push(EffectInfo {
+            id: vibez_core::id::EffectId::new(),
+            effect_type: EffectType::Gain,
+            bypass: false,
+            params: Vec::new(),
+            plugin: Some(dev.clone()),
+        });
+        track.plugin_instrument = Some(PluginDeviceInfo {
+            format: "clap".to_string(),
+            uid: "com.surge-synth-team.surge-xt".to_string(),
+            path: PathBuf::from("/plugins/Surge XT.clap"),
+            name: "Surge XT".to_string(),
+            state_b64: None,
+        });
+
+        let mut project = Project::default();
+        project.tracks.push(track);
+        project.save_to_file(&path).unwrap();
+        let loaded = Project::load_from_file(&path).unwrap();
+
+        assert_eq!(loaded.tracks[0].effects[0].plugin.as_ref(), Some(&dev));
+        assert_eq!(
+            loaded.tracks[0]
+                .plugin_instrument
+                .as_ref()
+                .map(|d| d.name.as_str()),
+            Some("Surge XT")
+        );
+    }
+
+    #[test]
+    fn pre_plugin_schema_still_loads() {
+        // A track serialized before the plugin fields existed must
+        // deserialize with them defaulted.
+        let json = r#"{
+            "id": 7, "name": "Old", "gain": 1.0, "pan": 0.0,
+            "mute": false, "solo": false,
+            "effects": [{ "id": 9, "effect_type": "Delay",
+                          "bypass": false, "params": [1.0] }]
+        }"#;
+        let track: TrackInfo = serde_json::from_str(json).unwrap();
+        assert!(track.effects[0].plugin.is_none());
+        assert!(track.plugin_instrument.is_none());
+    }
+
+    #[test]
     fn project_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.vibez");
@@ -257,6 +316,7 @@ mod tests {
             effect_type: EffectType::Delay,
             bypass: false,
             params: vec![500.0, 0.5, 0.3],
+            plugin: None,
         });
         track.native_instrument = Some(InstrumentStateInfo::SubtractiveSynth {
             params: vec![0.05, 0.2, 0.8, 0.4],

--- a/crates/vibez-ui/Cargo.toml
+++ b/crates/vibez-ui/Cargo.toml
@@ -16,6 +16,7 @@ vibez-dropbox = { workspace = true }
 iced = { workspace = true }
 rtrb = { workspace = true }
 serde = { workspace = true }
+base64 = { workspace = true }
 serde_json = { workspace = true }
 rfd = "0.15"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync"] }

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8958,14 +8958,12 @@ impl App {
                                 PluginCategory::Instrument => "inst",
                                 PluginCategory::Both => "fx+inst",
                             };
-                            let display: String = if plugin.name.chars().count() > 20 {
-                                format!("{}...", plugin.name.chars().take(18).collect::<String>())
-                            } else {
-                                plugin.name.clone()
-                            };
                             let plugin_id = plugin.id.clone();
+                            // Full name, wrapping inside the fixed
+                            // cell width: truncated names made the
+                            // LSP suite indistinguishable.
                             let cell = column![
-                                text(display).size(11).color(th::TEXT),
+                                text(plugin.name.clone()).size(11).color(th::TEXT),
                                 text(format!("{format_badge} {cat_label}"))
                                     .size(9)
                                     .color(th::TEXT_DIM),

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -59,6 +59,15 @@ struct PluginLoadResult {
     /// CLAP two-phase: partially loaded plugin to be finished on UI thread.
     clap_partial: Option<vibez_plugin_host::clap_host::instance::PartialClapPlugin>,
     sample_rate: f64,
+    /// Persistent identity for project save.
+    device_ref: vibez_core::effect::PluginDeviceInfo,
+    /// Pointer for live state capture at save time.
+    state_ptr: Option<vibez_plugin_host::PluginStatePtr>,
+    /// Saved state to restore (project reload). Applied on the UI
+    /// thread for CLAP; already applied in the loader for VST3.
+    pending_state: Option<Vec<u8>>,
+    /// Chain position to restore (project reload).
+    position: Option<usize>,
 }
 
 /// Result of loading a plugin instrument on a background thread.
@@ -71,6 +80,12 @@ struct PluginInstrumentLoadResult {
     /// CLAP two-phase: partially loaded plugin to be finished on UI thread.
     clap_partial: Option<vibez_plugin_host::clap_host::instance::PartialClapPlugin>,
     sample_rate: f64,
+    /// Persistent identity for project save.
+    device_ref: vibez_core::effect::PluginDeviceInfo,
+    /// Pointer for live state capture at save time.
+    state_ptr: Option<vibez_plugin_host::PluginStatePtr>,
+    /// Saved state to restore (project reload).
+    pending_state: Option<Vec<u8>>,
 }
 
 struct BounceAssets {
@@ -96,6 +111,9 @@ struct App {
     // Plugin GUI support
     plugin_window_manager: Option<PluginWindowManager>,
     plugin_gui_raw_ptrs: std::collections::HashMap<PluginGuiKey, PluginRawPtr>,
+    /// Raw pointers for live state capture at save time, keyed like
+    /// the GUI pointers. Entries live exactly as long as the device.
+    plugin_state_ptrs: std::collections::HashMap<PluginGuiKey, vibez_plugin_host::PluginStatePtr>,
 
     // Dropbox
     dropbox_settings: DropboxSettings,
@@ -195,6 +213,7 @@ impl App {
             plugin_instrument_tx,
             plugin_window_manager,
             plugin_gui_raw_ptrs: std::collections::HashMap::new(),
+            plugin_state_ptrs: std::collections::HashMap::new(),
             dropbox_settings,
             dropbox_cache,
             dropbox_client,
@@ -241,6 +260,10 @@ impl App {
         }
 
         self.state.tracks.clear();
+        // The engine drops all plugin instances with their tracks;
+        // stale raw pointers must go with them.
+        self.plugin_gui_raw_ptrs.clear();
+        self.plugin_state_ptrs.clear();
         self.state.selected_track = None;
         self.state.next_track_number = 1;
         self.state.selected_note_clip = None;
@@ -638,14 +661,31 @@ impl App {
         let effects = track
             .effects
             .iter()
-            .filter(|effect| effect.plugin_name.is_none())
-            .map(|effect| vibez_core::effect::EffectInfo {
-                id: effect.id,
-                effect_type: effect.effect_type,
-                bypass: effect.bypass,
-                params: effect.params.clone(),
+            .map(|effect| {
+                let plugin = effect.plugin_ref.as_ref().map(|dev| {
+                    let mut dev = dev.clone();
+                    dev.state_b64 = self.capture_device_state(PluginGuiKey::Effect {
+                        track_id: track.id,
+                        effect_id: effect.id,
+                    });
+                    dev
+                });
+                vibez_core::effect::EffectInfo {
+                    id: effect.id,
+                    effect_type: effect.effect_type,
+                    bypass: effect.bypass,
+                    params: effect.params.clone(),
+                    plugin,
+                }
             })
             .collect();
+
+        let plugin_instrument = track.plugin_instrument_ref.as_ref().map(|dev| {
+            let mut dev = dev.clone();
+            dev.state_b64 =
+                self.capture_device_state(PluginGuiKey::Instrument { track_id: track.id });
+            dev
+        });
 
         let native_instrument = match track.instrument_kind {
             Some(InstrumentKind::SubtractiveSynth) => Some(InstrumentStateInfo::SubtractiveSynth {
@@ -677,7 +717,17 @@ impl App {
             color_index: track.color_index,
             instrument: track.instrument_kind,
             native_instrument,
+            plugin_instrument,
         }
+    }
+
+    /// Base64-encoded live state of a plugin device, captured on the
+    /// UI thread via the pointer stashed at load time.
+    fn capture_device_state(&self, key: PluginGuiKey) -> Option<String> {
+        use base64::Engine;
+        let ptr = self.plugin_state_ptrs.get(&key)?;
+        let data = unsafe { vibez_plugin_host::capture_plugin_state(ptr) }?;
+        Some(base64::engine::general_purpose::STANDARD.encode(data))
     }
 
     fn project_from_state(&self) -> Project {
@@ -755,6 +805,16 @@ impl App {
 
     fn rebuild_from_loaded_project(&mut self, loaded: ProjectLoadResult) {
         self.clear_project_runtime();
+        // Third-party plugin devices load asynchronously after the
+        // built-in rebuild; collected here, spawned at the end.
+        let mut plugin_effect_requests: Vec<(
+            TrackId,
+            EffectId,
+            usize,
+            vibez_core::effect::PluginDeviceInfo,
+        )> = Vec::new();
+        let mut plugin_instrument_requests: Vec<(TrackId, vibez_core::effect::PluginDeviceInfo)> =
+            Vec::new();
         self.undo_history.clear();
         self.state.bpm = loaded.project.bpm;
         self.state.bpm_text = format!("{:.0}", loaded.project.bpm);
@@ -773,6 +833,9 @@ impl App {
             track.solo = track_info.solo;
             track.instrument_kind = track_info.instrument;
             track.has_instrument = track_info.instrument.is_some();
+            if let Some(dev) = &track_info.plugin_instrument {
+                plugin_instrument_requests.push((track_info.id, dev.clone()));
+            }
 
             match track.kind {
                 TrackKind::Audio => {
@@ -836,7 +899,16 @@ impl App {
                 }
             }
 
-            for effect_info in &track_info.effects {
+            for (chain_pos, effect_info) in track_info.effects.iter().enumerate() {
+                if let Some(dev) = &effect_info.plugin {
+                    plugin_effect_requests.push((
+                        track_info.id,
+                        effect_info.id,
+                        chain_pos,
+                        dev.clone(),
+                    ));
+                    continue;
+                }
                 let fx = vibez_dsp::factory::create_effect_with_params(
                     effect_info.effect_type,
                     self.state.sample_rate as f32,
@@ -851,6 +923,7 @@ impl App {
                     descriptors,
                     plugin_name: None,
                     has_plugin_gui: false,
+                    plugin_ref: None,
                 });
                 self.send_command(EngineCommand::AddEffect {
                     track_id: track_info.id,
@@ -991,6 +1064,93 @@ impl App {
                 loaded.warnings.len()
             )
         };
+
+        self.spawn_project_plugin_loads(plugin_effect_requests, plugin_instrument_requests);
+    }
+
+    /// Reload persisted plugin devices on one background thread, in
+    /// file order, so results arrive in order and chain positions
+    /// restore deterministically. Results flow through the same
+    /// channels as interactive plugin loads.
+    fn spawn_project_plugin_loads(
+        &mut self,
+        effect_requests: Vec<(
+            TrackId,
+            EffectId,
+            usize,
+            vibez_core::effect::PluginDeviceInfo,
+        )>,
+        instrument_requests: Vec<(TrackId, vibez_core::effect::PluginDeviceInfo)>,
+    ) {
+        if effect_requests.is_empty() && instrument_requests.is_empty() {
+            return;
+        }
+        let n = effect_requests.len() + instrument_requests.len();
+        self.state.status_text = format!("Loading {n} plugin(s)...");
+
+        let effect_tx = self.plugin_effect_tx.clone();
+        let instrument_tx = self.plugin_instrument_tx.clone();
+        let sample_rate = self.state.sample_rate as f64;
+
+        std::thread::spawn(move || {
+            use base64::Engine;
+            let decode = |dev: &vibez_core::effect::PluginDeviceInfo| {
+                dev.state_b64.as_ref().and_then(|b64| {
+                    base64::engine::general_purpose::STANDARD
+                        .decode(b64)
+                        .map_err(|e| {
+                            eprintln!("vibez: bad plugin state blob for {}: {e}", dev.name)
+                        })
+                        .ok()
+                })
+            };
+            let scan_info =
+                |dev: &vibez_core::effect::PluginDeviceInfo,
+                 category: vibez_plugin_host::PluginCategory| {
+                    let format = match dev.format.as_str() {
+                        "clap" => PluginFormat::Clap,
+                        _ => PluginFormat::Vst3,
+                    };
+                    PluginInfo {
+                        id: vibez_plugin_host::PluginId {
+                            format,
+                            uid: dev.uid.clone(),
+                        },
+                        name: dev.name.clone(),
+                        vendor: String::new(),
+                        category,
+                        format,
+                        path: dev.path.clone(),
+                    }
+                };
+
+            for (track_id, effect_id, chain_pos, dev) in effect_requests {
+                let info = scan_info(&dev, vibez_plugin_host::PluginCategory::Effect);
+                match load_plugin_effect_bg(&info, sample_rate, decode(&dev)) {
+                    Ok(mut result) => {
+                        result.track_id = track_id;
+                        result.effect_id = effect_id;
+                        result.position = Some(chain_pos);
+                        let _ = effect_tx.send(result);
+                    }
+                    Err(e) => {
+                        eprintln!("vibez: failed to reload plugin {}: {e}", dev.name);
+                    }
+                }
+            }
+            for (track_id, dev) in instrument_requests {
+                let info = scan_info(&dev, vibez_plugin_host::PluginCategory::Instrument);
+                match load_plugin_instrument_bg(&info, sample_rate, decode(&dev)) {
+                    Ok(mut result) => {
+                        result.track_id = track_id;
+                        let _ = instrument_tx.send(result);
+                    }
+                    Err(e) => {
+                        eprintln!("vibez: failed to reload plugin {}: {e}", dev.name);
+                    }
+                }
+            }
+        });
     }
 
     fn collect_bounce_assets(&self) -> BounceAssets {
@@ -2003,6 +2163,10 @@ impl App {
                     PluginGuiKey::Effect { track_id: tid, .. } => *tid != track_id,
                     PluginGuiKey::Instrument { track_id: tid } => *tid != track_id,
                 });
+                self.plugin_state_ptrs.retain(|k, _| match k {
+                    PluginGuiKey::Effect { track_id: tid, .. } => *tid != track_id,
+                    PluginGuiKey::Instrument { track_id: tid } => *tid != track_id,
+                });
 
                 self.send_command(EngineCommand::RemoveTrack(track_id));
                 self.state.tracks.retain(|t| t.id != track_id);
@@ -2191,6 +2355,7 @@ impl App {
                         descriptors,
                         plugin_name: None,
                         has_plugin_gui: false,
+                        plugin_ref: None,
                     });
                 }
                 self.send_command(EngineCommand::AddEffect {
@@ -2212,6 +2377,7 @@ impl App {
                     mgr.close(gui_key);
                 }
                 self.plugin_gui_raw_ptrs.remove(&gui_key);
+                self.plugin_state_ptrs.remove(&gui_key);
 
                 if let Some(track) = self.state.find_track_mut(track_id) {
                     track.effects.retain(|e| e.id != effect_id);
@@ -4115,6 +4281,7 @@ impl App {
                     mgr.close(gui_key);
                 }
                 self.plugin_gui_raw_ptrs.remove(&gui_key);
+                self.plugin_state_ptrs.remove(&gui_key);
 
                 if let Some(track) = self.state.find_track_mut(track_id) {
                     track.has_instrument = false;
@@ -4785,7 +4952,7 @@ impl App {
                     if is_instrument {
                         let tx = self.plugin_instrument_tx.clone();
                         std::thread::spawn(move || {
-                            match load_plugin_instrument_bg(&info, sample_rate) {
+                            match load_plugin_instrument_bg(&info, sample_rate, None) {
                                 Ok(mut result) => {
                                     result.track_id = track_id;
                                     let _ = tx.send(result);
@@ -4798,7 +4965,7 @@ impl App {
                     } else {
                         let tx = self.plugin_effect_tx.clone();
                         std::thread::spawn(move || {
-                            match load_plugin_effect_bg(&info, sample_rate) {
+                            match load_plugin_effect_bg(&info, sample_rate, None) {
                                 Ok(mut result) => {
                                     result.track_id = track_id;
                                     let _ = tx.send(result);
@@ -5533,7 +5700,7 @@ impl App {
 
     fn poll_plugin_loads(&mut self) {
         // Poll for loaded plugin effects
-        while let Ok(result) = self.plugin_effect_rx.try_recv() {
+        while let Ok(mut result) = self.plugin_effect_rx.try_recv() {
             let track_id = result.track_id;
             let effect_id = result.effect_id;
             let plugin_name = result.plugin_name.clone();
@@ -5550,8 +5717,17 @@ impl App {
                     result.sample_rate,
                     4096,
                 ) {
-                    Ok(clap_inst) => {
+                    Ok(mut clap_inst) => {
+                        if let Some(ref data) = result.pending_state {
+                            use vibez_plugin_host::PluginInstance;
+                            if !clap_inst.load_state(data) {
+                                eprintln!("vibez: {plugin_name} rejected saved state");
+                            }
+                        }
                         let raw_ptr = Some(PluginRawPtr::Clap(
+                            clap_inst.plugin_ptr() as *const std::ffi::c_void,
+                        ));
+                        result.state_ptr = Some(vibez_plugin_host::PluginStatePtr::Clap(
                             clap_inst.plugin_ptr() as *const std::ffi::c_void,
                         ));
                         let wrapper =
@@ -5579,11 +5755,18 @@ impl App {
                 };
                 self.plugin_gui_raw_ptrs.insert(key, raw_ptr);
             }
+            if let Some(state_ptr) = result.state_ptr {
+                let key = PluginGuiKey::Effect {
+                    track_id,
+                    effect_id,
+                };
+                self.plugin_state_ptrs.insert(key, state_ptr);
+            }
 
             if let Some(track) = self.state.find_track_mut(track_id) {
                 let descriptors: &'static [vibez_core::effect::ParamDescriptor] =
                     Box::leak(Vec::new().into_boxed_slice());
-                track.effects.push(UiEffect {
+                let ui_effect = UiEffect {
                     id: effect_id,
                     effect_type: EffectType::Gain,
                     bypass: false,
@@ -5591,19 +5774,24 @@ impl App {
                     descriptors,
                     plugin_name: Some(plugin_name.clone()),
                     has_plugin_gui: has_gui,
-                });
+                    plugin_ref: Some(result.device_ref.clone()),
+                };
+                match result.position {
+                    Some(pos) if pos < track.effects.len() => track.effects.insert(pos, ui_effect),
+                    _ => track.effects.push(ui_effect),
+                }
             }
             self.send_command(EngineCommand::AddPluginEffect {
                 track_id,
                 effect_id,
                 effect,
-                position: None,
+                position: result.position,
             });
             self.state.status_text = format!("Loaded {plugin_name}");
         }
 
         // Poll for loaded plugin instruments
-        while let Ok(result) = self.plugin_instrument_rx.try_recv() {
+        while let Ok(mut result) = self.plugin_instrument_rx.try_recv() {
             let track_id = result.track_id;
             let plugin_name = result.plugin_name.clone();
 
@@ -5617,8 +5805,17 @@ impl App {
                     result.sample_rate,
                     4096,
                 ) {
-                    Ok(clap_inst) => {
+                    Ok(mut clap_inst) => {
+                        if let Some(ref data) = result.pending_state {
+                            use vibez_plugin_host::PluginInstance;
+                            if !clap_inst.load_state(data) {
+                                eprintln!("vibez: {plugin_name} rejected saved state");
+                            }
+                        }
                         let raw_ptr = Some(PluginRawPtr::Clap(
+                            clap_inst.plugin_ptr() as *const std::ffi::c_void,
+                        ));
+                        result.state_ptr = Some(vibez_plugin_host::PluginStatePtr::Clap(
                             clap_inst.plugin_ptr() as *const std::ffi::c_void,
                         ));
                         let wrapper =
@@ -5643,10 +5840,15 @@ impl App {
                 let key = PluginGuiKey::Instrument { track_id };
                 self.plugin_gui_raw_ptrs.insert(key, raw_ptr);
             }
+            if let Some(state_ptr) = result.state_ptr {
+                let key = PluginGuiKey::Instrument { track_id };
+                self.plugin_state_ptrs.insert(key, state_ptr);
+            }
 
             if let Some(track) = self.state.find_track_mut(track_id) {
                 track.has_instrument = true;
                 track.plugin_instrument_name = Some(plugin_name.clone());
+                track.plugin_instrument_ref = Some(result.device_ref.clone());
                 track.has_plugin_instrument_gui = has_gui;
             }
             self.send_command(EngineCommand::SetPluginInstrument {
@@ -9507,10 +9709,28 @@ impl App {
     }
 }
 
+/// Persistent identity for a plugin device, built from scan info.
+fn plugin_device_ref(info: &PluginInfo) -> vibez_core::effect::PluginDeviceInfo {
+    vibez_core::effect::PluginDeviceInfo {
+        format: match info.format {
+            PluginFormat::Clap => "clap".to_string(),
+            PluginFormat::Vst3 => "vst3".to_string(),
+        },
+        uid: info.id.uid.clone(),
+        path: info.path.clone(),
+        name: info.name.clone(),
+        state_b64: None,
+    }
+}
+
 /// Phase 1 of plugin loading (runs on background thread).
 /// For CLAP: only loads the DSO — NO CLAP API calls (not even create_plugin).
 /// For VST3: fully loads (VST3 doesn't have JUCE MessageManager issues).
-fn load_plugin_effect_bg(info: &PluginInfo, sample_rate: f64) -> Result<PluginLoadResult, String> {
+fn load_plugin_effect_bg(
+    info: &PluginInfo,
+    sample_rate: f64,
+    saved_state: Option<Vec<u8>>,
+) -> Result<PluginLoadResult, String> {
     match info.format {
         PluginFormat::Clap => {
             let partial = vibez_plugin_host::clap_host::instance::ClapPluginInstance::load_partial(
@@ -9526,16 +9746,27 @@ fn load_plugin_effect_bg(info: &PluginInfo, sample_rate: f64) -> Result<PluginLo
                 gui_raw_ptr: None,
                 clap_partial: Some(partial),
                 sample_rate,
+                device_ref: plugin_device_ref(info),
+                state_ptr: None,
+                // CLAP state must be applied after init_on_main_thread.
+                pending_state: saved_state,
+                position: None,
             })
         }
         PluginFormat::Vst3 => {
-            let vst3_inst = vibez_plugin_host::vst3_host::instance::Vst3PluginInstance::load(
+            let mut vst3_inst = vibez_plugin_host::vst3_host::instance::Vst3PluginInstance::load(
                 &info.path,
                 &info.id.uid,
                 false,
                 sample_rate,
                 4096,
             )?;
+            if let Some(ref data) = saved_state {
+                use vibez_plugin_host::PluginInstance;
+                if !vst3_inst.load_state(data) {
+                    eprintln!("vibez: {} rejected saved state", vst3_inst.name());
+                }
+            }
             let gui_raw_ptr = {
                 let ctrl = vst3_inst.controller_ptr();
                 if ctrl.is_null() {
@@ -9544,6 +9775,9 @@ fn load_plugin_effect_bg(info: &PluginInfo, sample_rate: f64) -> Result<PluginLo
                     Some(PluginRawPtr::Vst3(ctrl))
                 }
             };
+            let state_ptr = Some(vibez_plugin_host::PluginStatePtr::Vst3Component(
+                vst3_inst.component_ptr(),
+            ));
             let name = vst3_inst.name().to_string();
             let wrapper = vibez_plugin_host::PluginEffectWrapper::new(Box::new(vst3_inst));
             Ok(PluginLoadResult {
@@ -9554,6 +9788,10 @@ fn load_plugin_effect_bg(info: &PluginInfo, sample_rate: f64) -> Result<PluginLo
                 gui_raw_ptr,
                 clap_partial: None,
                 sample_rate,
+                device_ref: plugin_device_ref(info),
+                state_ptr,
+                pending_state: None,
+                position: None,
             })
         }
     }
@@ -9563,6 +9801,7 @@ fn load_plugin_effect_bg(info: &PluginInfo, sample_rate: f64) -> Result<PluginLo
 fn load_plugin_instrument_bg(
     info: &PluginInfo,
     sample_rate: f64,
+    saved_state: Option<Vec<u8>>,
 ) -> Result<PluginInstrumentLoadResult, String> {
     match info.format {
         PluginFormat::Clap => {
@@ -9578,16 +9817,25 @@ fn load_plugin_instrument_bg(
                 gui_raw_ptr: None,
                 clap_partial: Some(partial),
                 sample_rate,
+                device_ref: plugin_device_ref(info),
+                state_ptr: None,
+                pending_state: saved_state,
             })
         }
         PluginFormat::Vst3 => {
-            let vst3_inst = vibez_plugin_host::vst3_host::instance::Vst3PluginInstance::load(
+            let mut vst3_inst = vibez_plugin_host::vst3_host::instance::Vst3PluginInstance::load(
                 &info.path,
                 &info.id.uid,
                 true,
                 sample_rate,
                 4096,
             )?;
+            if let Some(ref data) = saved_state {
+                use vibez_plugin_host::PluginInstance;
+                if !vst3_inst.load_state(data) {
+                    eprintln!("vibez: {} rejected saved state", vst3_inst.name());
+                }
+            }
             let gui_raw_ptr = {
                 let ctrl = vst3_inst.controller_ptr();
                 if ctrl.is_null() {
@@ -9596,6 +9844,9 @@ fn load_plugin_instrument_bg(
                     Some(PluginRawPtr::Vst3(ctrl))
                 }
             };
+            let state_ptr = Some(vibez_plugin_host::PluginStatePtr::Vst3Component(
+                vst3_inst.component_ptr(),
+            ));
             let name = vst3_inst.name().to_string();
             let wrapper = vibez_plugin_host::PluginInstrumentWrapper::new(Box::new(vst3_inst));
             Ok(PluginInstrumentLoadResult {
@@ -9605,6 +9856,9 @@ fn load_plugin_instrument_bg(
                 gui_raw_ptr,
                 clap_partial: None,
                 sample_rate,
+                device_ref: plugin_device_ref(info),
+                state_ptr,
+                pending_state: None,
             })
         }
     }

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -23,7 +23,7 @@ use vibez_engine::commands::EngineCommand;
 use vibez_engine::engine::AudioEngine;
 use vibez_engine::events::EngineEvent;
 use vibez_plugin_host::gui::PluginGuiKey;
-use vibez_plugin_host::{PluginCategory, PluginFormat, PluginInfo, PluginInstance};
+use vibez_plugin_host::{PluginCategory, PluginFormat, PluginInfo};
 use vibez_project::Project;
 
 use crate::icons;
@@ -58,13 +58,16 @@ struct PluginLoadResult {
     gui_raw_ptr: Option<PluginRawPtr>,
     /// CLAP two-phase: partially loaded plugin to be finished on UI thread.
     clap_partial: Option<vibez_plugin_host::clap_host::instance::PartialClapPlugin>,
+    /// VST3 two-phase: dlopen'd module to be instantiated on the UI
+    /// thread (JUCE MessageManager binds to the instantiating thread).
+    vst3_partial: Option<vibez_plugin_host::vst3_host::instance::PartialVst3Plugin>,
     sample_rate: f64,
     /// Persistent identity for project save.
     device_ref: vibez_core::effect::PluginDeviceInfo,
     /// Pointer for live state capture at save time.
     state_ptr: Option<vibez_plugin_host::PluginStatePtr>,
-    /// Saved state to restore (project reload). Applied on the UI
-    /// thread for CLAP; already applied in the loader for VST3.
+    /// Saved state to restore (project reload), applied on the UI
+    /// thread after phase-2 init.
     pending_state: Option<Vec<u8>>,
     /// Chain position to restore (project reload).
     position: Option<usize>,
@@ -79,6 +82,8 @@ struct PluginInstrumentLoadResult {
     gui_raw_ptr: Option<PluginRawPtr>,
     /// CLAP two-phase: partially loaded plugin to be finished on UI thread.
     clap_partial: Option<vibez_plugin_host::clap_host::instance::PartialClapPlugin>,
+    /// VST3 two-phase: dlopen'd module to be instantiated on the UI thread.
+    vst3_partial: Option<vibez_plugin_host::vst3_host::instance::PartialVst3Plugin>,
     sample_rate: f64,
     /// Persistent identity for project save.
     device_ref: vibez_core::effect::PluginDeviceInfo,
@@ -5740,6 +5745,39 @@ impl App {
                         continue;
                     }
                 }
+            } else if let Some(partial) = result.vst3_partial.take() {
+                match vibez_plugin_host::vst3_host::instance::Vst3PluginInstance::init_on_main_thread(
+                    partial,
+                    result.sample_rate,
+                    4096,
+                ) {
+                    Ok(mut vst3_inst) => {
+                        if let Some(ref data) = result.pending_state {
+                            use vibez_plugin_host::PluginInstance;
+                            if !vst3_inst.load_state(data) {
+                                eprintln!("vibez: {plugin_name} rejected saved state");
+                            }
+                        }
+                        let ctrl = vst3_inst.controller_ptr();
+                        let raw_ptr = if ctrl.is_null() {
+                            None
+                        } else {
+                            Some(PluginRawPtr::Vst3(ctrl))
+                        };
+                        result.state_ptr =
+                            Some(vibez_plugin_host::PluginStatePtr::Vst3Component(
+                                vst3_inst.component_ptr(),
+                            ));
+                        let wrapper =
+                            vibez_plugin_host::PluginEffectWrapper::new(Box::new(vst3_inst));
+                        (Box::new(wrapper), raw_ptr)
+                    }
+                    Err(e) => {
+                        eprintln!("vibez: VST3 init failed on UI thread: {e}");
+                        self.state.status_text = format!("Plugin init failed: {e}");
+                        continue;
+                    }
+                }
             } else if let Some(effect) = result.effect {
                 (effect, result.gui_raw_ptr)
             } else {
@@ -5824,6 +5862,39 @@ impl App {
                     }
                     Err(e) => {
                         eprintln!("vibez: CLAP instrument init failed on UI thread: {e}");
+                        self.state.status_text = format!("Plugin init failed: {e}");
+                        continue;
+                    }
+                }
+            } else if let Some(partial) = result.vst3_partial.take() {
+                match vibez_plugin_host::vst3_host::instance::Vst3PluginInstance::init_on_main_thread(
+                    partial,
+                    result.sample_rate,
+                    4096,
+                ) {
+                    Ok(mut vst3_inst) => {
+                        if let Some(ref data) = result.pending_state {
+                            use vibez_plugin_host::PluginInstance;
+                            if !vst3_inst.load_state(data) {
+                                eprintln!("vibez: {plugin_name} rejected saved state");
+                            }
+                        }
+                        let ctrl = vst3_inst.controller_ptr();
+                        let raw_ptr = if ctrl.is_null() {
+                            None
+                        } else {
+                            Some(PluginRawPtr::Vst3(ctrl))
+                        };
+                        result.state_ptr =
+                            Some(vibez_plugin_host::PluginStatePtr::Vst3Component(
+                                vst3_inst.component_ptr(),
+                            ));
+                        let wrapper =
+                            vibez_plugin_host::PluginInstrumentWrapper::new(Box::new(vst3_inst));
+                        (Box::new(wrapper), raw_ptr)
+                    }
+                    Err(e) => {
+                        eprintln!("vibez: VST3 instrument init failed on UI thread: {e}");
                         self.state.status_text = format!("Plugin init failed: {e}");
                         continue;
                     }
@@ -5921,6 +5992,14 @@ impl App {
         if let Some(ref mut rx) = self.event_rx {
             while let Ok(event) = rx.pop() {
                 match event {
+                    EngineEvent::DisposeEffect(cell) => {
+                        // Plugin teardown on the UI thread: dlclose,
+                        // COM release, JUCE MessageManager access.
+                        drop(cell.take());
+                    }
+                    EngineEvent::DisposeInstrument(cell) => {
+                        drop(cell.take());
+                    }
                     EngineEvent::PlaybackPosition(pos) => {
                         self.state.position_samples = pos;
                     }
@@ -9743,6 +9822,7 @@ fn load_plugin_effect_bg(
                 effect: None,
                 gui_raw_ptr: None,
                 clap_partial: Some(partial),
+                vst3_partial: None,
                 sample_rate,
                 device_ref: plugin_device_ref(info),
                 state_ptr: None,
@@ -9752,43 +9832,23 @@ fn load_plugin_effect_bg(
             })
         }
         PluginFormat::Vst3 => {
-            let mut vst3_inst = vibez_plugin_host::vst3_host::instance::Vst3PluginInstance::load(
+            let partial = vibez_plugin_host::vst3_host::instance::Vst3PluginInstance::load_partial(
                 &info.path,
                 &info.id.uid,
                 false,
-                sample_rate,
-                4096,
             )?;
-            if let Some(ref data) = saved_state {
-                use vibez_plugin_host::PluginInstance;
-                if !vst3_inst.load_state(data) {
-                    eprintln!("vibez: {} rejected saved state", vst3_inst.name());
-                }
-            }
-            let gui_raw_ptr = {
-                let ctrl = vst3_inst.controller_ptr();
-                if ctrl.is_null() {
-                    None
-                } else {
-                    Some(PluginRawPtr::Vst3(ctrl))
-                }
-            };
-            let state_ptr = Some(vibez_plugin_host::PluginStatePtr::Vst3Component(
-                vst3_inst.component_ptr(),
-            ));
-            let name = vst3_inst.name().to_string();
-            let wrapper = vibez_plugin_host::PluginEffectWrapper::new(Box::new(vst3_inst));
             Ok(PluginLoadResult {
                 track_id: TrackId::default(),
                 effect_id: EffectId::new(),
-                plugin_name: name,
-                effect: Some(Box::new(wrapper)),
-                gui_raw_ptr,
+                plugin_name: info.name.clone(),
+                effect: None,
+                gui_raw_ptr: None,
                 clap_partial: None,
+                vst3_partial: Some(partial),
                 sample_rate,
                 device_ref: plugin_device_ref(info),
-                state_ptr,
-                pending_state: None,
+                state_ptr: None,
+                pending_state: saved_state,
                 position: None,
             })
         }
@@ -9814,6 +9874,7 @@ fn load_plugin_instrument_bg(
                 instrument: None,
                 gui_raw_ptr: None,
                 clap_partial: Some(partial),
+                vst3_partial: None,
                 sample_rate,
                 device_ref: plugin_device_ref(info),
                 state_ptr: None,
@@ -9821,42 +9882,22 @@ fn load_plugin_instrument_bg(
             })
         }
         PluginFormat::Vst3 => {
-            let mut vst3_inst = vibez_plugin_host::vst3_host::instance::Vst3PluginInstance::load(
+            let partial = vibez_plugin_host::vst3_host::instance::Vst3PluginInstance::load_partial(
                 &info.path,
                 &info.id.uid,
                 true,
-                sample_rate,
-                4096,
             )?;
-            if let Some(ref data) = saved_state {
-                use vibez_plugin_host::PluginInstance;
-                if !vst3_inst.load_state(data) {
-                    eprintln!("vibez: {} rejected saved state", vst3_inst.name());
-                }
-            }
-            let gui_raw_ptr = {
-                let ctrl = vst3_inst.controller_ptr();
-                if ctrl.is_null() {
-                    None
-                } else {
-                    Some(PluginRawPtr::Vst3(ctrl))
-                }
-            };
-            let state_ptr = Some(vibez_plugin_host::PluginStatePtr::Vst3Component(
-                vst3_inst.component_ptr(),
-            ));
-            let name = vst3_inst.name().to_string();
-            let wrapper = vibez_plugin_host::PluginInstrumentWrapper::new(Box::new(vst3_inst));
             Ok(PluginInstrumentLoadResult {
                 track_id: TrackId::default(),
-                plugin_name: name,
-                instrument: Some(Box::new(wrapper)),
-                gui_raw_ptr,
+                plugin_name: info.name.clone(),
+                instrument: None,
+                gui_raw_ptr: None,
                 clap_partial: None,
+                vst3_partial: Some(partial),
                 sample_rate,
                 device_ref: plugin_device_ref(info),
-                state_ptr,
-                pending_state: None,
+                state_ptr: None,
+                pending_state: saved_state,
             })
         }
     }

--- a/crates/vibez-ui/src/plugin_window.rs
+++ b/crates/vibez-ui/src/plugin_window.rs
@@ -256,6 +256,12 @@ impl PluginWindowManager {
 
     /// Poll for X11 events (non-blocking). Returns events for closed windows.
     pub fn poll_events(&mut self) -> Vec<PluginWindowEvent> {
+        // VST3 Linux GUIs live off the host run loop: fire their
+        // timers and fd handlers every tick or JUCE editors freeze.
+        for window in self.windows.values() {
+            window.gui_handle.service_runloop();
+        }
+
         let mut events = Vec::new();
         loop {
             match self.conn.poll_for_event() {

--- a/crates/vibez-ui/src/state.rs
+++ b/crates/vibez-ui/src/state.rs
@@ -132,6 +132,8 @@ pub struct UiEffect {
     pub plugin_name: Option<String>,
     /// Whether this effect has a native plugin GUI available.
     pub has_plugin_gui: bool,
+    /// Persistent identity of the plugin backing this slot, if any.
+    pub plugin_ref: Option<vibez_core::effect::PluginDeviceInfo>,
 }
 
 /// A note clip (MIDI pattern) as represented in the UI.
@@ -177,6 +179,8 @@ pub struct UiTrack {
     pub selected_drum_pad: usize,
     /// Display name for external plugin instruments (e.g. "Dexed", "Surge XT").
     pub plugin_instrument_name: Option<String>,
+    /// Persistent identity of the plugin instrument, if any.
+    pub plugin_instrument_ref: Option<vibez_core::effect::PluginDeviceInfo>,
     /// Whether the plugin instrument has a native GUI.
     pub has_plugin_instrument_gui: bool,
 }
@@ -206,6 +210,7 @@ impl UiTrack {
             drum_rack_pads: default_drum_rack_pads(),
             selected_drum_pad: 0,
             plugin_instrument_name: None,
+            plugin_instrument_ref: None,
             has_plugin_instrument_gui: false,
         }
     }
@@ -238,6 +243,7 @@ impl UiTrack {
             drum_rack_pads: default_drum_rack_pads(),
             selected_drum_pad: 0,
             plugin_instrument_name: None,
+            plugin_instrument_ref: None,
             has_plugin_instrument_gui: false,
         }
     }


### PR DESCRIPTION
Started as plugin persistence (dogfood #12) and grew into making VST3 hosting actually work end to end; testing each fix peeled back another layer of never-executed code. All verified in the DAW (ZL EQ audibly processing with live analyzer, Dragonfly GUI, instant removal, state round-trip) plus a headless probe.

**Persistence (#12).** EffectInfo gains an optional PluginDeviceInfo (format/uid/path/name/state blob); TrackInfo gains plugin_instrument. State capture happens on the UI thread at save time via per-device raw pointers (same pattern as the GUI layer): CLAP via the clap.state extension, VST3 via getState/setState over a hand-built in-memory IBStream, with controller sync for dual-component plugins. Reload feeds persisted plugins through the existing async pipeline in file order so chain positions restore deterministically. Old projects load unchanged (regression test).

**Linux IRunLoop (#16).** VST3 GUIs on Linux require the host to provide IPlugFrame + IRunLoop; JUCE editors repaint and dispatch input exclusively from its timers/fd callbacks. Hand-built dual-interface COM object, serviced from the plugin window manager's poll tick.

**JUCE thread affinity (#18).** VST3 plugins were fully instantiated on a background thread; JUCE pins its MessageManager to the instantiating thread, freezing GUIs and deadlocking teardown. VST3 now uses the same two-phase load CLAP already had (dlopen in background, all plugin code on the UI thread). Additionally, the engine no longer destroys removed devices in the audio callback: they return over the event ring (DisposalCell) and are dropped on the UI thread.

**IHostApplication (#19).** We passed NULL as host context everywhere. JUCE links editor to processor by allocating an IMessage from the host application and sending it across the connection points; without it the editor binds to an orphaned processor (controls move, sound never changes). DPF's createView returns null outright. Full IHostApplication + IMessage + IAttributeList implementation, passed to setHostContext and both initialize calls. Plus: bus activation at init (JUCE skips processing on inactive buses), one AudioBusBuffers per reported bus (sidechains included), separate output buffers, stub IParameterChanges/IParamValueQueue, correct teardown order.

**Tooling.** examples/vst3_probe.rs loads a plugin headlessly, pushes audio through process(), and verifies processing/tail/createView/teardown; this is what found #19 and guards the whole chain.

Also fixes: plugin grid shows full wrapped names; clear_project_runtime no longer leaves dangling GUI pointers; four-column plugin menu clamps by content size.
