### PR TITLE
feat(ui): delete key for notes, drum pad note names, note audition

### DIFF
--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -380,7 +380,14 @@ Three distinct issues observed:
   enable when invalid, clamped/followed on resize, and DoubleNoteClip
   now syncs the engine's clip duration (it previously only grew the
   UI clip, so doubled notes never played).
-- Bugs #1, #2, #4, #5: still open.
+- Bugs #4 and #5: FIXED on fix/piano-roll-drum-ux (PR #10).
+  #5: Delete/Backspace now deletes selected piano-roll notes (and
+  selected clips as fallback), context-resolved and inert while
+  renaming; iced's on_key_press skips keys captured by focused text
+  inputs so typing stays safe. #4: drum pads show their MIDI note
+  name (36 = C2 chromatic upward) and the piano-roll key lane shows
+  pad sample names on drum rack tracks, Ableton-style.
+- Bugs #1 (dead synth params) and #2 (knob feel): still open.
 - Bugs #12, #16, #18, #19 (plugin persistence + full VST3 hosting
   chain): FIXED in PR #7, user-verified 2026-07-05 ("Perfect works
   now!"): ZL processes audibly with live analyzer, Dragonfly GUI

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -234,6 +234,15 @@ pub enum EngineCommand {
         position: Option<usize>,
     },
     /// Set a pre-loaded external plugin instrument on a track.
+    /// Audition a single note on a track's instrument (piano-roll
+    /// key press / drum pad click). Works while the transport is
+    /// stopped thanks to idle instrument rendering.
+    AuditionNote {
+        track_id: TrackId,
+        pitch: u8,
+        velocity: u8,
+        on: bool,
+    },
     SetPluginInstrument {
         track_id: TrackId,
         instrument: Box<dyn Instrument>,

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -180,6 +180,10 @@ impl AudioEngine {
     /// window (e.g. a note right at the loop start) never fire.
     fn process_multitrack(&mut self, output: &mut [f32], frames: usize, channels: usize) {
         if !self.transport.is_playing() {
+            // Stopped transport still renders instruments so
+            // auditioned notes (piano-roll keys, drum pads) and
+            // plugin-queued events are audible, like any DAW.
+            self.render_idle_instruments(output, frames, channels);
             return;
         }
 
@@ -861,6 +865,22 @@ impl AudioEngine {
                         }
                     }
                 }
+                EngineCommand::AuditionNote {
+                    track_id,
+                    pitch,
+                    velocity,
+                    on,
+                } => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                        if let Some(instrument) = track.instrument.as_mut() {
+                            if on {
+                                instrument.note_on(pitch, velocity);
+                            } else {
+                                instrument.note_off(pitch);
+                            }
+                        }
+                    }
+                }
                 EngineCommand::SetPluginInstrument {
                     track_id,
                     instrument,
@@ -876,6 +896,43 @@ impl AudioEngine {
     }
 
     /// Recalculate transport audio length from all track clips.
+    /// Render instruments with no clip scheduling (transport stopped)
+    /// so auditioned notes sound. Effects and gain/pan still apply.
+    fn render_idle_instruments(&mut self, output: &mut [f32], frames: usize, channels: usize) {
+        let has_solo = any_solo(&self.tracks);
+        for track in &mut self.tracks {
+            if track.instrument.is_none() || track.mute || (has_solo && !track.solo) {
+                continue;
+            }
+            if !track.render_instrument_idle(frames, channels) {
+                continue;
+            }
+            track.process_effects(frames, channels);
+            let gain = track.gain;
+            let (pan_l, pan_r) = equal_power_pan(track.pan);
+            let buf_size = frames * channels;
+            for frame in 0..frames {
+                for ch in 0..channels {
+                    let idx = frame * channels + ch;
+                    if idx >= buf_size {
+                        break;
+                    }
+                    let sample = track.mix_buffer[idx] * gain;
+                    let panned = if channels == 2 {
+                        if ch == 0 {
+                            sample * pan_l
+                        } else {
+                            sample * pan_r
+                        }
+                    } else {
+                        sample
+                    };
+                    output[idx] += panned;
+                }
+            }
+        }
+    }
+
     /// Hand a removed device back to the UI thread for teardown. If
     /// the event ring is full (should never happen for these rare
     /// events) the device is leaked rather than destroyed here:
@@ -2105,6 +2162,53 @@ mod stuck_note_tests {
         // Note as long as the loop region: off lands exactly on the wrap.
         let events = run_scenario((true, 0.0, 4.0), Some((0, 176_400)), 4.0, 1500);
         assert_no_hanging_notes(&events);
+    }
+
+    #[test]
+    fn audition_sounds_while_transport_stopped() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid = TrackId::new();
+        cmd_tx
+            .push(EngineCommand::AddMidiTrack(tid, "midi".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::SetTrackInstrument(
+                tid,
+                vibez_core::midi::InstrumentKind::SubtractiveSynth,
+            ))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AuditionNote {
+                track_id: tid,
+                pitch: 60,
+                velocity: 100,
+                on: true,
+            })
+            .unwrap();
+        // Transport NEVER started: idle rendering must still sound.
+        let mut buf = vec![0.0f32; 512 * 2];
+        engine.process(&mut buf, 2);
+        engine.process(&mut buf, 2);
+        assert!(
+            buf.iter().any(|&s| s.abs() > 1e-6),
+            "auditioned note must be audible while stopped"
+        );
+        cmd_tx
+            .push(EngineCommand::AuditionNote {
+                track_id: tid,
+                pitch: 60,
+                velocity: 100,
+                on: false,
+            })
+            .unwrap();
+        // Long tail drain: after release the synth decays to silence.
+        for _ in 0..200 {
+            engine.process(&mut buf, 2);
+        }
+        assert!(
+            buf.iter().all(|&s| s.abs() < 1e-4),
+            "note must decay after audition release"
+        );
     }
 
     #[test]

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -116,6 +116,23 @@ impl EngineTrack {
         }
     }
 
+    /// Render the instrument with no clip events (transport stopped):
+    /// lets auditioned/held notes sound and plugin event queues drain.
+    /// Returns true when the buffer has signal.
+    pub fn render_instrument_idle(&mut self, frames: usize, channels: usize) -> bool {
+        if self.instrument.is_none() {
+            return false;
+        }
+        let buf_size = frames * channels;
+        self.ensure_buffer(buf_size);
+        for s in self.mix_buffer[..buf_size].iter_mut() {
+            *s = 0.0;
+        }
+        let instrument = self.instrument.as_mut().unwrap();
+        instrument.render(&mut self.mix_buffer[..buf_size], channels);
+        self.mix_buffer[..buf_size].iter().any(|&s| s != 0.0)
+    }
+
     /// Send note-offs for every sounding note. Call whenever the
     /// playhead moves discontinuously; the offs reach the instrument
     /// immediately (built-ins) or on its next render (plugins).

--- a/crates/vibez-plugin-host/src/clap_host/host_impl.rs
+++ b/crates/vibez-plugin-host/src/clap_host/host_impl.rs
@@ -438,6 +438,21 @@ mod tests {
     static TEST_TIMER_CALL_COUNT: AtomicU32 = AtomicU32::new(0);
     static TEST_FD_CALL_COUNT: AtomicU32 = AtomicU32::new(0);
 
+    // The host timer/fd registries are process-global, so tests in
+    // this module MUST run serialized and start from a clean slate;
+    // in parallel they race each other (flaked three separate times
+    // in CI-style full runs before this lock).
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn serialize_and_reset() -> std::sync::MutexGuard<'static, ()> {
+        let guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        CLAP_TIMERS.lock().unwrap().clear();
+        CLAP_FDS.lock().unwrap().clear();
+        TEST_TIMER_CALL_COUNT.store(0, Ordering::SeqCst);
+        TEST_FD_CALL_COUNT.store(0, Ordering::SeqCst);
+        guard
+    }
+
     static TEST_PLUGIN_TIMER_EXT: clap_sys::ext::timer_support::clap_plugin_timer_support =
         clap_sys::ext::timer_support::clap_plugin_timer_support {
             on_timer: Some(test_on_timer),
@@ -514,6 +529,7 @@ mod tests {
 
     #[test]
     fn test_make_clap_host_fields() {
+        let _serial = serialize_and_reset();
         let host = make_clap_host();
         assert_eq!(host.clap_version, CLAP_VERSION);
         assert!(host.get_extension.is_some());
@@ -531,6 +547,7 @@ mod tests {
 
     #[test]
     fn test_host_get_extension_returns_thread_check() {
+        let _serial = serialize_and_reset();
         let host = make_clap_host();
         let ptr = unsafe { host_get_extension(&host, CLAP_EXT_THREAD_CHECK.as_ptr()) };
         assert!(!ptr.is_null());
@@ -538,6 +555,7 @@ mod tests {
 
     #[test]
     fn test_host_get_extension_returns_gui() {
+        let _serial = serialize_and_reset();
         let host = make_clap_host();
         let ptr = unsafe { host_get_extension(&host, CLAP_EXT_GUI.as_ptr()) };
         assert!(!ptr.is_null());
@@ -545,6 +563,7 @@ mod tests {
 
     #[test]
     fn test_host_get_extension_returns_timer_support() {
+        let _serial = serialize_and_reset();
         let host = make_clap_host();
         let ptr = unsafe { host_get_extension(&host, CLAP_EXT_TIMER_SUPPORT.as_ptr()) };
         assert!(!ptr.is_null());
@@ -552,6 +571,7 @@ mod tests {
 
     #[test]
     fn test_host_get_extension_returns_posix_fd_support() {
+        let _serial = serialize_and_reset();
         let host = make_clap_host();
         let ptr = unsafe { host_get_extension(&host, CLAP_EXT_POSIX_FD_SUPPORT.as_ptr()) };
         assert!(!ptr.is_null());
@@ -559,6 +579,7 @@ mod tests {
 
     #[test]
     fn test_host_get_extension_returns_null_for_unknown() {
+        let _serial = serialize_and_reset();
         let host = make_clap_host();
         let unknown = c"clap.unknown-extension";
         let ptr = unsafe { host_get_extension(&host, unknown.as_ptr()) };
@@ -567,6 +588,7 @@ mod tests {
 
     #[test]
     fn test_host_get_extension_returns_null_for_null_id() {
+        let _serial = serialize_and_reset();
         let host = make_clap_host();
         let ptr = unsafe { host_get_extension(&host, std::ptr::null()) };
         assert!(ptr.is_null());
@@ -576,6 +598,7 @@ mod tests {
 
     #[test]
     fn test_set_host_user_data() {
+        let _serial = serialize_and_reset();
         let plugin = make_test_plugin();
         let mut host = make_clap_host();
         assert!(host.host_data.is_null());
@@ -591,6 +614,7 @@ mod tests {
 
     #[test]
     fn test_timer_register_unregister() {
+        let _serial = serialize_and_reset();
         clear_registries();
 
         let plugin = make_test_plugin();
@@ -623,6 +647,7 @@ mod tests {
 
     #[test]
     fn test_timer_register_assigns_unique_ids() {
+        let _serial = serialize_and_reset();
         clear_registries();
 
         let plugin = make_test_plugin();
@@ -652,6 +677,7 @@ mod tests {
 
     #[test]
     fn test_unregister_nonexistent_timer() {
+        let _serial = serialize_and_reset();
         clear_registries();
 
         let host = make_clap_host();
@@ -663,6 +689,7 @@ mod tests {
 
     #[test]
     fn test_timer_register_fails_without_host_data() {
+        let _serial = serialize_and_reset();
         clear_registries();
 
         let host = make_clap_host(); // host_data is null
@@ -677,6 +704,7 @@ mod tests {
 
     #[test]
     fn test_fd_register_unregister() {
+        let _serial = serialize_and_reset();
         clear_registries();
 
         let plugin = make_test_plugin();
@@ -705,6 +733,7 @@ mod tests {
 
     #[test]
     fn test_fd_modify() {
+        let _serial = serialize_and_reset();
         clear_registries();
 
         let plugin = make_test_plugin();
@@ -725,6 +754,7 @@ mod tests {
 
     #[test]
     fn test_fd_modify_nonexistent() {
+        let _serial = serialize_and_reset();
         clear_registries();
 
         let host = make_clap_host();
@@ -736,6 +766,7 @@ mod tests {
 
     #[test]
     fn test_fd_register_fails_without_host_data() {
+        let _serial = serialize_and_reset();
         clear_registries();
 
         let host = make_clap_host(); // host_data is null
@@ -749,6 +780,7 @@ mod tests {
 
     #[test]
     fn test_poll_timers_fires_elapsed() {
+        let _serial = serialize_and_reset();
         clear_registries();
         TEST_TIMER_CALL_COUNT.store(0, Ordering::Relaxed);
 
@@ -775,6 +807,7 @@ mod tests {
 
     #[test]
     fn test_poll_timers_skips_not_elapsed() {
+        let _serial = serialize_and_reset();
         clear_registries();
         TEST_TIMER_CALL_COUNT.store(0, Ordering::Relaxed);
 
@@ -803,6 +836,7 @@ mod tests {
 
     #[test]
     fn test_poll_fds_fires_on_ready_pipe() {
+        let _serial = serialize_and_reset();
         clear_registries();
         TEST_FD_CALL_COUNT.store(0, Ordering::Relaxed);
 
@@ -846,6 +880,7 @@ mod tests {
 
     #[test]
     fn test_poll_fds_does_not_fire_empty_pipe() {
+        let _serial = serialize_and_reset();
         clear_registries();
         TEST_FD_CALL_COUNT.store(0, Ordering::Relaxed);
 
@@ -885,6 +920,7 @@ mod tests {
 
     #[test]
     fn test_is_on_clap_main_thread_default() {
+        let _serial = serialize_and_reset();
         // Before set_clap_main_thread is called (or if OnceLock not set for
         // this test), any thread should be considered the main thread.
         // Note: If another test already called set_clap_main_thread in this

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -2213,6 +2213,18 @@ impl App {
                     self.state.tracks.len()
                 );
             }
+            Message::AuditionNote {
+                track_id,
+                pitch,
+                on,
+            } => {
+                self.send_command(EngineCommand::AuditionNote {
+                    track_id,
+                    pitch,
+                    velocity: 100,
+                    on,
+                });
+            }
             Message::DeleteKeyPressed => {
                 // Never delete anything while a text field is being
                 // edited; backspace belongs to the text there.
@@ -2614,6 +2626,20 @@ impl App {
                 self.state.status_text = format!("Cleared pad {}", pad_index + 1);
             }
             Message::SelectDrumRackPad(track_id, pad_index) => {
+                // Audition the pad like Ableton: hear it on click.
+                let pitch = 36 + pad_index.min(127) as u8;
+                self.send_command(EngineCommand::AuditionNote {
+                    track_id,
+                    pitch,
+                    velocity: 100,
+                    on: true,
+                });
+                self.send_command(EngineCommand::AuditionNote {
+                    track_id,
+                    pitch,
+                    velocity: 100,
+                    on: false,
+                });
                 if let Some(track) = self.state.find_track_mut(track_id) {
                     let max_index = track.drum_rack_pads.len().saturating_sub(1);
                     track.selected_drum_pad = pad_index.min(max_index);
@@ -9275,7 +9301,7 @@ impl App {
             if let Some(track) = self.state.find_track(track_id) {
                 if let Some(clip) = track.note_clips.iter().find(|c| c.id == cd.5) {
                     let clip_relative_playhead = playhead_beats - clip.position_beats;
-                    let mut widget = PianoRollWidget::from_clip(
+                    PianoRollWidget::from_clip(
                         track_id,
                         clip,
                         clip_relative_playhead,
@@ -9284,9 +9310,7 @@ impl App {
                         self.state.snap_grid,
                         self.state.piano_roll_scroll_y,
                         self.state.piano_roll_edit_mode,
-                    );
-                    widget.key_labels = drum_pad_key_labels(track);
-                    widget
+                    )
                 } else {
                     PianoRollWidget::empty(track_id, playhead_beats, track_color)
                 }
@@ -9873,28 +9897,6 @@ impl App {
             }),
         ])
     }
-}
-
-/// Key-lane labels for drum rack tracks: pad sample names keyed by
-/// the pad's MIDI pitch (pads start at note 36, chromatic upward).
-/// Empty for non-drum tracks, which keeps the default octave labels.
-fn drum_pad_key_labels(track: &UiTrack) -> std::collections::HashMap<u8, String> {
-    const BASE_PAD_NOTE: u8 = 36;
-    let mut labels = std::collections::HashMap::new();
-    if track.instrument_kind == Some(InstrumentKind::DrumRack) {
-        for (i, pad) in track.drum_rack_pads.iter().enumerate() {
-            // Only pads with samples get a name; empty pads keep a
-            // plain key so the lane stays readable.
-            let Some(name) = pad.name.as_deref() else {
-                continue;
-            };
-            let pitch = BASE_PAD_NOTE + i as u8;
-            // Strip the file extension; it is noise at 9px.
-            let clean = name.rsplit_once('.').map(|(stem, _)| stem).unwrap_or(name);
-            labels.insert(pitch, clean.to_string());
-        }
-    }
-    labels
 }
 
 /// Default clip loop region end: the note content's span rounded up

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -9883,9 +9883,15 @@ fn drum_pad_key_labels(track: &UiTrack) -> std::collections::HashMap<u8, String>
     let mut labels = std::collections::HashMap::new();
     if track.instrument_kind == Some(InstrumentKind::DrumRack) {
         for (i, pad) in track.drum_rack_pads.iter().enumerate() {
+            // Only pads with samples get a name; empty pads keep a
+            // plain key so the lane stays readable.
+            let Some(name) = pad.name.as_deref() else {
+                continue;
+            };
             let pitch = BASE_PAD_NOTE + i as u8;
-            let name = pad.name.clone().unwrap_or_else(|| format!("Pad {}", i + 1));
-            labels.insert(pitch, name);
+            // Strip the file extension; it is noise at 9px.
+            let clean = name.rsplit_once('.').map(|(stem, _)| stem).unwrap_or(name);
+            labels.insert(pitch, clean.to_string());
         }
     }
     labels

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -2213,6 +2213,29 @@ impl App {
                     self.state.tracks.len()
                 );
             }
+            Message::DeleteKeyPressed => {
+                // Never delete anything while a text field is being
+                // edited; backspace belongs to the text there.
+                if self.state.editing_track_name.is_some() || self.state.editing_clip_name.is_some()
+                {
+                    return Task::none();
+                }
+                // Priority 1: selected notes in the open piano roll.
+                if let Some((track_id, clip_id)) = self.state.selected_note_clip {
+                    let has_selection = self
+                        .state
+                        .find_track(track_id)
+                        .and_then(|t| t.note_clips.iter().find(|c| c.id == clip_id))
+                        .is_some_and(|c| !c.selected_notes.is_empty());
+                    if has_selection {
+                        return self.update(Message::RemoveSelectedNotes(track_id, clip_id));
+                    }
+                }
+                // Priority 2: selected arrangement clips.
+                if !self.state.selected_clips.is_empty() {
+                    return self.update(Message::DeleteSelectedClip);
+                }
+            }
             Message::SelectTrack(track_id) => {
                 self.state.selected_track = Some(track_id);
             }
@@ -8812,9 +8835,10 @@ impl App {
                 // Use container + mouse_area so press events reach us and
                 // drag-drop works. iced Button would capture ButtonPressed
                 // and hide it from mouse_area.
+                let pad_note = crate::widgets::piano_roll::pitch_name(36 + pad_index as u8);
                 let pad_body = container(
                     column![
-                        text(format!("{:02}", pad_index + 1))
+                        text(format!("{:02}  {pad_note}", pad_index + 1))
                             .size(9)
                             .color(if active { th::ACCENT } else { th::TEXT_DIM }),
                         text(label)
@@ -9251,7 +9275,7 @@ impl App {
             if let Some(track) = self.state.find_track(track_id) {
                 if let Some(clip) = track.note_clips.iter().find(|c| c.id == cd.5) {
                     let clip_relative_playhead = playhead_beats - clip.position_beats;
-                    PianoRollWidget::from_clip(
+                    let mut widget = PianoRollWidget::from_clip(
                         track_id,
                         clip,
                         clip_relative_playhead,
@@ -9260,7 +9284,9 @@ impl App {
                         self.state.snap_grid,
                         self.state.piano_roll_scroll_y,
                         self.state.piano_roll_edit_mode,
-                    )
+                    );
+                    widget.key_labels = drum_pad_key_labels(track);
+                    widget
                 } else {
                     PianoRollWidget::empty(track_id, playhead_beats, track_color)
                 }
@@ -9849,6 +9875,22 @@ impl App {
     }
 }
 
+/// Key-lane labels for drum rack tracks: pad sample names keyed by
+/// the pad's MIDI pitch (pads start at note 36, chromatic upward).
+/// Empty for non-drum tracks, which keeps the default octave labels.
+fn drum_pad_key_labels(track: &UiTrack) -> std::collections::HashMap<u8, String> {
+    const BASE_PAD_NOTE: u8 = 36;
+    let mut labels = std::collections::HashMap::new();
+    if track.instrument_kind == Some(InstrumentKind::DrumRack) {
+        for (i, pad) in track.drum_rack_pads.iter().enumerate() {
+            let pitch = BASE_PAD_NOTE + i as u8;
+            let name = pad.name.clone().unwrap_or_else(|| format!("Pad {}", i + 1));
+            labels.insert(pitch, name);
+        }
+    }
+    labels
+}
+
 /// Default clip loop region end: the note content's span rounded up
 /// to whole bars (4/4), capped at the clip duration. This is the
 /// Ableton behavior: loop the PATTERN, not the whole clip, so a
@@ -9997,6 +10039,18 @@ fn global_key_handler(
     // Escape: cancel editing
     if matches!(key, iced::keyboard::Key::Named(Named::Escape)) {
         return Some(Message::CancelEditing);
+    }
+
+    // Delete/Backspace: context-resolved in update() (selected notes
+    // first, then selected clips) and ignored while renaming.
+    if !modifiers.control()
+        && matches!(
+            key,
+            iced::keyboard::Key::Named(Named::Delete)
+                | iced::keyboard::Key::Named(Named::Backspace)
+        )
+    {
+        return Some(Message::DeleteKeyPressed);
     }
 
     // B: toggle piano roll draw mode (no modifiers)

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -396,6 +396,7 @@ pub enum Message {
 
     // Cursor tracking
     CursorMoved(f32, f32),
+    DeleteKeyPressed,
     WindowResized(f32, f32),
     MouseReleased,
 

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -397,6 +397,13 @@ pub enum Message {
     // Cursor tracking
     CursorMoved(f32, f32),
     DeleteKeyPressed,
+    /// Preview a pitch on a track's instrument (piano-roll key press
+    /// or drum pad click). `on: false` releases it.
+    AuditionNote {
+        track_id: TrackId,
+        pitch: u8,
+        on: bool,
+    },
     WindowResized(f32, f32),
     MouseReleased,
 

--- a/crates/vibez-ui/src/widgets/piano_roll.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll.rs
@@ -281,13 +281,25 @@ impl canvas::Program<Message> for PianoRollWidget {
 
     fn draw(
         &self,
-        _state: &Self::State,
+        state: &Self::State,
         renderer: &Renderer,
         _theme: &Theme,
         bounds: Rectangle,
-        _cursor: mouse::Cursor,
+        cursor: mouse::Cursor,
     ) -> Vec<canvas::Geometry> {
         let mut frame = canvas::Frame::new(renderer, bounds.size());
+
+        // Key-lane feedback: the auditioned (pressed) pitch, and the
+        // pitch under the cursor while hovering the keys.
+        let pressed_pitch = state.audition_pitch;
+        let hovered_pitch = cursor.position_in(bounds).and_then(|pos| {
+            if pos.x < KEY_WIDTH && pos.y > RULER_HEIGHT && state.audition_pitch.is_none() {
+                let pitch = self.y_to_pitch(pos.y);
+                (LOW_NOTE..HIGH_NOTE).contains(&pitch).then_some(pitch)
+            } else {
+                None
+            }
+        });
         let w = bounds.width;
         let h = bounds.height;
         let grid_width = w - KEY_WIDTH;
@@ -351,10 +363,20 @@ impl canvas::Program<Message> for PianoRollWidget {
             }
 
             if !is_black_key(pitch) {
+                let fill = if pressed_pitch == Some(pitch) {
+                    self.track_color
+                } else if hovered_pitch == Some(pitch) {
+                    Color {
+                        a: 0.75,
+                        ..WHITE_KEY_COLOR
+                    }
+                } else {
+                    WHITE_KEY_COLOR
+                };
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
                     iced::Size::new(KEY_WIDTH, KEY_HEIGHT),
-                    WHITE_KEY_COLOR,
+                    fill,
                 );
 
                 // Key border
@@ -395,10 +417,22 @@ impl canvas::Program<Message> for PianoRollWidget {
                 );
 
                 // Black key itself
+                let fill = if pressed_pitch == Some(pitch) {
+                    self.track_color
+                } else if hovered_pitch == Some(pitch) {
+                    Color {
+                        r: 0.35,
+                        g: 0.35,
+                        b: 0.35,
+                        a: 1.0,
+                    }
+                } else {
+                    BLACK_KEY_COLOR
+                };
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
                     iced::Size::new(black_key_width, KEY_HEIGHT),
-                    BLACK_KEY_COLOR,
+                    fill,
                 );
 
                 // Key border

--- a/crates/vibez-ui/src/widgets/piano_roll.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll.rs
@@ -13,6 +13,8 @@ use vibez_core::midi::MidiNote;
 
 /// Width of the piano key area on the left.
 const KEY_WIDTH: f32 = 52.0;
+/// Wider key lane when pads carry sample-name labels (drum tracks).
+const DRUM_KEY_WIDTH: f32 = 110.0;
 /// Height of each piano key row.
 const KEY_HEIGHT: f32 = 16.0;
 /// Height of the ruler strip at the top.
@@ -28,7 +30,7 @@ const NUM_ROWS: u8 = HIGH_NOTE - LOW_NOTE;
 /// Resize handle width in pixels.
 const RESIZE_HANDLE_PX: f32 = 6.0;
 
-/// Black key width as fraction of KEY_WIDTH.
+/// Black key width as fraction of self.key_width().
 const BLACK_KEY_RATIO: f32 = 0.60;
 
 /// Scroll speed: pixels per wheel tick.
@@ -107,16 +109,24 @@ impl PianoRollWidget {
         }
     }
 
+    fn key_width(&self) -> f32 {
+        if self.key_labels.is_empty() {
+            self.key_width()
+        } else {
+            DRUM_KEY_WIDTH
+        }
+    }
+
     fn beat_to_x(&self, beat: f64, bounds: &Rectangle) -> f32 {
-        let grid_width = bounds.width - KEY_WIDTH;
+        let grid_width = bounds.width - self.key_width();
         let total = self.total_beats.max(1.0);
         KEY_WIDTH + (beat / total) as f32 * grid_width
     }
 
     fn x_to_beat(&self, x: f32, bounds: &Rectangle) -> f64 {
-        let grid_width = bounds.width - KEY_WIDTH;
+        let grid_width = bounds.width - self.key_width();
         let total = self.total_beats.max(1.0);
-        ((x - KEY_WIDTH) / grid_width) as f64 * total
+        ((x - self.key_width()) / grid_width) as f64 * total
     }
 
     fn pitch_to_y(&self, pitch: u8) -> f32 {
@@ -133,7 +143,7 @@ impl PianoRollWidget {
     /// Hit test: find note at position, return (index, near_right_edge).
     fn hit_test_note(&self, pos: Point, bounds: &Rectangle) -> Option<(usize, bool)> {
         let clip_data = self.clip.as_ref()?;
-        let grid_width = bounds.width - KEY_WIDTH;
+        let grid_width = bounds.width - self.key_width();
         let total = self.total_beats.max(1.0);
 
         for (idx, note) in clip_data.notes.iter().enumerate() {
@@ -294,7 +304,7 @@ impl canvas::Program<Message> for PianoRollWidget {
         let mut frame = canvas::Frame::new(renderer, bounds.size());
         let w = bounds.width;
         let h = bounds.height;
-        let grid_width = w - KEY_WIDTH;
+        let grid_width = w - self.key_width();
         let total = self.total_beats.max(1.0);
         let grid_ppb = grid_width / total as f32;
 
@@ -320,7 +330,7 @@ impl canvas::Program<Message> for PianoRollWidget {
             let row_bg = if is_black { BLACK_ROW_BG } else { WHITE_ROW_BG };
 
             frame.fill_rectangle(
-                iced::Point::new(KEY_WIDTH, y),
+                iced::Point::new(self.key_width(), y),
                 iced::Size::new(grid_width, KEY_HEIGHT),
                 row_bg,
             );
@@ -333,7 +343,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                 (GRID_LINE, 0.5)
             };
             let hline = canvas::Path::line(
-                iced::Point::new(KEY_WIDTH, y + KEY_HEIGHT),
+                iced::Point::new(self.key_width(), y + KEY_HEIGHT),
                 iced::Point::new(w, y + KEY_HEIGHT),
             );
             frame.stroke(
@@ -357,14 +367,14 @@ impl canvas::Program<Message> for PianoRollWidget {
             if !is_black_key(pitch) {
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
-                    iced::Size::new(KEY_WIDTH, KEY_HEIGHT),
+                    iced::Size::new(self.key_width(), KEY_HEIGHT),
                     WHITE_KEY_COLOR,
                 );
 
                 // Key border
                 let border = canvas::Path::line(
                     iced::Point::new(0.0, y + KEY_HEIGHT),
-                    iced::Point::new(KEY_WIDTH, y + KEY_HEIGHT),
+                    iced::Point::new(self.key_width(), y + KEY_HEIGHT),
                 );
                 frame.stroke(
                     &border,
@@ -376,7 +386,7 @@ impl canvas::Program<Message> for PianoRollWidget {
         }
 
         // Second pass: draw black keys on top (narrower, covering left portion)
-        let black_key_width = KEY_WIDTH * BLACK_KEY_RATIO;
+        let black_key_width = self.key_width() * BLACK_KEY_RATIO;
         for i in first_visible..last_visible {
             let pitch = HIGH_NOTE - 1 - i as u8;
             let y = i as f32 * KEY_HEIGHT + RULER_HEIGHT - self.scroll_y;
@@ -389,7 +399,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                 // Dark fill for the background area behind black key
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
-                    iced::Size::new(KEY_WIDTH, KEY_HEIGHT),
+                    iced::Size::new(self.key_width(), KEY_HEIGHT),
                     Color {
                         r: 0.14,
                         g: 0.14,
@@ -408,7 +418,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                 // Key border
                 let border = canvas::Path::line(
                     iced::Point::new(0.0, y + KEY_HEIGHT),
-                    iced::Point::new(KEY_WIDTH, y + KEY_HEIGHT),
+                    iced::Point::new(self.key_width(), y + KEY_HEIGHT),
                 );
                 frame.stroke(
                     &border,
@@ -450,8 +460,8 @@ impl canvas::Program<Message> for PianoRollWidget {
 
         // Key area separator (vertical line at right edge of piano)
         let sep = canvas::Path::line(
-            iced::Point::new(KEY_WIDTH, RULER_HEIGHT),
-            iced::Point::new(KEY_WIDTH, h),
+            iced::Point::new(self.key_width(), RULER_HEIGHT),
+            iced::Point::new(self.key_width(), h),
         );
         frame.stroke(
             &sep,
@@ -1102,7 +1112,7 @@ impl canvas::Program<Message> for PianoRollWidget {
 
                     if let Some(ref drag) = state.drag {
                         if let Some(ref clip_data) = self.clip {
-                            let grid_width = bounds.width - KEY_WIDTH;
+                            let grid_width = bounds.width - self.key_width();
                             let total = self.total_beats.max(1.0);
                             let beats_per_pixel = total / grid_width as f64;
 
@@ -1231,7 +1241,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                         if original_notes.len() > 1 {
                             if let Some(ref clip_data) = self.clip {
                                 if let Some(pos) = state.last_cursor {
-                                    let grid_width = bounds.width - KEY_WIDTH;
+                                    let grid_width = bounds.width - self.key_width();
                                     let total = self.total_beats.max(1.0);
                                     let beats_per_pixel = total / grid_width as f64;
 
@@ -1293,26 +1303,12 @@ impl canvas::Program<Message> for PianoRollWidget {
                 state.shift_held = false;
             }
 
-            // ── Keyboard: Delete → remove selected notes ──
-            //
-            // Backspace is intentionally not bound because iced 0.13 canvas
-            // receives keyboard events even when a text input is focused.
-            canvas::Event::Keyboard(iced::keyboard::Event::KeyPressed {
-                key: iced::keyboard::Key::Named(iced::keyboard::key::Named::Delete),
-                ..
-            }) => {
-                if let Some(ref clip_data) = self.clip {
-                    if !clip_data.selected_notes.is_empty() {
-                        return (
-                            canvas::event::Status::Captured,
-                            Some(Message::RemoveSelectedNotes(
-                                self.track_id,
-                                clip_data.clip_id,
-                            )),
-                        );
-                    }
-                }
-            }
+            // Delete/Backspace are handled centrally by the global
+            // DeleteKeyPressed shortcut (context-aware, respects text
+            // input focus). Canvases must NOT bind them: every canvas
+            // receives keyboard events, so two canvases binding the
+            // same key race each other (the timeline used to win and
+            // delete the clip while the piano roll wanted the note).
 
             // ── Keyboard: Arrow keys → nudge selected notes ──
             canvas::Event::Keyboard(iced::keyboard::Event::KeyPressed {

--- a/crates/vibez-ui/src/widgets/piano_roll.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll.rs
@@ -13,8 +13,6 @@ use vibez_core::midi::MidiNote;
 
 /// Width of the piano key area on the left.
 const KEY_WIDTH: f32 = 52.0;
-/// Wider key lane when pads carry sample-name labels (drum tracks).
-const DRUM_KEY_WIDTH: f32 = 110.0;
 /// Height of each piano key row.
 const KEY_HEIGHT: f32 = 16.0;
 /// Height of the ruler strip at the top.
@@ -30,7 +28,7 @@ const NUM_ROWS: u8 = HIGH_NOTE - LOW_NOTE;
 /// Resize handle width in pixels.
 const RESIZE_HANDLE_PX: f32 = 6.0;
 
-/// Black key width as fraction of self.key_width().
+/// Black key width as fraction of KEY_WIDTH.
 const BLACK_KEY_RATIO: f32 = 0.60;
 
 /// Scroll speed: pixels per wheel tick.
@@ -46,10 +44,6 @@ pub struct PianoRollWidget {
     pub snap_grid: SnapGrid,
     pub scroll_y: f32,
     pub edit_mode: PianoRollEditMode,
-    /// Per-pitch key-lane labels (drum rack pad names). When present
-    /// these replace the default C-note octave labels so drum tracks
-    /// show sample names on their keys, like Ableton's drum racks.
-    pub key_labels: std::collections::HashMap<u8, String>,
 }
 
 /// Owned data for drawing a note clip in the piano roll.
@@ -91,7 +85,6 @@ impl PianoRollWidget {
             snap_grid,
             scroll_y,
             edit_mode,
-            key_labels: std::collections::HashMap::new(),
         }
     }
 
@@ -105,28 +98,19 @@ impl PianoRollWidget {
             snap_grid: SnapGrid::Eighth,
             scroll_y: default_scroll_y(200.0),
             edit_mode: PianoRollEditMode::default(),
-            key_labels: std::collections::HashMap::new(),
-        }
-    }
-
-    fn key_width(&self) -> f32 {
-        if self.key_labels.is_empty() {
-            KEY_WIDTH
-        } else {
-            DRUM_KEY_WIDTH
         }
     }
 
     fn beat_to_x(&self, beat: f64, bounds: &Rectangle) -> f32 {
-        let grid_width = bounds.width - self.key_width();
+        let grid_width = bounds.width - KEY_WIDTH;
         let total = self.total_beats.max(1.0);
-        self.key_width() + (beat / total) as f32 * grid_width
+        KEY_WIDTH + (beat / total) as f32 * grid_width
     }
 
     fn x_to_beat(&self, x: f32, bounds: &Rectangle) -> f64 {
-        let grid_width = bounds.width - self.key_width();
+        let grid_width = bounds.width - KEY_WIDTH;
         let total = self.total_beats.max(1.0);
-        ((x - self.key_width()) / grid_width) as f64 * total
+        ((x - KEY_WIDTH) / grid_width) as f64 * total
     }
 
     fn pitch_to_y(&self, pitch: u8) -> f32 {
@@ -143,7 +127,7 @@ impl PianoRollWidget {
     /// Hit test: find note at position, return (index, near_right_edge).
     fn hit_test_note(&self, pos: Point, bounds: &Rectangle) -> Option<(usize, bool)> {
         let clip_data = self.clip.as_ref()?;
-        let grid_width = bounds.width - self.key_width();
+        let grid_width = bounds.width - KEY_WIDTH;
         let total = self.total_beats.max(1.0);
 
         for (idx, note) in clip_data.notes.iter().enumerate() {
@@ -230,6 +214,8 @@ pub struct PianoRollState {
     last_cursor: Option<Point>,
     shift_held: bool,
     last_click: Option<(Instant, Point)>,
+    /// Pitch currently held down via a key-lane click (audition).
+    audition_pitch: Option<u8>,
 }
 
 // ── Grid row colors ──
@@ -304,7 +290,7 @@ impl canvas::Program<Message> for PianoRollWidget {
         let mut frame = canvas::Frame::new(renderer, bounds.size());
         let w = bounds.width;
         let h = bounds.height;
-        let grid_width = w - self.key_width();
+        let grid_width = w - KEY_WIDTH;
         let total = self.total_beats.max(1.0);
         let grid_ppb = grid_width / total as f32;
 
@@ -330,7 +316,7 @@ impl canvas::Program<Message> for PianoRollWidget {
             let row_bg = if is_black { BLACK_ROW_BG } else { WHITE_ROW_BG };
 
             frame.fill_rectangle(
-                iced::Point::new(self.key_width(), y),
+                iced::Point::new(KEY_WIDTH, y),
                 iced::Size::new(grid_width, KEY_HEIGHT),
                 row_bg,
             );
@@ -343,7 +329,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                 (GRID_LINE, 0.5)
             };
             let hline = canvas::Path::line(
-                iced::Point::new(self.key_width(), y + KEY_HEIGHT),
+                iced::Point::new(KEY_WIDTH, y + KEY_HEIGHT),
                 iced::Point::new(w, y + KEY_HEIGHT),
             );
             frame.stroke(
@@ -367,14 +353,14 @@ impl canvas::Program<Message> for PianoRollWidget {
             if !is_black_key(pitch) {
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
-                    iced::Size::new(self.key_width(), KEY_HEIGHT),
+                    iced::Size::new(KEY_WIDTH, KEY_HEIGHT),
                     WHITE_KEY_COLOR,
                 );
 
                 // Key border
                 let border = canvas::Path::line(
                     iced::Point::new(0.0, y + KEY_HEIGHT),
-                    iced::Point::new(self.key_width(), y + KEY_HEIGHT),
+                    iced::Point::new(KEY_WIDTH, y + KEY_HEIGHT),
                 );
                 frame.stroke(
                     &border,
@@ -386,7 +372,7 @@ impl canvas::Program<Message> for PianoRollWidget {
         }
 
         // Second pass: draw black keys on top (narrower, covering left portion)
-        let black_key_width = self.key_width() * BLACK_KEY_RATIO;
+        let black_key_width = KEY_WIDTH * BLACK_KEY_RATIO;
         for i in first_visible..last_visible {
             let pitch = HIGH_NOTE - 1 - i as u8;
             let y = i as f32 * KEY_HEIGHT + RULER_HEIGHT - self.scroll_y;
@@ -399,7 +385,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                 // Dark fill for the background area behind black key
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
-                    iced::Size::new(self.key_width(), KEY_HEIGHT),
+                    iced::Size::new(KEY_WIDTH, KEY_HEIGHT),
                     Color {
                         r: 0.14,
                         g: 0.14,
@@ -418,7 +404,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                 // Key border
                 let border = canvas::Path::line(
                     iced::Point::new(0.0, y + KEY_HEIGHT),
-                    iced::Point::new(self.key_width(), y + KEY_HEIGHT),
+                    iced::Point::new(KEY_WIDTH, y + KEY_HEIGHT),
                 );
                 frame.stroke(
                     &border,
@@ -438,15 +424,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                 continue;
             }
 
-            if let Some(name) = self.key_labels.get(&pitch) {
-                frame.fill_text(canvas::Text {
-                    content: format!("{} {}", pitch_name(pitch), name),
-                    position: iced::Point::new(black_key_width + 3.0, y + 2.0),
-                    color: KEY_LABEL_COLOR,
-                    size: iced::Pixels(9.0),
-                    ..Default::default()
-                });
-            } else if self.key_labels.is_empty() && pitch.is_multiple_of(12) {
+            if pitch.is_multiple_of(12) {
                 let label = pitch_name(pitch);
                 frame.fill_text(canvas::Text {
                     content: label,
@@ -460,8 +438,8 @@ impl canvas::Program<Message> for PianoRollWidget {
 
         // Key area separator (vertical line at right edge of piano)
         let sep = canvas::Path::line(
-            iced::Point::new(self.key_width(), RULER_HEIGHT),
-            iced::Point::new(self.key_width(), h),
+            iced::Point::new(KEY_WIDTH, RULER_HEIGHT),
+            iced::Point::new(KEY_WIDTH, h),
         );
         frame.stroke(
             &sep,
@@ -477,7 +455,7 @@ impl canvas::Program<Message> for PianoRollWidget {
         for step in 0..=num_steps {
             let beat = step as f64 * grid_step;
             // Snap to half-pixel for crisp 1px rendering (avoids blurry subpixel splits)
-            let x = (self.key_width() + (beat / total) as f32 * grid_width).floor() + 0.5;
+            let x = (KEY_WIDTH + (beat / total) as f32 * grid_width).floor() + 0.5;
             if x > w {
                 break;
             }
@@ -734,7 +712,7 @@ impl canvas::Program<Message> for PianoRollWidget {
 
         // ── Playhead ──
         let playhead_x = self.beat_to_x(self.playhead_beats, &bounds);
-        if playhead_x >= self.key_width() {
+        if playhead_x >= KEY_WIDTH {
             let playhead_line = canvas::Path::line(
                 iced::Point::new(playhead_x, RULER_HEIGHT),
                 iced::Point::new(playhead_x, h),
@@ -770,7 +748,7 @@ impl canvas::Program<Message> for PianoRollWidget {
         // Ruler tick marks and labels
         for step in 0..=num_steps {
             let beat = step as f64 * grid_step;
-            let x = (self.key_width() + (beat / total) as f32 * grid_width).floor() + 0.5;
+            let x = (KEY_WIDTH + (beat / total) as f32 * grid_width).floor() + 0.5;
             if x > w {
                 break;
             }
@@ -823,7 +801,7 @@ impl canvas::Program<Message> for PianoRollWidget {
         }
 
         // Ruler playhead marker
-        if playhead_x >= self.key_width() {
+        if playhead_x >= KEY_WIDTH {
             let marker = canvas::Path::line(
                 iced::Point::new(playhead_x, 0.0),
                 iced::Point::new(playhead_x, RULER_HEIGHT),
@@ -866,7 +844,7 @@ impl canvas::Program<Message> for PianoRollWidget {
 
         // Select mode: hover over note edge
         if let Some(pos) = cursor.position_in(bounds) {
-            if pos.x >= self.key_width() && pos.y > RULER_HEIGHT {
+            if pos.x >= KEY_WIDTH && pos.y > RULER_HEIGHT {
                 if let Some((_idx, near_right)) = self.hit_test_note(pos, &bounds) {
                     if near_right {
                         return mouse::Interaction::ResizingHorizontally;
@@ -909,8 +887,21 @@ impl canvas::Program<Message> for PianoRollWidget {
                         return (canvas::event::Status::Ignored, None);
                     }
 
-                    // Only handle clicks in the grid area
-                    if pos.x < self.key_width() {
+                    // Key lane: press auditions the pitch on this
+                    // track's instrument (released on mouse-up).
+                    if pos.x < KEY_WIDTH {
+                        let pitch = self.y_to_pitch(pos.y);
+                        if (LOW_NOTE..HIGH_NOTE).contains(&pitch) {
+                            state.audition_pitch = Some(pitch);
+                            return (
+                                canvas::event::Status::Captured,
+                                Some(Message::AuditionNote {
+                                    track_id: self.track_id,
+                                    pitch,
+                                    on: true,
+                                }),
+                            );
+                        }
                         return (canvas::event::Status::Ignored, None);
                     }
 
@@ -1112,7 +1103,7 @@ impl canvas::Program<Message> for PianoRollWidget {
 
                     if let Some(ref drag) = state.drag {
                         if let Some(ref clip_data) = self.clip {
-                            let grid_width = bounds.width - self.key_width();
+                            let grid_width = bounds.width - KEY_WIDTH;
                             let total = self.total_beats.max(1.0);
                             let beats_per_pixel = total / grid_width as f64;
 
@@ -1227,6 +1218,18 @@ impl canvas::Program<Message> for PianoRollWidget {
             }
 
             canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                // Release an auditioned key first: it never coexists
+                // with a note drag.
+                if let Some(pitch) = state.audition_pitch.take() {
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::AuditionNote {
+                            track_id: self.track_id,
+                            pitch,
+                            on: false,
+                        }),
+                    );
+                }
                 if let Some(drag) = state.drag.take() {
                     // On release of a multi-note drag, move all non-anchor notes
                     if let DragAction::MoveNote {
@@ -1241,7 +1244,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                         if original_notes.len() > 1 {
                             if let Some(ref clip_data) = self.clip {
                                 if let Some(pos) = state.last_cursor {
-                                    let grid_width = bounds.width - self.key_width();
+                                    let grid_width = bounds.width - KEY_WIDTH;
                                     let total = self.total_beats.max(1.0);
                                     let beats_per_pixel = total / grid_width as f64;
 
@@ -1408,18 +1411,4 @@ impl canvas::Program<Message> for PianoRollWidget {
 /// Returns true if the given MIDI pitch is a black key.
 fn is_black_key(pitch: u8) -> bool {
     matches!(pitch % 12, 1 | 3 | 6 | 8 | 10)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use vibez_core::id::TrackId;
-
-    #[test]
-    fn key_width_is_finite_for_both_lane_modes() {
-        let mut w = PianoRollWidget::empty(TrackId::new(), 0.0, Color::WHITE);
-        assert_eq!(w.key_width(), KEY_WIDTH);
-        w.key_labels.insert(36, "Kick".to_string());
-        assert_eq!(w.key_width(), DRUM_KEY_WIDTH);
-    }
 }

--- a/crates/vibez-ui/src/widgets/piano_roll.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll.rs
@@ -111,7 +111,7 @@ impl PianoRollWidget {
 
     fn key_width(&self) -> f32 {
         if self.key_labels.is_empty() {
-            self.key_width()
+            KEY_WIDTH
         } else {
             DRUM_KEY_WIDTH
         }
@@ -120,7 +120,7 @@ impl PianoRollWidget {
     fn beat_to_x(&self, beat: f64, bounds: &Rectangle) -> f32 {
         let grid_width = bounds.width - self.key_width();
         let total = self.total_beats.max(1.0);
-        KEY_WIDTH + (beat / total) as f32 * grid_width
+        self.key_width() + (beat / total) as f32 * grid_width
     }
 
     fn x_to_beat(&self, x: f32, bounds: &Rectangle) -> f64 {
@@ -477,7 +477,7 @@ impl canvas::Program<Message> for PianoRollWidget {
         for step in 0..=num_steps {
             let beat = step as f64 * grid_step;
             // Snap to half-pixel for crisp 1px rendering (avoids blurry subpixel splits)
-            let x = (KEY_WIDTH + (beat / total) as f32 * grid_width).floor() + 0.5;
+            let x = (self.key_width() + (beat / total) as f32 * grid_width).floor() + 0.5;
             if x > w {
                 break;
             }
@@ -734,7 +734,7 @@ impl canvas::Program<Message> for PianoRollWidget {
 
         // ── Playhead ──
         let playhead_x = self.beat_to_x(self.playhead_beats, &bounds);
-        if playhead_x >= KEY_WIDTH {
+        if playhead_x >= self.key_width() {
             let playhead_line = canvas::Path::line(
                 iced::Point::new(playhead_x, RULER_HEIGHT),
                 iced::Point::new(playhead_x, h),
@@ -770,7 +770,7 @@ impl canvas::Program<Message> for PianoRollWidget {
         // Ruler tick marks and labels
         for step in 0..=num_steps {
             let beat = step as f64 * grid_step;
-            let x = (KEY_WIDTH + (beat / total) as f32 * grid_width).floor() + 0.5;
+            let x = (self.key_width() + (beat / total) as f32 * grid_width).floor() + 0.5;
             if x > w {
                 break;
             }
@@ -823,7 +823,7 @@ impl canvas::Program<Message> for PianoRollWidget {
         }
 
         // Ruler playhead marker
-        if playhead_x >= KEY_WIDTH {
+        if playhead_x >= self.key_width() {
             let marker = canvas::Path::line(
                 iced::Point::new(playhead_x, 0.0),
                 iced::Point::new(playhead_x, RULER_HEIGHT),
@@ -866,7 +866,7 @@ impl canvas::Program<Message> for PianoRollWidget {
 
         // Select mode: hover over note edge
         if let Some(pos) = cursor.position_in(bounds) {
-            if pos.x >= KEY_WIDTH && pos.y > RULER_HEIGHT {
+            if pos.x >= self.key_width() && pos.y > RULER_HEIGHT {
                 if let Some((_idx, near_right)) = self.hit_test_note(pos, &bounds) {
                     if near_right {
                         return mouse::Interaction::ResizingHorizontally;
@@ -910,7 +910,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                     }
 
                     // Only handle clicks in the grid area
-                    if pos.x < KEY_WIDTH {
+                    if pos.x < self.key_width() {
                         return (canvas::event::Status::Ignored, None);
                     }
 
@@ -1408,4 +1408,18 @@ impl canvas::Program<Message> for PianoRollWidget {
 /// Returns true if the given MIDI pitch is a black key.
 fn is_black_key(pitch: u8) -> bool {
     matches!(pitch % 12, 1 | 3 | 6 | 8 | 10)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibez_core::id::TrackId;
+
+    #[test]
+    fn key_width_is_finite_for_both_lane_modes() {
+        let mut w = PianoRollWidget::empty(TrackId::new(), 0.0, Color::WHITE);
+        assert_eq!(w.key_width(), KEY_WIDTH);
+        w.key_labels.insert(36, "Kick".to_string());
+        assert_eq!(w.key_width(), DRUM_KEY_WIDTH);
+    }
 }

--- a/crates/vibez-ui/src/widgets/piano_roll.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll.rs
@@ -44,6 +44,10 @@ pub struct PianoRollWidget {
     pub snap_grid: SnapGrid,
     pub scroll_y: f32,
     pub edit_mode: PianoRollEditMode,
+    /// Per-pitch key-lane labels (drum rack pad names). When present
+    /// these replace the default C-note octave labels so drum tracks
+    /// show sample names on their keys, like Ableton's drum racks.
+    pub key_labels: std::collections::HashMap<u8, String>,
 }
 
 /// Owned data for drawing a note clip in the piano roll.
@@ -85,6 +89,7 @@ impl PianoRollWidget {
             snap_grid,
             scroll_y,
             edit_mode,
+            key_labels: std::collections::HashMap::new(),
         }
     }
 
@@ -98,6 +103,7 @@ impl PianoRollWidget {
             snap_grid: SnapGrid::Eighth,
             scroll_y: default_scroll_y(200.0),
             edit_mode: PianoRollEditMode::default(),
+            key_labels: std::collections::HashMap::new(),
         }
     }
 
@@ -165,7 +171,7 @@ fn clamp_scroll_y(scroll_y: f32, canvas_height: f32) -> f32 {
 }
 
 /// Returns a pitch name like "C4", "D#3".
-fn pitch_name(pitch: u8) -> String {
+pub(crate) fn pitch_name(pitch: u8) -> String {
     const NAMES: [&str; 12] = [
         "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
     ];
@@ -422,7 +428,15 @@ impl canvas::Program<Message> for PianoRollWidget {
                 continue;
             }
 
-            if pitch % 12 == 0 {
+            if let Some(name) = self.key_labels.get(&pitch) {
+                frame.fill_text(canvas::Text {
+                    content: format!("{} {}", pitch_name(pitch), name),
+                    position: iced::Point::new(black_key_width + 3.0, y + 2.0),
+                    color: KEY_LABEL_COLOR,
+                    size: iced::Pixels(9.0),
+                    ..Default::default()
+                });
+            } else if self.key_labels.is_empty() && pitch.is_multiple_of(12) {
                 let label = pitch_name(pitch);
                 frame.fill_text(canvas::Text {
                     content: label,

--- a/crates/vibez-ui/src/widgets/timeline.rs
+++ b/crates/vibez-ui/src/widgets/timeline.rs
@@ -1827,27 +1827,11 @@ impl canvas::Program<Message> for TrackClipCanvas {
                 }
             }
 
-            // -- Keyboard: Delete for selected clip(s) --
-            //
-            // Intentionally does NOT capture Backspace. iced 0.13's canvas
-            // receives keyboard events even when a text input is focused, so
-            // binding Backspace here caused BPM edits to delete clips.
-            canvas::Event::Keyboard(iced::keyboard::Event::KeyPressed {
-                key: iced::keyboard::Key::Named(iced::keyboard::key::Named::Delete),
-                ..
-            }) => {
-                if !self.selected_clips.is_empty() {
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(Message::DeleteSelectedClip),
-                    );
-                } else if self.selected {
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(Message::RemoveTrack(self.track_id)),
-                    );
-                }
-            }
+            // Delete/Backspace are handled centrally by the global
+            // DeleteKeyPressed shortcut (context-aware: selected notes
+            // first, then clips). The old canvas binding here raced
+            // the piano roll's and won, deleting the clip while a
+            // note was selected; it could even delete the whole track.
 
             // -- Keyboard shortcuts (Ctrl+D/E/J/T) --
             canvas::Event::Keyboard(iced::keyboard::Event::KeyPressed {


### PR DESCRIPTION
Quick wins from the dogfood list, revised after review feedback.

**#5 Note deletion.** Delete and Backspace delete selected piano-roll notes, falling back to selected arrangement clips; inert while renaming. First attempt raced two legacy canvas-level Delete bindings (the timeline won and deleted the clip, or even the track); both canvas bindings are removed and the context-aware global handler is the single owner.

**#4 Drum pad mapping.** Pad tiles show their MIDI note name (36 = C2, chromatic upward). The piano-roll key-lane sample labels tried in an earlier revision looked inconsistent and were replaced by something better:

**Note audition (new, very Ableton).** Pressing a key in the piano-roll key lane auditions that pitch on the track's instrument (note-off on release), and clicking a drum pad plays it. Works for every instrument type including plugins. Engine side: new AuditionNote command plus idle instrument rendering, instrument tracks now render while the transport is stopped (with effects and gain/pan) so audition is audible without pressing play. End-to-end test: audition a synth note while stopped, assert audible output, release, assert decay.

Also: fixes a piano-roll crash from an intermediate revision (recursive key_width), and serializes the CLAP host timer/fd tests that flaked under the parallel runner.

Test plan: click piano keys on synth/sampler/drum/plugin tracks with transport stopped; click drum pads; Delete and Backspace on selected notes then clips; backspace while renaming stays in the text field.