### PR TITLE
feat(devices): built-in instruments functional and presentable (params, editors, design system)

### DIFF
--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -387,7 +387,18 @@ Three distinct issues observed:
   inputs so typing stays safe. #4: drum pads show their MIDI note
   name (36 = C2 chromatic upward) and the piano-roll key lane shows
   pad sample names on drum rack tracks, Ableton-style.
-- Bugs #1 (dead synth params) and #2 (knob feel): still open.
+- Bug #1 (dead synth params): FIXED on fix/synth-params (PR #11).
+  Root cause was almost comic: view_synth_device was a MOCKUP with
+  hardcoded labels and a literal "0.50" string; no knobs, no
+  messages, Message::SetInstrumentParam was never sent from any
+  view. The engine-side param path worked all along (regression
+  test now proves closing the filter darkens the output). The card
+  is now real: waveform selector buttons + knobs for ADSR, cutoff,
+  resonance, volume, reusing the effect-knob widget generalized to
+  instrument targets.
+- Bug #2 (knob feel): still open, though the effect knob widget
+  already has drag/shift-fine/double-click-reset/scroll; needs a
+  feel pass against Ableton.
 - PR #10 also added note audition (piano-roll keys + drum pads,
   hover/pressed visuals) backed by idle instrument rendering: the
   engine now renders instrument tracks while the transport is

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -2165,6 +2165,53 @@ mod stuck_note_tests {
     }
 
     #[test]
+    fn instrument_params_change_the_sound() {
+        let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+        let tid = TrackId::new();
+        cmd_tx
+            .push(EngineCommand::AddMidiTrack(tid, "midi".into()))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::SetTrackInstrument(
+                tid,
+                vibez_core::midi::InstrumentKind::SubtractiveSynth,
+            ))
+            .unwrap();
+        cmd_tx
+            .push(EngineCommand::AuditionNote {
+                track_id: tid,
+                pitch: 60,
+                velocity: 100,
+                on: true,
+            })
+            .unwrap();
+        let mut open_buf = vec![0.0f32; 2048 * 2];
+        engine.process(&mut open_buf, 2);
+        engine.process(&mut open_buf, 2);
+
+        // Slam the filter shut (param 5 = cutoff in Hz) and compare.
+        cmd_tx
+            .push(EngineCommand::SetInstrumentParam {
+                track_id: tid,
+                param_index: 5,
+                value: 60.0,
+            })
+            .unwrap();
+        let mut closed_buf = vec![0.0f32; 2048 * 2];
+        engine.process(&mut closed_buf, 2);
+        engine.process(&mut closed_buf, 2);
+
+        let rms = |b: &[f32]| (b.iter().map(|s| s * s).sum::<f32>() / b.len() as f32).sqrt();
+        let open_rms = rms(&open_buf);
+        let closed_rms = rms(&closed_buf);
+        assert!(open_rms > 0.0);
+        assert!(
+            closed_rms < open_rms * 0.7,
+            "60 Hz cutoff must audibly darken/quiet a C4 saw: open={open_rms} closed={closed_rms}"
+        );
+    }
+
+    #[test]
     fn audition_sounds_while_transport_stopped() {
         let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
         let tid = TrackId::new();

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8581,7 +8581,7 @@ impl App {
                         devices_row = devices_row.push(card);
                     }
                     _ => {
-                        let synth_card = self.view_synth_device(track_id, track_color);
+                        let synth_card = self.view_synth_device(track_id, track, track_color);
                         devices_row = devices_row.push(synth_card);
                     }
                 }
@@ -8738,23 +8738,98 @@ impl App {
     }
 
     /// Synth device card for instrument tracks.
-    fn view_synth_device(&self, _track_id: TrackId, track_color: Color) -> Element<'_, Message> {
+    fn view_synth_device<'a>(
+        &'a self,
+        track_id: TrackId,
+        track: &'a UiTrack,
+        track_color: Color,
+    ) -> Element<'a, Message> {
+        use crate::widgets::effect_knob::EffectKnobWidget;
         let dot = text("\u{25CF}").size(8).color(track_color);
         let name = text("Synth").size(11).color(th::TEXT);
 
         let title =
             Self::device_title_bar(row![dot, name].spacing(4).align_y(iced::Alignment::Center));
 
-        let param_names = ["Attack", "Decay", "Sustain", "Release"];
-        let mut params_col = column![].spacing(3);
-        for pn in &param_names {
-            let label = text(*pn).size(9).color(th::TEXT_DIM);
-            let value = text("0.50").size(8).color(th::TEXT_MUTED);
-            params_col = params_col.push(column![label, value].spacing(1));
-        }
-        let body = container(params_col).padding([6, 6]).width(Length::Fill);
+        let descriptors = vibez_instruments::synth::SYNTH_PARAMS;
 
-        Self::device_card(column![title, body].width(Length::Fixed(120.0)))
+        // Param 0 is the waveform: a selector reads better than a knob.
+        let wave_value = track
+            .instrument_params
+            .first()
+            .copied()
+            .unwrap_or(descriptors[0].default)
+            .round() as usize;
+        let mut wave_row = row![].spacing(2);
+        for (i, label) in ["Sin", "Saw", "Sqr", "Tri"].iter().enumerate() {
+            let active = wave_value == i;
+            let btn =
+                button(
+                    text(*label)
+                        .size(9)
+                        .color(if active { th::ACCENT } else { th::TEXT_DIM }),
+                )
+                .on_press(Message::SetInstrumentParam(track_id, 0, i as f32))
+                .padding([2, 6])
+                .style(move |_theme: &Theme, _status| button::Style {
+                    background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
+                    text_color: if active { th::ACCENT } else { th::TEXT_DIM },
+                    border: iced::Border {
+                        color: if active { th::ACCENT_DIM } else { th::BORDER },
+                        width: 1.0,
+                        radius: 3.0.into(),
+                    },
+                    ..Default::default()
+                });
+            wave_row = wave_row.push(btn);
+        }
+
+        // Remaining params get real knobs, four per row.
+        let mut param_rows = column![].spacing(6);
+        let mut current_row = row![].spacing(8);
+        let mut count = 0;
+        for (i, descriptor) in descriptors.iter().enumerate().skip(1) {
+            let value = track
+                .instrument_params
+                .get(i)
+                .copied()
+                .unwrap_or(descriptor.default);
+            let knob = EffectKnobWidget::for_instrument(
+                track_id,
+                i,
+                value,
+                descriptor.min,
+                descriptor.max,
+                descriptor.default,
+                track_color,
+            );
+            let knob_canvas: Element<'a, Message> = canvas(knob)
+                .width(Length::Fixed(32.0))
+                .height(Length::Fixed(32.0))
+                .into();
+            let label = text(descriptor.name).size(9).color(th::TEXT_DIM);
+            let value_label = text(format!("{value:.2}{}", descriptor.unit))
+                .size(8)
+                .color(th::TEXT_MUTED);
+            let param_col = column![knob_canvas, label, value_label]
+                .spacing(1)
+                .align_x(iced::Alignment::Center);
+            current_row = current_row.push(param_col);
+            count += 1;
+            if count % 4 == 0 {
+                param_rows = param_rows.push(current_row);
+                current_row = row![].spacing(8);
+            }
+        }
+        if count % 4 != 0 {
+            param_rows = param_rows.push(current_row);
+        }
+
+        let body = container(column![wave_row, param_rows].spacing(6))
+            .padding([6, 7])
+            .width(Length::Fill);
+
+        Self::device_card(column![title, body].width(Length::Fixed(260.0)))
     }
 
     /// Sampler device card.

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -28,8 +28,8 @@ use vibez_project::Project;
 
 use crate::icons;
 use crate::message::{
-    BrowserImportTarget, LoadedClipData, LoadedDrumRackPadData, LoadedSamplerData, Message,
-    ProjectLoadResult, SampleLibraryScanResult,
+    BrowserImportTarget, DrumPadParam, LoadedClipData, LoadedDrumRackPadData, LoadedSamplerData,
+    Message, ProjectLoadResult, SampleLibraryScanResult,
 };
 use crate::plugin_window::{PluginRawPtr, PluginWindowEvent, PluginWindowManager};
 use crate::state::{
@@ -1956,6 +1956,9 @@ impl App {
                 | Message::SamplerSampleDecoded(..)
                 | Message::DrumRackPadSampleDecoded(..)
                 | Message::ClearDrumRackPad(..)
+                | Message::SetDrumPadParam { .. }
+                | Message::SetDrumPadOneShot { .. }
+                | Message::SetDrumPadChokeGroup { .. }
                 | Message::BrowserSampleDecoded(..)
                 | Message::ToggleClipLoop(..)
                 | Message::SetClipLoopRegion { .. }
@@ -2645,6 +2648,67 @@ impl App {
                     track.selected_drum_pad = pad_index.min(max_index);
                 }
                 self.state.selected_track = Some(track_id);
+            }
+            Message::SetDrumPadParam {
+                track_id,
+                pad_index,
+                param,
+                value,
+            } => {
+                let mut changed = false;
+                if let Some(track) = self.state.find_track_mut(track_id) {
+                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
+                        match param {
+                            DrumPadParam::Gain => pad.gain = value.clamp(0.0, 2.0),
+                            DrumPadParam::Pan => pad.pan = value.clamp(-1.0, 1.0),
+                            DrumPadParam::Start => pad.start = value.clamp(0.0, 1.0),
+                            DrumPadParam::End => pad.end = value.clamp(0.0, 1.0),
+                            DrumPadParam::CoarseTune => {
+                                pad.coarse_tune = value.clamp(-24.0, 24.0).round() as i8;
+                            }
+                            DrumPadParam::FineTune => pad.fine_tune = value.clamp(-100.0, 100.0),
+                        }
+                        changed = true;
+                    }
+                }
+                if changed {
+                    self.sync_drum_rack_pad_state(track_id, pad_index);
+                    self.state.status_text = format!("Pad {} updated", pad_index + 1);
+                }
+            }
+            Message::SetDrumPadOneShot {
+                track_id,
+                pad_index,
+                one_shot,
+            } => {
+                let mut changed = false;
+                if let Some(track) = self.state.find_track_mut(track_id) {
+                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
+                        pad.one_shot = one_shot;
+                        changed = true;
+                    }
+                }
+                if changed {
+                    self.sync_drum_rack_pad_state(track_id, pad_index);
+                    self.state.status_text = format!("Pad {} updated", pad_index + 1);
+                }
+            }
+            Message::SetDrumPadChokeGroup {
+                track_id,
+                pad_index,
+                choke_group,
+            } => {
+                let mut changed = false;
+                if let Some(track) = self.state.find_track_mut(track_id) {
+                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
+                        pad.choke_group = choke_group;
+                        changed = true;
+                    }
+                }
+                if changed {
+                    self.sync_drum_rack_pad_state(track_id, pad_index);
+                    self.state.status_text = format!("Pad {} updated", pad_index + 1);
+                }
             }
 
             // -- Clip looping --
@@ -8839,6 +8903,7 @@ impl App {
         track: &'a UiTrack,
         track_color: Color,
     ) -> Element<'a, Message> {
+        use crate::widgets::effect_knob::EffectKnobWidget;
         let dot = text("\u{25CF}").size(8).color(track_color);
         let name = text("Sampler").size(11).color(th::TEXT);
 
@@ -8874,19 +8939,52 @@ impl App {
             .spacing(6)
             .align_y(iced::Alignment::Center);
 
-        let param_names = ["Attack", "Decay", "Sustain", "Release", "Volume"];
-        let mut params_col = column![].spacing(2);
-        for pn in &param_names {
-            let label = text(*pn).size(9).color(th::TEXT_DIM);
-            let value = text("\u{2014}").size(8).color(th::TEXT_MUTED);
-            params_col = params_col.push(column![label, value].spacing(1));
+        let descriptors = vibez_instruments::sampler::SAMPLER_PARAMS;
+        let mut param_rows = column![].spacing(6);
+        let mut current_row = row![].spacing(8);
+        let mut count = 0;
+        for (i, descriptor) in descriptors.iter().enumerate() {
+            let value = track
+                .instrument_params
+                .get(i)
+                .copied()
+                .unwrap_or(descriptor.default);
+            let knob = EffectKnobWidget::for_instrument(
+                track_id,
+                i,
+                value,
+                descriptor.min,
+                descriptor.max,
+                descriptor.default,
+                track_color,
+            );
+            let knob_canvas: Element<'a, Message> = canvas(knob)
+                .width(Length::Fixed(32.0))
+                .height(Length::Fixed(32.0))
+                .into();
+            let label = text(descriptor.name).size(9).color(th::TEXT_DIM);
+            let value_label = text(format!("{value:.2}{}", descriptor.unit))
+                .size(8)
+                .color(th::TEXT_MUTED);
+            let param_col = column![knob_canvas, label, value_label]
+                .spacing(1)
+                .align_x(iced::Alignment::Center);
+            current_row = current_row.push(param_col);
+            count += 1;
+            if count % 4 == 0 {
+                param_rows = param_rows.push(current_row);
+                current_row = row![].spacing(8);
+            }
+        }
+        if count % 4 != 0 {
+            param_rows = param_rows.push(current_row);
         }
 
-        let body = container(column![sample_row, params_col].spacing(6))
-            .padding([6, 6])
+        let body = container(column![sample_row, param_rows].spacing(6))
+            .padding([6, 7])
             .width(Length::Fill);
 
-        Self::device_card(column![title, body].width(Length::Fixed(140.0)))
+        Self::device_card(column![title, body].width(Length::Fixed(260.0)))
     }
 
     fn view_drum_rack_device<'a>(
@@ -8895,6 +8993,7 @@ impl App {
         track: &'a UiTrack,
         track_color: Color,
     ) -> Element<'a, Message> {
+        use crate::widgets::effect_knob::EffectKnobWidget;
         let dot = text("\u{25CF}").size(8).color(track_color);
         let name = text("Drum Rack").size(11).color(th::TEXT);
         let selected_pad = track
@@ -8983,6 +9082,7 @@ impl App {
             .as_ref()
             .map(MediaSourceRef::display_name)
             .unwrap_or_else(|| "Use the browser or Load".to_string());
+        let selected_pad_state = &track.drum_rack_pads[selected_pad];
 
         let load_btn = button(text("Load").size(9).color(th::TEXT))
             .on_press(Message::LoadDrumRackPadSample(track_id, selected_pad))
@@ -9033,7 +9133,177 @@ impl App {
         ]
         .spacing(4);
 
-        let body = container(column![grid, footer].spacing(8))
+        let drum_params = [
+            (
+                "Gain",
+                format!("{:.2}", selected_pad_state.gain),
+                selected_pad_state.gain,
+                0.0,
+                2.0,
+                1.0,
+                DrumPadParam::Gain,
+            ),
+            (
+                "Pan",
+                format!("{:.2}", selected_pad_state.pan),
+                selected_pad_state.pan,
+                -1.0,
+                1.0,
+                0.0,
+                DrumPadParam::Pan,
+            ),
+            (
+                "Start",
+                format!("{:.0}%", selected_pad_state.start * 100.0),
+                selected_pad_state.start,
+                0.0,
+                1.0,
+                0.0,
+                DrumPadParam::Start,
+            ),
+            (
+                "End",
+                format!("{:.0}%", selected_pad_state.end * 100.0),
+                selected_pad_state.end,
+                0.0,
+                1.0,
+                1.0,
+                DrumPadParam::End,
+            ),
+            (
+                "Coarse",
+                format!("{}st", selected_pad_state.coarse_tune),
+                selected_pad_state.coarse_tune as f32,
+                -24.0,
+                24.0,
+                0.0,
+                DrumPadParam::CoarseTune,
+            ),
+            (
+                "Fine",
+                format!("{:.0}ct", selected_pad_state.fine_tune),
+                selected_pad_state.fine_tune,
+                -100.0,
+                100.0,
+                0.0,
+                DrumPadParam::FineTune,
+            ),
+        ];
+
+        let mut param_rows = column![].spacing(6);
+        let mut current_row = row![].spacing(8);
+        for (i, (label_text, value_text, value, min, max, default, param)) in
+            drum_params.iter().enumerate()
+        {
+            let knob = EffectKnobWidget::for_drum_pad(
+                track_id,
+                selected_pad,
+                *param,
+                *value,
+                *min,
+                *max,
+                *default,
+                track_color,
+            );
+            let knob_canvas: Element<'a, Message> = canvas(knob)
+                .width(Length::Fixed(32.0))
+                .height(Length::Fixed(32.0))
+                .into();
+            let label = text(*label_text).size(9).color(th::TEXT_DIM);
+            let value_label = text(value_text.clone()).size(8).color(th::TEXT_MUTED);
+            let param_col = column![knob_canvas, label, value_label]
+                .spacing(1)
+                .align_x(iced::Alignment::Center);
+            current_row = current_row.push(param_col);
+            if (i + 1) % 3 == 0 {
+                param_rows = param_rows.push(current_row);
+                current_row = row![].spacing(8);
+            }
+        }
+
+        let one_shot_active = selected_pad_state.one_shot;
+        let one_shot_btn = button(text("One-shot").size(9).color(if one_shot_active {
+            th::ACCENT
+        } else {
+            th::TEXT_DIM
+        }))
+        .on_press(Message::SetDrumPadOneShot {
+            track_id,
+            pad_index: selected_pad,
+            one_shot: !one_shot_active,
+        })
+        .padding([2, 6])
+        .style(move |_theme: &Theme, _status| button::Style {
+            background: Some(
+                if one_shot_active {
+                    th::ACCENT_DIM
+                } else {
+                    th::BG_DARK
+                }
+                .into(),
+            ),
+            text_color: if one_shot_active {
+                th::ACCENT
+            } else {
+                th::TEXT_DIM
+            },
+            border: iced::Border {
+                color: if one_shot_active {
+                    th::ACCENT_DIM
+                } else {
+                    th::BORDER
+                },
+                width: 1.0,
+                radius: 3.0.into(),
+            },
+            ..Default::default()
+        });
+
+        let mut choke_row = row![text("Choke").size(9).color(th::TEXT_DIM)]
+            .spacing(2)
+            .align_y(iced::Alignment::Center);
+        for (group, label) in [
+            (None, "Off"),
+            (Some(1), "1"),
+            (Some(2), "2"),
+            (Some(3), "3"),
+            (Some(4), "4"),
+        ] {
+            let active = selected_pad_state.choke_group == group;
+            let btn =
+                button(
+                    text(label)
+                        .size(9)
+                        .color(if active { th::ACCENT } else { th::TEXT_DIM }),
+                )
+                .on_press(Message::SetDrumPadChokeGroup {
+                    track_id,
+                    pad_index: selected_pad,
+                    choke_group: group,
+                })
+                .padding([2, 6])
+                .style(move |_theme: &Theme, _status| button::Style {
+                    background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
+                    text_color: if active { th::ACCENT } else { th::TEXT_DIM },
+                    border: iced::Border {
+                        color: if active { th::ACCENT_DIM } else { th::BORDER },
+                        width: 1.0,
+                        radius: 3.0.into(),
+                    },
+                    ..Default::default()
+                });
+            choke_row = choke_row.push(btn);
+        }
+
+        let editor = column![
+            param_rows,
+            row![one_shot_btn, choke_row]
+                .spacing(8)
+                .align_y(iced::Alignment::Center)
+        ]
+        .spacing(6);
+
+        let body = container(column![grid, footer, editor].spacing(8))
             .padding([6, 6])
             .width(Length::Fill);
 

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8848,10 +8848,10 @@ impl App {
             wave_row = wave_row.push(btn);
         }
 
-        // Remaining params get real knobs, four per row.
-        let mut param_rows = column![].spacing(6);
-        let mut current_row = row![].spacing(8);
-        let mut count = 0;
+        // Remaining params get real knobs in ONE row: the devices
+        // panel scrolls horizontally, so width is free and height is
+        // the scarce resource (stacked rows clip their labels).
+        let mut knob_row = row![].spacing(8);
         for (i, descriptor) in descriptors.iter().enumerate().skip(1) {
             let value = track
                 .instrument_params
@@ -8881,22 +8881,14 @@ impl App {
                 .spacing(1)
                 .width(Length::Fixed(52.0))
                 .align_x(iced::Alignment::Center);
-            current_row = current_row.push(param_col);
-            count += 1;
-            if count % 4 == 0 {
-                param_rows = param_rows.push(current_row);
-                current_row = row![].spacing(8);
-            }
-        }
-        if count % 4 != 0 {
-            param_rows = param_rows.push(current_row);
+            knob_row = knob_row.push(param_col);
         }
 
-        let body = container(column![wave_row, param_rows].spacing(6))
+        let body = container(column![wave_row, knob_row].spacing(6))
             .padding([6, 7])
             .width(Length::Fill);
 
-        Self::device_card(column![title, body].width(Length::Fixed(260.0)))
+        Self::device_card(column![title, body].width(Length::Fixed(440.0)))
     }
 
     /// Sampler device card.
@@ -8943,9 +8935,9 @@ impl App {
             .align_y(iced::Alignment::Center);
 
         let descriptors = vibez_instruments::sampler::SAMPLER_PARAMS;
-        let mut param_rows = column![].spacing(6);
-        let mut current_row = row![].spacing(8);
-        let mut count = 0;
+        // One knob row: the devices panel scrolls horizontally and
+        // stacked rows clip their labels vertically.
+        let mut knob_row = row![].spacing(8);
         for (i, descriptor) in descriptors.iter().enumerate() {
             let value = track
                 .instrument_params
@@ -8975,22 +8967,14 @@ impl App {
                 .spacing(1)
                 .width(Length::Fixed(52.0))
                 .align_x(iced::Alignment::Center);
-            current_row = current_row.push(param_col);
-            count += 1;
-            if count % 4 == 0 {
-                param_rows = param_rows.push(current_row);
-                current_row = row![].spacing(8);
-            }
-        }
-        if count % 4 != 0 {
-            param_rows = param_rows.push(current_row);
+            knob_row = knob_row.push(param_col);
         }
 
-        let body = container(column![sample_row, param_rows].spacing(6))
+        let body = container(column![sample_row, knob_row].spacing(6))
             .padding([6, 7])
             .width(Length::Fill);
 
-        Self::device_card(column![title, body].width(Length::Fixed(260.0)))
+        Self::device_card(column![title, body].width(Length::Fixed(400.0)))
     }
 
     fn view_drum_rack_device<'a>(
@@ -9310,11 +9294,17 @@ impl App {
         ]
         .spacing(6);
 
-        let body = container(column![grid, footer, editor].spacing(8))
-            .padding([6, 6])
-            .width(Length::Fill);
+        // Editor sits BESIDE the pad grid: the grid already spends
+        // the panel's height budget, anything below it clips.
+        let body = container(
+            row![column![grid, footer].spacing(6), editor]
+                .spacing(12)
+                .align_y(iced::Alignment::Start),
+        )
+        .padding([6, 6])
+        .width(Length::Fill);
 
-        Self::device_card(column![title, body].width(Length::Fixed(300.0)))
+        Self::device_card(column![title, body].width(Length::Fixed(500.0)))
     }
 
     /// Placeholder card for MIDI tracks with no instrument attached.

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8661,9 +8661,13 @@ impl App {
             devices_row = devices_row.push(slot);
         }
 
-        let scrollable_devices = scrollable(devices_row).direction(
-            scrollable::Direction::Horizontal(scrollable::Scrollbar::default()),
-        );
+        let scrollable_devices =
+            scrollable(devices_row).direction(scrollable::Direction::Horizontal(
+                scrollable::Scrollbar::new()
+                    .width(5)
+                    .scroller_width(5)
+                    .spacing(4),
+            ));
 
         let content = column![header, scrollable_devices]
             .spacing(6)
@@ -8967,7 +8971,10 @@ impl App {
         .spacing(10)
         .align_y(iced::Alignment::Start);
 
-        Self::device_card(column![title, Self::device_body(body.into())])
+        // OSC 66 + envelope 240 + filter 118 + out 56 + chrome.
+        Self::device_card(
+            column![title, Self::device_body(body.into())].width(Length::Fixed(570.0)),
+        )
     }
 
     /// Sampler device card.
@@ -9008,8 +9015,18 @@ impl App {
             )
         };
 
+        // Long file names must not blow the section open; the
+        // waveform display defines the section width.
         let sample_label = match &track.sample_name {
-            Some(name) => text(name.as_str()).size(10).color(th::TEXT),
+            Some(name) => {
+                let display = if name.chars().count() > 24 {
+                    let head: String = name.chars().take(21).collect();
+                    format!("{head}...")
+                } else {
+                    name.clone()
+                };
+                text(display).size(10).color(th::TEXT)
+            }
             None => text("No Sample").size(10).color(th::TEXT_MUTED),
         };
         let load_btn = button(text("Load").size(9).color(th::TEXT))
@@ -9046,6 +9063,7 @@ impl App {
                 .align_y(iced::Alignment::Center)
         ]
         .spacing(5)
+        .width(Length::Fixed(190.0))
         .align_x(iced::Alignment::Start);
 
         let adsr: Element<'a, Message> = canvas(crate::widgets::mini_waveform::AdsrScope {
@@ -9081,7 +9099,17 @@ impl App {
         .spacing(10)
         .align_y(iced::Alignment::Start);
 
-        Self::device_card(column![title, Self::device_body(body.into())])
+        // Width = sample 190 + tune 56 + envelope 240 + dividers,
+        // spacing, padding. Fixed so the Fill title strip and card
+        // background actually render (Fill inside a shrink column
+        // collapses in iced).
+        let card = Self::device_card(
+            column![title, Self::device_body(body.into())].width(Length::Fixed(560.0)),
+        );
+        // The whole card accepts browser drops, like drum pads.
+        mouse_area(card)
+            .on_release(Message::DropSampleOnSampler { track_id })
+            .into()
     }
 
     fn view_drum_rack_device<'a>(
@@ -9399,7 +9427,10 @@ impl App {
         .spacing(10)
         .align_y(iced::Alignment::Start);
 
-        Self::device_card(column![title, Self::device_body(body.into())])
+        // Pads 220 + editor (six knob columns) + chrome.
+        Self::device_card(
+            column![title, Self::device_body(body.into())].width(Length::Fixed(650.0)),
+        )
     }
 
     /// Placeholder card for MIDI tracks with no instrument attached.

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8695,6 +8695,57 @@ impl App {
             })
     }
 
+    /// Standard device title row: colored dot, name, optional remove.
+    fn device_title_row(
+        name: &str,
+        track_color: Color,
+        remove: Option<Message>,
+    ) -> iced::widget::Row<'_, Message> {
+        let dot = text("\u{25CF}").size(8).color(track_color);
+        let name = text(name.to_string()).size(11).color(th::TEXT);
+        let mut r = row![dot, name].spacing(5).align_y(iced::Alignment::Center);
+        if let Some(msg) = remove {
+            let remove_btn: Element<'_, Message> =
+                Self::device_icon_btn(icons::X, th::TEXT_DIM, th::DANGER, msg).into();
+            r = r.push(horizontal_space().width(Length::Fixed(12.0)));
+            r = r.push(remove_btn);
+        }
+        r
+    }
+
+    /// Labeled section inside a device body, Ableton-style: a tiny
+    /// uppercase header above the section's controls.
+    fn device_section<'a>(
+        label: &'static str,
+        content: Element<'a, Message>,
+    ) -> Element<'a, Message> {
+        column![text(label).size(8).color(th::TEXT_MUTED), content]
+            .spacing(6)
+            .align_x(iced::Alignment::Start)
+            .into()
+    }
+
+    /// Thin vertical rule separating device sections.
+    fn device_divider() -> Element<'static, Message> {
+        container(text(""))
+            .width(Length::Fixed(1.0))
+            .height(Length::Fixed(th::DEVICE_BODY_H - 12.0))
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::DIVIDER.into()),
+                ..Default::default()
+            })
+            .into()
+    }
+
+    /// Standard device body: fixed rack height so every card in the
+    /// chain lines up like a hardware rack, consistent padding.
+    fn device_body(content: Element<'_, Message>) -> Element<'_, Message> {
+        container(content)
+            .padding([8, 10])
+            .height(Length::Fixed(th::DEVICE_BODY_H))
+            .into()
+    }
+
     /// Wrap card content in the standard device card container.
     fn device_card(content: iced::widget::Column<'_, Message>) -> Element<'_, Message> {
         container(content)
@@ -8808,87 +8859,93 @@ impl App {
         track: &'a UiTrack,
         track_color: Color,
     ) -> Element<'a, Message> {
-        use crate::widgets::effect_knob::EffectKnobWidget;
-        let dot = text("\u{25CF}").size(8).color(track_color);
-        let name = text("Synth").size(11).color(th::TEXT);
-
-        let title =
-            Self::device_title_bar(row![dot, name].spacing(4).align_y(iced::Alignment::Center));
+        use crate::widgets::effect_knob::{format_value, param_column, EffectKnobWidget};
+        let title = Self::device_title_bar(Self::device_title_row(
+            "Synth",
+            track_color,
+            Some(Message::RemoveTrackInstrument(track_id)),
+        ));
 
         let descriptors = vibez_instruments::synth::SYNTH_PARAMS;
-
-        // Param 0 is the waveform: a selector reads better than a knob.
-        let wave_value = track
-            .instrument_params
-            .first()
-            .copied()
-            .unwrap_or(descriptors[0].default)
-            .round() as usize;
-        let mut wave_row = row![].spacing(2);
-        for (i, label) in ["Sin", "Saw", "Sqr", "Tri"].iter().enumerate() {
-            let active = wave_value == i;
-            let btn =
-                button(
-                    text(*label)
-                        .size(9)
-                        .color(if active { th::ACCENT } else { th::TEXT_DIM }),
-                )
-                .on_press(Message::SetInstrumentParam(track_id, 0, i as f32))
-                .padding([2, 6])
-                .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
-                    text_color: if active { th::ACCENT } else { th::TEXT_DIM },
-                    border: iced::Border {
-                        color: if active { th::ACCENT_DIM } else { th::BORDER },
-                        width: 1.0,
-                        radius: 3.0.into(),
-                    },
-                    ..Default::default()
-                });
-            wave_row = wave_row.push(btn);
-        }
-
-        // Remaining params get real knobs in ONE row: the devices
-        // panel scrolls horizontally, so width is free and height is
-        // the scarce resource (stacked rows clip their labels).
-        let mut knob_row = row![].spacing(8);
-        for (i, descriptor) in descriptors.iter().enumerate().skip(1) {
-            let value = track
+        let value_of = |i: usize| {
+            track
                 .instrument_params
                 .get(i)
                 .copied()
-                .unwrap_or(descriptor.default);
-            let knob = EffectKnobWidget::for_instrument(
-                track_id,
-                i,
-                value,
-                descriptor.min,
-                descriptor.max,
-                descriptor.default,
-                track_color,
-            );
-            let knob_canvas: Element<'a, Message> = canvas(knob)
-                .width(Length::Fixed(32.0))
-                .height(Length::Fixed(32.0))
-                .into();
-            let label = text(short_param_name(descriptor.name))
-                .size(9)
-                .color(th::TEXT_DIM);
-            let value_label = text(format!("{value:.2}{}", descriptor.unit))
-                .size(8)
-                .color(th::TEXT_MUTED);
-            let param_col = column![knob_canvas, label, value_label]
-                .spacing(1)
-                .width(Length::Fixed(52.0))
-                .align_x(iced::Alignment::Center);
-            knob_row = knob_row.push(param_col);
-        }
+                .unwrap_or(descriptors[i].default)
+        };
+        let knob = |i: usize, label: &str| {
+            param_column(
+                EffectKnobWidget::for_instrument(
+                    track_id,
+                    i,
+                    value_of(i),
+                    descriptors[i].min,
+                    descriptors[i].max,
+                    descriptors[i].default,
+                    track_color,
+                ),
+                label.to_string(),
+                format_value(value_of(i), descriptors[i].unit),
+            )
+        };
 
-        let body = container(column![wave_row, knob_row].spacing(6))
-            .padding([6, 7])
-            .width(Length::Fill);
+        // OSC section: 2x2 waveform selector grid.
+        let wave_value = value_of(0).round() as usize;
+        let wave_btn = |i: usize, label: &'static str| {
+            let active = wave_value == i;
+            button(
+                text(label)
+                    .size(9)
+                    .width(Length::Fixed(30.0))
+                    .align_x(iced::Alignment::Center)
+                    .color(if active { th::BG_DARK } else { th::TEXT_DIM }),
+            )
+            .on_press(Message::SetInstrumentParam(track_id, 0, i as f32))
+            .padding([3, 4])
+            .style(move |_theme: &Theme, _status| button::Style {
+                background: Some(if active { th::ACCENT } else { th::BG_DARK }.into()),
+                text_color: if active { th::BG_DARK } else { th::TEXT_DIM },
+                border: iced::Border {
+                    color: if active { th::ACCENT } else { th::BORDER },
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                ..Default::default()
+            })
+        };
+        let osc = column![
+            row![wave_btn(0, "Sin"), wave_btn(1, "Saw")].spacing(3),
+            row![wave_btn(2, "Sqr"), wave_btn(3, "Tri")].spacing(3),
+        ]
+        .spacing(3);
 
-        Self::device_card(column![title, body].width(Length::Fixed(440.0)))
+        let body = row![
+            Self::device_section("OSC", osc.into()),
+            Self::device_divider(),
+            Self::device_section(
+                "ENVELOPE",
+                row![
+                    knob(1, "Attack"),
+                    knob(2, "Decay"),
+                    knob(3, "Sustain"),
+                    knob(4, "Release")
+                ]
+                .spacing(6)
+                .into()
+            ),
+            Self::device_divider(),
+            Self::device_section(
+                "FILTER",
+                row![knob(5, "Cutoff"), knob(6, "Res")].spacing(6).into()
+            ),
+            Self::device_divider(),
+            Self::device_section("OUT", knob(7, "Volume")),
+        ]
+        .spacing(10)
+        .align_y(iced::Alignment::Start);
+
+        Self::device_card(column![title, Self::device_body(body.into())])
     }
 
     /// Sampler device card.
@@ -8898,18 +8955,41 @@ impl App {
         track: &'a UiTrack,
         track_color: Color,
     ) -> Element<'a, Message> {
-        use crate::widgets::effect_knob::EffectKnobWidget;
-        let dot = text("\u{25CF}").size(8).color(track_color);
-        let name = text("Sampler").size(11).color(th::TEXT);
+        use crate::widgets::effect_knob::{format_value, param_column, EffectKnobWidget};
+        let title = Self::device_title_bar(Self::device_title_row(
+            "Sampler",
+            track_color,
+            Some(Message::RemoveTrackInstrument(track_id)),
+        ));
 
-        let title =
-            Self::device_title_bar(row![dot, name].spacing(4).align_y(iced::Alignment::Center));
+        let descriptors = vibez_instruments::sampler::SAMPLER_PARAMS;
+        let value_of = |i: usize| {
+            track
+                .instrument_params
+                .get(i)
+                .copied()
+                .unwrap_or(descriptors[i].default)
+        };
+        let knob = |i: usize, label: &str| {
+            param_column(
+                EffectKnobWidget::for_instrument(
+                    track_id,
+                    i,
+                    value_of(i),
+                    descriptors[i].min,
+                    descriptors[i].max,
+                    descriptors[i].default,
+                    track_color,
+                ),
+                label.to_string(),
+                format_value(value_of(i), descriptors[i].unit),
+            )
+        };
 
         let sample_label = match &track.sample_name {
             Some(name) => text(name.as_str()).size(10).color(th::TEXT),
             None => text("No Sample").size(10).color(th::TEXT_MUTED),
         };
-
         let load_btn = button(text("Load").size(9).color(th::TEXT))
             .on_press(Message::LoadSamplerSample(track_id))
             .padding([2, 8])
@@ -8929,52 +9009,29 @@ impl App {
                     ..Default::default()
                 }
             });
+        let sample = column![sample_label, load_btn, knob(0, "Root")]
+            .spacing(4)
+            .align_x(iced::Alignment::Center);
 
-        let sample_row = row![sample_label, load_btn]
-            .spacing(6)
-            .align_y(iced::Alignment::Center);
+        let body = row![
+            Self::device_section("SAMPLE", sample.into()),
+            Self::device_divider(),
+            Self::device_section(
+                "ENVELOPE",
+                row![
+                    knob(1, "Attack"),
+                    knob(2, "Decay"),
+                    knob(3, "Sustain"),
+                    knob(4, "Release")
+                ]
+                .spacing(6)
+                .into()
+            ),
+        ]
+        .spacing(10)
+        .align_y(iced::Alignment::Start);
 
-        let descriptors = vibez_instruments::sampler::SAMPLER_PARAMS;
-        // One knob row: the devices panel scrolls horizontally and
-        // stacked rows clip their labels vertically.
-        let mut knob_row = row![].spacing(8);
-        for (i, descriptor) in descriptors.iter().enumerate() {
-            let value = track
-                .instrument_params
-                .get(i)
-                .copied()
-                .unwrap_or(descriptor.default);
-            let knob = EffectKnobWidget::for_instrument(
-                track_id,
-                i,
-                value,
-                descriptor.min,
-                descriptor.max,
-                descriptor.default,
-                track_color,
-            );
-            let knob_canvas: Element<'a, Message> = canvas(knob)
-                .width(Length::Fixed(32.0))
-                .height(Length::Fixed(32.0))
-                .into();
-            let label = text(short_param_name(descriptor.name))
-                .size(9)
-                .color(th::TEXT_DIM);
-            let value_label = text(format!("{value:.2}{}", descriptor.unit))
-                .size(8)
-                .color(th::TEXT_MUTED);
-            let param_col = column![knob_canvas, label, value_label]
-                .spacing(1)
-                .width(Length::Fixed(52.0))
-                .align_x(iced::Alignment::Center);
-            knob_row = knob_row.push(param_col);
-        }
-
-        let body = container(column![sample_row, knob_row].spacing(6))
-            .padding([6, 7])
-            .width(Length::Fill);
-
-        Self::device_card(column![title, body].width(Length::Fixed(400.0)))
+        Self::device_card(column![title, Self::device_body(body.into())])
     }
 
     fn view_drum_rack_device<'a>(
@@ -8983,26 +9040,15 @@ impl App {
         track: &'a UiTrack,
         track_color: Color,
     ) -> Element<'a, Message> {
-        use crate::widgets::effect_knob::EffectKnobWidget;
-        let dot = text("\u{25CF}").size(8).color(track_color);
-        let name = text("Drum Rack").size(11).color(th::TEXT);
+        use crate::widgets::effect_knob::{param_column, EffectKnobWidget};
         let selected_pad = track
             .selected_drum_pad
             .min(track.drum_rack_pads.len().saturating_sub(1));
-
-        let remove: Element<'a, Message> = Self::device_icon_btn(
-            icons::X,
-            th::TEXT_DIM,
-            th::DANGER,
-            Message::RemoveTrackInstrument(track_id),
-        )
-        .into();
-
-        let title = Self::device_title_bar(
-            row![dot, name, horizontal_space(), remove]
-                .spacing(4)
-                .align_y(iced::Alignment::Center),
-        );
+        let title = Self::device_title_bar(Self::device_title_row(
+            "Drum Rack",
+            track_color,
+            Some(Message::RemoveTrackInstrument(track_id)),
+        ));
 
         let mut grid = column![].spacing(4);
         for row_index in 0..4 {
@@ -9015,8 +9061,8 @@ impl App {
                     .name
                     .as_deref()
                     .map(|name| {
-                        if name.len() > 10 {
-                            format!("{}...", &name[..10])
+                        if name.len() > 7 {
+                            format!("{}..", &name[..7])
                         } else {
                             name.to_string()
                         }
@@ -9038,8 +9084,8 @@ impl App {
                     .spacing(2)
                     .align_x(iced::Alignment::Center),
                 )
-                .padding([8, 6])
-                .width(Length::Fixed(60.0))
+                .padding([3, 4])
+                .width(Length::Fixed(52.0))
                 .style(move |_theme: &Theme| container::Style {
                     background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
                     text_color: Some(if active { th::ACCENT } else { th::TEXT }),
@@ -9180,11 +9226,8 @@ impl App {
             ),
         ];
 
-        let mut param_rows = column![].spacing(6);
-        let mut current_row = row![].spacing(8);
-        for (i, (label_text, value_text, value, min, max, default, param)) in
-            drum_params.iter().enumerate()
-        {
+        let mut knob_row = row![].spacing(6);
+        for (label_text, value_text, value, min, max, default, param) in drum_params.iter() {
             let knob = EffectKnobWidget::for_drum_pad(
                 track_id,
                 selected_pad,
@@ -9195,21 +9238,11 @@ impl App {
                 *default,
                 track_color,
             );
-            let knob_canvas: Element<'a, Message> = canvas(knob)
-                .width(Length::Fixed(32.0))
-                .height(Length::Fixed(32.0))
-                .into();
-            let label = text(*label_text).size(9).color(th::TEXT_DIM);
-            let value_label = text(value_text.clone()).size(8).color(th::TEXT_MUTED);
-            let param_col = column![knob_canvas, label, value_label]
-                .spacing(1)
-                .width(Length::Fixed(52.0))
-                .align_x(iced::Alignment::Center);
-            current_row = current_row.push(param_col);
-            if (i + 1) % 3 == 0 {
-                param_rows = param_rows.push(current_row);
-                current_row = row![].spacing(8);
-            }
+            knob_row = knob_row.push(param_column(
+                knob,
+                label_text.to_string(),
+                value_text.clone(),
+            ));
         }
 
         let one_shot_active = selected_pad_state.one_shot;
@@ -9287,24 +9320,26 @@ impl App {
         }
 
         let editor = column![
-            param_rows,
+            footer,
+            knob_row,
             row![one_shot_btn, choke_row]
                 .spacing(8)
                 .align_y(iced::Alignment::Center)
         ]
         .spacing(6);
 
-        // Editor sits BESIDE the pad grid: the grid already spends
-        // the panel's height budget, anything below it clips.
-        let body = container(
-            row![column![grid, footer].spacing(6), editor]
-                .spacing(12)
-                .align_y(iced::Alignment::Start),
-        )
-        .padding([6, 6])
-        .width(Length::Fill);
+        // Pads and the selected pad's editor sit side by side in
+        // labeled sections; the panel scrolls horizontally so the
+        // card grows sideways, never past the rack height.
+        let body = row![
+            Self::device_section("PADS", grid.into()),
+            Self::device_divider(),
+            Self::device_section("PAD", editor.into()),
+        ]
+        .spacing(10)
+        .align_y(iced::Alignment::Start);
 
-        Self::device_card(column![title, body].width(Length::Fixed(500.0)))
+        Self::device_card(column![title, Self::device_body(body.into())])
     }
 
     /// Placeholder card for MIDI tracks with no instrument attached.
@@ -10238,17 +10273,6 @@ impl App {
                 _ => None,
             }),
         ])
-    }
-}
-
-/// Compact display name for a device parameter: multi-word
-/// descriptor names wrap illegibly under a 32px knob.
-fn short_param_name(name: &str) -> &str {
-    match name {
-        "Filter Cutoff" => "Cutoff",
-        "Filter Res" => "Res",
-        "Root Note" => "Root",
-        other => other,
     }
 }
 

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8914,26 +8914,48 @@ impl App {
                 ..Default::default()
             })
         };
+        let scope: Element<'a, Message> = canvas(crate::widgets::mini_waveform::OscScope {
+            waveform_index: wave_value,
+            color: track_color,
+        })
+        .width(Length::Fixed(66.0))
+        .height(Length::Fixed(38.0))
+        .into();
         let osc = column![
+            scope,
             row![wave_btn(0, "Sin"), wave_btn(1, "Saw")].spacing(3),
             row![wave_btn(2, "Sqr"), wave_btn(3, "Tri")].spacing(3),
         ]
-        .spacing(3);
+        .spacing(3)
+        .align_x(iced::Alignment::Center);
+
+        let adsr: Element<'a, Message> = canvas(crate::widgets::mini_waveform::AdsrScope {
+            attack: value_of(1),
+            decay: value_of(2),
+            sustain: value_of(3),
+            release: value_of(4),
+            color: track_color,
+        })
+        .width(Length::Fixed(240.0))
+        .height(Length::Fixed(34.0))
+        .into();
+        let envelope = column![
+            adsr,
+            row![
+                knob(1, "Attack"),
+                knob(2, "Decay"),
+                knob(3, "Sustain"),
+                knob(4, "Release")
+            ]
+            .spacing(6)
+        ]
+        .spacing(5)
+        .align_x(iced::Alignment::Center);
 
         let body = row![
             Self::device_section("OSC", osc.into()),
             Self::device_divider(),
-            Self::device_section(
-                "ENVELOPE",
-                row![
-                    knob(1, "Attack"),
-                    knob(2, "Decay"),
-                    knob(3, "Sustain"),
-                    knob(4, "Release")
-                ]
-                .spacing(6)
-                .into()
-            ),
+            Self::device_section("ENVELOPE", envelope.into()),
             Self::device_divider(),
             Self::device_section(
                 "FILTER",
@@ -9009,24 +9031,52 @@ impl App {
                     ..Default::default()
                 }
             });
-        let sample = column![sample_label, load_btn, knob(0, "Root")]
-            .spacing(4)
-            .align_x(iced::Alignment::Center);
+        let waveform: Element<'a, Message> = canvas(crate::widgets::mini_waveform::MiniWaveform {
+            audio: track.sample_audio.clone(),
+            color: track_color,
+            region: None,
+        })
+        .width(Length::Fixed(190.0))
+        .height(Length::Fixed(56.0))
+        .into();
+        let sample = column![
+            waveform,
+            row![sample_label, load_btn]
+                .spacing(8)
+                .align_y(iced::Alignment::Center)
+        ]
+        .spacing(5)
+        .align_x(iced::Alignment::Start);
+
+        let adsr: Element<'a, Message> = canvas(crate::widgets::mini_waveform::AdsrScope {
+            attack: value_of(1),
+            decay: value_of(2),
+            sustain: value_of(3),
+            release: value_of(4),
+            color: track_color,
+        })
+        .width(Length::Fixed(240.0))
+        .height(Length::Fixed(34.0))
+        .into();
+        let envelope = column![
+            adsr,
+            row![
+                knob(1, "Attack"),
+                knob(2, "Decay"),
+                knob(3, "Sustain"),
+                knob(4, "Release")
+            ]
+            .spacing(6)
+        ]
+        .spacing(5)
+        .align_x(iced::Alignment::Center);
 
         let body = row![
             Self::device_section("SAMPLE", sample.into()),
             Self::device_divider(),
-            Self::device_section(
-                "ENVELOPE",
-                row![
-                    knob(1, "Attack"),
-                    knob(2, "Decay"),
-                    knob(3, "Sustain"),
-                    knob(4, "Release")
-                ]
-                .spacing(6)
-                .into()
-            ),
+            Self::device_section("TUNE", knob(0, "Root")),
+            Self::device_divider(),
+            Self::device_section("ENVELOPE", envelope.into()),
         ]
         .spacing(10)
         .align_y(iced::Alignment::Start);
@@ -9319,8 +9369,18 @@ impl App {
             choke_row = choke_row.push(btn);
         }
 
+        let pad_wave: Element<'a, Message> = canvas(crate::widgets::mini_waveform::MiniWaveform {
+            audio: track.drum_rack_pads[selected_pad].audio.clone(),
+            color: track_color,
+            region: Some((selected_pad_state.start, selected_pad_state.end)),
+        })
+        .width(Length::Fixed(190.0))
+        .height(Length::Fixed(40.0))
+        .into();
         let editor = column![
-            footer,
+            row![footer, pad_wave]
+                .spacing(10)
+                .align_y(iced::Alignment::Center),
             knob_row,
             row![one_shot_btn, choke_row]
                 .spacing(8)

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8871,12 +8871,15 @@ impl App {
                 .width(Length::Fixed(32.0))
                 .height(Length::Fixed(32.0))
                 .into();
-            let label = text(descriptor.name).size(9).color(th::TEXT_DIM);
+            let label = text(short_param_name(descriptor.name))
+                .size(9)
+                .color(th::TEXT_DIM);
             let value_label = text(format!("{value:.2}{}", descriptor.unit))
                 .size(8)
                 .color(th::TEXT_MUTED);
             let param_col = column![knob_canvas, label, value_label]
                 .spacing(1)
+                .width(Length::Fixed(52.0))
                 .align_x(iced::Alignment::Center);
             current_row = current_row.push(param_col);
             count += 1;
@@ -8962,12 +8965,15 @@ impl App {
                 .width(Length::Fixed(32.0))
                 .height(Length::Fixed(32.0))
                 .into();
-            let label = text(descriptor.name).size(9).color(th::TEXT_DIM);
+            let label = text(short_param_name(descriptor.name))
+                .size(9)
+                .color(th::TEXT_DIM);
             let value_label = text(format!("{value:.2}{}", descriptor.unit))
                 .size(8)
                 .color(th::TEXT_MUTED);
             let param_col = column![knob_canvas, label, value_label]
                 .spacing(1)
+                .width(Length::Fixed(52.0))
                 .align_x(iced::Alignment::Center);
             current_row = current_row.push(param_col);
             count += 1;
@@ -9213,6 +9219,7 @@ impl App {
             let value_label = text(value_text.clone()).size(8).color(th::TEXT_MUTED);
             let param_col = column![knob_canvas, label, value_label]
                 .spacing(1)
+                .width(Length::Fixed(52.0))
                 .align_x(iced::Alignment::Center);
             current_row = current_row.push(param_col);
             if (i + 1) % 3 == 0 {
@@ -10241,6 +10248,17 @@ impl App {
                 _ => None,
             }),
         ])
+    }
+}
+
+/// Compact display name for a device parameter: multi-word
+/// descriptor names wrap illegibly under a 32px knob.
+fn short_param_name(name: &str) -> &str {
+    match name {
+        "Filter Cutoff" => "Cutoff",
+        "Filter Res" => "Res",
+        "Root Note" => "Root",
+        other => other,
     }
 }
 

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -16,6 +16,16 @@ use crate::state::{
     SampleBrowserEntry, SettingsTab, SnapGrid, Workspace,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DrumPadParam {
+    Gain,
+    Pan,
+    Start,
+    End,
+    CoarseTune,
+    FineTune,
+}
+
 #[derive(Debug, Clone)]
 pub struct LoadedClipData {
     pub info: ClipInfo,
@@ -207,6 +217,22 @@ pub enum Message {
     DrumRackPadDecodeError(TrackId, usize, String),
     ClearDrumRackPad(TrackId, usize),
     SelectDrumRackPad(TrackId, usize),
+    SetDrumPadParam {
+        track_id: TrackId,
+        pad_index: usize,
+        param: DrumPadParam,
+        value: f32,
+    },
+    SetDrumPadOneShot {
+        track_id: TrackId,
+        pad_index: usize,
+        one_shot: bool,
+    },
+    SetDrumPadChokeGroup {
+        track_id: TrackId,
+        pad_index: usize,
+        choke_group: Option<u8>,
+    },
 
     // Zoom / scroll
     ZoomIn,

--- a/crates/vibez-ui/src/theme.rs
+++ b/crates/vibez-ui/src/theme.rs
@@ -334,3 +334,7 @@ pub fn vibez_theme() -> Theme {
         },
     )
 }
+
+/// Uniform device-card body height across the device chain: the
+/// panel scrolls horizontally, so cards share one rack height.
+pub const DEVICE_BODY_H: f32 = 168.0;

--- a/crates/vibez-ui/src/theme.rs
+++ b/crates/vibez-ui/src/theme.rs
@@ -337,4 +337,4 @@ pub fn vibez_theme() -> Theme {
 
 /// Uniform device-card body height across the device chain: the
 /// panel scrolls horizontally, so cards share one rack height.
-pub const DEVICE_BODY_H: f32 = 168.0;
+pub const DEVICE_BODY_H: f32 = 176.0;

--- a/crates/vibez-ui/src/widgets/effect_knob.rs
+++ b/crates/vibez-ui/src/widgets/effect_knob.rs
@@ -5,7 +5,7 @@ use iced::mouse;
 use iced::widget::canvas;
 use iced::{Color, Rectangle, Renderer, Theme};
 
-use crate::message::Message;
+use crate::message::{DrumPadParam, Message};
 use crate::theme;
 use vibez_core::id::{EffectId, TrackId};
 
@@ -28,6 +28,10 @@ const DOUBLE_CLICK_MS: u64 = 300;
 pub enum KnobTarget {
     Effect(EffectId),
     Instrument,
+    DrumPad {
+        pad_index: usize,
+        param: DrumPadParam,
+    },
 }
 
 /// Generalized rotary knob widget for device parameters with
@@ -90,6 +94,30 @@ impl EffectKnobWidget {
         }
     }
 
+    /// Knob bound to a drum rack pad parameter.
+    #[allow(clippy::too_many_arguments)]
+    pub fn for_drum_pad(
+        track_id: TrackId,
+        pad_index: usize,
+        param: DrumPadParam,
+        value: f32,
+        min: f32,
+        max: f32,
+        default: f32,
+        arc_color: Color,
+    ) -> Self {
+        Self {
+            track_id,
+            target: KnobTarget::DrumPad { pad_index, param },
+            param_index: 0,
+            value,
+            min,
+            max,
+            default,
+            arc_color,
+        }
+    }
+
     fn set_value_message(&self, value: f32) -> Message {
         match self.target {
             KnobTarget::Effect(effect_id) => {
@@ -98,6 +126,12 @@ impl EffectKnobWidget {
             KnobTarget::Instrument => {
                 Message::SetInstrumentParam(self.track_id, self.param_index, value)
             }
+            KnobTarget::DrumPad { pad_index, param } => Message::SetDrumPadParam {
+                track_id: self.track_id,
+                pad_index,
+                param,
+                value,
+            },
         }
     }
 

--- a/crates/vibez-ui/src/widgets/effect_knob.rs
+++ b/crates/vibez-ui/src/widgets/effect_knob.rs
@@ -2,8 +2,8 @@ use std::time::Instant;
 
 use iced::keyboard;
 use iced::mouse;
-use iced::widget::canvas;
-use iced::{Color, Rectangle, Renderer, Theme};
+use iced::widget::{canvas, column, text};
+use iced::{Color, Element, Length, Rectangle, Renderer, Theme};
 
 use crate::message::{DrumPadParam, Message};
 use crate::theme;
@@ -151,6 +151,48 @@ impl EffectKnobWidget {
     }
 }
 
+/// Standard width of a knob+label+value column in device cards.
+pub const PARAM_COLUMN_WIDTH: f32 = 56.0;
+/// Standard knob canvas size in device cards.
+pub const KNOB_SIZE: f32 = 36.0;
+
+/// The one true knob column: knob, name, value. Every device card
+/// (effects and instruments) uses this so density, typography, and
+/// spacing stay consistent across the whole device chain.
+pub fn param_column<'a>(
+    knob: EffectKnobWidget,
+    label: String,
+    value_text: String,
+) -> Element<'a, Message> {
+    let knob_canvas: Element<'a, Message> = canvas(knob)
+        .width(Length::Fixed(KNOB_SIZE))
+        .height(Length::Fixed(KNOB_SIZE))
+        .into();
+    column![
+        knob_canvas,
+        text(label).size(9).color(theme::TEXT_DIM),
+        text(value_text).size(9).color(theme::TEXT),
+    ]
+    .spacing(2)
+    .width(Length::Fixed(PARAM_COLUMN_WIDTH))
+    .align_x(iced::Alignment::Center)
+    .into()
+}
+
+/// Musical value formatting shared by every device card: note names
+/// for pitch params, kHz above 1000 Hz, ms below one second.
+pub fn format_value(value: f32, unit: &str) -> String {
+    match unit {
+        "note" => crate::widgets::piano_roll::pitch_name(value.round().clamp(0.0, 127.0) as u8),
+        "Hz" if value >= 1000.0 => format!("{:.1} kHz", value / 1000.0),
+        "Hz" => format!("{value:.0} Hz"),
+        "s" if value < 1.0 => format!("{:.0} ms", value * 1000.0),
+        "s" => format!("{value:.2} s"),
+        "" => format!("{value:.2}"),
+        other => format!("{value:.1} {other}"),
+    }
+}
+
 /// State for mouse interaction.
 #[derive(Debug, Default)]
 pub struct EffectKnobState {
@@ -165,50 +207,87 @@ impl canvas::Program<Message> for EffectKnobWidget {
 
     fn draw(
         &self,
-        _state: &Self::State,
+        state: &Self::State,
         renderer: &Renderer,
         _theme: &Theme,
         bounds: Rectangle,
-        _cursor: mouse::Cursor,
+        cursor: mouse::Cursor,
     ) -> Vec<canvas::Geometry> {
         let mut frame = canvas::Frame::new(renderer, bounds.size());
         let w = bounds.width;
         let h = bounds.height;
         let center = iced::Point::new(w / 2.0, h / 2.0);
-        let radius = (w.min(h) / 2.0 - 3.0).max(4.0);
+        let radius = (w.min(h) / 2.0 - 3.0).max(6.0);
+        let engaged = state.dragging || cursor.is_over(bounds);
 
-        // Background circle
-        let bg_circle = canvas::Path::circle(center, radius);
-        frame.fill(&bg_circle, theme::KNOB_BG);
+        // Knob body: darker than the card so it reads as a physical
+        // control (the old body used the card's own color and was
+        // invisible). Subtle ring border, brighter while engaged.
+        let body = canvas::Path::circle(center, radius);
+        frame.fill(
+            &body,
+            Color {
+                r: 0.09,
+                g: 0.09,
+                b: 0.09,
+                a: 1.0,
+            },
+        );
+        let ring = canvas::Path::circle(center, radius);
+        frame.stroke(
+            &ring,
+            canvas::Stroke::default()
+                .with_color(if engaged {
+                    self.arc_color
+                } else {
+                    theme::BORDER
+                })
+                .with_width(1.0),
+        );
 
-        let arc_radius = radius - 2.0;
-        let segments = 40;
+        let arc_radius = radius - 1.5;
+        let segments = 48;
         let norm = self.normalized();
 
-        // Background arc (full 270-degree range)
+        // Track arc: visible neutral grey along the full sweep.
         let bg_arc = build_arc(center, arc_radius, ARC_START, ARC_END, segments);
         frame.stroke(
             &bg_arc,
             canvas::Stroke::default()
-                .with_color(theme::FADER_TRACK)
-                .with_width(3.0),
+                .with_color(Color {
+                    r: 0.24,
+                    g: 0.24,
+                    b: 0.24,
+                    a: 1.0,
+                })
+                .with_width(2.5),
         );
 
-        // Value arc (filled portion) using track color
+        // Value arc in the track color, slightly brighter when engaged.
         let value_angle = ARC_START + norm * (ARC_END - ARC_START);
         if norm > 0.005 {
             let value_arc = build_arc(center, arc_radius, ARC_START, value_angle, segments);
+            let arc_color = if engaged {
+                Color {
+                    r: (self.arc_color.r * 1.25).min(1.0),
+                    g: (self.arc_color.g * 1.25).min(1.0),
+                    b: (self.arc_color.b * 1.25).min(1.0),
+                    a: 1.0,
+                }
+            } else {
+                self.arc_color
+            };
             frame.stroke(
                 &value_arc,
                 canvas::Stroke::default()
-                    .with_color(self.arc_color)
-                    .with_width(3.0),
+                    .with_color(arc_color)
+                    .with_width(2.5),
             );
         }
 
-        // Pointer line from center toward current value angle
-        let pointer_inner = radius * 0.25;
-        let pointer_outer = radius - 3.0;
+        // Pointer line, the Ableton-style position indicator.
+        let pointer_inner = radius * 0.30;
+        let pointer_outer = radius - 3.5;
         let pointer = canvas::Path::line(
             iced::Point::new(
                 center.x + pointer_inner * value_angle.cos(),
@@ -222,7 +301,11 @@ impl canvas::Program<Message> for EffectKnobWidget {
         frame.stroke(
             &pointer,
             canvas::Stroke::default()
-                .with_color(theme::TEXT)
+                .with_color(if engaged {
+                    theme::TEXT
+                } else {
+                    theme::TEXT_DIM
+                })
                 .with_width(2.0),
         );
 

--- a/crates/vibez-ui/src/widgets/effect_knob.rs
+++ b/crates/vibez-ui/src/widgets/effect_knob.rs
@@ -22,10 +22,19 @@ const SCROLL_STEP: f32 = 0.02;
 /// Double-click window in milliseconds.
 const DOUBLE_CLICK_MS: u64 = 300;
 
-/// Generalized rotary knob widget for effect parameters with arbitrary min/max.
+/// What a parameter knob controls: an effect slot or the track's
+/// native instrument. Determines which message value changes emit.
+#[derive(Clone, Copy)]
+pub enum KnobTarget {
+    Effect(EffectId),
+    Instrument,
+}
+
+/// Generalized rotary knob widget for device parameters with
+/// arbitrary min/max (effects and native instruments).
 pub struct EffectKnobWidget {
     pub track_id: TrackId,
-    pub effect_id: EffectId,
+    pub target: KnobTarget,
     pub param_index: usize,
     pub value: f32,
     pub min: f32,
@@ -48,13 +57,47 @@ impl EffectKnobWidget {
     ) -> Self {
         Self {
             track_id,
-            effect_id,
+            target: KnobTarget::Effect(effect_id),
             param_index,
             value,
             min,
             max,
             default,
             arc_color,
+        }
+    }
+
+    /// Knob bound to the track's native instrument parameter.
+    #[allow(clippy::too_many_arguments)]
+    pub fn for_instrument(
+        track_id: TrackId,
+        param_index: usize,
+        value: f32,
+        min: f32,
+        max: f32,
+        default: f32,
+        arc_color: Color,
+    ) -> Self {
+        Self {
+            track_id,
+            target: KnobTarget::Instrument,
+            param_index,
+            value,
+            min,
+            max,
+            default,
+            arc_color,
+        }
+    }
+
+    fn set_value_message(&self, value: f32) -> Message {
+        match self.target {
+            KnobTarget::Effect(effect_id) => {
+                Message::SetEffectParam(self.track_id, effect_id, self.param_index, value)
+            }
+            KnobTarget::Instrument => {
+                Message::SetInstrumentParam(self.track_id, self.param_index, value)
+            }
         }
     }
 
@@ -192,12 +235,7 @@ impl canvas::Program<Message> for EffectKnobWidget {
                             state.last_click = None;
                             return (
                                 canvas::event::Status::Captured,
-                                Some(Message::SetEffectParam(
-                                    self.track_id,
-                                    self.effect_id,
-                                    self.param_index,
-                                    self.default,
-                                )),
+                                Some(self.set_value_message(self.default)),
                             );
                         }
                     }
@@ -238,12 +276,7 @@ impl canvas::Program<Message> for EffectKnobWidget {
 
                         return (
                             canvas::event::Status::Captured,
-                            Some(Message::SetEffectParam(
-                                self.track_id,
-                                self.effect_id,
-                                self.param_index,
-                                new_value,
-                            )),
+                            Some(self.set_value_message(new_value)),
                         );
                     }
                 }
@@ -269,12 +302,7 @@ impl canvas::Program<Message> for EffectKnobWidget {
 
                     return (
                         canvas::event::Status::Captured,
-                        Some(Message::SetEffectParam(
-                            self.track_id,
-                            self.effect_id,
-                            self.param_index,
-                            new_value,
-                        )),
+                        Some(self.set_value_message(new_value)),
                     );
                 }
             }

--- a/crates/vibez-ui/src/widgets/effect_slot.rs
+++ b/crates/vibez-ui/src/widgets/effect_slot.rs
@@ -1,15 +1,13 @@
-use iced::widget::{button, canvas, column, container, row, text, Space};
+use iced::widget::{button, column, container, row, text, Space};
 use iced::{Color, Element, Length, Theme};
 
 use crate::icons;
 use crate::message::Message;
 use crate::state::UiEffect;
 use crate::theme as th;
-use crate::widgets::effect_knob::EffectKnobWidget;
+use crate::widgets::effect_knob::{param_column, EffectKnobWidget};
 use vibez_core::id::TrackId;
 use vibez_plugin_host::gui::PluginGuiKey;
-
-const CARD_WIDTH: f32 = 220.0;
 
 /// Render an Ableton-style device card for the detail panel.
 pub fn view_effect_slot<'a>(
@@ -169,10 +167,9 @@ pub fn view_effect_slot<'a>(
         } else {
             track_color
         };
-        let mut param_rows = column![].spacing(6);
-        let mut current_row = row![].spacing(8);
-        let mut count = 0;
-
+        // One knob row in the shared column format: the devices
+        // panel scrolls horizontally and stacked rows clip.
+        let mut knob_row = row![].spacing(6);
         for (i, descriptor) in effect.descriptors.iter().enumerate() {
             let value = effect.params.get(i).copied().unwrap_or(descriptor.default);
             let knob = EffectKnobWidget::new(
@@ -185,42 +182,25 @@ pub fn view_effect_slot<'a>(
                 descriptor.default,
                 knob_color,
             );
-            let knob_canvas: Element<'a, Message> = canvas(knob)
-                .width(Length::Fixed(32.0))
-                .height(Length::Fixed(32.0))
-                .into();
-
-            let label = text(descriptor.name).size(9).color(th::TEXT_DIM);
-            let value_text = format_param_value(value, descriptor.unit);
-            let value_label = text(value_text).size(8).color(th::TEXT_MUTED);
-
-            let param_col = column![knob_canvas, label, value_label]
-                .spacing(1)
-                .align_x(iced::Alignment::Center);
-
-            current_row = current_row.push(param_col);
-            count += 1;
-
-            if count % 4 == 0 {
-                param_rows = param_rows.push(current_row);
-                current_row = row![].spacing(8);
-            }
+            knob_row = knob_row.push(param_column(
+                knob,
+                descriptor.name.to_string(),
+                crate::widgets::effect_knob::format_value(value, descriptor.unit),
+            ));
         }
 
-        if count % 4 != 0 {
-            param_rows = param_rows.push(current_row);
-        }
-
-        container(param_rows)
-            .padding([6, 7])
-            .width(Length::Fill)
+        container(knob_row)
+            .padding([8, 10])
+            .height(Length::Fixed(th::DEVICE_BODY_H))
             .into()
     } else {
-        Space::new(Length::Fill, Length::Fixed(2.0)).into()
+        container(Space::new(Length::Fixed(120.0), Length::Fixed(2.0)))
+            .height(Length::Fixed(th::DEVICE_BODY_H))
+            .into()
     };
 
     // ── Card ─────────────────────────────────────────────────
-    let card = column![title_bar, body].width(Length::Fixed(CARD_WIDTH));
+    let card = column![title_bar, body];
 
     container(card)
         .style(|_theme: &Theme| container::Style {
@@ -261,14 +241,4 @@ fn action_btn(
                 ..Default::default()
             }
         })
-}
-
-fn format_param_value(value: f32, unit: &str) -> String {
-    if unit.is_empty() {
-        format!("{value:.2}")
-    } else if unit == "Hz" && value >= 1000.0 {
-        format!("{:.1}k{unit}", value / 1000.0)
-    } else {
-        format!("{value:.1}{unit}")
-    }
 }

--- a/crates/vibez-ui/src/widgets/effect_slot.rs
+++ b/crates/vibez-ui/src/widgets/effect_slot.rs
@@ -18,6 +18,7 @@ pub fn view_effect_slot<'a>(
     let is_bypassed = effect.bypass;
     let has_params = !effect.descriptors.is_empty();
     let has_gui = effect.has_plugin_gui;
+    let is_plugin = effect.plugin_name.is_some();
 
     let dot_color = if is_bypassed {
         th::TEXT_MUTED
@@ -58,7 +59,10 @@ pub fn view_effect_slot<'a>(
 
     // Fixed-size controls on the right
     // Edit button (open plugin GUI) — only for effects with a native GUI
-    let edit_btn: Option<iced::widget::Button<'_, Message>> = if has_gui {
+    let make_edit = || -> Option<iced::widget::Button<'a, Message>> {
+        if !has_gui {
+            return None;
+        }
         let gui_key = PluginGuiKey::Effect {
             track_id,
             effect_id: effect.id,
@@ -84,8 +88,6 @@ pub fn view_effect_slot<'a>(
                     }
                 }),
         )
-    } else {
-        None
     };
 
     let bypass_label = if is_bypassed { "Off" } else { "On" };
@@ -94,44 +96,50 @@ pub fn view_effect_slot<'a>(
     } else {
         th::SUCCESS
     };
-    let bypass_btn = button(text(bypass_label).size(9).color(bypass_color))
-        .on_press(Message::ToggleEffectBypass(track_id, effect.id))
-        .padding([2, 5])
-        .style(move |_theme: &Theme, status| {
-            let bg = match status {
-                button::Status::Hovered => Some(th::BG_HOVER.into()),
-                _ => None,
-            };
-            button::Style {
-                background: bg,
-                text_color: bypass_color,
-                border: iced::Border {
-                    color: if is_bypassed {
-                        th::BORDER
-                    } else {
-                        th::darken(th::SUCCESS, 0.5)
+    let make_bypass = move || {
+        button(text(bypass_label).size(9).color(bypass_color))
+            .on_press(Message::ToggleEffectBypass(track_id, effect.id))
+            .padding([2, 5])
+            .style(move |_theme: &Theme, status| {
+                let bg = match status {
+                    button::Status::Hovered => Some(th::BG_HOVER.into()),
+                    _ => None,
+                };
+                button::Style {
+                    background: bg,
+                    text_color: bypass_color,
+                    border: iced::Border {
+                        color: if is_bypassed {
+                            th::BORDER
+                        } else {
+                            th::darken(th::SUCCESS, 0.5)
+                        },
+                        width: 1.0,
+                        radius: 3.0.into(),
                     },
-                    width: 1.0,
-                    radius: 3.0.into(),
-                },
-                ..Default::default()
-            }
-        });
+                    ..Default::default()
+                }
+            })
+    };
 
-    let move_up: Element<'a, Message> = action_btn(
-        icons::CHEVRON_UP,
-        th::TEXT_DIM,
-        th::TEXT,
-        Message::MoveEffectUp(track_id, effect.id),
-    )
-    .into();
-    let move_down: Element<'a, Message> = action_btn(
-        icons::CHEVRON_DOWN,
-        th::TEXT_DIM,
-        th::TEXT,
-        Message::MoveEffectDown(track_id, effect.id),
-    )
-    .into();
+    let make_move_up = || -> Element<'a, Message> {
+        action_btn(
+            icons::CHEVRON_UP,
+            th::TEXT_DIM,
+            th::TEXT,
+            Message::MoveEffectUp(track_id, effect.id),
+        )
+        .into()
+    };
+    let make_move_down = || -> Element<'a, Message> {
+        action_btn(
+            icons::CHEVRON_DOWN,
+            th::TEXT_DIM,
+            th::TEXT,
+            Message::MoveEffectDown(track_id, effect.id),
+        )
+        .into()
+    };
     let remove: Element<'a, Message> = action_btn(
         icons::X,
         th::TEXT_DIM,
@@ -143,14 +151,20 @@ pub fn view_effect_slot<'a>(
     let mut title_row = row![dot, name_section]
         .spacing(3)
         .align_y(iced::Alignment::Center);
-    if let Some(eb) = edit_btn {
-        title_row = title_row.push(eb);
+    if is_plugin {
+        // Plugins: name gets the title to itself; Edit/On/reorder
+        // live in the body where they have room.
+        title_row = title_row.push(remove);
+    } else {
+        if let Some(eb) = make_edit() {
+            title_row = title_row.push(eb);
+        }
+        title_row = title_row
+            .push(make_bypass())
+            .push(make_move_up())
+            .push(make_move_down())
+            .push(remove);
     }
-    title_row = title_row
-        .push(bypass_btn)
-        .push(move_up)
-        .push(move_down)
-        .push(remove);
 
     let title_bar = container(title_row)
         .padding([4, 6])
@@ -193,6 +207,42 @@ pub fn view_effect_slot<'a>(
             .padding([8, 10])
             .height(Length::Fixed(th::DEVICE_BODY_H))
             .into()
+    } else if is_plugin {
+        // External plugin face: format badge, prominent Edit, then
+        // bypass and chain-reorder controls.
+        let format_label = effect
+            .plugin_ref
+            .as_ref()
+            .map(|d| d.format.to_uppercase())
+            .unwrap_or_else(|| "PLUGIN".to_string());
+        let badge = container(text(format_label).size(8).color(th::ACCENT))
+            .padding([2, 8])
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::BG_DARK.into()),
+                border: iced::Border {
+                    color: th::ACCENT_DIM,
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                ..Default::default()
+            });
+
+        let mut face = column![badge].spacing(10).align_x(iced::Alignment::Center);
+        if let Some(eb) = make_edit() {
+            face = face.push(eb.padding([5, 22]));
+        }
+        face = face.push(
+            row![make_bypass(), make_move_up(), make_move_down()]
+                .spacing(4)
+                .align_y(iced::Alignment::Center),
+        );
+
+        container(face)
+            .width(Length::Fill)
+            .height(Length::Fixed(th::DEVICE_BODY_H))
+            .align_x(iced::Alignment::Center)
+            .align_y(iced::Alignment::Center)
+            .into()
     } else {
         container(Space::new(Length::Fixed(120.0), Length::Fixed(2.0)))
             .height(Length::Fixed(th::DEVICE_BODY_H))
@@ -207,7 +257,11 @@ pub fn view_effect_slot<'a>(
     } else {
         0
     };
-    let card_w = (knob_count as f32 * 62.0 + 24.0).max(150.0);
+    let card_w = if is_plugin {
+        190.0
+    } else {
+        (knob_count as f32 * 62.0 + 24.0).max(150.0)
+    };
     let card = column![title_bar, body].width(Length::Fixed(card_w));
 
     container(card)

--- a/crates/vibez-ui/src/widgets/effect_slot.rs
+++ b/crates/vibez-ui/src/widgets/effect_slot.rs
@@ -200,7 +200,15 @@ pub fn view_effect_slot<'a>(
     };
 
     // ── Card ─────────────────────────────────────────────────
-    let card = column![title_bar, body];
+    // Fixed width computed from the knob count: a Fill title strip
+    // inside a shrink column collapses the card chrome in iced.
+    let knob_count = if has_params && !has_gui {
+        effect.descriptors.len()
+    } else {
+        0
+    };
+    let card_w = (knob_count as f32 * 62.0 + 24.0).max(150.0);
+    let card = column![title_bar, body].width(Length::Fixed(card_w));
 
     container(card)
         .style(|_theme: &Theme| container::Style {

--- a/crates/vibez-ui/src/widgets/mini_waveform.rs
+++ b/crates/vibez-ui/src/widgets/mini_waveform.rs
@@ -1,0 +1,328 @@
+//! Small visual displays for device cards: sample waveforms
+//! (sampler, drum pads), an oscillator scope, and an ADSR envelope
+//! curve. Modeled on Ableton's Simpler/Operator displays: a device
+//! should show what it will sound like, not just knobs.
+
+use std::cell::Cell;
+use std::sync::Arc;
+
+use iced::mouse;
+use iced::widget::canvas;
+use iced::{Color, Rectangle, Renderer, Theme};
+
+use crate::message::Message;
+use crate::theme;
+use vibez_core::audio_buffer::DecodedAudio;
+
+/// Filled min/max waveform of a loaded sample, with an optional
+/// highlighted playback region (drum pad start/end trim). Rendering
+/// is cached and invalidated by a fingerprint of the audio pointer
+/// and region, so the 60fps UI tick does not re-scan the sample.
+pub struct MiniWaveform {
+    pub audio: Option<Arc<DecodedAudio>>,
+    pub color: Color,
+    /// Normalized playback region (start, end); audio outside it is
+    /// dimmed and marker lines are drawn at the edges.
+    pub region: Option<(f32, f32)>,
+}
+
+pub struct MiniWaveformState {
+    cache: canvas::Cache,
+    fingerprint: Cell<u64>,
+}
+
+impl Default for MiniWaveformState {
+    fn default() -> Self {
+        Self {
+            cache: canvas::Cache::new(),
+            fingerprint: Cell::new(u64::MAX),
+        }
+    }
+}
+
+impl MiniWaveform {
+    fn fingerprint(&self) -> u64 {
+        let ptr = self
+            .audio
+            .as_ref()
+            .map(|a| Arc::as_ptr(a) as u64)
+            .unwrap_or(0);
+        let (s, e) = self.region.unwrap_or((0.0, 1.0));
+        ptr ^ ((s.to_bits() as u64) << 32) ^ (e.to_bits() as u64)
+    }
+}
+
+impl canvas::Program<Message> for MiniWaveform {
+    type State = MiniWaveformState;
+
+    fn draw(
+        &self,
+        state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let fp = self.fingerprint();
+        if state.fingerprint.get() != fp {
+            state.cache.clear();
+            state.fingerprint.set(fp);
+        }
+
+        let geometry = state.cache.draw(renderer, bounds.size(), |frame| {
+            let w = frame.width();
+            let h = frame.height();
+
+            // Panel background.
+            let bg = canvas::Path::rounded_rectangle(
+                iced::Point::ORIGIN,
+                iced::Size::new(w, h),
+                3.0.into(),
+            );
+            frame.fill(
+                &bg,
+                Color {
+                    r: 0.07,
+                    g: 0.07,
+                    b: 0.07,
+                    a: 1.0,
+                },
+            );
+
+            let Some(audio) = &self.audio else {
+                // Empty state: flat center line.
+                let line = canvas::Path::line(
+                    iced::Point::new(4.0, h / 2.0),
+                    iced::Point::new(w - 4.0, h / 2.0),
+                );
+                frame.stroke(
+                    &line,
+                    canvas::Stroke::default()
+                        .with_color(theme::BORDER)
+                        .with_width(1.0),
+                );
+                return;
+            };
+
+            let samples = &audio.channels[0];
+            if samples.is_empty() {
+                return;
+            }
+            let (region_start, region_end) = self.region.unwrap_or((0.0, 1.0));
+            let mid = h / 2.0;
+            let usable_h = h / 2.0 - 2.0;
+            let columns = (w as usize).saturating_sub(4).max(1);
+            let per_column = (samples.len() / columns).max(1);
+
+            for col in 0..columns {
+                let begin = col * per_column;
+                if begin >= samples.len() {
+                    break;
+                }
+                let end = ((col + 1) * per_column).min(samples.len());
+                let mut min = f32::MAX;
+                let mut max = f32::MIN;
+                // Stride within the column so huge files stay cheap.
+                let stride = ((end - begin) / 64).max(1);
+                let mut i = begin;
+                while i < end {
+                    let s = samples[i];
+                    min = min.min(s);
+                    max = max.max(s);
+                    i += stride;
+                }
+                if min > max {
+                    continue;
+                }
+                let pos = col as f32 / columns as f32;
+                let in_region = pos >= region_start && pos <= region_end;
+                let color = if in_region {
+                    self.color
+                } else {
+                    Color {
+                        a: 0.22,
+                        ..self.color
+                    }
+                };
+                let x = 2.0 + col as f32;
+                let top = mid - max.clamp(-1.0, 1.0) * usable_h;
+                let bottom = mid - min.clamp(-1.0, 1.0) * usable_h;
+                frame.fill_rectangle(
+                    iced::Point::new(x, top.min(bottom)),
+                    iced::Size::new(1.0, (bottom - top).abs().max(1.0)),
+                    color,
+                );
+            }
+
+            // Region edge markers.
+            if let Some((s, e)) = self.region {
+                for pos in [s, e] {
+                    let x = 2.0 + pos.clamp(0.0, 1.0) * (w - 4.0);
+                    let line =
+                        canvas::Path::line(iced::Point::new(x, 2.0), iced::Point::new(x, h - 2.0));
+                    frame.stroke(
+                        &line,
+                        canvas::Stroke::default()
+                            .with_color(theme::TEXT_DIM)
+                            .with_width(1.0),
+                    );
+                }
+            }
+        });
+
+        vec![geometry]
+    }
+}
+
+/// One analytic cycle of the synth's selected oscillator shape.
+pub struct OscScope {
+    pub waveform_index: usize,
+    pub color: Color,
+}
+
+impl canvas::Program<Message> for OscScope {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let w = frame.width();
+        let h = frame.height();
+
+        let bg =
+            canvas::Path::rounded_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), 3.0.into());
+        frame.fill(
+            &bg,
+            Color {
+                r: 0.07,
+                g: 0.07,
+                b: 0.07,
+                a: 1.0,
+            },
+        );
+
+        let mid = h / 2.0;
+        let amp = h / 2.0 - 4.0;
+        let points = 96;
+        let shape = |phase: f32| -> f32 {
+            match self.waveform_index {
+                0 => (phase * std::f32::consts::TAU).sin(),
+                1 => 1.0 - 2.0 * phase, // saw
+                2 => {
+                    if phase < 0.5 {
+                        1.0
+                    } else {
+                        -1.0
+                    }
+                }
+                _ => {
+                    // triangle
+                    if phase < 0.25 {
+                        4.0 * phase
+                    } else if phase < 0.75 {
+                        2.0 - 4.0 * phase
+                    } else {
+                        4.0 * phase - 4.0
+                    }
+                }
+            }
+        };
+
+        let path = canvas::Path::new(|b| {
+            for i in 0..=points {
+                let phase = i as f32 / points as f32;
+                let x = 3.0 + phase * (w - 6.0);
+                let y = mid - shape(phase) * amp;
+                if i == 0 {
+                    b.move_to(iced::Point::new(x, y));
+                } else {
+                    b.line_to(iced::Point::new(x, y));
+                }
+            }
+        });
+        frame.stroke(
+            &path,
+            canvas::Stroke::default()
+                .with_color(self.color)
+                .with_width(1.5),
+        );
+
+        vec![frame.into_geometry()]
+    }
+}
+
+/// ADSR envelope curve: attack rise, decay to the sustain plateau,
+/// release tail. Time segments share the width proportionally with a
+/// fixed plateau so short envelopes stay readable.
+pub struct AdsrScope {
+    pub attack: f32,
+    pub decay: f32,
+    pub sustain: f32,
+    pub release: f32,
+    pub color: Color,
+}
+
+impl canvas::Program<Message> for AdsrScope {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let w = frame.width();
+        let h = frame.height();
+
+        let bg =
+            canvas::Path::rounded_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), 3.0.into());
+        frame.fill(
+            &bg,
+            Color {
+                r: 0.07,
+                g: 0.07,
+                b: 0.07,
+                a: 1.0,
+            },
+        );
+
+        let pad = 3.0;
+        let top = pad;
+        let bottom = h - pad;
+        let usable_w = w - pad * 2.0;
+        let sustain_y = bottom - self.sustain.clamp(0.0, 1.0) * (bottom - top);
+
+        // Time-proportional widths with a fixed sustain plateau.
+        let total_t = (self.attack + self.decay + self.release).max(0.001);
+        let plateau = usable_w * 0.22;
+        let time_w = usable_w - plateau;
+        let ax = pad + time_w * (self.attack / total_t);
+        let dx = ax + time_w * (self.decay / total_t);
+        let sx = dx + plateau;
+
+        let path = canvas::Path::new(|b| {
+            b.move_to(iced::Point::new(pad, bottom));
+            b.line_to(iced::Point::new(ax, top));
+            b.line_to(iced::Point::new(dx, sustain_y));
+            b.line_to(iced::Point::new(sx, sustain_y));
+            b.line_to(iced::Point::new(pad + usable_w, bottom));
+        });
+        frame.stroke(
+            &path,
+            canvas::Stroke::default()
+                .with_color(self.color)
+                .with_width(1.5),
+        );
+
+        vec![frame.into_geometry()]
+    }
+}

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -3,6 +3,7 @@ pub mod effect_knob;
 pub mod effect_slot;
 pub mod fader;
 pub mod knob;
+pub mod mini_waveform;
 pub mod mixer_strip;
 pub mod piano_roll;
 pub mod timeline;


### PR DESCRIPTION
Started as dogfood bug #1 (dead synth params) and became the full built-in device overhaul, verified card by card in the DAW.

**Functional**
- Synth card was a mockup (hardcoded labels, literal '0.50', no messages): now a real device with waveform selector and working ADSR/cutoff/res/volume knobs. End-to-end regression test pins the engine path.
- Sampler gets real Root/ADSR knobs (delegated to Codex, reviewed); drum rack gains the per-pad editor the engine always supported: gain, pan, start/end trim, coarse/fine tune (cents verified against engine math), one-shot, choke groups.
- Sampler is finally a browser drop target (handler existed, nothing ever sent the message).

**Visual: one device design system across synth, sampler, drum rack, and all effect cards**
- Knobs redrawn to read as physical controls (the old knob body and track arc were literally the same color as the card background): dark body, ring, visible track, colored value arc, pointer line, hover/drag emphasis.
- Ableton-style labeled sections with vertical dividers (synth OSC | ENVELOPE | FILTER | OUT, sampler SAMPLE | TUNE | ENVELOPE, drum PADS | PAD), uniform rack height, one shared knob column, musical value formatting (C3, 2.5 kHz, 35 ms).
- Live displays: sampler waveform, drum pad waveform with start/end trim shaded as knobs turn, synth oscillator scope and ADSR curve on both envelope sections.
- External plugin face: name in the title, VST3/CLAP badge, prominent Edit, bypass/reorder controls.
- Layout hardening: cards use content-computed widths (a Fill title strip inside a shrink column collapses card chrome in iced), long names truncate, slim scrollbar.

Nine commits, one from Codex under review. fmt/clippy/tests green throughout; every regression found in dogfooding this PR was fixed within it.