### PR TITLE
fix(ui): plugin window resize contract (#9)

### DIFF
--- a/.notes/ROADMAP-to-ableton-replacement.md
+++ b/.notes/ROADMAP-to-ableton-replacement.md
@@ -1,0 +1,77 @@
+# Roadmap: the DAW Alex would replace Ableton with
+
+Captured 2026-07-06 at the end of the stabilization phase (dogfood
+bugs #1-#22 all closed, user producing tracks). This is the wishlist
+in Alex's own ordering, seeded with implementation notes from the
+session that built the current foundation. Whoever picks these up:
+read `.notes/PRIME_DIRECTION.md` and the memory notes first; the
+decision filter is "does this help finish more usable electronic
+tracks per day?"
+
+## 1. Architecture refactor (agreed FIRST, before new features)
+Goals in Alex's words: maintainable, isolate bugs, allow testing.
+app.rs is ~11k lines holding update(), all views, and orchestration.
+Sketch already recorded in PRIME_DIRECTION amendment: domain-split
+Message enum with per-domain controllers owning state slices;
+extract view families to widgets/ (device cards already moved);
+async pipelines (plugin load, warp, project IO) become services with
+channel interfaces, unit-testable without iced. Start with a plan
+for sign-off, not code.
+
+## 2. Automation + LFOs
+Lanes on tracks writing param changes over time. Engine side: the
+per-block command pattern already exists; automation is a per-block
+param schedule evaluated in EngineTrack::render. Plugin params need
+the VST3 IParameterChanges queues (a discard stub exists in
+vst3_host/instance.rs to build on) and CLAP param events in
+process(); the host already builds event lists for notes.
+IComponentHandler must be implemented for GUI-write-back (DPF
+plugins already assert about it; see dogfood #22 note).
+
+## 3. Recording in (audio + MIDI in)
+cpal input streams exist in the stack. Engine needs an input ring +
+punch-in clip writer. MIDI in via midir (already a workspace dep!):
+idle instrument rendering (PR #10) means live input will sound while
+stopped: that groundwork is done.
+
+## 4. MIDI out
+midir output; engine note scheduler already produces timed events
+per block (mixer.rs); a MidiOutTrack kind could forward them.
+
+## 5/6. Review all instruments and effects
+The cards are honest now (PR #11/#12) but the DSP deserves a pass:
+synth filter quality, sampler interpolation, effect algorithm
+quality. Keep the "plugins do the deep work" strategy; built-ins are
+bread and butter.
+
+## 7. Velocity
+Piano roll has velocity visualization already; needs editing (drag
+on the velocity lane) and instruments honoring it properly
+(SpyInstrument tests show the plumbing carries velocity end-to-end).
+
+## 8-11. Mix view: parametric EQ per strip, bus view, sends
+The mix-desk concept is in `.notes/feature-mix-desk.md`. Engine
+needs bus tracks (sum groups) and per-strip EQ as a built-in device;
+sends = per-track tap into bus inputs with gain. The parametric EQ
+sending to busses = send knob per band? Clarify with Alex. A
+performance view (clip launcher?) also listed: clarify scope.
+
+## 12. Grid sizes / bars+phrases view
+Arrangement ruler currently fixed; Ableton shows adaptive bar/phrase
+divisions by zoom. timeline.rs draws the ruler; make divisions a
+function of zoom level (1/4 bar .. 8 bars).
+
+## 13. Plugin and sample marketplace
+Big. Out of local scope; needs a server story. The sample browser +
+Dropbox integration are the seeds.
+
+## 14. Controller support
+MIDI learn: midir input -> map CC to Message::SetEffectParam /
+SetInstrumentParam / mixer params. The single knob widget
+(EffectKnobWidget) makes visual feedback uniform.
+
+## Known small debts
+- Undo drops plugin devices (snapshots carry built-ins only).
+- DPF fComponentHandler assert noise (ties into automation work).
+- Knob drag-feel tuning vs Ableton if it ever bothers again.
+- PR #4 umbrella: merge feature branch to main.

--- a/.notes/dogfood-2026-07-03.md
+++ b/.notes/dogfood-2026-07-03.md
@@ -113,6 +113,10 @@ Every bug/friction point below, in the order encountered.
   loops is the core workflow.
 
 ### 9. Plugin window resize leaves dead space / framebuffer garbage
+### (FIXED in PR #15: non-resizable plugins get min==max WM size
+### hints so the window hard-locks to the GUI size; resizable ones
+### get ConfigureNotify forwarded to clap gui.set_size / VST3
+### IPlugView::onSize. Original report below.)
 - Found 2026-07-04 while testing LSP plugins (Graphic Equalizer x16 Mono).
 - Actual: stretching the plugin window bigger than the plugin GUI leaves
   the plugin at its original size with uninitialized black/garbage rows

--- a/crates/vibez-plugin-host/src/clap_host/host_impl.rs
+++ b/crates/vibez-plugin-host/src/clap_host/host_impl.rs
@@ -361,11 +361,33 @@ static CLAP_HOST_GUI_IMPL: clap_host_gui = clap_host_gui {
 
 unsafe extern "C" fn host_gui_resize_hints_changed(_host: *const clap_host) {}
 
+/// GUI resize requests from plugins, keyed by plugin pointer. The
+/// plugin window manager drains this every tick and resizes the
+/// actual X11 window; returning true without acting (the previous
+/// behavior) made plugins render at a size the window never had.
+static PENDING_GUI_RESIZES: Mutex<Vec<(usize, u32, u32)>> = Mutex::new(Vec::new());
+
+/// Drain pending plugin-initiated GUI resizes: (plugin_ptr, w, h).
+pub fn take_pending_gui_resizes() -> Vec<(usize, u32, u32)> {
+    PENDING_GUI_RESIZES
+        .lock()
+        .map(|mut v| std::mem::take(&mut *v))
+        .unwrap_or_default()
+}
+
 unsafe extern "C" fn host_gui_request_resize(
-    _host: *const clap_host,
-    _width: u32,
-    _height: u32,
+    host: *const clap_host,
+    width: u32,
+    height: u32,
 ) -> bool {
+    if host.is_null() || (*host).host_data.is_null() {
+        return false;
+    }
+    let data = &*((*host).host_data as *const ClapHostUserData);
+    if let Ok(mut pending) = PENDING_GUI_RESIZES.lock() {
+        pending.retain(|(p, _, _)| *p != data.plugin_ptr as usize);
+        pending.push((data.plugin_ptr as usize, width, height));
+    }
     true
 }
 

--- a/crates/vibez-plugin-host/src/gui.rs
+++ b/crates/vibez-plugin-host/src/gui.rs
@@ -47,6 +47,22 @@ impl PluginGuiHandle {
         }
     }
 
+    /// Whether the plugin GUI supports live resizing by the host.
+    pub fn can_resize(&self) -> bool {
+        match self {
+            PluginGuiHandle::Clap(h) => h.can_resize(),
+            PluginGuiHandle::Vst3(h) => h.can_resize(),
+        }
+    }
+
+    /// Forward a host-window resize to the plugin GUI.
+    pub fn set_size(&mut self, width: u32, height: u32) -> bool {
+        match self {
+            PluginGuiHandle::Clap(h) => h.set_size(width, height),
+            PluginGuiHandle::Vst3(h) => h.set_size(width, height),
+        }
+    }
+
     /// Query the preferred GUI size from the plugin.
     pub fn get_size(&self) -> Option<(u32, u32)> {
         match self {
@@ -114,6 +130,30 @@ pub struct ClapGuiHandle {
 unsafe impl Send for ClapGuiHandle {}
 
 impl ClapGuiHandle {
+    /// CLAP `clap_plugin_gui::can_resize`.
+    pub fn can_resize(&self) -> bool {
+        if self.gui_ext.is_null() {
+            return false;
+        }
+        let gui = unsafe { &*self.gui_ext };
+        match gui.can_resize {
+            Some(f) => unsafe { f(self.plugin_ptr) },
+            None => false,
+        }
+    }
+
+    /// CLAP `clap_plugin_gui::set_size`.
+    pub fn set_size(&mut self, width: u32, height: u32) -> bool {
+        if self.gui_ext.is_null() {
+            return false;
+        }
+        let gui = unsafe { &*self.gui_ext };
+        match gui.set_size {
+            Some(f) => unsafe { f(self.plugin_ptr, width, height) },
+            None => false,
+        }
+    }
+
     /// Create a new CLAP GUI handle from a raw `*const c_void` pointer.
     /// This is the safe-to-call-from-anywhere entry point that avoids
     /// exposing `clap_plugin` types to crates that don't depend on `clap-sys`.
@@ -278,6 +318,41 @@ impl Vst3GuiHandle {
             frame: None,
             open: false,
         })
+    }
+
+    /// IPlugView::canResize - vtable [13]. kResultTrue (0) means yes.
+    pub fn can_resize(&self) -> bool {
+        if self.plug_view.is_null() {
+            return false;
+        }
+        type CanResizeFn = unsafe extern "system" fn(*mut c_void) -> i32;
+        let vtbl = unsafe { *(self.plug_view as *const *const *const c_void) };
+        let can_resize: CanResizeFn = unsafe { std::mem::transmute(*vtbl.add(13)) };
+        unsafe { can_resize(self.plug_view) == 0 }
+    }
+
+    /// IPlugView::onSize - vtable [10]. Rect uses left/top/right/bottom.
+    pub fn set_size(&mut self, width: u32, height: u32) -> bool {
+        if self.plug_view.is_null() {
+            return false;
+        }
+        #[repr(C)]
+        struct ViewRect {
+            left: i32,
+            top: i32,
+            right: i32,
+            bottom: i32,
+        }
+        type OnSizeFn = unsafe extern "system" fn(*mut c_void, *mut ViewRect) -> i32;
+        let vtbl = unsafe { *(self.plug_view as *const *const *const c_void) };
+        let on_size: OnSizeFn = unsafe { std::mem::transmute(*vtbl.add(10)) };
+        let mut rect = ViewRect {
+            left: 0,
+            top: 0,
+            right: width as i32,
+            bottom: height as i32,
+        };
+        unsafe { on_size(self.plug_view, &mut rect) == 0 }
     }
 
     /// Pump this view's run loop (timers + fd handlers). JUCE editors

--- a/crates/vibez-plugin-host/src/gui.rs
+++ b/crates/vibez-plugin-host/src/gui.rs
@@ -39,6 +39,23 @@ impl PluginGuiHandle {
         }
     }
 
+    /// CLAP plugin pointer for matching plugin-initiated resize
+    /// requests; None for VST3.
+    pub fn clap_plugin_ptr(&self) -> Option<usize> {
+        match self {
+            PluginGuiHandle::Clap(h) => Some(h.plugin_ptr as usize),
+            PluginGuiHandle::Vst3(_) => None,
+        }
+    }
+
+    /// Plugin-initiated resize request (VST3 IPlugFrame::resizeView).
+    pub fn take_pending_resize(&self) -> Option<(u32, u32)> {
+        match self {
+            PluginGuiHandle::Clap(_) => None,
+            PluginGuiHandle::Vst3(h) => h.frame.as_ref().and_then(|f| f.take_pending_resize()),
+        }
+    }
+
     /// Whether the plugin actually supports a GUI.
     pub fn has_gui(&self) -> bool {
         match self {

--- a/crates/vibez-plugin-host/src/vst3_host/runloop.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/runloop.rs
@@ -79,6 +79,9 @@ unsafe impl Send for TimerEntry {}
 pub struct RunLoopRegistry {
     event_handlers: Vec<EventHandlerEntry>,
     timers: Vec<TimerEntry>,
+    /// Plugin-initiated view resize (IPlugFrame::resizeView), for the
+    /// window manager to apply to the host window.
+    pending_resize: Option<(u32, u32)>,
 }
 
 impl RunLoopRegistry {
@@ -257,16 +260,31 @@ unsafe extern "system" fn frame_release(this: *mut Frame) -> u32 {
 }
 
 unsafe extern "system" fn resize_view(
-    _this: *mut Frame,
+    this: *mut Frame,
     view: *mut c_void,
     rect: *mut c_void,
 ) -> i32 {
     if view.is_null() || rect.is_null() {
         return K_INVALID_ARGUMENT;
     }
-    // Accept the request and echo it back via IPlugView::onSize
-    // (vtable [10]). Resizing the host X11 window itself is bug #9
-    // territory; this keeps plugin-initiated resizes consistent.
+    #[repr(C)]
+    struct ViewRect {
+        left: i32,
+        top: i32,
+        right: i32,
+        bottom: i32,
+    }
+    // Record the requested size for the window manager to apply to
+    // the host window, then accept via IPlugView::onSize (vtable
+    // [10]) so the view lays out for what it asked.
+    let r = &*(rect as *const ViewRect);
+    let w = (r.right - r.left).max(0) as u32;
+    let h = (r.bottom - r.top).max(0) as u32;
+    if w > 0 && h > 0 {
+        if let Ok(mut reg) = (*(*this).registry).lock() {
+            reg.pending_resize = Some((w, h));
+        }
+    }
     type OnSizeFn = unsafe extern "system" fn(*mut c_void, *mut c_void) -> i32;
     let vtbl = *(view as *const *const *const c_void);
     let on_size: OnSizeFn = std::mem::transmute(*vtbl.add(10));
@@ -402,6 +420,14 @@ impl HostPlugFrame {
     /// Fire due timers and ready fds for this view's plugin.
     pub fn service(&self) {
         service_registry(&self.registry);
+    }
+
+    /// Take a plugin-initiated resize request, if any.
+    pub fn take_pending_resize(&self) -> Option<(u32, u32)> {
+        self.registry
+            .lock()
+            .ok()
+            .and_then(|mut reg| reg.pending_resize.take())
     }
 }
 

--- a/crates/vibez-ui/src/plugin_window.rs
+++ b/crates/vibez-ui/src/plugin_window.rs
@@ -34,6 +34,9 @@ struct OpenPluginWindow {
     gui_handle: PluginGuiHandle,
     #[allow(dead_code)]
     title: String,
+    /// Last size forwarded to the plugin, to filter duplicate
+    /// ConfigureNotify events.
+    size: (u16, u16),
 }
 
 /// Synchronous plugin window manager that runs on the UI thread.
@@ -197,6 +200,24 @@ impl PluginWindowManager {
             }
         }
 
+        // Resize policy (dogfood bug #9): plugins that cannot resize
+        // get a hard-locked window (min == max size hints), so the WM
+        // never exposes dead framebuffer space; resizable plugins get
+        // their resizes forwarded from ConfigureNotify in poll_events.
+        let can_resize = handle.can_resize();
+        if !can_resize {
+            let hints = x11rb::properties::WmSizeHints {
+                min_size: Some((width as i32, height as i32)),
+                max_size: Some((width as i32, height as i32)),
+                ..Default::default()
+            };
+            let _ = hints.set_normal_hints(&self.conn, window_id);
+        }
+        eprintln!(
+            "vibez: open_window — plugin can_resize={can_resize}, window {}locked",
+            if can_resize { "un" } else { "" }
+        );
+
         eprintln!("vibez: open_window — calling show()");
         handle.show();
         let _ = self.conn.flush();
@@ -213,6 +234,7 @@ impl PluginWindowManager {
                 x11_window_id: window_id,
                 gui_handle: handle,
                 title,
+                size: (width as u16, height as u16),
             },
         );
 
@@ -266,6 +288,20 @@ impl PluginWindowManager {
         loop {
             match self.conn.poll_for_event() {
                 Ok(Some(event)) => {
+                    if let x11rb::protocol::Event::ConfigureNotify(cfg) = &event {
+                        if let Some(win) = self
+                            .windows
+                            .values_mut()
+                            .find(|w| w.x11_window_id == cfg.window)
+                        {
+                            let new_size = (cfg.width, cfg.height);
+                            if new_size != win.size && new_size.0 > 0 && new_size.1 > 0 {
+                                win.size = new_size;
+                                win.gui_handle
+                                    .set_size(new_size.0 as u32, new_size.1 as u32);
+                            }
+                        }
+                    }
                     if let x11rb::protocol::Event::ClientMessage(cm) = event {
                         if cm.format == 32 && cm.data.as_data32()[0] == self.wm_delete_window {
                             let key = self

--- a/crates/vibez-ui/src/plugin_window.rs
+++ b/crates/vibez-ui/src/plugin_window.rs
@@ -37,6 +37,9 @@ struct OpenPluginWindow {
     /// Last size forwarded to the plugin, to filter duplicate
     /// ConfigureNotify events.
     size: (u16, u16),
+    /// Whether the plugin GUI resizes; locked windows carry min==max
+    /// WM hints that must move with plugin-initiated resizes.
+    can_resize: bool,
 }
 
 /// Synchronous plugin window manager that runs on the UI thread.
@@ -200,10 +203,37 @@ impl PluginWindowManager {
             }
         }
 
+        eprintln!("vibez: open_window — calling show()");
+        handle.show();
+        let _ = self.conn.flush();
+
+        // The pre-attach size query lies for some plugins (VST3 has
+        // no view yet at that point; some CLAP GUIs only know their
+        // size after create/attach), which shipped 800x600 windows
+        // with clipped or floating GUIs. Re-query now and make the
+        // window match reality.
+        let (mut width, mut height) = (width, height);
+        if let Some((w, h)) = handle.get_size() {
+            if (w, h) != (width, height) && w > 0 && h > 0 {
+                eprintln!(
+                    "vibez: open_window — post-attach size correction {width}x{height} -> {w}x{h}"
+                );
+                width = w;
+                height = h;
+                let _ = self.conn.configure_window(
+                    window_id,
+                    &xproto::ConfigureWindowAux::new()
+                        .width(width)
+                        .height(height),
+                );
+            }
+        }
+
         // Resize policy (dogfood bug #9): plugins that cannot resize
-        // get a hard-locked window (min == max size hints), so the WM
+        // get a hard-locked window (min == max size hints) so the WM
         // never exposes dead framebuffer space; resizable plugins get
-        // their resizes forwarded from ConfigureNotify in poll_events.
+        // their resizes forwarded from ConfigureNotify in poll_events
+        // and their own requests applied from the pending queues.
         let can_resize = handle.can_resize();
         if !can_resize {
             let hints = x11rb::properties::WmSizeHints {
@@ -217,9 +247,6 @@ impl PluginWindowManager {
             "vibez: open_window — plugin can_resize={can_resize}, window {}locked",
             if can_resize { "un" } else { "" }
         );
-
-        eprintln!("vibez: open_window — calling show()");
-        handle.show();
         let _ = self.conn.flush();
 
         // Mark as open
@@ -235,6 +262,7 @@ impl PluginWindowManager {
                 gui_handle: handle,
                 title,
                 size: (width as u16, height as u16),
+                can_resize,
             },
         );
 
@@ -282,6 +310,52 @@ impl PluginWindowManager {
         // timers and fd handlers every tick or JUCE editors freeze.
         for window in self.windows.values() {
             window.gui_handle.service_runloop();
+        }
+
+        // Plugin-initiated resize requests: CLAP request_resize
+        // callbacks land in a queue keyed by plugin pointer; VST3
+        // resizeView requests sit on each view's frame.
+        let clap_requests = vibez_plugin_host::clap_host::host_impl::take_pending_gui_resizes();
+        let mut apply: Vec<(u32, u16, u16, bool)> = Vec::new();
+        for window in self.windows.values_mut() {
+            let request = window.gui_handle.take_pending_resize().or_else(|| {
+                window.gui_handle.clap_plugin_ptr().and_then(|ptr| {
+                    clap_requests
+                        .iter()
+                        .find(|(p, _, _)| *p == ptr)
+                        .map(|&(_, w, h)| (w, h))
+                })
+            });
+            if let Some((w, h)) = request {
+                let new_size = (w as u16, h as u16);
+                if new_size != window.size && w > 0 && h > 0 {
+                    window.size = new_size;
+                    apply.push((
+                        window.x11_window_id,
+                        new_size.0,
+                        new_size.1,
+                        window.can_resize,
+                    ));
+                }
+            }
+        }
+        for (win_id, w, h, can_resize) in apply {
+            if !can_resize {
+                // Move the lock with the window or the WM refuses
+                // the plugin's own resize.
+                let hints = x11rb::properties::WmSizeHints {
+                    min_size: Some((w as i32, h as i32)),
+                    max_size: Some((w as i32, h as i32)),
+                    ..Default::default()
+                };
+                let _ = hints.set_normal_hints(&self.conn, win_id);
+            }
+            let _ = self.conn.configure_window(
+                win_id,
+                &xproto::ConfigureWindowAux::new()
+                    .width(w as u32)
+                    .height(h as u32),
+            );
         }
 
         let mut events = Vec::new();


### PR DESCRIPTION
The last bug from the original dogfood log. Stretching a plugin window bigger than its GUI left uninitialized black rows below (screenshot in the log).

The host now honors the plugin resize contract on both APIs:
- Open queries CLAP gui.can_resize / VST3 IPlugView::canResize.
- Non-resizable: WM_NORMAL_HINTS with min == max lock the X11 window to the plugin's reported size; the WM refuses to stretch it, so dead space is impossible.
- Resizable: ConfigureNotify events forward to CLAP gui.set_size / VST3 IPlugView::onSize (deduplicated), so the GUI reflows with the window.

Test plan: open ZL Equalizer (resizable JUCE GUI): dragging the window edge should reflow the plugin; open Dragonfly or an LSP GUI and try to stretch it: the window should refuse (locked), no garbage rows either way.