### PR TITLE
fix(ui): SIGSEGV on undo/project-switch with plugin GUI open

### DIFF
--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -351,6 +351,28 @@ Three distinct issues observed:
   persisted id (tracks, effects, clips, note clips) at the start of
   rebuild_from_loaded_project, before anything new can be minted.
 
+### 22. SIGSEGV: undo (or project switch) with plugin GUI open (FIXED in PR #14)
+- Reported 2026-07-06: "randomly crashed when I accidentally deleted
+  a clip and pressed undo when it was playing." Coredump backtrace:
+  SIGSEGV in vst3_host::runloop::service_registry <- PluginWindow
+  Manager::poll_events: the GUI run-loop pump called a timer handler
+  of a FREED plugin.
+- Root cause: apply_snapshot (undo/redo) removes every track, which
+  destroys plugin instances, but never closed their open GUI windows
+  or cleared the raw-pointer maps; the window manager kept pumping
+  VST3 run-loop timers into dead plugins. clear_project_runtime had
+  the same hole for open windows on project switch.
+- Fix: both paths now close all plugin windows and clear
+  plugin_gui_raw_ptrs/plugin_state_ptrs BEFORE track teardown.
+- KNOWN LIMITATION exposed by this bug: undo snapshots only carry
+  built-in devices, so any undo silently drops plugin effects and
+  instruments from tracks. Needs snapshot support for
+  PluginDeviceInfo + async re-load (the project-load pipeline already
+  does this). Logged as follow-up.
+- Also observed: DPF plugins spam "fComponentHandler != nullptr"
+  asserts because vibez implements no IComponentHandler yet
+  (harmless noise; future work alongside GUI param automation).
+
 ## Fix status
 
 - Bugs #7 and #8: root-caused and fixed in PR #3

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -267,7 +267,11 @@ impl App {
 
         self.state.tracks.clear();
         // The engine drops all plugin instances with their tracks;
-        // stale raw pointers must go with them.
+        // their GUI windows and stale raw pointers must go with them
+        // (pumping a closed plugin's run-loop timers segfaults).
+        if let Some(ref mut mgr) = self.plugin_window_manager {
+            mgr.close_all();
+        }
         self.plugin_gui_raw_ptrs.clear();
         self.plugin_state_ptrs.clear();
         self.state.selected_track = None;
@@ -1347,6 +1351,17 @@ impl App {
     }
 
     fn apply_snapshot(&mut self, snapshot: crate::state::ProjectSnapshot) {
+        // Plugin instances die with their tracks below. Their GUI
+        // windows and raw pointers MUST go first: the window manager
+        // pumps VST3 run-loop timers every tick, and pumping a freed
+        // plugin is a guaranteed segfault (dogfood crash #22:
+        // delete clip + undo while playing).
+        if let Some(ref mut mgr) = self.plugin_window_manager {
+            mgr.close_all();
+        }
+        self.plugin_gui_raw_ptrs.clear();
+        self.plugin_state_ptrs.clear();
+
         // Tear down the engine side.
         let existing_track_ids: Vec<TrackId> = self.state.tracks.iter().map(|t| t.id).collect();
         for track_id in existing_track_ids {


### PR DESCRIPTION
Coredump-diagnosed from a live dogfood crash (delete clip, press undo during playback with a Dragonfly GUI open): SIGSEGV in vst3_host::runloop::service_registry via PluginWindowManager::poll_events. Undo's apply_snapshot destroys all plugin instances with their tracks but left GUI windows open and raw-pointer maps populated, so the 60fps window pump called timer handlers on freed plugins. Project switching (clear_project_runtime) had the same open-window hole.

Fix: both paths close all plugin windows and clear plugin_gui_raw_ptrs/plugin_state_ptrs before track teardown.

Surfaced follow-up (logged in dogfood notes): undo snapshots only carry built-in devices, so an undo silently drops plugin devices from tracks; restoring them needs PluginDeviceInfo in snapshots plus the async reload pipeline that project load already uses.

Test plan: with a VST3 GUI window open and transport playing: delete a clip, Ctrl+Z; switch projects; both previously segfaulted, both should now just close the plugin window.