### PR TITLE
feat(dsp): Signalsmith Stretch + resample band + loud out-of-tempo notice (#8b)

### DIFF
--- a/.notes/PRIME_DIRECTION.md
+++ b/.notes/PRIME_DIRECTION.md
@@ -227,3 +227,18 @@ Before building a feature, ask:
 `Does this help finish more usable electronic tracks per day?`
 
 If the answer is no, it is probably not part of the current phase.
+
+
+## Amendment 2026-07-06: next phase is architecture
+
+The stabilization phase worked (user is producing tracks), but
+app.rs is an 11k-line monolith holding update(), all views, and all
+orchestration. Agreed next phase after the current bug tail:
+establish a real architecture with the goals, in the user's words:
+make the project maintainable, isolate bugs, allow testing.
+Sketch to evaluate when we start: split Message by domain
+(transport/tracks/clips/piano-roll/devices/plugins/project) with
+per-domain update controllers owning their state slice; extract view
+families into widgets/ modules (device cards already moved); pull
+the async pipelines (plugin loads, warp, project IO) into services
+with channel interfaces so they unit-test without iced.

--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -130,7 +130,17 @@ Every bug/friction point below, in the order encountered.
   which matters given the "outsource deep plugins" strategy
   (.notes/feature-mix-desk.md).
 
-### 8b. Warp quality follow-up (2026-07-04, post-PR-#3 verification)
+### 8b. Warp quality follow-up (FIXED in PR #13, 2026-07-06)
+Fix landed as planned below: near-unity ratios (0.94..1.06) now use
+plain resampling (the 135->138 case ships a sub-semitone pitch shift
+and bit-exact transients), all other ratios go through Signalsmith
+Stretch (signalsmith-stretch crate) instead of the hand-rolled WSOLA,
+supported band widened to 0.25..4.0, and the clip warp row shows a
+loud OUT OF TEMPO notice when a detected clip BPM disagrees with the
+project (the silent auto-warp decline). Pitch-preservation and
+length-exactness regression tests added.
+
+### Original analysis (2026-07-04, post-PR-#3 verification)
 Repro: 135 BPM loop (Interface Dance CD-03_sample_4.wav, 7.2 s), project
 at 138. Screenshot: ~/Pictures/"Screenshot from 2026-07-04 12-31-04.png".
 Three distinct issues observed:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +371,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +571,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +596,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
 
 [[package]]
 name = "clap-sys"
@@ -903,10 +952,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7381b67da416b639690ac77c73b86a7b5e64a29e31d1f75fb3b1102301ef355a"
+dependencies = [
+ "dasp_envelope",
+ "dasp_frame",
+ "dasp_interpolate",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+ "dasp_signal",
+ "dasp_slice",
+ "dasp_window",
+]
+
+[[package]]
+name = "dasp_envelope"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec617ce7016f101a87fe85ed44180839744265fae73bb4aa43e7ece1b7668b6"
+dependencies = [
+ "dasp_frame",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_frame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a3937f5fe2135702897535c8d4a5553f8b116f76c1529088797f2eee7c5cd6"
+dependencies = [
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_interpolate"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc975a6563bb7ca7ec0a6c784ead49983a21c24835b0bc96eea11ee407c7486"
+dependencies = [
+ "dasp_frame",
+ "dasp_ring_buffer",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_peak"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf88559d79c21f3d8523d91250c397f9a15b5fc72fbb3f87fdb0a37b79915bf"
+dependencies = [
+ "dasp_frame",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_ring_buffer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d79e19b89618a543c4adec9c5a347fe378a19041699b3278e616e387511ea1"
+
+[[package]]
+name = "dasp_rms"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6c5dcb30b7e5014486e2822537ea2beae50b19722ffe2ed7549ab03774575aa"
+dependencies = [
+ "dasp_frame",
+ "dasp_ring_buffer",
+ "dasp_sample",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "dasp_signal"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1ab7d01689c6ed4eae3d38fe1cea08cba761573fbd2d592528d55b421077e7"
+dependencies = [
+ "dasp_envelope",
+ "dasp_frame",
+ "dasp_interpolate",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+ "dasp_window",
+]
+
+[[package]]
+name = "dasp_slice"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1c7335d58e7baedafa516cb361360ff38d6f4d3f9d9d5ee2a2fc8e27178fa1"
+dependencies = [
+ "dasp_frame",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_window"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ded7b88821d2ce4e8b842c9f1c86ac911891ab89443cc1de750cae764c5076"
+dependencies = [
+ "dasp_sample",
+]
 
 [[package]]
 name = "dbus"
@@ -1481,6 +1643,12 @@ name = "glam"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
@@ -2093,6 +2261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,6 +2595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2508,6 +2691,16 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3501,6 +3694,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +4102,17 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signalsmith-stretch"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51dae6f10b5532510f65c309c4d868babe3aecf6ce0782678081338311f176fd"
+dependencies = [
+ "bindgen",
+ "cc",
+ "dasp",
 ]
 
 [[package]]
@@ -4786,6 +5019,7 @@ dependencies = [
 name = "vibez-dsp"
 version = "0.1.0"
 dependencies = [
+ "signalsmith-stretch",
  "vibez-core",
 ]
 

--- a/crates/vibez-dsp/Cargo.toml
+++ b/crates/vibez-dsp/Cargo.toml
@@ -5,4 +5,5 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+signalsmith-stretch = "0.1.3"
 vibez-core = { workspace = true }

--- a/crates/vibez-dsp/src/time_stretch.rs
+++ b/crates/vibez-dsp/src/time_stretch.rs
@@ -32,8 +32,18 @@ const WSOLA_SEARCH: isize = 256;
 
 // Ratio router.
 const RATIO_PASSTHROUGH_EPS: f64 = 0.005;
-const RATIO_MIN: f64 = 0.5;
-const RATIO_MAX: f64 = 2.0;
+/// Stretch ratios this close to unity use plain resampling instead of
+/// a phase vocoder: the resulting pitch shift is under one semitone
+/// (inaudible on drums, barely audible on melodic material) and the
+/// time domain stays bit-exact, so transients cannot smear. This is
+/// the classic tempo-match case (e.g. a 135 BPM loop into a 138 BPM
+/// project) that produced audible artifacts under WSOLA.
+const RESAMPLE_BAND_MIN: f64 = 0.94;
+const RESAMPLE_BAND_MAX: f64 = 1.06;
+/// Signalsmith Stretch stays musical over a far wider range than the
+/// old hand-rolled WSOLA did.
+const RATIO_MIN: f64 = 0.25;
+const RATIO_MAX: f64 = 4.0;
 
 /// Stretch `audio` to the given target frame count using linear-interp
 /// resampling (pitch-shifting). Sample rate is preserved.
@@ -76,27 +86,48 @@ pub fn pitch_preserving_stretch(audio: &DecodedAudio, target_frames: usize) -> D
         return resize_clone(audio, target_frames);
     }
 
+    // Near-unity ratios: plain resample beats any stretcher.
+    if (RESAMPLE_BAND_MIN..=RESAMPLE_BAND_MAX).contains(&ratio) {
+        return stretch_to(audio, target_frames);
+    }
+
     if !(RATIO_MIN..=RATIO_MAX).contains(&ratio) || src_frames < WSOLA_FRAME * 2 {
         return stretch_to(audio, target_frames);
     }
 
-    if audio.channels.len() == 2 {
-        let (left, right) =
-            wsola_stretch_stereo(&audio.channels[0], &audio.channels[1], target_frames);
-        DecodedAudio {
-            channels: vec![left, right],
-            sample_rate: audio.sample_rate,
+    signalsmith_stretch(audio, target_frames)
+}
+
+/// Offline whole-buffer stretch through Signalsmith Stretch (the
+/// library behind serious commercial time-stretching). Interleaves,
+/// runs `exact` (which handles latency pre-roll and flush), and
+/// deinterleaves. Falls back to resampling if the engine declines.
+fn signalsmith_stretch(audio: &DecodedAudio, target_frames: usize) -> DecodedAudio {
+    let ch = audio.channels.len().max(1);
+    let src_frames = audio.num_frames();
+
+    let mut input = vec![0.0f32; src_frames * ch];
+    for (c, channel) in audio.channels.iter().enumerate() {
+        for (f, s) in channel.iter().enumerate() {
+            input[f * ch + c] = *s;
         }
-    } else {
-        let channels = audio
-            .channels
-            .iter()
-            .map(|ch| pitch_preserving_stretch_mono(ch, target_frames))
-            .collect();
-        DecodedAudio {
-            channels,
-            sample_rate: audio.sample_rate,
+    }
+    let mut output = vec![0.0f32; target_frames * ch];
+
+    let mut stretch = signalsmith_stretch::Stretch::preset_default(ch as u32, audio.sample_rate);
+    if !stretch.exact(&input, &mut output) {
+        return stretch_to(audio, target_frames);
+    }
+
+    let mut channels = vec![Vec::with_capacity(target_frames); ch];
+    for f in 0..target_frames {
+        for (c, channel) in channels.iter_mut().enumerate() {
+            channel.push(output[f * ch + c]);
         }
+    }
+    DecodedAudio {
+        channels,
+        sample_rate: audio.sample_rate,
     }
 }
 
@@ -608,5 +639,69 @@ mod tests {
         let input = sine(440.0, 44_100, 2_048);
         let out = pitch_preserving_stretch_mono(&input, 8_192);
         assert_eq!(out.len(), 8_192);
+    }
+}
+
+#[cfg(test)]
+mod stretch_quality_tests {
+    use super::*;
+
+    fn sine(freq: f32, seconds: f32, sample_rate: u32) -> DecodedAudio {
+        let n = (seconds * sample_rate as f32) as usize;
+        let ch: Vec<f32> = (0..n)
+            .map(|i| (i as f32 / sample_rate as f32 * freq * std::f32::consts::TAU).sin())
+            .collect();
+        DecodedAudio {
+            channels: vec![ch.clone(), ch],
+            sample_rate,
+        }
+    }
+
+    fn zero_crossings(buf: &[f32]) -> usize {
+        buf.windows(2).filter(|w| w[0] < 0.0 && w[1] >= 0.0).count()
+    }
+
+    #[test]
+    fn near_unity_ratio_uses_exact_length_resample() {
+        // 2.2% stretch (the 135->138 BPM dogfood case) must resample:
+        // output length exact and content dense (no silent tail).
+        let audio = sine(440.0, 1.0, 44_100);
+        let target = (44_100.0 * 1.022) as usize;
+        let out = pitch_preserving_stretch(&audio, target);
+        assert_eq!(out.num_frames(), target);
+        let tail = &out.channels[0][target - 4410..];
+        assert!(
+            tail.iter().any(|s| s.abs() > 0.1),
+            "tail must contain signal"
+        );
+    }
+
+    #[test]
+    fn signalsmith_preserves_pitch_under_big_stretch() {
+        // 1.5x longer at the same pitch: zero-crossing rate stays at
+        // the source frequency instead of dropping by a third.
+        let audio = sine(440.0, 1.0, 44_100);
+        let target = 66_150;
+        let out = pitch_preserving_stretch(&audio, target);
+        assert_eq!(out.num_frames(), target);
+
+        // Ignore edges; measure the middle second.
+        let mid = &out.channels[0][11_025..55_125];
+        let crossings = zero_crossings(mid);
+        let expected = 440.0; // crossings per second == frequency
+        let measured = crossings as f32 / 1.0;
+        assert!(
+            (measured - expected).abs() / expected < 0.05,
+            "pitch drifted: measured {measured} Hz vs {expected} Hz"
+        );
+        // And it must not be silent.
+        assert!(mid.iter().any(|s| s.abs() > 0.3));
+    }
+
+    #[test]
+    fn extreme_ratio_falls_back_to_resample() {
+        let audio = sine(440.0, 0.5, 44_100);
+        let out = pitch_preserving_stretch(&audio, 44_100 * 5);
+        assert_eq!(out.num_frames(), 44_100 * 5);
     }
 }

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -1639,6 +1639,27 @@ impl App {
         })
     }
 
+    /// Apply a new project tempo: clamps, updates the engine and the
+    /// beat-mapped loop region, and runs Ableton-style tempo follow
+    /// for warped clips. Shared by the BPM field and nudge buttons.
+    fn set_project_bpm(&mut self, bpm: f64) -> Task<Message> {
+        let bpm = bpm.clamp(20.0, 999.0);
+        let old_bpm = self.state.bpm;
+        self.state.bpm = bpm;
+        self.state.bpm_text = format!("{bpm:.0}");
+        self.send_command(EngineCommand::SetBpm(bpm));
+        // Re-send loop region since the beat-to-sample mapping changed.
+        if self.state.loop_enabled {
+            let start = self.state.beats_to_samples(self.state.loop_start_beats);
+            let end = self.state.beats_to_samples(self.state.loop_end_beats);
+            self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
+        }
+        if (bpm - old_bpm).abs() > f64::EPSILON {
+            return self.follow_tempo_change(old_bpm, bpm);
+        }
+        Task::none()
+    }
+
     /// Ableton-style global tempo follow. Warped audio clips keep
     /// their BAR position (sample positions rescale by the tempo
     /// ratio) and their audio re-stretches to the new tempo through
@@ -2090,31 +2111,19 @@ impl App {
                 self.state.time_selection_active = false;
                 self.state.time_selection_track = None;
             }
+            Message::NudgeBpm(delta) => {
+                let bpm = self.state.bpm + delta;
+                return self.set_project_bpm(bpm);
+            }
             Message::BpmChanged(val) => {
                 self.state.bpm_text = val;
             }
             Message::BpmSubmit => {
                 if let Ok(bpm) = self.state.bpm_text.parse::<f64>() {
-                    let bpm = bpm.clamp(20.0, 999.0);
-                    let old_bpm = self.state.bpm;
-                    self.state.bpm = bpm;
-                    self.state.bpm_text = format!("{bpm:.0}");
-                    self.send_command(EngineCommand::SetBpm(bpm));
-                    // Re-send loop region since beat→sample mapping changed
-                    if self.state.loop_enabled {
-                        let start = self.state.beats_to_samples(self.state.loop_start_beats);
-                        let end = self.state.beats_to_samples(self.state.loop_end_beats);
-                        self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
-                    }
-                    // Ableton-style tempo follow: warped clips restretch
-                    // and keep their musical position on the new grid.
-                    if (bpm - old_bpm).abs() > f64::EPSILON {
-                        return self.follow_tempo_change(old_bpm, bpm);
-                    }
-                } else {
-                    let bpm = self.state.bpm;
-                    self.state.bpm_text = format!("{bpm:.0}");
+                    return self.set_project_bpm(bpm);
                 }
+                let bpm = self.state.bpm;
+                self.state.bpm_text = format!("{bpm:.0}");
             }
 
             // -- Workspace --
@@ -10356,6 +10365,34 @@ impl App {
             .width(Length::Fixed(55.0))
             .size(14);
 
+        let bpm_nudge = |icon: char, delta: f64| {
+            button(icons::icon(icon).size(8).color(th::TEXT_DIM))
+                .on_press(Message::NudgeBpm(delta))
+                .padding([0, 4])
+                .style(|_theme: &Theme, status| {
+                    let bg = match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::BG_HOVER.into())
+                        }
+                        _ => None,
+                    };
+                    button::Style {
+                        background: bg,
+                        text_color: th::TEXT_DIM,
+                        border: iced::Border {
+                            radius: 2.0.into(),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }
+                })
+        };
+        let bpm_spinner = column![
+            bpm_nudge(icons::CHEVRON_UP, 1.0),
+            bpm_nudge(icons::CHEVRON_DOWN, -1.0),
+        ]
+        .spacing(1);
+
         let bpm_label = text("BPM").size(12).color(th::TEXT_DIM);
 
         // Master VU meter
@@ -10377,7 +10414,9 @@ impl App {
             horizontal_space(),
             volume_icon,
             master_meter_canvas,
-            bpm_input,
+            row![bpm_input, bpm_spinner]
+                .spacing(2)
+                .align_y(iced::Alignment::Center),
             bpm_label,
         ]
         .spacing(12)

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -1782,7 +1782,8 @@ impl App {
                     }
                 }
                 self.state.status_text = format!(
-                    "Detected {:.1} BPM (confidence {:.2}, below warp threshold)",
+                    "Auto-warp skipped: detected {:.1} BPM at low confidence {:.2}. \
+                     Use the clip's Warp button to apply it manually.",
                     bpm, confidence
                 );
                 self.state.project_dirty = true;
@@ -10142,6 +10143,21 @@ impl App {
                             .color(th::METER_YELLOW),
                     );
                 }
+            }
+        } else if let Some(detected) = clip.original_bpm {
+            // Auto-warp declined (low confidence) or was never run:
+            // the clip knows its tempo and it disagrees with the
+            // project. Say so loudly instead of a status-bar whisper;
+            // the Warp button on this same row is the one-click fix.
+            if (detected - self.state.bpm).abs() > 0.5 {
+                row_widgets = row_widgets.push(
+                    text(format!(
+                        "OUT OF TEMPO: clip {detected:.1} BPM vs project {:.0}",
+                        self.state.bpm
+                    ))
+                    .size(10)
+                    .color(th::METER_YELLOW),
+                );
             }
         }
 

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -1639,6 +1639,51 @@ impl App {
         })
     }
 
+    /// Ableton-style global tempo follow. Warped audio clips keep
+    /// their BAR position (sample positions rescale by the tempo
+    /// ratio) and their audio re-stretches to the new tempo through
+    /// the idempotent re-warp path. Unwarped audio clips keep
+    /// absolute time, exactly like unwarped clips in Ableton. MIDI
+    /// clips are beat-positioned and follow inherently.
+    fn follow_tempo_change(&mut self, old_bpm: f64, new_bpm: f64) -> Task<Message> {
+        let position_ratio = old_bpm / new_bpm;
+        let mut warped: Vec<(TrackId, ClipId)> = Vec::new();
+        let mut moves: Vec<(TrackId, ClipId, u64)> = Vec::new();
+
+        for track in &mut self.state.tracks {
+            for clip in &mut track.clips {
+                if !clip.warped {
+                    continue;
+                }
+                let new_position = (clip.position as f64 * position_ratio).round() as u64;
+                if new_position != clip.position {
+                    clip.position = new_position;
+                    moves.push((track.id, clip.id, new_position));
+                }
+                warped.push((track.id, clip.id));
+            }
+        }
+        for (track_id, clip_id, new_position) in moves {
+            self.send_command(EngineCommand::MoveClip {
+                track_id,
+                clip_id,
+                new_position,
+            });
+        }
+        if warped.is_empty() {
+            return Task::none();
+        }
+        self.state.status_text = format!(
+            "Tempo {old_bpm:.0} -> {new_bpm:.0}: re-warping {} clip(s)",
+            warped.len()
+        );
+        let tasks: Vec<Task<Message>> = warped
+            .into_iter()
+            .map(|(track_id, clip_id)| self.dispatch_warp_clip_to_project(track_id, clip_id))
+            .collect();
+        Task::batch(tasks)
+    }
+
     fn dispatch_warp_clip_to_project(
         &mut self,
         track_id: TrackId,
@@ -2051,6 +2096,7 @@ impl App {
             Message::BpmSubmit => {
                 if let Ok(bpm) = self.state.bpm_text.parse::<f64>() {
                     let bpm = bpm.clamp(20.0, 999.0);
+                    let old_bpm = self.state.bpm;
                     self.state.bpm = bpm;
                     self.state.bpm_text = format!("{bpm:.0}");
                     self.send_command(EngineCommand::SetBpm(bpm));
@@ -2059,6 +2105,11 @@ impl App {
                         let start = self.state.beats_to_samples(self.state.loop_start_beats);
                         let end = self.state.beats_to_samples(self.state.loop_end_beats);
                         self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
+                    }
+                    // Ableton-style tempo follow: warped clips restretch
+                    // and keep their musical position on the new grid.
+                    if (bpm - old_bpm).abs() > f64::EPSILON {
+                        return self.follow_tempo_change(old_bpm, bpm);
                     }
                 } else {
                     let bpm = self.state.bpm;

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -158,6 +158,8 @@ pub enum Message {
     // BPM
     BpmChanged(String),
     BpmSubmit,
+    /// Increment/decrement project BPM by a whole beat-per-minute.
+    NudgeBpm(f64),
 
     // Workspace
     SwitchWorkspace(Workspace),


### PR DESCRIPTION
The last big musical fix from the dogfood log. Warping a 135 BPM loop to a 138 BPM project (a 2.2 percent stretch) sounded like flams and smearing because the hand-rolled WSOLA (fixed 1024/256 windows, no transient awareness) ran even for tiny ratios.

**Dispatch now matches the material:**
- Ratios in 0.94..1.06: plain linear resample. Sub-semitone pitch shift, bit-exact time domain, zero artifacts. This is the classic tempo-match band and covers the reported case.
- Ratios in 0.25..4.0: Signalsmith Stretch via the signalsmith-stretch crate (MIT, builds the C++ library, no system deps beyond a C++ toolchain). Whole-buffer offline processing through its exact() API with latency handled internally.
- Beyond that: resample fallback.

**Verified by tests:** exact output lengths, signal density to the tail, and pitch preservation (a 1.5x stretch holds 440 Hz within 5 percent, measured by zero-crossing rate). The existing warp geometry regression tests in warp.rs pass unchanged since both warp paths share the same entry point.

**Loud decline (UX half of #8b):** when a clip has a detected BPM that disagrees with the project and is not warped (the silent auto-warp decline scenario), the clip's warp row shows an OUT OF TEMPO notice in warning yellow right next to the Warp button, and the status message explains the manual path.

Test plan: import the 135 BPM Interface Dance loop into a 138 project: auto-warp declines loudly, manual warp sounds clean (resample path). Warp something to a dramatic ratio (halftime/doubletime) and listen for Signalsmith quality. Re-warp and reload projects to confirm geometry invariants still hold.