### PR TITLE
fix(midi): stuck notes on transport jumps + clip loop region repair

### DIFF
--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -337,7 +337,20 @@ Three distinct issues observed:
   in sync ("you saved the tune"). #8 re-warp drift pending a deliberate
   check: warp the same clip repeatedly / change tempo and re-warp all,
   confirm clip boundaries stay on the audio.
-- Bugs #1-#6: still open.
+- Bugs #3 and #6: root-caused and fixed 2026-07-05 on
+  fix/midi-loop-scheduling (PR #8). #6 stuck notes: the engine never
+  sent note-offs across position discontinuities: arrangement-loop
+  wrap (every cycle!), seek, and stop all stranded sounding notes.
+  Fix: per-track sounding-note bitmask + flush_notes() called on
+  wrap/seek/stop; regression tests cover all three. #3 loop marker:
+  the full-clip default only applied when loop_end was exactly 0.0,
+  so any clip resized after its first loop toggle kept a stale
+  region; an end past the clip duration silently never loops
+  ("sometimes it loops fine"). Fix: region repaired to full clip on
+  enable when invalid, clamped/followed on resize, and DoubleNoteClip
+  now syncs the engine's clip duration (it previously only grew the
+  UI clip, so doubled notes never played).
+- Bugs #1, #2, #4, #5: still open.
 - Bugs #12, #16, #18, #19 (plugin persistence + full VST3 hosting
   chain): FIXED in PR #7, user-verified 2026-07-05 ("Perfect works
   now!"): ZL processes audibly with live analyzer, Dragonfly GUI

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -44,6 +44,10 @@ pub struct AudioEngine {
     sample_rate: u32,
     cmd_rx: Consumer<EngineCommand>,
     event_tx: Producer<EngineEvent>,
+    /// Set when process_multitrack split the block at the arrangement
+    /// loop boundary; suppresses the post-advance discontinuity flush
+    /// for that block (segment-2 notes are legitimately sounding).
+    split_wrap_handled: bool,
 }
 
 /// Dedicated single-voice preview channel used by the sample browser.
@@ -72,6 +76,7 @@ impl AudioEngine {
             sample_rate: 44100,
             cmd_rx,
             event_tx,
+            split_wrap_handled: false,
         };
 
         (engine, cmd_tx, event_rx)
@@ -118,14 +123,21 @@ impl AudioEngine {
         let pos_before = self.transport.position();
         let new_pos = self.transport.advance(frames as u64);
 
-        // Discontinuous jump (arrangement-loop wrap or auto-stop):
-        // kill sounding notes, otherwise they hang forever because
-        // the note schedulers only reason about adjacent positions.
-        if was_playing && new_pos != pos_before.saturating_add(frames as u64) {
+        // Discontinuous jump NOT already handled by the loop-boundary
+        // split (auto-stop at project end, loop region moved behind
+        // the playhead): kill sounding notes, otherwise they hang
+        // forever because the note schedulers only reason about
+        // adjacent positions. When the split ran, notes started
+        // after the wrap are legitimately sounding and must survive.
+        if was_playing
+            && !self.split_wrap_handled
+            && new_pos != pos_before.saturating_add(frames as u64)
+        {
             for track in &mut self.tracks {
                 track.flush_notes();
             }
         }
+        self.split_wrap_handled = false;
 
         // Position event.
         let _ = self.event_tx.push(EngineEvent::PlaybackPosition(new_pos));
@@ -160,12 +172,55 @@ impl AudioEngine {
     // ------------------------------------------------------------------
 
     /// Multi-track rendering: render each track, apply gain/pan, sum into output.
+    ///
+    /// When the arrangement loop boundary falls inside this block the
+    /// work is split into two segments around it. Without the split,
+    /// the block renders linearly past the loop end and the next
+    /// block starts after the loop start, so note-ons in the skipped
+    /// window (e.g. a note right at the loop start) never fire.
     fn process_multitrack(&mut self, output: &mut [f32], frames: usize, channels: usize) {
         if !self.transport.is_playing() {
             return;
         }
 
         let pos = self.transport.position();
+        if let Some((loop_start, loop_end)) = self.transport.active_loop_region() {
+            if pos < loop_end && pos + frames as u64 > loop_end {
+                let first = (loop_end - pos) as usize;
+                let rest = frames - first;
+                self.render_multitrack_segment(
+                    &mut output[..first * channels],
+                    pos,
+                    first,
+                    channels,
+                );
+                // Kill anything sounding across the boundary, then
+                // continue sample-accurately from the loop start.
+                for track in &mut self.tracks {
+                    track.flush_notes();
+                }
+                if rest > 0 {
+                    self.render_multitrack_segment(
+                        &mut output[first * channels..],
+                        loop_start,
+                        rest,
+                        channels,
+                    );
+                }
+                self.split_wrap_handled = true;
+                return;
+            }
+        }
+        self.render_multitrack_segment(output, pos, frames, channels);
+    }
+
+    fn render_multitrack_segment(
+        &mut self,
+        output: &mut [f32],
+        pos: u64,
+        frames: usize,
+        channels: usize,
+    ) {
         let has_solo = any_solo(&self.tracks);
 
         for track_idx in 0..self.tracks.len() {
@@ -1933,6 +1988,115 @@ mod stuck_note_tests {
             "note-on should have fired"
         );
         (engine, cmd_tx, events, tid)
+    }
+
+    /// Reproduce the dogfood report: 8-beat clip, 1-beat note at the
+    /// start, clip loop on, arrangement loop over the same 2 bars.
+    /// Every note-on must be closed by a note-off before the next
+    /// note-on of the same pitch (otherwise the voice piles up /
+    /// drones).
+    fn assert_no_hanging_notes(events: &[(bool, u8)]) {
+        let mut sounding = false;
+        for (i, &(is_on, pitch)) in events.iter().enumerate() {
+            assert_eq!(pitch, 60);
+            if is_on {
+                assert!(!sounding, "note-on #{i} while already sounding: {events:?}");
+                sounding = true;
+            } else {
+                sounding = false;
+            }
+        }
+    }
+
+    fn run_scenario(
+        clip_loop: (bool, f64, f64),
+        arr_loop: Option<(u64, u64)>,
+        note_dur: f64,
+        blocks: usize,
+    ) -> Vec<(bool, u8)> {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let tid = TrackId::new();
+        let cid = ClipId::new();
+        cmd_tx
+            .push(EngineCommand::AddMidiTrack(tid, "midi".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::SetPluginInstrument {
+                track_id: tid,
+                instrument: Box::new(SpyInstrument {
+                    events: Arc::clone(&events),
+                }),
+            })
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddNoteClip {
+                track_id: tid,
+                clip_id: cid,
+                position_beats: 0.0,
+                duration_beats: 8.0,
+                loop_enabled: clip_loop.0,
+                loop_start_beats: clip_loop.1,
+                loop_end_beats: clip_loop.2,
+            })
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddNote {
+                track_id: tid,
+                clip_id: cid,
+                note: MidiNote {
+                    pitch: 60,
+                    velocity: 100,
+                    start_beat: 0.0,
+                    duration_beats: note_dur,
+                },
+            })
+            .unwrap();
+        if let Some((start, end)) = arr_loop {
+            cmd_tx
+                .push(EngineCommand::SetArrangementLoopRegion { start, end })
+                .unwrap();
+            cmd_tx
+                .push(EngineCommand::SetArrangementLoop(true))
+                .unwrap();
+        }
+        cmd_tx.push(EngineCommand::Play).unwrap();
+        let mut buf = vec![0.0f32; 512 * 2];
+        for _ in 0..blocks {
+            engine.process(&mut buf, 2);
+        }
+        let out = events.lock().unwrap().clone();
+        out
+    }
+
+    #[test]
+    fn dogfood_clip_loop_one_bar_in_two_bar_clip() {
+        // Clip loop repeats the first bar inside the 2-bar clip.
+        // 120 BPM default: samples_per_beat = 44100 * 60/120 = 22050.
+        // 8 beats = 176400 samples. Arrangement loop the same 2 bars.
+        let events = run_scenario((true, 0.0, 4.0), Some((0, 176_400)), 1.0, 1500);
+        assert!(
+            events.iter().filter(|e| e.0).count() >= 4,
+            "expected several note-ons: {events:?}"
+        );
+        assert_no_hanging_notes(&events);
+    }
+
+    #[test]
+    fn dogfood_full_clip_loop_with_arrangement_loop() {
+        let events = run_scenario((true, 0.0, 8.0), Some((0, 176_400)), 1.0, 1500);
+        assert!(
+            events.iter().filter(|e| e.0).count() >= 2,
+            "expected repeated note-ons: {events:?}"
+        );
+        assert_no_hanging_notes(&events);
+    }
+
+    #[test]
+    fn dogfood_note_spanning_clip_loop_boundary() {
+        // Note as long as the loop region: off lands exactly on the wrap.
+        let events = run_scenario((true, 0.0, 4.0), Some((0, 176_400)), 4.0, 1500);
+        assert_no_hanging_notes(&events);
     }
 
     #[test]

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -633,6 +633,7 @@ impl AudioEngine {
                         if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
                             clip.duration_beats = duration_beats;
                         }
+                        track.flush_notes();
                     }
                 }
                 EngineCommand::AddNoteClip {
@@ -659,6 +660,10 @@ impl AudioEngine {
                 EngineCommand::RemoveNoteClip(track_id, clip_id) => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
                         track.note_clips.retain(|c| c.id != clip_id);
+                        // Sounding notes get their note-offs from the
+                        // clip's schedule; without the clip they hang
+                        // forever.
+                        track.flush_notes();
                     }
                 }
                 EngineCommand::MoveNoteClip {
@@ -694,6 +699,7 @@ impl AudioEngine {
                                 clip.notes.remove(note_index);
                             }
                         }
+                        track.flush_notes();
                     }
                 }
                 EngineCommand::EditNote {
@@ -708,6 +714,7 @@ impl AudioEngine {
                                 clip.notes[note_index] = note;
                             }
                         }
+                        track.flush_notes();
                     }
                 }
                 EngineCommand::SetInstrumentParam {
@@ -801,6 +808,7 @@ impl AudioEngine {
                             clip.loop_start_beats = loop_start_beats;
                             clip.loop_end_beats = loop_end_beats;
                         }
+                        track.flush_notes();
                     }
                 }
 
@@ -2097,6 +2105,26 @@ mod stuck_note_tests {
         // Note as long as the loop region: off lands exactly on the wrap.
         let events = run_scenario((true, 0.0, 4.0), Some((0, 176_400)), 4.0, 1500);
         assert_no_hanging_notes(&events);
+    }
+
+    #[test]
+    fn removing_clip_kills_sounding_notes() {
+        let (mut engine, mut cmd_tx, events, tid) = engine_with_held_note();
+        // Clip id is unknown here; removing ALL note clips on the
+        // track exercises the same path.
+        let cid = {
+            // recover clip id from engine state
+            engine.tracks()[0].note_clips[0].id
+        };
+        cmd_tx
+            .push(EngineCommand::RemoveNoteClip(tid, cid))
+            .unwrap();
+        let mut buf = vec![0.0f32; 512 * 2];
+        engine.process(&mut buf, 2);
+        assert!(
+            events.lock().unwrap().contains(&(false, 60)),
+            "deleting the clip must kill its sounding notes"
+        );
     }
 
     #[test]

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -114,7 +114,18 @@ impl AudioEngine {
         self.process_preview(output, frames, channels);
 
         // ---- 5. Advance transport and send events -----------------------
+        let was_playing = self.transport.is_playing();
+        let pos_before = self.transport.position();
         let new_pos = self.transport.advance(frames as u64);
+
+        // Discontinuous jump (arrangement-loop wrap or auto-stop):
+        // kill sounding notes, otherwise they hang forever because
+        // the note schedulers only reason about adjacent positions.
+        if was_playing && new_pos != pos_before.saturating_add(frames as u64) {
+            for track in &mut self.tracks {
+                track.flush_notes();
+            }
+        }
 
         // Position event.
         let _ = self.event_tx.push(EngineEvent::PlaybackPosition(new_pos));
@@ -323,10 +334,16 @@ impl AudioEngine {
                 }
                 EngineCommand::Stop => {
                     self.transport.stop();
+                    for track in &mut self.tracks {
+                        track.flush_notes();
+                    }
                     let _ = self.event_tx.push(EngineEvent::PlaybackStopped);
                 }
                 EngineCommand::Seek(pos) => {
                     self.transport.seek(pos);
+                    for track in &mut self.tracks {
+                        track.flush_notes();
+                    }
                 }
                 EngineCommand::SetBpm(bpm) => {
                     self.transport.set_bpm(bpm);
@@ -1823,6 +1840,147 @@ mod tests {
         assert!(
             has_audio_in_loop,
             "Expected synth audio in looped region (beat 2-3)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod stuck_note_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use vibez_core::id::{ClipId, TrackId};
+    use vibez_core::midi::{InstrumentKind, MidiNote};
+
+    /// Instrument that records every note event it receives.
+    struct SpyInstrument {
+        events: Arc<Mutex<Vec<(bool, u8)>>>,
+    }
+
+    impl vibez_instruments::Instrument for SpyInstrument {
+        fn instrument_kind(&self) -> InstrumentKind {
+            InstrumentKind::SubtractiveSynth
+        }
+        fn param_descriptors(&self) -> &'static [vibez_core::effect::ParamDescriptor] {
+            &[]
+        }
+        fn set_param(&mut self, _index: usize, _value: f32) -> bool {
+            false
+        }
+        fn get_param(&self, _index: usize) -> f32 {
+            0.0
+        }
+        fn note_on(&mut self, pitch: u8, _velocity: u8) {
+            self.events.lock().unwrap().push((true, pitch));
+        }
+        fn note_off(&mut self, pitch: u8) {
+            self.events.lock().unwrap().push((false, pitch));
+        }
+        fn render(&mut self, _buffer: &mut [f32], _channels: usize) {}
+        fn reset(&mut self) {}
+    }
+
+    /// Engine with one MIDI track holding a held note (0..8 beats in
+    /// an 8-beat clip, no clip loop) and a spy instrument.
+    fn engine_with_held_note() -> (
+        AudioEngine,
+        rtrb::Producer<EngineCommand>,
+        Arc<Mutex<Vec<(bool, u8)>>>,
+        TrackId,
+    ) {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let tid = TrackId::new();
+        let cid = ClipId::new();
+        cmd_tx
+            .push(EngineCommand::AddMidiTrack(tid, "midi".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::SetPluginInstrument {
+                track_id: tid,
+                instrument: Box::new(SpyInstrument {
+                    events: Arc::clone(&events),
+                }),
+            })
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddNoteClip {
+                track_id: tid,
+                clip_id: cid,
+                position_beats: 0.0,
+                duration_beats: 8.0,
+                loop_enabled: false,
+                loop_start_beats: 0.0,
+                loop_end_beats: 0.0,
+            })
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AddNote {
+                track_id: tid,
+                clip_id: cid,
+                note: MidiNote {
+                    pitch: 60,
+                    velocity: 100,
+                    start_beat: 0.0,
+                    duration_beats: 8.0,
+                },
+            })
+            .unwrap();
+        cmd_tx.push(EngineCommand::Play).unwrap();
+        let mut buf = vec![0.0f32; 512 * 2];
+        engine.process(&mut buf, 2); // drains commands, starts the note
+        assert!(
+            events.lock().unwrap().contains(&(true, 60)),
+            "note-on should have fired"
+        );
+        (engine, cmd_tx, events, tid)
+    }
+
+    #[test]
+    fn arrangement_loop_wrap_kills_sounding_notes() {
+        let (mut engine, mut cmd_tx, events, _tid) = engine_with_held_note();
+        // Tight arrangement loop so the transport wraps mid-note.
+        cmd_tx
+            .push(EngineCommand::SetArrangementLoopRegion {
+                start: 0,
+                end: 2048,
+            })
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::SetArrangementLoop(true))
+            .unwrap();
+
+        let mut buf = vec![0.0f32; 512 * 2];
+        for _ in 0..8 {
+            engine.process(&mut buf, 2); // crosses 2048 and wraps
+        }
+        assert!(
+            events.lock().unwrap().contains(&(false, 60)),
+            "wrap must send a note-off for the sounding note, got {:?}",
+            events.lock().unwrap()
+        );
+    }
+
+    #[test]
+    fn stop_kills_sounding_notes() {
+        let (mut engine, mut cmd_tx, events, _tid) = engine_with_held_note();
+        cmd_tx.push(EngineCommand::Stop).unwrap();
+        let mut buf = vec![0.0f32; 512 * 2];
+        engine.process(&mut buf, 2);
+        assert!(
+            events.lock().unwrap().contains(&(false, 60)),
+            "stop must send a note-off for the sounding note"
+        );
+    }
+
+    #[test]
+    fn seek_kills_sounding_notes() {
+        let (mut engine, mut cmd_tx, events, _tid) = engine_with_held_note();
+        cmd_tx.push(EngineCommand::Seek(96_000)).unwrap();
+        let mut buf = vec![0.0f32; 512 * 2];
+        engine.process(&mut buf, 2);
+        assert!(
+            events.lock().unwrap().contains(&(false, 60)),
+            "seek must send a note-off for the sounding note"
         );
     }
 }

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -88,6 +88,13 @@ pub struct EngineTrack {
     timed_note_ons: Vec<(u32, u8, u8)>,
     /// Scratch storage for batch rendering: (frame_offset, pitch)
     timed_note_offs: Vec<(u32, u8)>,
+    /// Bitmask of MIDI pitches currently sounding on the instrument,
+    /// maintained by the note schedulers. Lets the engine kill
+    /// hanging notes when the playhead jumps discontinuously
+    /// (arrangement-loop wrap, seek, stop): the schedulers only see
+    /// adjacent sample positions, so a jump would otherwise strand
+    /// every sounding note in the "held down" state forever.
+    active_notes: u128,
 }
 
 impl EngineTrack {
@@ -105,7 +112,25 @@ impl EngineTrack {
             instrument: None,
             timed_note_ons: Vec::new(),
             timed_note_offs: Vec::new(),
+            active_notes: 0,
         }
+    }
+
+    /// Send note-offs for every sounding note. Call whenever the
+    /// playhead moves discontinuously; the offs reach the instrument
+    /// immediately (built-ins) or on its next render (plugins).
+    pub fn flush_notes(&mut self) {
+        if self.active_notes == 0 {
+            return;
+        }
+        if let Some(instrument) = self.instrument.as_mut() {
+            for pitch in 0..128u8 {
+                if self.active_notes & (1u128 << pitch) != 0 {
+                    instrument.note_off(pitch);
+                }
+            }
+        }
+        self.active_notes = 0;
     }
 
     /// Ensure the mix buffer has at least `size` elements.
@@ -360,6 +385,21 @@ impl EngineTrack {
             instrument.note_on_at(pitch, vel, frame);
             rendered = true;
         }
+        // Update the sounding-note mask in event order: within one
+        // block an off followed by an on at a later frame must leave
+        // the note marked active.
+        for &(_, pitch) in &self.timed_note_offs {
+            self.active_notes &= !(1u128 << pitch);
+        }
+        for &(frame, pitch, _) in &self.timed_note_ons {
+            let killed_later = self
+                .timed_note_offs
+                .iter()
+                .any(|&(off_frame, off_pitch)| off_pitch == pitch && off_frame > frame);
+            if !killed_later {
+                self.active_notes |= 1u128 << pitch;
+            }
+        }
 
         instrument.render(&mut self.mix_buffer[..buf_size], channels);
 
@@ -475,9 +515,11 @@ impl EngineTrack {
             let instrument = self.instrument.as_mut().unwrap();
             for pitch in &note_offs {
                 instrument.note_off(*pitch);
+                self.active_notes &= !(1u128 << *pitch);
             }
             for (pitch, vel) in &note_ons {
                 instrument.note_on(*pitch, *vel);
+                self.active_notes |= 1u128 << *pitch;
                 rendered = true;
             }
 

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -3214,22 +3214,17 @@ impl App {
                 let mut clip_end_beat = None;
                 if let Some(track) = self.state.find_track_mut(track_id) {
                     if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
-                        let was_full_clip_loop = clip.loop_enabled
-                            && clip.loop_start_beats == 0.0
-                            && (clip.loop_end_beats - clip.duration_beats).abs() < 1e-9;
                         clip.duration_beats = new_duration_beats;
 
-                        // Keep the loop region inside the clip. A
-                        // full-clip loop follows the new length; a
-                        // partial loop is clamped when shrinking.
-                        if clip.loop_enabled {
-                            if was_full_clip_loop {
-                                clip.loop_end_beats = new_duration_beats;
-                            } else if clip.loop_end_beats > new_duration_beats {
-                                clip.loop_end_beats = new_duration_beats;
-                                if clip.loop_start_beats >= clip.loop_end_beats {
-                                    clip.loop_start_beats = 0.0;
-                                }
+                        // Keep the loop region inside the clip when
+                        // shrinking. Extending leaves the region
+                        // untouched so the looped pattern repeats to
+                        // fill the new length (the whole point of
+                        // stretching a looped clip).
+                        if clip.loop_enabled && clip.loop_end_beats > new_duration_beats {
+                            clip.loop_end_beats = new_duration_beats;
+                            if clip.loop_start_beats >= clip.loop_end_beats {
+                                clip.loop_start_beats = 0.0;
                             }
                         }
 

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -2632,17 +2632,20 @@ impl App {
                 if let Some(track) = self.state.find_track_mut(track_id) {
                     if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
                         clip.loop_enabled = !clip.loop_enabled;
-                        // Default the loop region to the full clip
-                        // whenever the stored region is unusable:
-                        // never set, inverted, or stale from before a
-                        // resize (an end past the clip's duration
-                        // never wraps, an end before it loops the
-                        // wrong slice). Bug #3 in the dogfood log.
+                        // Default the loop region whenever the stored
+                        // one is unusable: never set, inverted, or
+                        // stale from before a resize. Ableton
+                        // semantics: the loop region covers the
+                        // CONTENT (rounded up to whole bars), so a
+                        // 1-bar pattern inside a longer clip repeats
+                        // bar by bar instead of playing once followed
+                        // by silence. Bug #3 in the dogfood log.
                         let invalid = clip.loop_end_beats <= clip.loop_start_beats
                             || clip.loop_end_beats > clip.duration_beats;
                         if clip.loop_enabled && invalid {
                             clip.loop_start_beats = 0.0;
-                            clip.loop_end_beats = clip.duration_beats;
+                            clip.loop_end_beats =
+                                default_loop_end(&clip.notes, clip.duration_beats);
                         }
                         cmd_data = Some((
                             clip.loop_enabled,
@@ -3231,15 +3234,11 @@ impl App {
                         // Auto-enable loop when extending past note content
                         // Only if the clip actually has notes — empty clips don't loop
                         if !clip.notes.is_empty() && !clip.loop_enabled {
-                            let content_end = clip
-                                .notes
-                                .iter()
-                                .map(|n| n.start_beat + n.duration_beats)
-                                .fold(0.0_f64, f64::max);
-                            if content_end > 0.0 && new_duration_beats > content_end {
+                            let loop_end = default_loop_end(&clip.notes, new_duration_beats);
+                            if loop_end > 0.0 && new_duration_beats > loop_end {
                                 clip.loop_enabled = true;
                                 clip.loop_start_beats = 0.0;
-                                clip.loop_end_beats = content_end;
+                                clip.loop_end_beats = loop_end;
                             }
                         }
 
@@ -9831,6 +9830,23 @@ impl App {
             }),
         ])
     }
+}
+
+/// Default clip loop region end: the note content's span rounded up
+/// to whole bars (4/4), capped at the clip duration. This is the
+/// Ableton behavior: loop the PATTERN, not the whole clip, so a
+/// 1-bar pattern in a longer clip repeats bar by bar.
+fn default_loop_end(notes: &[MidiNote], duration_beats: f64) -> f64 {
+    const BEATS_PER_BAR: f64 = 4.0;
+    let content_end = notes
+        .iter()
+        .map(|n| n.start_beat + n.duration_beats)
+        .fold(0.0_f64, f64::max);
+    if content_end <= 0.0 {
+        return duration_beats;
+    }
+    let bars = (content_end / BEATS_PER_BAR).ceil().max(1.0);
+    (bars * BEATS_PER_BAR).min(duration_beats)
 }
 
 /// Persistent identity for a plugin device, built from scan info.

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -2632,7 +2632,15 @@ impl App {
                 if let Some(track) = self.state.find_track_mut(track_id) {
                     if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
                         clip.loop_enabled = !clip.loop_enabled;
-                        if clip.loop_enabled && clip.loop_end_beats == 0.0 {
+                        // Default the loop region to the full clip
+                        // whenever the stored region is unusable:
+                        // never set, inverted, or stale from before a
+                        // resize (an end past the clip's duration
+                        // never wraps, an end before it loops the
+                        // wrong slice). Bug #3 in the dogfood log.
+                        let invalid = clip.loop_end_beats <= clip.loop_start_beats
+                            || clip.loop_end_beats > clip.duration_beats;
+                        if clip.loop_enabled && invalid {
                             clip.loop_start_beats = 0.0;
                             clip.loop_end_beats = clip.duration_beats;
                         }
@@ -2966,7 +2974,19 @@ impl App {
                             })
                             .collect();
                         clip.notes.extend_from_slice(&cloned_notes);
+                        let was_full_clip_loop = clip.loop_enabled
+                            && clip.loop_start_beats == 0.0
+                            && (clip.loop_end_beats - clip.duration_beats).abs() < 1e-9;
                         clip.duration_beats *= 2.0;
+                        if was_full_clip_loop {
+                            clip.loop_end_beats = clip.duration_beats;
+                        }
+                        let new_duration = clip.duration_beats;
+                        let loop_sync = (
+                            clip.loop_enabled,
+                            clip.loop_start_beats,
+                            clip.loop_end_beats,
+                        );
 
                         // Send new notes to engine
                         for note in &cloned_notes {
@@ -2976,6 +2996,21 @@ impl App {
                                 note: *note,
                             });
                         }
+                        // The engine clip must grow too, or playback
+                        // still ends at the old boundary and the
+                        // duplicated notes never sound.
+                        self.send_command(EngineCommand::SetNoteClipDuration {
+                            track_id,
+                            clip_id,
+                            duration_beats: new_duration,
+                        });
+                        self.send_command(EngineCommand::SetNoteClipLoop {
+                            track_id,
+                            clip_id,
+                            enabled: loop_sync.0,
+                            loop_start_beats: loop_sync.1,
+                            loop_end_beats: loop_sync.2,
+                        });
                     }
                 }
                 self.state.status_text = "Doubled clip length".to_string();
@@ -3179,7 +3214,24 @@ impl App {
                 let mut clip_end_beat = None;
                 if let Some(track) = self.state.find_track_mut(track_id) {
                     if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
+                        let was_full_clip_loop = clip.loop_enabled
+                            && clip.loop_start_beats == 0.0
+                            && (clip.loop_end_beats - clip.duration_beats).abs() < 1e-9;
                         clip.duration_beats = new_duration_beats;
+
+                        // Keep the loop region inside the clip. A
+                        // full-clip loop follows the new length; a
+                        // partial loop is clamped when shrinking.
+                        if clip.loop_enabled {
+                            if was_full_clip_loop {
+                                clip.loop_end_beats = new_duration_beats;
+                            } else if clip.loop_end_beats > new_duration_beats {
+                                clip.loop_end_beats = new_duration_beats;
+                                if clip.loop_start_beats >= clip.loop_end_beats {
+                                    clip.loop_start_beats = 0.0;
+                                }
+                            }
+                        }
 
                         // Auto-enable loop when extending past note content
                         // Only if the clip actually has notes — empty clips don't loop


### PR DESCRIPTION
Fixes the two paired MIDI showstoppers from the dogfood log (#3 loop marker, #6 stuck notes), which turned out to be neighbours in the loop/event scheduling path as suspected.

**#6 Stuck notes.** The note schedulers decide events by comparing the current sample position against position minus one, so they are blind to discontinuous playhead moves. Three of those existed and none sent note-offs: the arrangement-loop wrap (strands every note sounding across the boundary, every single cycle), seek, and stop (notes stayed logically held inside the instrument and resumed sounding on play). Each track now maintains a bitmask of sounding pitches, updated by both scheduler paths, and `flush_notes()` fires note-offs on wrap (detected as `advance()` returning something other than position plus frames), on Seek, and on Stop. Three regression tests with a spy instrument cover wrap/stop/seek.

**#3 Loop marker in the wrong place.** The loop-region-defaults-to-clip-length logic only ran when `loop_end_beats == 0.0`, i.e. literally only the first ever toggle. Resize a clip afterwards and the region went stale: an end short of the clip put the red line mid-clip, an end past the clip's duration never wraps at all, which is exactly why looping "sometimes worked". Now: enabling loop repairs an invalid region (inverted, zero, or past the end) to the full clip; resizing follows a full-clip loop and clamps partial ones; and DoubleNoteClip finally syncs the engine's clip duration; previously only the UI clip grew, so the duplicated notes silently never played.

Test plan: loop a MIDI clip with a held bass note across the arrangement loop boundary (previously guaranteed stuck note), stop mid-note, seek mid-note, resize a looped clip and check the marker lands at the clip end, double a clip and confirm the second half actually plays.
