### PR TITLE
refactor(ui): domain architecture, tranche 1: state slices + transport domain

### DIFF
--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8,6 +8,7 @@ use iced::widget::{
 };
 use iced::{Color, Element, Length, Subscription, Task, Theme};
 
+use crate::domains::transport::TransportMsg;
 use rtrb::{Consumer, Producer};
 use vibez_audio_io::audio_stream::AudioOutputStream;
 use vibez_audio_io::file_io;
@@ -1383,10 +1384,16 @@ impl App {
         self.state.next_track_number = snapshot.next_track_number;
 
         self.send_command(EngineCommand::SetBpm(self.state.transport.bpm));
-        self.send_command(EngineCommand::SetArrangementLoop(self.state.transport.loop_enabled));
+        self.send_command(EngineCommand::SetArrangementLoop(
+            self.state.transport.loop_enabled,
+        ));
         if self.state.transport.loop_enabled {
-            let start = self.state.beats_to_samples(self.state.transport.loop_start_beats);
-            let end = self.state.beats_to_samples(self.state.transport.loop_end_beats);
+            let start = self
+                .state
+                .beats_to_samples(self.state.transport.loop_start_beats);
+            let end = self
+                .state
+                .beats_to_samples(self.state.transport.loop_end_beats);
             self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
         }
 
@@ -1623,7 +1630,8 @@ impl App {
                 clip_id: success.new_clip_id,
             });
 
-        let duration_seconds = success.new_duration as f64 / self.state.transport.sample_rate as f64;
+        let duration_seconds =
+            success.new_duration as f64 / self.state.transport.sample_rate as f64;
         self.state.status_text = format!(
             "Quantized {} slice(s) to {} ({:.1}s)",
             success.slice_count, success.grid_label, duration_seconds
@@ -1657,25 +1665,23 @@ impl App {
         })
     }
 
-    /// Apply a new project tempo: clamps, updates the engine and the
-    /// beat-mapped loop region, and runs Ableton-style tempo follow
-    /// for warped clips. Shared by the BPM field and nudge buttons.
-    fn set_project_bpm(&mut self, bpm: f64) -> Task<Message> {
-        let bpm = bpm.clamp(20.0, 999.0);
-        let old_bpm = self.state.transport.bpm;
-        self.state.transport.bpm = bpm;
-        self.state.transport.bpm_text = format!("{bpm:.0}");
-        self.send_command(EngineCommand::SetBpm(bpm));
-        // Re-send loop region since the beat-to-sample mapping changed.
-        if self.state.transport.loop_enabled {
-            let start = self.state.beats_to_samples(self.state.transport.loop_start_beats);
-            let end = self.state.beats_to_samples(self.state.transport.loop_end_beats);
-            self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
+    /// Route a cross-domain effect requested by the transport domain.
+    fn apply_transport_action(
+        &mut self,
+        action: crate::domains::transport::TransportAction,
+    ) -> Task<Message> {
+        use crate::domains::transport::TransportAction;
+        match action {
+            TransportAction::None => Task::none(),
+            TransportAction::ClearTimeSelection => {
+                self.state.time_selection_active = false;
+                self.state.time_selection_track = None;
+                Task::none()
+            }
+            TransportAction::TempoChanged { old_bpm, new_bpm } => {
+                self.follow_tempo_change(old_bpm, new_bpm)
+            }
         }
-        if (bpm - old_bpm).abs() > f64::EPSILON {
-            return self.follow_tempo_change(old_bpm, bpm);
-        }
-        Task::none()
     }
 
     /// Ableton-style global tempo follow. Warped audio clips keep
@@ -1825,7 +1831,10 @@ impl App {
         clip_id: ClipId,
         audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
     ) -> Task<Message> {
-        if !self.state.auto_warp_on_import || self.state.transport.bpm <= 0.0 || self.state.transport.sample_rate == 0 {
+        if !self.state.auto_warp_on_import
+            || self.state.transport.bpm <= 0.0
+            || self.state.transport.sample_rate == 0
+        {
             return Task::none();
         }
         let input = AutoWarpInput {
@@ -1977,9 +1986,9 @@ impl App {
             let keep_menu = matches!(
                 message,
                 Message::Tick
-                    | Message::EnginePosition(_)
+                    | Message::Transport(TransportMsg::EnginePosition(_))
                     | Message::EngineMetering { .. }
-                    | Message::EngineStopped
+                    | Message::Transport(TransportMsg::EngineStopped)
                     | Message::EngineTrackMeter { .. }
                     | Message::ShowContextMenu { .. }
                     | Message::DismissContextMenu
@@ -2022,7 +2031,7 @@ impl App {
 
         let should_mark_dirty = matches!(
             &message,
-            Message::BpmSubmit
+            Message::Transport(TransportMsg::BpmSubmit)
                 | Message::AddTrack
                 | Message::RemoveTrack(_)
                 | Message::ClipAudioDecoded(..)
@@ -2071,8 +2080,8 @@ impl App {
                 | Message::DuplicateSelectedClip
                 | Message::SplitSelectedAtPlayhead
                 | Message::JoinSelectedClips
-                | Message::ToggleArrangementLoop
-                | Message::SetArrangementLoopRegion { .. }
+                | Message::Transport(TransportMsg::ToggleArrangementLoop)
+                | Message::Transport(TransportMsg::SetArrangementLoopRegion { .. })
                 | Message::DeleteClipsInRegion { .. }
                 | Message::SplitClipsAtRegion { .. }
                 | Message::CreateClipFromSelection
@@ -2101,47 +2110,26 @@ impl App {
         }
 
         match message {
-            Message::Play => {
-                self.state.transport.playing = true;
-                self.send_command(EngineCommand::Play);
-            }
-            Message::Stop => {
-                self.state.transport.playing = false;
-                self.state.transport.position_samples = 0;
-                self.send_command(EngineCommand::Stop);
-                self.send_command(EngineCommand::Seek(0));
-            }
-            Message::TogglePlayback => {
-                if self.state.transport.playing {
-                    return self.update(Message::Stop);
-                } else {
-                    return self.update(Message::Play);
-                }
-            }
-            Message::Seek(normalized) => {
-                let total = self.state.total_duration_samples();
-                if total > 0 {
-                    let sample_pos = (normalized * total as f64) as u64;
-                    self.state.transport.position_samples = sample_pos;
-                    self.send_command(EngineCommand::Seek(sample_pos));
-                }
-                // Simple click clears the time selection
-                self.state.time_selection_active = false;
-                self.state.time_selection_track = None;
-            }
-            Message::NudgeBpm(delta) => {
-                let bpm = self.state.transport.bpm + delta;
-                return self.set_project_bpm(bpm);
-            }
-            Message::BpmChanged(val) => {
-                self.state.transport.bpm_text = val;
-            }
-            Message::BpmSubmit => {
-                if let Ok(bpm) = self.state.transport.bpm_text.parse::<f64>() {
-                    return self.set_project_bpm(bpm);
-                }
-                let bpm = self.state.transport.bpm;
-                self.state.transport.bpm_text = format!("{bpm:.0}");
+            // The transport domain owns its logic entirely; app.rs
+            // only computes the cross-domain context, routes the
+            // message, and applies the returned action.
+            Message::Transport(msg) => {
+                let ctx = crate::domains::transport::TransportCtx {
+                    total_duration_samples: self.state.total_duration_samples(),
+                    time_selection: if self.state.time_selection_active {
+                        Some((
+                            self.state.selection_start_beats,
+                            self.state.selection_end_beats,
+                        ))
+                    } else {
+                        None
+                    },
+                };
+                let action = {
+                    let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+                    self.state.transport.update(msg, &mut engine, ctx)
+                };
+                return self.apply_transport_action(action);
             }
 
             // -- Workspace --
@@ -2225,15 +2213,9 @@ impl App {
                     }
                 }
             }
-            Message::EnginePosition(pos) => {
-                self.state.transport.position_samples = pos;
-            }
             Message::EngineMetering { peak_l, peak_r } => {
                 self.state.peak_l = peak_l;
                 self.state.peak_r = peak_r;
-            }
-            Message::EngineStopped => {
-                self.state.transport.playing = false;
             }
 
             // -- Multi-track messages --
@@ -2480,8 +2462,10 @@ impl App {
             // -- Effects --
             Message::AddEffect(track_id, effect_type) => {
                 let effect_id = vibez_core::id::EffectId::new();
-                let fx =
-                    vibez_dsp::factory::create_effect(effect_type, self.state.transport.sample_rate as f32);
+                let fx = vibez_dsp::factory::create_effect(
+                    effect_type,
+                    self.state.transport.sample_rate as f32,
+                );
                 let descriptors = fx.param_descriptors();
                 let params: Vec<f32> = descriptors.iter().map(|d| d.default).collect();
 
@@ -4084,33 +4068,6 @@ impl App {
             }
 
             // -- Arrangement loop --
-            Message::ToggleArrangementLoop => {
-                self.state.transport.loop_enabled = !self.state.transport.loop_enabled;
-                self.send_command(EngineCommand::SetArrangementLoop(self.state.transport.loop_enabled));
-                if self.state.transport.loop_enabled {
-                    // Copy selection to loop region when enabling loop with active selection
-                    if self.state.time_selection_active
-                        && self.state.selection_end_beats > self.state.selection_start_beats
-                    {
-                        self.state.transport.loop_start_beats = self.state.selection_start_beats;
-                        self.state.transport.loop_end_beats = self.state.selection_end_beats;
-                    }
-                    let start = self.state.beats_to_samples(self.state.transport.loop_start_beats);
-                    let end = self.state.beats_to_samples(self.state.transport.loop_end_beats);
-                    self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
-                }
-            }
-            Message::SetArrangementLoopRegion {
-                start_beats,
-                end_beats,
-            } => {
-                self.state.transport.loop_start_beats = start_beats;
-                self.state.transport.loop_end_beats = end_beats;
-                let start = self.state.beats_to_samples(start_beats);
-                let end = self.state.beats_to_samples(end_beats);
-                self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
-            }
-
             // -- Time selection + context menu --
             Message::SetTimeSelection {
                 start_beats,
@@ -4129,8 +4086,12 @@ impl App {
                 self.state.context_menu = None;
                 self.state.transport.loop_start_beats = self.state.selection_start_beats;
                 self.state.transport.loop_end_beats = self.state.selection_end_beats;
-                let start = self.state.beats_to_samples(self.state.transport.loop_start_beats);
-                let end = self.state.beats_to_samples(self.state.transport.loop_end_beats);
+                let start = self
+                    .state
+                    .beats_to_samples(self.state.transport.loop_start_beats);
+                let end = self
+                    .state
+                    .beats_to_samples(self.state.transport.loop_end_beats);
                 self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
                 if !self.state.transport.loop_enabled {
                     self.state.transport.loop_enabled = true;
@@ -4688,8 +4649,10 @@ impl App {
                     .into_iter()
                     .map(|(tid, cid)| self.dispatch_warp_clip_to_project(tid, cid))
                     .collect();
-                self.state.status_text =
-                    format!("Re-warping {count} clip(s) to {:.0} BPM", self.state.transport.bpm);
+                self.state.status_text = format!(
+                    "Re-warping {count} clip(s) to {:.0} BPM",
+                    self.state.transport.bpm
+                );
                 return Task::batch(tasks);
             }
             Message::AddSampleLibraryRoot => {
@@ -5324,7 +5287,8 @@ impl App {
             } => {
                 self.state.context_menu = None;
                 let (range, insert_pos, name) = if is_note_clip {
-                    let spb = self.state.transport.sample_rate as f64 * 60.0 / self.state.transport.bpm;
+                    let spb =
+                        self.state.transport.sample_rate as f64 * 60.0 / self.state.transport.bpm;
                     let track_opt = self.state.find_track(track_id);
                     let nc = track_opt.and_then(|t| t.note_clips.iter().find(|c| c.id == clip_id));
                     match nc {
@@ -10290,7 +10254,7 @@ impl App {
     fn view_transport(&self) -> Element<'_, Message> {
         // Skip back button
         let skip_back_btn = button(icons::icon(icons::SKIP_BACK).size(16).color(th::TEXT))
-            .on_press(Message::Stop)
+            .on_press(Message::Transport(TransportMsg::Stop))
             .padding([8, 12])
             .style(|_theme: &Theme, _status| button::Style {
                 background: Some(th::BG_ELEVATED.into()),
@@ -10306,7 +10270,7 @@ impl App {
         // Play/Pause button
         let play_pause_btn = if self.state.transport.playing {
             button(icons::icon(icons::PAUSE).size(16).color(th::ACCENT))
-                .on_press(Message::Stop)
+                .on_press(Message::Transport(TransportMsg::Stop))
                 .padding([8, 14])
                 .style(|_theme: &Theme, _status| button::Style {
                     background: Some(th::BG_ELEVATED.into()),
@@ -10320,7 +10284,7 @@ impl App {
                 })
         } else {
             button(icons::icon(icons::PLAY).size(16).color(th::SUCCESS))
-                .on_press(Message::Play)
+                .on_press(Message::Transport(TransportMsg::Play))
                 .padding([8, 14])
                 .style(|_theme: &Theme, _status| button::Style {
                     background: Some(th::BG_ELEVATED.into()),
@@ -10337,7 +10301,7 @@ impl App {
         // Loop toggle button
         let loop_btn = if self.state.transport.loop_enabled {
             button(icons::icon(icons::REPEAT).size(16).color(th::ACCENT))
-                .on_press(Message::ToggleArrangementLoop)
+                .on_press(Message::Transport(TransportMsg::ToggleArrangementLoop))
                 .padding([8, 12])
                 .style(|_theme: &Theme, _status| button::Style {
                     background: Some(th::BG_ELEVATED.into()),
@@ -10351,7 +10315,7 @@ impl App {
                 })
         } else {
             button(icons::icon(icons::REPEAT).size(16).color(th::TEXT_DIM))
-                .on_press(Message::ToggleArrangementLoop)
+                .on_press(Message::Transport(TransportMsg::ToggleArrangementLoop))
                 .padding([8, 12])
                 .style(|_theme: &Theme, _status| button::Style {
                     background: Some(th::BG_ELEVATED.into()),
@@ -10378,14 +10342,14 @@ impl App {
 
         // BPM
         let bpm_input = text_input("BPM", &self.state.transport.bpm_text)
-            .on_input(Message::BpmChanged)
-            .on_submit(Message::BpmSubmit)
+            .on_input(|t| Message::Transport(TransportMsg::BpmChanged(t)))
+            .on_submit(Message::Transport(TransportMsg::BpmSubmit))
             .width(Length::Fixed(55.0))
             .size(14);
 
         let bpm_nudge = |icon: char, delta: f64| {
             button(icons::icon(icon).size(8).color(th::TEXT_DIM))
-                .on_press(Message::NudgeBpm(delta))
+                .on_press(Message::Transport(TransportMsg::NudgeBpm(delta)))
                 .padding([0, 4])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
@@ -10634,7 +10598,7 @@ fn global_key_handler(
 
     // Space: toggle playback (no modifiers required)
     if matches!(key, iced::keyboard::Key::Named(Named::Space)) {
-        return Some(Message::TogglePlayback);
+        return Some(Message::Transport(TransportMsg::TogglePlayback));
     }
 
     // Escape: cancel editing
@@ -10679,7 +10643,7 @@ fn global_key_handler(
             "m" => Some(Message::CreateClipFromSelection),
             "e" => Some(Message::SplitSelectedAtPlayhead),
             "j" => Some(Message::JoinSelectedClips),
-            "l" => Some(Message::ToggleArrangementLoop),
+            "l" => Some(Message::Transport(TransportMsg::ToggleArrangementLoop)),
             "0" => Some(Message::ZoomToFit),
             "z" | "Z" => {
                 if modifiers.shift() {

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -184,7 +184,10 @@ impl App {
         };
 
         let state = AppState {
-            sample_rate,
+            transport: crate::state::TransportState {
+                sample_rate,
+                ..Default::default()
+            },
             sample_browser_open: ui_settings.sample_browser_open,
             sample_browser_roots: ui_settings.sample_library_roots,
             auto_warp_on_import: ui_settings.auto_warp_on_import,
@@ -229,7 +232,7 @@ impl App {
         };
 
         // Inform the engine of the actual sample rate
-        app.send_command(EngineCommand::SetBpm(app.state.bpm));
+        app.send_command(EngineCommand::SetBpm(app.state.transport.bpm));
 
         let startup_task = if app.state.sample_browser_roots.is_empty() {
             Task::none()
@@ -255,8 +258,8 @@ impl App {
     }
 
     fn clear_project_runtime(&mut self) {
-        self.state.playing = false;
-        self.state.position_samples = 0;
+        self.state.transport.playing = false;
+        self.state.transport.position_samples = 0;
         self.send_command(EngineCommand::Stop);
         self.send_command(EngineCommand::Seek(0));
 
@@ -278,9 +281,9 @@ impl App {
         self.state.next_track_number = 1;
         self.state.selected_note_clip = None;
         self.state.selected_clips.clear();
-        self.state.loop_enabled = false;
-        self.state.loop_start_beats = 0.0;
-        self.state.loop_end_beats = 4.0;
+        self.state.transport.loop_enabled = false;
+        self.state.transport.loop_start_beats = 0.0;
+        self.state.transport.loop_end_beats = 4.0;
         self.state.time_selection_active = false;
         self.state.selection_start_beats = 0.0;
         self.state.selection_end_beats = 0.0;
@@ -295,9 +298,9 @@ impl App {
 
     fn reset_to_new_project(&mut self) {
         self.clear_project_runtime();
-        self.state.bpm = vibez_core::constants::DEFAULT_BPM;
-        self.state.bpm_text = format!("{:.0}", self.state.bpm);
-        self.send_command(EngineCommand::SetBpm(self.state.bpm));
+        self.state.transport.bpm = vibez_core::constants::DEFAULT_BPM;
+        self.state.transport.bpm_text = format!("{:.0}", self.state.transport.bpm);
+        self.send_command(EngineCommand::SetBpm(self.state.transport.bpm));
         self.state.current_project_path = None;
         self.state.project_dirty = false;
         self.undo_history.clear();
@@ -805,8 +808,8 @@ impl App {
                 .and_then(|path| path.file_stem())
                 .map(|name| name.to_string_lossy().to_string())
                 .unwrap_or_else(|| "Untitled".to_string()),
-            bpm: self.state.bpm,
-            sample_rate: self.state.sample_rate,
+            bpm: self.state.transport.bpm,
+            sample_rate: self.state.transport.sample_rate,
             tracks,
             clips,
             note_clips,
@@ -842,8 +845,8 @@ impl App {
         let mut plugin_instrument_requests: Vec<(TrackId, vibez_core::effect::PluginDeviceInfo)> =
             Vec::new();
         self.undo_history.clear();
-        self.state.bpm = loaded.project.bpm;
-        self.state.bpm_text = format!("{:.0}", loaded.project.bpm);
+        self.state.transport.bpm = loaded.project.bpm;
+        self.state.transport.bpm_text = format!("{:.0}", loaded.project.bpm);
         self.send_command(EngineCommand::SetBpm(loaded.project.bpm));
 
         for track_info in &loaded.project.tracks {
@@ -937,7 +940,7 @@ impl App {
                 }
                 let fx = vibez_dsp::factory::create_effect_with_params(
                     effect_info.effect_type,
-                    self.state.sample_rate as f32,
+                    self.state.transport.sample_rate as f32,
                     &effect_info.params,
                 );
                 let descriptors = fx.param_descriptors();
@@ -1116,7 +1119,7 @@ impl App {
 
         let effect_tx = self.plugin_effect_tx.clone();
         let instrument_tx = self.plugin_instrument_tx.clone();
-        let sample_rate = self.state.sample_rate as f64;
+        let sample_rate = self.state.transport.sample_rate as f64;
 
         std::thread::spawn(move || {
             use base64::Engine;
@@ -1242,8 +1245,8 @@ impl App {
         let assets = self.collect_bounce_assets();
         let project = self.project_from_state();
         let wav_path = self.next_bounce_path();
-        let sample_rate = self.state.sample_rate;
-        let bpm = self.state.bpm;
+        let sample_rate = self.state.transport.sample_rate;
+        let bpm = self.state.transport.bpm;
 
         let request = vibez_engine::render::BounceRequest {
             tracks: project.tracks,
@@ -1333,11 +1336,11 @@ impl App {
     fn take_snapshot(&self) -> crate::state::ProjectSnapshot {
         crate::state::ProjectSnapshot {
             tracks: self.state.tracks.clone(),
-            bpm: self.state.bpm,
-            bpm_text: self.state.bpm_text.clone(),
-            loop_enabled: self.state.loop_enabled,
-            loop_start_beats: self.state.loop_start_beats,
-            loop_end_beats: self.state.loop_end_beats,
+            bpm: self.state.transport.bpm,
+            bpm_text: self.state.transport.bpm_text.clone(),
+            loop_enabled: self.state.transport.loop_enabled,
+            loop_start_beats: self.state.transport.loop_start_beats,
+            loop_end_beats: self.state.transport.loop_end_beats,
             selected_track: self.state.selected_track,
             selected_clips: self.state.selected_clips.clone(),
             selected_note_clip: self.state.selected_note_clip,
@@ -1369,21 +1372,21 @@ impl App {
         }
 
         self.state.tracks = snapshot.tracks;
-        self.state.bpm = snapshot.bpm;
-        self.state.bpm_text = snapshot.bpm_text;
-        self.state.loop_enabled = snapshot.loop_enabled;
-        self.state.loop_start_beats = snapshot.loop_start_beats;
-        self.state.loop_end_beats = snapshot.loop_end_beats;
+        self.state.transport.bpm = snapshot.bpm;
+        self.state.transport.bpm_text = snapshot.bpm_text;
+        self.state.transport.loop_enabled = snapshot.loop_enabled;
+        self.state.transport.loop_start_beats = snapshot.loop_start_beats;
+        self.state.transport.loop_end_beats = snapshot.loop_end_beats;
         self.state.selected_track = snapshot.selected_track;
         self.state.selected_clips = snapshot.selected_clips;
         self.state.selected_note_clip = snapshot.selected_note_clip;
         self.state.next_track_number = snapshot.next_track_number;
 
-        self.send_command(EngineCommand::SetBpm(self.state.bpm));
-        self.send_command(EngineCommand::SetArrangementLoop(self.state.loop_enabled));
-        if self.state.loop_enabled {
-            let start = self.state.beats_to_samples(self.state.loop_start_beats);
-            let end = self.state.beats_to_samples(self.state.loop_end_beats);
+        self.send_command(EngineCommand::SetBpm(self.state.transport.bpm));
+        self.send_command(EngineCommand::SetArrangementLoop(self.state.transport.loop_enabled));
+        if self.state.transport.loop_enabled {
+            let start = self.state.beats_to_samples(self.state.transport.loop_start_beats);
+            let end = self.state.beats_to_samples(self.state.transport.loop_end_beats);
             self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
         }
 
@@ -1539,15 +1542,15 @@ impl App {
             self.state.status_text = "Clip not found".to_string();
             return Task::none();
         };
-        if self.state.bpm <= 0.0 || self.state.sample_rate == 0 {
+        if self.state.transport.bpm <= 0.0 || self.state.transport.sample_rate == 0 {
             self.state.status_text = "Cannot quantize at zero BPM".to_string();
             return Task::none();
         }
 
         let input = QuantizeInput {
             audio: Arc::clone(&clip.audio),
-            bpm: self.state.bpm,
-            sample_rate: self.state.sample_rate,
+            bpm: self.state.transport.bpm,
+            sample_rate: self.state.transport.sample_rate,
             grid,
             clip_position: clip.position,
             clip_source_offset: clip.source_offset,
@@ -1620,7 +1623,7 @@ impl App {
                 clip_id: success.new_clip_id,
             });
 
-        let duration_seconds = success.new_duration as f64 / self.state.sample_rate as f64;
+        let duration_seconds = success.new_duration as f64 / self.state.transport.sample_rate as f64;
         self.state.status_text = format!(
             "Quantized {} slice(s) to {} ({:.1}s)",
             success.slice_count, success.grid_label, duration_seconds
@@ -1642,7 +1645,7 @@ impl App {
             .original_audio
             .clone()
             .unwrap_or_else(|| Arc::clone(&clip.audio));
-        let sample_rate = self.state.sample_rate;
+        let sample_rate = self.state.transport.sample_rate;
         self.state.status_text = format!("Detecting BPM for {}...", clip.name);
         Task::perform(detect_clip_bpm_async(audio, sample_rate), move |estimate| {
             Message::ClipBpmDetected {
@@ -1659,14 +1662,14 @@ impl App {
     /// for warped clips. Shared by the BPM field and nudge buttons.
     fn set_project_bpm(&mut self, bpm: f64) -> Task<Message> {
         let bpm = bpm.clamp(20.0, 999.0);
-        let old_bpm = self.state.bpm;
-        self.state.bpm = bpm;
-        self.state.bpm_text = format!("{bpm:.0}");
+        let old_bpm = self.state.transport.bpm;
+        self.state.transport.bpm = bpm;
+        self.state.transport.bpm_text = format!("{bpm:.0}");
         self.send_command(EngineCommand::SetBpm(bpm));
         // Re-send loop region since the beat-to-sample mapping changed.
-        if self.state.loop_enabled {
-            let start = self.state.beats_to_samples(self.state.loop_start_beats);
-            let end = self.state.beats_to_samples(self.state.loop_end_beats);
+        if self.state.transport.loop_enabled {
+            let start = self.state.beats_to_samples(self.state.transport.loop_start_beats);
+            let end = self.state.beats_to_samples(self.state.transport.loop_end_beats);
             self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
         }
         if (bpm - old_bpm).abs() > f64::EPSILON {
@@ -1725,8 +1728,8 @@ impl App {
         track_id: TrackId,
         clip_id: ClipId,
     ) -> Task<Message> {
-        let project_bpm = self.state.bpm;
-        let sample_rate = self.state.sample_rate;
+        let project_bpm = self.state.transport.bpm;
+        let sample_rate = self.state.transport.sample_rate;
         if project_bpm <= 0.0 || sample_rate == 0 {
             self.state.status_text = "Cannot warp at zero BPM".to_string();
             return Task::none();
@@ -1822,13 +1825,13 @@ impl App {
         clip_id: ClipId,
         audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
     ) -> Task<Message> {
-        if !self.state.auto_warp_on_import || self.state.bpm <= 0.0 || self.state.sample_rate == 0 {
+        if !self.state.auto_warp_on_import || self.state.transport.bpm <= 0.0 || self.state.transport.sample_rate == 0 {
             return Task::none();
         }
         let input = AutoWarpInput {
             audio,
-            sample_rate: self.state.sample_rate,
-            project_bpm: self.state.bpm,
+            sample_rate: self.state.transport.sample_rate,
+            project_bpm: self.state.transport.bpm,
             confidence_threshold: self.state.warp_confidence_threshold,
         };
         Task::perform(auto_warp_clip_async(input), move |outcome| {
@@ -2099,17 +2102,17 @@ impl App {
 
         match message {
             Message::Play => {
-                self.state.playing = true;
+                self.state.transport.playing = true;
                 self.send_command(EngineCommand::Play);
             }
             Message::Stop => {
-                self.state.playing = false;
-                self.state.position_samples = 0;
+                self.state.transport.playing = false;
+                self.state.transport.position_samples = 0;
                 self.send_command(EngineCommand::Stop);
                 self.send_command(EngineCommand::Seek(0));
             }
             Message::TogglePlayback => {
-                if self.state.playing {
+                if self.state.transport.playing {
                     return self.update(Message::Stop);
                 } else {
                     return self.update(Message::Play);
@@ -2119,7 +2122,7 @@ impl App {
                 let total = self.state.total_duration_samples();
                 if total > 0 {
                     let sample_pos = (normalized * total as f64) as u64;
-                    self.state.position_samples = sample_pos;
+                    self.state.transport.position_samples = sample_pos;
                     self.send_command(EngineCommand::Seek(sample_pos));
                 }
                 // Simple click clears the time selection
@@ -2127,18 +2130,18 @@ impl App {
                 self.state.time_selection_track = None;
             }
             Message::NudgeBpm(delta) => {
-                let bpm = self.state.bpm + delta;
+                let bpm = self.state.transport.bpm + delta;
                 return self.set_project_bpm(bpm);
             }
             Message::BpmChanged(val) => {
-                self.state.bpm_text = val;
+                self.state.transport.bpm_text = val;
             }
             Message::BpmSubmit => {
-                if let Ok(bpm) = self.state.bpm_text.parse::<f64>() {
+                if let Ok(bpm) = self.state.transport.bpm_text.parse::<f64>() {
                     return self.set_project_bpm(bpm);
                 }
-                let bpm = self.state.bpm;
-                self.state.bpm_text = format!("{bpm:.0}");
+                let bpm = self.state.transport.bpm;
+                self.state.transport.bpm_text = format!("{bpm:.0}");
             }
 
             // -- Workspace --
@@ -2223,14 +2226,14 @@ impl App {
                 }
             }
             Message::EnginePosition(pos) => {
-                self.state.position_samples = pos;
+                self.state.transport.position_samples = pos;
             }
             Message::EngineMetering { peak_l, peak_r } => {
                 self.state.peak_l = peak_l;
                 self.state.peak_r = peak_r;
             }
             Message::EngineStopped => {
-                self.state.playing = false;
+                self.state.transport.playing = false;
             }
 
             // -- Multi-track messages --
@@ -2478,7 +2481,7 @@ impl App {
             Message::AddEffect(track_id, effect_type) => {
                 let effect_id = vibez_core::id::EffectId::new();
                 let fx =
-                    vibez_dsp::factory::create_effect(effect_type, self.state.sample_rate as f32);
+                    vibez_dsp::factory::create_effect(effect_type, self.state.transport.sample_rate as f32);
                 let descriptors = fx.param_descriptors();
                 let params: Vec<f32> = descriptors.iter().map(|d| d.default).collect();
 
@@ -3356,7 +3359,7 @@ impl App {
                 new_duration,
             } => {
                 // Update UI state — auto-enable loop when extending past source length
-                let spb = 60.0 * self.state.sample_rate as f64 / self.state.bpm;
+                let spb = 60.0 * self.state.transport.sample_rate as f64 / self.state.transport.bpm;
                 let mut sync_data = None;
                 let mut clip_end_beat = None;
                 if let Some(track) = self.state.find_track_mut(track_id) {
@@ -4038,7 +4041,7 @@ impl App {
                             let _ = self.update(Message::SplitAudioClip {
                                 track_id,
                                 clip_id,
-                                split_position: self.state.position_samples,
+                                split_position: self.state.transport.position_samples,
                             });
                         }
                         ArrangementSelection::NoteClip { track_id, clip_id } => {
@@ -4082,18 +4085,18 @@ impl App {
 
             // -- Arrangement loop --
             Message::ToggleArrangementLoop => {
-                self.state.loop_enabled = !self.state.loop_enabled;
-                self.send_command(EngineCommand::SetArrangementLoop(self.state.loop_enabled));
-                if self.state.loop_enabled {
+                self.state.transport.loop_enabled = !self.state.transport.loop_enabled;
+                self.send_command(EngineCommand::SetArrangementLoop(self.state.transport.loop_enabled));
+                if self.state.transport.loop_enabled {
                     // Copy selection to loop region when enabling loop with active selection
                     if self.state.time_selection_active
                         && self.state.selection_end_beats > self.state.selection_start_beats
                     {
-                        self.state.loop_start_beats = self.state.selection_start_beats;
-                        self.state.loop_end_beats = self.state.selection_end_beats;
+                        self.state.transport.loop_start_beats = self.state.selection_start_beats;
+                        self.state.transport.loop_end_beats = self.state.selection_end_beats;
                     }
-                    let start = self.state.beats_to_samples(self.state.loop_start_beats);
-                    let end = self.state.beats_to_samples(self.state.loop_end_beats);
+                    let start = self.state.beats_to_samples(self.state.transport.loop_start_beats);
+                    let end = self.state.beats_to_samples(self.state.transport.loop_end_beats);
                     self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
                 }
             }
@@ -4101,8 +4104,8 @@ impl App {
                 start_beats,
                 end_beats,
             } => {
-                self.state.loop_start_beats = start_beats;
-                self.state.loop_end_beats = end_beats;
+                self.state.transport.loop_start_beats = start_beats;
+                self.state.transport.loop_end_beats = end_beats;
                 let start = self.state.beats_to_samples(start_beats);
                 let end = self.state.beats_to_samples(end_beats);
                 self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
@@ -4124,13 +4127,13 @@ impl App {
             }
             Message::SetSelectionAsLoop => {
                 self.state.context_menu = None;
-                self.state.loop_start_beats = self.state.selection_start_beats;
-                self.state.loop_end_beats = self.state.selection_end_beats;
-                let start = self.state.beats_to_samples(self.state.loop_start_beats);
-                let end = self.state.beats_to_samples(self.state.loop_end_beats);
+                self.state.transport.loop_start_beats = self.state.selection_start_beats;
+                self.state.transport.loop_end_beats = self.state.selection_end_beats;
+                let start = self.state.beats_to_samples(self.state.transport.loop_start_beats);
+                let end = self.state.beats_to_samples(self.state.transport.loop_end_beats);
                 self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
-                if !self.state.loop_enabled {
-                    self.state.loop_enabled = true;
+                if !self.state.transport.loop_enabled {
+                    self.state.transport.loop_enabled = true;
                     self.send_command(EngineCommand::SetArrangementLoop(true));
                 }
             }
@@ -4198,8 +4201,8 @@ impl App {
                 track_id: target_track,
             } => {
                 self.state.context_menu = None;
-                let spb = if self.state.bpm > 0.0 {
-                    self.state.sample_rate as f64 * 60.0 / self.state.bpm
+                let spb = if self.state.transport.bpm > 0.0 {
+                    self.state.transport.sample_rate as f64 * 60.0 / self.state.transport.bpm
                 } else {
                     0.0
                 };
@@ -4252,8 +4255,8 @@ impl App {
                 track_id: target_track,
             } => {
                 self.state.context_menu = None;
-                let spb = if self.state.bpm > 0.0 {
-                    self.state.sample_rate as f64 * 60.0 / self.state.bpm
+                let spb = if self.state.transport.bpm > 0.0 {
+                    self.state.transport.sample_rate as f64 * 60.0 / self.state.transport.bpm
                 } else {
                     0.0
                 };
@@ -4509,7 +4512,7 @@ impl App {
 
             // -- Instrument attach/detach --
             Message::SetTrackInstrument(track_id, instrument_kind) => {
-                let sample_rate = self.state.sample_rate as f32;
+                let sample_rate = self.state.transport.sample_rate as f32;
                 let instrument_params = default_instrument_params(instrument_kind, sample_rate);
                 if let Some(track) = self.state.find_track_mut(track_id) {
                     track.has_instrument = true;
@@ -4686,7 +4689,7 @@ impl App {
                     .map(|(tid, cid)| self.dispatch_warp_clip_to_project(tid, cid))
                     .collect();
                 self.state.status_text =
-                    format!("Re-warping {count} clip(s) to {:.0} BPM", self.state.bpm);
+                    format!("Re-warping {count} clip(s) to {:.0} BPM", self.state.transport.bpm);
                 return Task::batch(tasks);
             }
             Message::AddSampleLibraryRoot => {
@@ -5103,7 +5106,7 @@ impl App {
                             if let Err(e) = stream.play() {
                                 eprintln!("vibez: failed to restart audio stream: {e}");
                             }
-                            self.state.sample_rate = sr;
+                            self.state.transport.sample_rate = sr;
                             self.state.status_text =
                                 format!("Audio restarted — buffer {size}, {sr} Hz");
                         }
@@ -5203,7 +5206,7 @@ impl App {
                     .find(|p| p.id == plugin_id)
                     .cloned()
                 {
-                    let sample_rate = self.state.sample_rate as f64;
+                    let sample_rate = self.state.transport.sample_rate as f64;
                     let is_instrument = info.category.is_instrument();
                     let loading_name = info.name.clone();
 
@@ -5321,7 +5324,7 @@ impl App {
             } => {
                 self.state.context_menu = None;
                 let (range, insert_pos, name) = if is_note_clip {
-                    let spb = self.state.sample_rate as f64 * 60.0 / self.state.bpm;
+                    let spb = self.state.transport.sample_rate as f64 * 60.0 / self.state.transport.bpm;
                     let track_opt = self.state.find_track(track_id);
                     let nc = track_opt.and_then(|t| t.note_clips.iter().find(|c| c.id == clip_id));
                     match nc {
@@ -5521,8 +5524,8 @@ impl App {
                 }
                 let assets = self.collect_bounce_assets();
                 let project = self.project_from_state();
-                let sample_rate = self.state.sample_rate;
-                let bpm = self.state.bpm;
+                let sample_rate = self.state.transport.sample_rate;
+                let bpm = self.state.transport.bpm;
                 let request = vibez_engine::render::BounceRequest {
                     tracks: project.tracks,
                     audio_clips: project.clips,
@@ -6254,17 +6257,17 @@ impl App {
                         drop(cell.take());
                     }
                     EngineEvent::PlaybackPosition(pos) => {
-                        self.state.position_samples = pos;
+                        self.state.transport.position_samples = pos;
                     }
                     EngineEvent::Metering { peak_l, peak_r, .. } => {
                         self.state.peak_l = peak_l.max(self.state.peak_l * 0.85);
                         self.state.peak_r = peak_r.max(self.state.peak_r * 0.85);
                     }
                     EngineEvent::PlaybackStopped => {
-                        self.state.playing = false;
+                        self.state.transport.playing = false;
                     }
                     EngineEvent::PlaybackStarted => {
-                        self.state.playing = true;
+                        self.state.transport.playing = true;
                     }
                     EngineEvent::TrackMeter {
                         track_id,
@@ -6607,7 +6610,7 @@ impl App {
         }
 
         let sr_label = text("Sample Rate").size(14).color(th::TEXT);
-        let sr_value = text(format!("{} Hz", self.state.sample_rate))
+        let sr_value = text(format!("{} Hz", self.state.transport.sample_rate))
             .size(13)
             .color(th::TEXT_DIM);
 
@@ -7118,7 +7121,7 @@ impl App {
                         },
                     ));
                 } else {
-                    let split_sample = self.state.position_samples;
+                    let split_sample = self.state.transport.position_samples;
                     col = col.push(menu_btn(
                         icons::SCISSORS,
                         "Split at Playhead".into(),
@@ -8274,8 +8277,8 @@ impl App {
         }
 
         let playhead_beats = self.state.position_beats();
-        let sample_rate = self.state.sample_rate;
-        let bpm = self.state.bpm;
+        let sample_rate = self.state.transport.sample_rate;
+        let bpm = self.state.transport.bpm;
         let zoom_level = self.state.zoom_level;
         let scroll_offset = self.state.scroll_offset_beats;
         let total_beats = self.state.total_beats();
@@ -8287,9 +8290,9 @@ impl App {
             zoom_level,
             scroll_offset_beats: scroll_offset,
             total_beats,
-            loop_enabled: self.state.loop_enabled,
-            loop_start_beats: self.state.loop_start_beats,
-            loop_end_beats: self.state.loop_end_beats,
+            loop_enabled: self.state.transport.loop_enabled,
+            loop_start_beats: self.state.transport.loop_start_beats,
+            loop_end_beats: self.state.transport.loop_end_beats,
             time_selection_active: self.state.time_selection_active,
             selection_start_beats: self.state.selection_start_beats,
             selection_end_beats: self.state.selection_end_beats,
@@ -8324,9 +8327,9 @@ impl App {
             zoom_level,
             playhead_beats,
             bpm,
-            loop_enabled: self.state.loop_enabled,
-            loop_start_beats: self.state.loop_start_beats,
-            loop_end_beats: self.state.loop_end_beats,
+            loop_enabled: self.state.transport.loop_enabled,
+            loop_start_beats: self.state.transport.loop_start_beats,
+            loop_end_beats: self.state.transport.loop_end_beats,
             tracks: self
                 .state
                 .tracks
@@ -8415,9 +8418,9 @@ impl App {
                 track_ids.clone(),
                 track_kinds.clone(),
                 selected_clips,
-                self.state.loop_enabled,
-                self.state.loop_start_beats,
-                self.state.loop_end_beats,
+                self.state.transport.loop_enabled,
+                self.state.transport.loop_start_beats,
+                self.state.transport.loop_end_beats,
                 self.state.time_selection_active,
                 self.state.selection_start_beats,
                 self.state.selection_end_beats,
@@ -10080,7 +10083,7 @@ impl App {
         clip: &UiClip,
         track_color: Color,
     ) -> Element<'_, Message> {
-        let playhead_samples = self.state.position_samples;
+        let playhead_samples = self.state.transport.position_samples;
         let playhead_normalized = if clip.duration > 0
             && playhead_samples >= clip.position
             && playhead_samples < clip.position + clip.duration
@@ -10094,7 +10097,7 @@ impl App {
             audio: Arc::clone(&clip.audio),
             duration_samples: clip.duration,
             source_offset: clip.source_offset,
-            sample_rate: self.state.sample_rate,
+            sample_rate: self.state.transport.sample_rate,
             track_color,
             playhead_normalized,
             loop_enabled: clip.loop_enabled,
@@ -10111,7 +10114,7 @@ impl App {
         let clip_info = text(format!(
             "{}: {:.1}s",
             clip.name,
-            clip.duration as f64 / self.state.sample_rate as f64
+            clip.duration as f64 / self.state.transport.sample_rate as f64
         ))
         .size(10)
         .color(th::TEXT_MUTED);
@@ -10190,7 +10193,7 @@ impl App {
             .style(button_style);
 
         let warp_btn = button(
-            text(format!("Warp → {:.0} BPM", self.state.bpm))
+            text(format!("Warp → {:.0} BPM", self.state.transport.bpm))
                 .size(11)
                 .color(th::TEXT),
         )
@@ -10210,7 +10213,7 @@ impl App {
             row_widgets = row_widgets.push(clear_btn);
 
             if let Some(warped_to) = clip.warped_to_bpm {
-                let stale = (warped_to - self.state.bpm).abs() > 0.01;
+                let stale = (warped_to - self.state.transport.bpm).abs() > 0.01;
                 if stale {
                     row_widgets = row_widgets.push(
                         text(format!("(was {:.0})", warped_to))
@@ -10224,11 +10227,11 @@ impl App {
             // the clip knows its tempo and it disagrees with the
             // project. Say so loudly instead of a status-bar whisper;
             // the Warp button on this same row is the one-click fix.
-            if (detected - self.state.bpm).abs() > 0.5 {
+            if (detected - self.state.transport.bpm).abs() > 0.5 {
                 row_widgets = row_widgets.push(
                     text(format!(
                         "OUT OF TEMPO: clip {detected:.1} BPM vs project {:.0}",
-                        self.state.bpm
+                        self.state.transport.bpm
                     ))
                     .size(10)
                     .color(th::METER_YELLOW),
@@ -10301,7 +10304,7 @@ impl App {
             });
 
         // Play/Pause button
-        let play_pause_btn = if self.state.playing {
+        let play_pause_btn = if self.state.transport.playing {
             button(icons::icon(icons::PAUSE).size(16).color(th::ACCENT))
                 .on_press(Message::Stop)
                 .padding([8, 14])
@@ -10332,7 +10335,7 @@ impl App {
         };
 
         // Loop toggle button
-        let loop_btn = if self.state.loop_enabled {
+        let loop_btn = if self.state.transport.loop_enabled {
             button(icons::icon(icons::REPEAT).size(16).color(th::ACCENT))
                 .on_press(Message::ToggleArrangementLoop)
                 .padding([8, 12])
@@ -10374,7 +10377,7 @@ impl App {
         .color(th::TEXT);
 
         // BPM
-        let bpm_input = text_input("BPM", &self.state.bpm_text)
+        let bpm_input = text_input("BPM", &self.state.transport.bpm_text)
             .on_input(Message::BpmChanged)
             .on_submit(Message::BpmSubmit)
             .width(Length::Fixed(55.0))

--- a/crates/vibez-ui/src/domains/mod.rs
+++ b/crates/vibez-ui/src/domains/mod.rs
@@ -1,0 +1,44 @@
+//! Domain modules: the architecture refactor's core pattern.
+//!
+//! Each domain owns a slice of application state (defined in
+//! `state.rs`), its own message enum, and an `update` function that
+//! can only touch its own slice plus the narrow interfaces below.
+//! app.rs shrinks to a router. TypeScript mental model: these are
+//! Redux slices; `EngineHandle` is an injected service interface.
+
+pub mod transport;
+
+use vibez_engine::commands::EngineCommand;
+
+/// The one way domains talk to the audio engine. A trait (interface)
+/// instead of the concrete channel so tests can inject a recorder
+/// and assert on the exact commands a message produced.
+pub trait EngineHandle {
+    fn send(&mut self, cmd: EngineCommand);
+}
+
+/// Production implementation: wraps the real lock-free command queue.
+pub struct EngineTx<'a>(pub &'a mut Option<rtrb::Producer<EngineCommand>>);
+
+impl EngineHandle for EngineTx<'_> {
+    fn send(&mut self, cmd: EngineCommand) {
+        if let Some(tx) = self.0.as_mut() {
+            let _ = tx.push(cmd);
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test_support {
+    use super::*;
+
+    /// Test double: records every command instead of sending it.
+    #[derive(Default)]
+    pub struct RecordingEngine(pub Vec<EngineCommand>);
+
+    impl EngineHandle for RecordingEngine {
+        fn send(&mut self, cmd: EngineCommand) {
+            self.0.push(cmd);
+        }
+    }
+}

--- a/crates/vibez-ui/src/domains/transport.rs
+++ b/crates/vibez-ui/src/domains/transport.rs
@@ -1,0 +1,299 @@
+//! Transport domain: playback, tempo, and the arrangement loop.
+//!
+//! The reference implementation of the domain pattern. `update`
+//! receives only the transport slice, an engine handle, and a small
+//! read-only context of facts from other domains; anything it cannot
+//! do itself is returned as a [`TransportAction`] for app.rs to
+//! route. That boundary is what isolates bugs and makes this file
+//! unit-testable without iced.
+
+use vibez_engine::commands::EngineCommand;
+
+use super::EngineHandle;
+use crate::state::TransportState;
+
+/// Messages the transport domain handles.
+#[derive(Debug, Clone)]
+pub enum TransportMsg {
+    Play,
+    Stop,
+    TogglePlayback,
+    /// Seek to a normalized [0, 1] position on the timeline.
+    Seek(f64),
+    BpmChanged(String),
+    BpmSubmit,
+    /// Increment/decrement project BPM by a whole beat-per-minute.
+    NudgeBpm(f64),
+    ToggleArrangementLoop,
+    SetArrangementLoopRegion {
+        start_beats: f64,
+        end_beats: f64,
+    },
+    /// Engine events routed to this domain.
+    EnginePosition(u64),
+    EngineStopped,
+}
+
+/// Read-only facts from other domains that transport decisions need.
+/// Computed by the router; keeps this module free of arrangement
+/// internals.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TransportCtx {
+    /// Total arrangement length in samples (for Seek normalization).
+    pub total_duration_samples: u64,
+    /// Active time selection in beats, if any (loop-enable copies it).
+    pub time_selection: Option<(f64, f64)>,
+}
+
+/// Cross-domain effects the transport cannot perform itself. The
+/// router (app.rs) translates these into calls on other domains.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TransportAction {
+    None,
+    /// A seek happened; the arrangement should clear its time selection.
+    ClearTimeSelection,
+    /// The project tempo changed; warped clips must follow.
+    TempoChanged {
+        old_bpm: f64,
+        new_bpm: f64,
+    },
+}
+
+impl TransportState {
+    /// Beat position -> absolute sample position at the current tempo.
+    pub fn beats_to_samples_at(&self, beats: f64) -> u64 {
+        if self.bpm > 0.0 {
+            (beats * self.sample_rate as f64 * 60.0 / self.bpm) as u64
+        } else {
+            0
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        msg: TransportMsg,
+        engine: &mut impl EngineHandle,
+        ctx: TransportCtx,
+    ) -> TransportAction {
+        match msg {
+            TransportMsg::Play => {
+                self.playing = true;
+                engine.send(EngineCommand::Play);
+                TransportAction::None
+            }
+            TransportMsg::Stop => {
+                self.playing = false;
+                self.position_samples = 0;
+                engine.send(EngineCommand::Stop);
+                engine.send(EngineCommand::Seek(0));
+                TransportAction::None
+            }
+            TransportMsg::TogglePlayback => {
+                let next = if self.playing {
+                    TransportMsg::Stop
+                } else {
+                    TransportMsg::Play
+                };
+                self.update(next, engine, ctx)
+            }
+            TransportMsg::Seek(normalized) => {
+                if ctx.total_duration_samples > 0 {
+                    let sample_pos =
+                        (normalized.clamp(0.0, 1.0) * ctx.total_duration_samples as f64) as u64;
+                    self.position_samples = sample_pos;
+                    engine.send(EngineCommand::Seek(sample_pos));
+                }
+                TransportAction::ClearTimeSelection
+            }
+            TransportMsg::BpmChanged(text) => {
+                self.bpm_text = text;
+                TransportAction::None
+            }
+            TransportMsg::BpmSubmit => match self.bpm_text.parse::<f64>() {
+                Ok(bpm) => self.set_bpm(bpm, engine),
+                Err(_) => {
+                    self.bpm_text = format!("{:.0}", self.bpm);
+                    TransportAction::None
+                }
+            },
+            TransportMsg::NudgeBpm(delta) => {
+                let bpm = self.bpm + delta;
+                self.set_bpm(bpm, engine)
+            }
+            TransportMsg::ToggleArrangementLoop => {
+                self.loop_enabled = !self.loop_enabled;
+                engine.send(EngineCommand::SetArrangementLoop(self.loop_enabled));
+                if self.loop_enabled {
+                    // Enabling the loop adopts an active time selection.
+                    if let Some((start, end)) = ctx.time_selection {
+                        if end > start {
+                            self.loop_start_beats = start;
+                            self.loop_end_beats = end;
+                        }
+                    }
+                    self.send_loop_region(engine);
+                }
+                TransportAction::None
+            }
+            TransportMsg::SetArrangementLoopRegion {
+                start_beats,
+                end_beats,
+            } => {
+                self.loop_start_beats = start_beats;
+                self.loop_end_beats = end_beats;
+                self.send_loop_region(engine);
+                TransportAction::None
+            }
+            TransportMsg::EnginePosition(pos) => {
+                self.position_samples = pos;
+                TransportAction::None
+            }
+            TransportMsg::EngineStopped => {
+                self.playing = false;
+                TransportAction::None
+            }
+        }
+    }
+
+    /// Apply a new tempo: clamp, notify the engine, remap the loop
+    /// region, and report the change so warped clips can follow.
+    fn set_bpm(&mut self, bpm: f64, engine: &mut impl EngineHandle) -> TransportAction {
+        let bpm = bpm.clamp(20.0, 999.0);
+        let old_bpm = self.bpm;
+        self.bpm = bpm;
+        self.bpm_text = format!("{bpm:.0}");
+        engine.send(EngineCommand::SetBpm(bpm));
+        if self.loop_enabled {
+            self.send_loop_region(engine);
+        }
+        if (bpm - old_bpm).abs() > f64::EPSILON {
+            TransportAction::TempoChanged {
+                old_bpm,
+                new_bpm: bpm,
+            }
+        } else {
+            TransportAction::None
+        }
+    }
+
+    fn send_loop_region(&self, engine: &mut impl EngineHandle) {
+        let start = self.beats_to_samples_at(self.loop_start_beats);
+        let end = self.beats_to_samples_at(self.loop_end_beats);
+        engine.send(EngineCommand::SetArrangementLoopRegion { start, end });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::RecordingEngine;
+    use super::*;
+
+    fn transport() -> TransportState {
+        TransportState::default()
+    }
+
+    #[test]
+    fn play_sends_play_and_sets_state() {
+        let mut t = transport();
+        let mut engine = RecordingEngine::default();
+        t.update(TransportMsg::Play, &mut engine, TransportCtx::default());
+        assert!(t.playing);
+        assert!(matches!(engine.0[0], EngineCommand::Play));
+    }
+
+    #[test]
+    fn stop_resets_position_and_seeks_zero() {
+        let mut t = transport();
+        t.playing = true;
+        t.position_samples = 12345;
+        let mut engine = RecordingEngine::default();
+        t.update(TransportMsg::Stop, &mut engine, TransportCtx::default());
+        assert!(!t.playing);
+        assert_eq!(t.position_samples, 0);
+        assert!(matches!(engine.0[1], EngineCommand::Seek(0)));
+    }
+
+    #[test]
+    fn bpm_submit_parses_clamps_and_reports_change() {
+        let mut t = transport();
+        t.bpm_text = "1500".to_string();
+        let mut engine = RecordingEngine::default();
+        let action = t.update(
+            TransportMsg::BpmSubmit,
+            &mut engine,
+            TransportCtx::default(),
+        );
+        assert_eq!(t.bpm, 999.0);
+        assert_eq!(
+            action,
+            TransportAction::TempoChanged {
+                old_bpm: 120.0,
+                new_bpm: 999.0
+            }
+        );
+        assert!(matches!(engine.0[0], EngineCommand::SetBpm(b) if (b - 999.0).abs() < 1e-9));
+    }
+
+    #[test]
+    fn garbage_bpm_text_restores_current_tempo() {
+        let mut t = transport();
+        t.bpm_text = "not a number".to_string();
+        let mut engine = RecordingEngine::default();
+        let action = t.update(
+            TransportMsg::BpmSubmit,
+            &mut engine,
+            TransportCtx::default(),
+        );
+        assert_eq!(action, TransportAction::None);
+        assert_eq!(t.bpm_text, "120");
+        assert!(engine.0.is_empty());
+    }
+
+    #[test]
+    fn seek_clamps_and_requests_selection_clear() {
+        let mut t = transport();
+        let mut engine = RecordingEngine::default();
+        let ctx = TransportCtx {
+            total_duration_samples: 1000,
+            time_selection: None,
+        };
+        let action = t.update(TransportMsg::Seek(2.0), &mut engine, ctx);
+        assert_eq!(t.position_samples, 1000);
+        assert_eq!(action, TransportAction::ClearTimeSelection);
+    }
+
+    #[test]
+    fn enabling_loop_adopts_time_selection() {
+        let mut t = transport();
+        let mut engine = RecordingEngine::default();
+        let ctx = TransportCtx {
+            total_duration_samples: 0,
+            time_selection: Some((4.0, 8.0)),
+        };
+        t.update(TransportMsg::ToggleArrangementLoop, &mut engine, ctx);
+        assert!(t.loop_enabled);
+        assert_eq!((t.loop_start_beats, t.loop_end_beats), (4.0, 8.0));
+        assert!(matches!(
+            engine.0[1],
+            EngineCommand::SetArrangementLoopRegion { .. }
+        ));
+    }
+
+    #[test]
+    fn nudge_from_spinner_reports_tempo_change() {
+        let mut t = transport();
+        let mut engine = RecordingEngine::default();
+        let action = t.update(
+            TransportMsg::NudgeBpm(1.0),
+            &mut engine,
+            TransportCtx::default(),
+        );
+        assert_eq!(
+            action,
+            TransportAction::TempoChanged {
+                old_bpm: 120.0,
+                new_bpm: 121.0
+            }
+        );
+    }
+}

--- a/crates/vibez-ui/src/lib.rs
+++ b/crates/vibez-ui/src/lib.rs
@@ -1,4 +1,5 @@
 mod app;
+mod domains;
 pub mod icons;
 mod message;
 pub mod plugin_window;

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -149,29 +149,18 @@ pub struct ProjectLoadResult {
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    // Transport
-    Play,
-    Stop,
-    TogglePlayback,
-    Seek(f64),
-
-    // BPM
-    BpmChanged(String),
-    BpmSubmit,
-    /// Increment/decrement project BPM by a whole beat-per-minute.
-    NudgeBpm(f64),
+    /// Transport domain (playback, tempo, arrangement loop).
+    Transport(crate::domains::transport::TransportMsg),
 
     // Workspace
     SwitchWorkspace(Workspace),
 
     // Engine events
     Tick,
-    EnginePosition(u64),
     EngineMetering {
         peak_l: f32,
         peak_r: f32,
     },
-    EngineStopped,
 
     // Multi-track
     AddTrack,
@@ -349,11 +338,6 @@ pub enum Message {
     SwitchDetailTab(DetailPanelTab),
 
     // Arrangement loop
-    ToggleArrangementLoop,
-    SetArrangementLoopRegion {
-        start_beats: f64,
-        end_beats: f64,
-    },
 
     // Time selection + context menu
     SetTimeSelection {

--- a/crates/vibez-ui/src/state.rs
+++ b/crates/vibez-ui/src/state.rs
@@ -464,15 +464,40 @@ pub struct DeviceContextMenu {
     pub search: String,
 }
 
-pub struct AppState {
-    // Transport
+/// Transport domain state: playback position, tempo, and the
+/// arrangement loop. First extracted domain slice of the
+/// architecture refactor: owns everything the transport bar and the
+/// beat/sample math need, and nothing else.
+#[derive(Debug)]
+pub struct TransportState {
     pub playing: bool,
     pub position_samples: u64,
     pub sample_rate: u32,
-
-    // BPM
     pub bpm: f64,
     pub bpm_text: String,
+    pub loop_enabled: bool,
+    pub loop_start_beats: f64,
+    pub loop_end_beats: f64,
+}
+
+impl Default for TransportState {
+    fn default() -> Self {
+        Self {
+            playing: false,
+            position_samples: 0,
+            sample_rate: 44_100,
+            bpm: 120.0,
+            bpm_text: "120".to_string(),
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 4.0,
+        }
+    }
+}
+
+pub struct AppState {
+    // Transport domain slice (playback, tempo, arrangement loop).
+    pub transport: TransportState,
 
     // Metering (master)
     pub peak_l: f32,
@@ -505,10 +530,6 @@ pub struct AppState {
     pub detail_panel_tab: DetailPanelTab,
 
     // Arrangement loop
-    pub loop_enabled: bool,
-    pub loop_start_beats: f64,
-    pub loop_end_beats: f64,
-
     // Time selection (visible brackets on arrangement — independent from loop)
     pub time_selection_active: bool,
     pub selection_start_beats: f64,
@@ -590,11 +611,11 @@ pub struct AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            playing: false,
-            position_samples: 0,
-            sample_rate: 44_100,
-            bpm: DEFAULT_BPM,
-            bpm_text: format!("{DEFAULT_BPM:.0}"),
+            transport: TransportState {
+                bpm: DEFAULT_BPM,
+                bpm_text: format!("{DEFAULT_BPM:.0}"),
+                ..TransportState::default()
+            },
             peak_l: 0.0,
             peak_r: 0.0,
             status_text: "Ready — Add a track to get started".to_string(),
@@ -609,9 +630,6 @@ impl Default for AppState {
             selected_note_clip: None,
             selected_clips: HashSet::new(),
             detail_panel_tab: DetailPanelTab::Clip,
-            loop_enabled: false,
-            loop_start_beats: 0.0,
-            loop_end_beats: 4.0,
             time_selection_active: false,
             selection_start_beats: 0.0,
             selection_end_beats: 0.0,
@@ -662,17 +680,17 @@ pub fn default_drum_rack_pads() -> Vec<UiDrumPad> {
 
 impl AppState {
     pub fn position_seconds(&self) -> f64 {
-        self.position_samples as f64 / self.sample_rate as f64
+        self.transport.position_samples as f64 / self.transport.sample_rate as f64
     }
 
     pub fn position_beats(&self) -> f64 {
-        self.position_seconds() * self.bpm / 60.0
+        self.position_seconds() * self.transport.bpm / 60.0
     }
 
     pub fn duration_seconds(&self) -> f64 {
         let samples = self.total_duration_samples();
         if samples > 0 {
-            samples as f64 / self.sample_rate as f64
+            samples as f64 / self.transport.sample_rate as f64
         } else {
             0.0
         }
@@ -721,8 +739,8 @@ impl AppState {
     /// Total duration in beats across all tracks, with generous padding.
     pub fn total_beats(&self) -> f64 {
         let dur = self.duration_seconds();
-        if dur > 0.0 && self.bpm > 0.0 {
-            let content_beats = dur * self.bpm / 60.0;
+        if dur > 0.0 && self.transport.bpm > 0.0 {
+            let content_beats = dur * self.transport.bpm / 60.0;
             // Pad by 32 beats or 25% of content, whichever is larger
             let padding = (content_beats * 0.25).max(32.0);
             (content_beats + padding).max(64.0)
@@ -734,8 +752,8 @@ impl AppState {
 
     /// Convert a beat value to a sample position.
     pub fn beats_to_samples(&self, beats: f64) -> u64 {
-        if self.bpm > 0.0 {
-            (beats * self.sample_rate as f64 * 60.0 / self.bpm) as u64
+        if self.transport.bpm > 0.0 {
+            (beats * self.transport.sample_rate as f64 * 60.0 / self.transport.bpm) as u64
         } else {
             0
         }
@@ -779,8 +797,8 @@ impl AppState {
             .unwrap_or(0);
 
         // Include note clips: convert beat positions to samples
-        let spb = if self.bpm > 0.0 {
-            self.sample_rate as f64 * 60.0 / self.bpm
+        let spb = if self.transport.bpm > 0.0 {
+            self.transport.sample_rate as f64 * 60.0 / self.transport.bpm
         } else {
             0.0
         };

--- a/crates/vibez-ui/src/widgets/timeline.rs
+++ b/crates/vibez-ui/src/widgets/timeline.rs
@@ -4,6 +4,7 @@ use iced::mouse;
 use iced::widget::canvas;
 use iced::{Color, Rectangle, Renderer, Theme};
 
+use crate::domains::transport::TransportMsg;
 use crate::message::Message;
 use crate::state::{ArrangementSelection, ContextMenuTarget, UiTrack};
 use crate::theme;
@@ -520,7 +521,7 @@ impl canvas::Program<Message> for RulerWidget {
                             // Short click → seek + clear selection
                             if self.total_beats > 0.0 {
                                 let normalized = (*beat / self.total_beats).clamp(0.0, 1.0);
-                                Some(Message::Seek(normalized))
+                                Some(Message::Transport(TransportMsg::Seek(normalized)))
                             } else {
                                 None
                             }
@@ -1780,7 +1781,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                             // Short click → seek + clear selection
                             if self.total_beats > 0.0 {
                                 let normalized = (*beat / self.total_beats).clamp(0.0, 1.0);
-                                Some(Message::Seek(normalized))
+                                Some(Message::Transport(TransportMsg::Seek(normalized)))
                             } else {
                                 None
                             }

--- a/crates/vibez-ui/src/widgets/waveform.rs
+++ b/crates/vibez-ui/src/widgets/waveform.rs
@@ -6,6 +6,7 @@ use iced::{Color, Rectangle, Renderer, Theme};
 
 use vibez_core::audio_buffer::DecodedAudio;
 
+use crate::domains::transport::TransportMsg;
 use crate::theme;
 
 pub struct WaveformWidget {
@@ -171,7 +172,9 @@ impl canvas::Program<crate::message::Message> for WaveformWidget {
                 let normalized = (pos.x / bounds.width) as f64;
                 return (
                     canvas::event::Status::Captured,
-                    Some(crate::message::Message::Seek(normalized.clamp(0.0, 1.0))),
+                    Some(crate::message::Message::Transport(TransportMsg::Seek(
+                        normalized.clamp(0.0, 1.0),
+                    ))),
                 );
             }
         }


### PR DESCRIPTION
First tranche of the agreed architecture refactor (goals: maintainable, bugs isolated, testable). Zero intended behavior change; full workspace suite green at every commit.

**The pattern (TypeScript mental model: Redux slices + injected service interfaces):**
- AppState begins splitting into domain slices; TransportState (playback, tempo, arrangement loop) is the first, with the compiler enumerating all 145 usage sites during the move.
- domains/mod.rs introduces EngineHandle, the one interface domains use to reach the engine: production wraps the lock-free queue, tests inject a RecordingEngine double.
- domains/transport.rs is the reference domain: TransportMsg (11 former top-level Message variants), an update() owning all transport logic, TransportCtx for read-only cross-domain facts in, TransportAction for cross-domain effects out (seek clears time selection; tempo changes trigger warped-clip follow). app.rs's eleven handler arms collapse into one 20-line router arm.
- Seven unit tests: the first UI-logic unit tests in the codebase (play/stop command sequences, BPM parse/clamp/tempo-follow reporting, seek clamping, loop adopting the time selection).

**Why merge now:** every commit is a safe checkpoint; merging keeps main as the base while the next (hairier) tranche extracts the devices/plugins domain on a fresh branch.

Test plan: transport bar in the app (play/stop/space/seek/BPM typing/nudge spinner/loop toggle with an active selection): identical behavior to before; cargo test shows domains::transport tests.