### PR TITLE
fix(ui): whole track header selects the track

### DIFF
--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -325,6 +325,19 @@ Three distinct issues observed:
 - vst3_probe verifies both plugins end to end: processing altered
   audio, reverb tail, createView non-null, clean teardown.
 
+### 20. Track header not clickable for selection (FIXED in PR #9)
+- Reported 2026-07-05: clicking a track's header column does not
+  select the track, so the Clip/Devices panel stays on the previous
+  track and Ctrl+M creates clips on the wrongly focused track.
+- Root cause: only the track NAME text (a zero-padding button) sent
+  SelectTrack; the remaining ~99% of the 220px header was dead space.
+  All track-creation paths already selected the new track; the user's
+  follow-up click on dead space just could not move selection.
+- Fix: the whole header is now a mouse_area sending SelectTrack
+  (child widgets still capture their own clicks first), and
+  SelectNoteClip also focuses the clip's track like arrangement clip
+  selection already did.
+
 ## Fix status
 
 - Bugs #7 and #8: root-caused and fixed in PR #3

--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -338,6 +338,19 @@ Three distinct issues observed:
   SelectNoteClip also focuses the clip's track like arrangement clip
   selection already did.
 
+### 21. Duplicate ids after project load: "multiple tracks selected" (FIXED in PR #9)
+- Screenshot 2026-07-05 21:00: two track headers highlighted as
+  selected at once after creating tracks in a loaded project.
+- Root cause: the global id counter (vibez-core id.rs) restarts at 1
+  every launch, while loaded projects carry ids minted by the saving
+  session's counter. A track/clip created after load can receive the
+  SAME raw id as a loaded object: selection then highlights both and
+  every engine command addressed by id hits both. Far worse than a
+  visual glitch; likely behind earlier "spooky" behavior too.
+- Fix: ensure_ids_above() seeds the counter past the highest
+  persisted id (tracks, effects, clips, note clips) at the start of
+  rebuild_from_loaded_project, before anything new can be minted.
+
 ## Fix status
 
 - Bugs #7 and #8: root-caused and fixed in PR #3

--- a/crates/vibez-core/src/id.rs
+++ b/crates/vibez-core/src/id.rs
@@ -7,6 +7,16 @@ fn next_id() -> u64 {
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
 }
 
+/// Advance the global id counter past `raw`. MUST be called with the
+/// highest raw id found in any loaded project before minting new ids:
+/// persisted ids come from a previous session's counter, while this
+/// session's counter restarts at 1, so a new track/clip could
+/// otherwise receive the same id as a loaded one. Two objects sharing
+/// an id makes selection highlight both and engine commands hit both.
+pub fn ensure_ids_above(raw: u64) {
+    NEXT_ID.fetch_max(raw.saturating_add(1), Ordering::Relaxed);
+}
+
 macro_rules! typed_id {
     ($name:ident) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -43,6 +53,17 @@ typed_id!(EffectId);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ensure_ids_above_prevents_collisions() {
+        ensure_ids_above(1_000_000);
+        let id = TrackId::new();
+        assert!(id.raw() > 1_000_000);
+        // Lower values must not move the counter backwards.
+        ensure_ids_above(5);
+        let id2 = TrackId::new();
+        assert!(id2.raw() > id.raw());
+    }
 
     #[test]
     fn ids_are_unique() {

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -2709,6 +2709,7 @@ impl App {
             }
             Message::SelectNoteClip(track_id, clip_id) => {
                 self.state.selected_note_clip = Some((track_id, clip_id));
+                self.state.selected_track = Some(track_id);
             }
             Message::AddNote {
                 track_id,

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -810,6 +810,22 @@ impl App {
 
     fn rebuild_from_loaded_project(&mut self, loaded: ProjectLoadResult) {
         self.clear_project_runtime();
+
+        // Seed the global id counter past every persisted id BEFORE
+        // anything new is created: loaded ids come from a previous
+        // session's counter, and a collision makes two objects
+        // answer to the same id (double selection, engine commands
+        // hitting both).
+        let max_loaded_id = loaded
+            .project
+            .tracks
+            .iter()
+            .flat_map(|t| std::iter::once(t.id.raw()).chain(t.effects.iter().map(|e| e.id.raw())))
+            .chain(loaded.project.clips.iter().map(|c| c.id.raw()))
+            .chain(loaded.project.note_clips.iter().map(|c| c.id.raw()))
+            .max()
+            .unwrap_or(0);
+        vibez_core::id::ensure_ids_above(max_loaded_id);
         // Third-party plugin devices load asynchronously after the
         // built-in rebuild; collected here, spawned at the end.
         let mut plugin_effect_requests: Vec<(

--- a/crates/vibez-ui/src/widgets/track_header.rs
+++ b/crates/vibez-ui/src/widgets/track_header.rs
@@ -1,4 +1,6 @@
-use iced::widget::{button, canvas, column, container, horizontal_space, row, text, text_input};
+use iced::widget::{
+    button, canvas, column, container, horizontal_space, mouse_area, row, text, text_input,
+};
 use iced::{Element, Length, Theme};
 
 use crate::icons;
@@ -195,22 +197,27 @@ pub fn view_track_header<'a>(
 
     let header_with_bar = row![color_bar, header].height(Length::Fill);
 
-    container(header_with_bar)
-        .style(move |_theme: &Theme| container::Style {
-            background: Some(
-                if selected {
-                    th::TRACK_BG_SELECTED
-                } else {
-                    th::BG_SURFACE
-                }
-                .into(),
-            ),
-            border: iced::Border {
-                color: if selected { th::ACCENT_DIM } else { th::BORDER },
-                width: if selected { 1.0 } else { 0.0 },
-                radius: 0.0.into(),
-            },
-            ..Default::default()
-        })
+    let card = container(header_with_bar).style(move |_theme: &Theme| container::Style {
+        background: Some(
+            if selected {
+                th::TRACK_BG_SELECTED
+            } else {
+                th::BG_SURFACE
+            }
+            .into(),
+        ),
+        border: iced::Border {
+            color: if selected { th::ACCENT_DIM } else { th::BORDER },
+            width: if selected { 1.0 } else { 0.0 },
+            radius: 0.0.into(),
+        },
+        ..Default::default()
+    });
+
+    // The whole header column selects the track. Child widgets
+    // (name, M/S, add, delete, fader) capture their own clicks first,
+    // so this only fires on otherwise-dead header space.
+    mouse_area(card)
+        .on_press(Message::SelectTrack(track.id))
         .into()
 }


### PR DESCRIPTION
Clicking a track header did nothing unless you hit the name text exactly: only the name (a zero-padding button) sent SelectTrack, the rest of the 220px column was dead space. Selection stayed on the previous track, the Clip/Devices panel did not follow, and Ctrl+M created clips on the wrongly focused track (dogfood #20).

The whole header is now a mouse_area sending SelectTrack. Child widgets (name, mute/solo, add, delete, fader) capture their clicks first, so their behavior is unchanged; only previously-dead space gains the select action. SelectNoteClip also focuses the clip's track now, matching what arrangement clip selection already did.

Test plan: create a new track, click anywhere on another track's header (not the name): selection ring and the Devices panel should move to it; Ctrl+M should target that track. Clicking the name still selects (or starts rename when already selected).