### PR TITLE
refactor(ui): domain architecture, tranche 2: devices domain

### DIFF
--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -290,7 +290,7 @@ impl App {
         self.state.selection_end_beats = 0.0;
         self.state.scroll_offset_beats = 0.0;
         self.state.context_menu = None;
-        self.state.device_context_menu = None;
+        self.state.devices.context_menu = None;
         self.state.file_menu_open = false;
         self.state.editing_track_name = None;
         self.state.editing_clip_name = None;
@@ -1665,6 +1665,23 @@ impl App {
         })
     }
 
+    /// Route cross-domain effects requested by the devices domain.
+    fn apply_devices_action(&mut self, action: crate::domains::devices::DevicesAction) {
+        if let Some(key) = action.close_gui {
+            if let Some(ref mut mgr) = self.plugin_window_manager {
+                mgr.close(key);
+            }
+            self.plugin_gui_raw_ptrs.remove(&key);
+            self.plugin_state_ptrs.remove(&key);
+        }
+        if let Some(track_id) = action.select_track {
+            self.state.selected_track = Some(track_id);
+        }
+        if let Some(status) = action.status {
+            self.state.status_text = status;
+        }
+    }
+
     /// Route a cross-domain effect requested by the transport domain.
     fn apply_transport_action(
         &mut self,
@@ -2040,20 +2057,9 @@ impl App {
                 | Message::SetTrackPan(..)
                 | Message::SetTrackMute(_)
                 | Message::SetTrackSolo(_)
-                | Message::AddEffect(..)
-                | Message::RemoveEffect(..)
-                | Message::SetEffectParam(..)
-                | Message::ToggleEffectBypass(..)
-                | Message::MoveEffectUp(..)
-                | Message::MoveEffectDown(..)
                 | Message::AddInstrumentTrack
-                | Message::SetInstrumentParam(..)
                 | Message::SamplerSampleDecoded(..)
                 | Message::DrumRackPadSampleDecoded(..)
-                | Message::ClearDrumRackPad(..)
-                | Message::SetDrumPadParam { .. }
-                | Message::SetDrumPadOneShot { .. }
-                | Message::SetDrumPadChokeGroup { .. }
                 | Message::BrowserSampleDecoded(..)
                 | Message::ToggleClipLoop(..)
                 | Message::SetClipLoopRegion { .. }
@@ -2093,8 +2099,6 @@ impl App {
                 | Message::RenameTrack(..)
                 | Message::RenameClip(..)
                 | Message::AddMidiTrack
-                | Message::SetTrackInstrument(..)
-                | Message::RemoveTrackInstrument(_)
                 | Message::HalveNoteClip(..)
                 | Message::QuantizeNoteClip { .. }
                 | Message::AudioQuantizeReady { .. }
@@ -2103,7 +2107,7 @@ impl App {
                 | Message::ClipWarpReady { .. }
                 | Message::ClearClipWarp { .. }
                 | Message::ClipAutoWarpReady { .. }
-        );
+        ) || matches!(&message, Message::Devices(m) if m.marks_dirty());
         if should_mark_dirty {
             self.push_undo_snapshot();
             self.mark_project_dirty();
@@ -2130,6 +2134,19 @@ impl App {
                     self.state.transport.update(msg, &mut engine, ctx)
                 };
                 return self.apply_transport_action(action);
+            }
+            // Devices domain: same routing pattern. Tracks are the
+            // shared model handed in explicitly; the returned action
+            // carries GUI teardown / selection / status effects.
+            Message::Devices(msg) => {
+                let sample_rate = self.state.transport.sample_rate;
+                let action = {
+                    let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+                    self.state
+                        .devices
+                        .update(msg, &mut engine, &mut self.state.tracks, sample_rate)
+                };
+                self.apply_devices_action(action);
             }
 
             // -- Workspace --
@@ -2277,18 +2294,6 @@ impl App {
                     "Removed {removed_name}. {} track(s) remain.",
                     self.state.tracks.len()
                 );
-            }
-            Message::AuditionNote {
-                track_id,
-                pitch,
-                on,
-            } => {
-                self.send_command(EngineCommand::AuditionNote {
-                    track_id,
-                    pitch,
-                    velocity: 100,
-                    on,
-                });
             }
             Message::DeleteKeyPressed => {
                 // Never delete anything while a text field is being
@@ -2460,112 +2465,6 @@ impl App {
             }
 
             // -- Effects --
-            Message::AddEffect(track_id, effect_type) => {
-                let effect_id = vibez_core::id::EffectId::new();
-                let fx = vibez_dsp::factory::create_effect(
-                    effect_type,
-                    self.state.transport.sample_rate as f32,
-                );
-                let descriptors = fx.param_descriptors();
-                let params: Vec<f32> = descriptors.iter().map(|d| d.default).collect();
-
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    track.effects.push(UiEffect {
-                        id: effect_id,
-                        effect_type,
-                        bypass: false,
-                        params,
-                        descriptors,
-                        plugin_name: None,
-                        has_plugin_gui: false,
-                        plugin_ref: None,
-                    });
-                }
-                self.send_command(EngineCommand::AddEffect {
-                    track_id,
-                    effect_id,
-                    effect_type,
-                    position: None,
-                });
-                self.state.device_context_menu = None;
-                self.state.status_text = format!("Added {} effect", effect_type.name());
-            }
-            Message::RemoveEffect(track_id, effect_id) => {
-                // Close plugin GUI window if open
-                let gui_key = PluginGuiKey::Effect {
-                    track_id,
-                    effect_id,
-                };
-                if let Some(ref mut mgr) = self.plugin_window_manager {
-                    mgr.close(gui_key);
-                }
-                self.plugin_gui_raw_ptrs.remove(&gui_key);
-                self.plugin_state_ptrs.remove(&gui_key);
-
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    track.effects.retain(|e| e.id != effect_id);
-                }
-                self.send_command(EngineCommand::RemoveEffect(track_id, effect_id));
-                self.state.status_text = "Removed effect".to_string();
-            }
-            Message::SetEffectParam(track_id, effect_id, param_index, value) => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    if let Some(effect) = track.effects.iter_mut().find(|e| e.id == effect_id) {
-                        if param_index < effect.params.len() {
-                            let desc = &effect.descriptors[param_index];
-                            let clamped = value.clamp(desc.min, desc.max);
-                            effect.params[param_index] = clamped;
-                            self.send_command(EngineCommand::SetEffectParam {
-                                track_id,
-                                effect_id,
-                                param_index,
-                                value: clamped,
-                            });
-                        }
-                    }
-                }
-            }
-            Message::ToggleEffectBypass(track_id, effect_id) => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    if let Some(effect) = track.effects.iter_mut().find(|e| e.id == effect_id) {
-                        effect.bypass = !effect.bypass;
-                        let bypass = effect.bypass;
-                        self.send_command(EngineCommand::SetEffectBypass {
-                            track_id,
-                            effect_id,
-                            bypass,
-                        });
-                    }
-                }
-            }
-            Message::MoveEffectUp(track_id, effect_id) => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    if let Some(idx) = track.effects.iter().position(|e| e.id == effect_id) {
-                        if idx > 0 {
-                            track.effects.swap(idx, idx - 1);
-                            self.send_command(EngineCommand::MoveEffect {
-                                track_id,
-                                effect_id,
-                                new_index: idx - 1,
-                            });
-                        }
-                    }
-                }
-            }
-            Message::MoveEffectDown(track_id, effect_id) => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    if let Some(idx) = track.effects.iter().position(|e| e.id == effect_id) {
-                        if idx + 1 < track.effects.len() {
-                            track.effects.swap(idx, idx + 1);
-                            self.send_command(EngineCommand::MoveEffect {
-                                track_id,
-                                effect_id,
-                                new_index: idx + 1,
-                            });
-                        }
-                    }
-                }
-            }
 
             // -- Instrument tracks --
             Message::AddInstrumentTrack => {
@@ -2582,19 +2481,6 @@ impl App {
                 self.state.tracks.push(track);
                 self.state.selected_track = Some(id);
                 self.state.status_text = format!("{} tracks", self.state.tracks.len());
-            }
-            Message::SetInstrumentParam(track_id, param_index, value) => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    if param_index < track.instrument_params.len() {
-                        track.instrument_params[param_index] = value;
-                    }
-                }
-                self.send_command(EngineCommand::SetInstrumentParam {
-                    track_id,
-                    param_index,
-                    value,
-                });
-                self.state.status_text = format!("Param {param_index} = {value:.2}");
             }
 
             // -- Sampler --
@@ -2678,101 +2564,6 @@ impl App {
             Message::DrumRackPadDecodeError(track_id, _pad_index, err) => {
                 self.state.selected_track = Some(track_id);
                 self.state.status_text = format!("Drum pad load error: {err}");
-            }
-            Message::ClearDrumRackPad(track_id, pad_index) => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
-                        *pad = UiDrumPad::default();
-                    }
-                }
-                self.sync_drum_rack_pad_state(track_id, pad_index);
-                self.send_command(EngineCommand::ClearDrumRackPad {
-                    track_id,
-                    pad_index,
-                });
-                self.state.status_text = format!("Cleared pad {}", pad_index + 1);
-            }
-            Message::SelectDrumRackPad(track_id, pad_index) => {
-                // Audition the pad like Ableton: hear it on click.
-                let pitch = 36 + pad_index.min(127) as u8;
-                self.send_command(EngineCommand::AuditionNote {
-                    track_id,
-                    pitch,
-                    velocity: 100,
-                    on: true,
-                });
-                self.send_command(EngineCommand::AuditionNote {
-                    track_id,
-                    pitch,
-                    velocity: 100,
-                    on: false,
-                });
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    let max_index = track.drum_rack_pads.len().saturating_sub(1);
-                    track.selected_drum_pad = pad_index.min(max_index);
-                }
-                self.state.selected_track = Some(track_id);
-            }
-            Message::SetDrumPadParam {
-                track_id,
-                pad_index,
-                param,
-                value,
-            } => {
-                let mut changed = false;
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
-                        match param {
-                            DrumPadParam::Gain => pad.gain = value.clamp(0.0, 2.0),
-                            DrumPadParam::Pan => pad.pan = value.clamp(-1.0, 1.0),
-                            DrumPadParam::Start => pad.start = value.clamp(0.0, 1.0),
-                            DrumPadParam::End => pad.end = value.clamp(0.0, 1.0),
-                            DrumPadParam::CoarseTune => {
-                                pad.coarse_tune = value.clamp(-24.0, 24.0).round() as i8;
-                            }
-                            DrumPadParam::FineTune => pad.fine_tune = value.clamp(-100.0, 100.0),
-                        }
-                        changed = true;
-                    }
-                }
-                if changed {
-                    self.sync_drum_rack_pad_state(track_id, pad_index);
-                    self.state.status_text = format!("Pad {} updated", pad_index + 1);
-                }
-            }
-            Message::SetDrumPadOneShot {
-                track_id,
-                pad_index,
-                one_shot,
-            } => {
-                let mut changed = false;
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
-                        pad.one_shot = one_shot;
-                        changed = true;
-                    }
-                }
-                if changed {
-                    self.sync_drum_rack_pad_state(track_id, pad_index);
-                    self.state.status_text = format!("Pad {} updated", pad_index + 1);
-                }
-            }
-            Message::SetDrumPadChokeGroup {
-                track_id,
-                pad_index,
-                choke_group,
-            } => {
-                let mut changed = false;
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
-                        pad.choke_group = choke_group;
-                        changed = true;
-                    }
-                }
-                if changed {
-                    self.sync_drum_rack_pad_state(track_id, pad_index);
-                    self.state.status_text = format!("Pad {} updated", pad_index + 1);
-                }
             }
 
             // -- Clip looping --
@@ -4436,7 +4227,7 @@ impl App {
                 self.state.editing_track_name = None;
                 self.state.editing_clip_name = None;
                 self.state.edit_name_text.clear();
-                self.state.device_context_menu = None;
+                self.state.devices.context_menu = None;
             }
             Message::RenameTrack(track_id, new_name) => {
                 if let Some(track) = self.state.find_track_mut(track_id) {
@@ -4472,53 +4263,6 @@ impl App {
             }
 
             // -- Instrument attach/detach --
-            Message::SetTrackInstrument(track_id, instrument_kind) => {
-                let sample_rate = self.state.transport.sample_rate as f32;
-                let instrument_params = default_instrument_params(instrument_kind, sample_rate);
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    track.has_instrument = true;
-                    track.instrument_kind = Some(instrument_kind);
-                    track.sample_name = None;
-                    track.sample_source = None;
-                    track.sample_audio = None;
-                    track.instrument_params = instrument_params.clone();
-                    track.drum_rack_pads = (0..16).map(|_| UiDrumPad::default()).collect();
-                    track.selected_drum_pad = 0;
-                }
-                self.send_command(EngineCommand::SetTrackInstrument(track_id, instrument_kind));
-                for (param_index, value) in instrument_params.into_iter().enumerate() {
-                    self.send_command(EngineCommand::SetInstrumentParam {
-                        track_id,
-                        param_index,
-                        value,
-                    });
-                }
-                self.state.device_context_menu = None;
-                self.state.status_text = format!("Added {}", instrument_kind.name());
-            }
-            Message::RemoveTrackInstrument(track_id) => {
-                // Close plugin GUI window if open
-                let gui_key = PluginGuiKey::Instrument { track_id };
-                if let Some(ref mut mgr) = self.plugin_window_manager {
-                    mgr.close(gui_key);
-                }
-                self.plugin_gui_raw_ptrs.remove(&gui_key);
-                self.plugin_state_ptrs.remove(&gui_key);
-
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    track.has_instrument = false;
-                    track.instrument_kind = None;
-                    track.sample_name = None;
-                    track.sample_source = None;
-                    track.instrument_params.clear();
-                    track.drum_rack_pads = (0..16).map(|_| UiDrumPad::default()).collect();
-                    track.selected_drum_pad = 0;
-                    track.plugin_instrument_name = None;
-                    track.has_plugin_instrument_gui = false;
-                }
-                self.send_command(EngineCommand::RemoveTrackInstrument(track_id));
-                self.state.status_text = "Removed instrument".to_string();
-            }
 
             // -- Pattern halve --
             Message::HalveNoteClip(track_id, clip_id) => {
@@ -4551,37 +4295,6 @@ impl App {
             }
 
             // -- Device context menu --
-            Message::ShowDeviceContextMenu { x, y, track_id } => {
-                use crate::state::{DeviceContextMenu, DeviceMenuCategory};
-                let is_midi = self
-                    .state
-                    .find_track(track_id)
-                    .is_some_and(|t| t.kind.is_midi());
-                self.state.device_context_menu = Some(DeviceContextMenu {
-                    x,
-                    y,
-                    track_id,
-                    category: Some(if is_midi {
-                        DeviceMenuCategory::Instruments
-                    } else {
-                        DeviceMenuCategory::Effects
-                    }),
-                    search: String::new(),
-                });
-            }
-            Message::DismissDeviceContextMenu => {
-                self.state.device_context_menu = None;
-            }
-            Message::SetDeviceMenuCategory(category) => {
-                if let Some(ref mut menu) = self.state.device_context_menu {
-                    menu.category = Some(category);
-                }
-            }
-            Message::DeviceMenuSearch(query) => {
-                if let Some(ref mut menu) = self.state.device_context_menu {
-                    menu.search = query;
-                }
-            }
 
             // -- Sample browser --
             Message::ToggleSampleBrowser => {
@@ -4871,7 +4584,7 @@ impl App {
                             self.send_command(EngineCommand::StartPreview(audio));
                             self.state.status_text = format!("Pad {}: {}", pad_index + 1, name);
                         }
-                        return self.update(Message::SelectDrumRackPad(track_id, pad_index));
+                        return self.update(Message::select_drum_rack_pad(track_id, pad_index));
                     }
                 }
             }
@@ -5160,7 +4873,7 @@ impl App {
 
             // -- Plugin loading --
             Message::AddPluginToTrack(track_id, plugin_id) => {
-                self.state.device_context_menu = None;
+                self.state.devices.context_menu = None;
                 if let Some(info) = self
                     .state
                     .plugin_settings
@@ -6287,7 +6000,7 @@ impl App {
             stack![base_layout, self.view_context_menu_overlay()].into()
         } else if self.state.editing_clip_name.is_some() {
             stack![base_layout, self.view_rename_overlay()].into()
-        } else if self.state.device_context_menu.is_some() {
+        } else if self.state.devices.context_menu.is_some() {
             stack![base_layout, self.view_device_context_menu_overlay()].into()
         } else {
             base_layout
@@ -8720,11 +8433,13 @@ impl App {
 
         // Wrap in mouse_area for right-click context menu
         mouse_area(content)
-            .on_right_press(Message::ShowDeviceContextMenu {
-                x: self.state.cursor_x,
-                y: self.state.cursor_y,
-                track_id,
-            })
+            .on_right_press(Message::Devices(
+                crate::domains::devices::DevicesMsg::ShowContextMenu {
+                    x: self.state.cursor_x,
+                    y: self.state.cursor_y,
+                    track_id,
+                },
+            ))
             .into()
     }
 
@@ -8883,7 +8598,7 @@ impl App {
             icons::X,
             th::TEXT_DIM,
             th::DANGER,
-            Message::RemoveTrackInstrument(track_id),
+            Message::remove_track_instrument(track_id),
         )
         .into();
 
@@ -8911,7 +8626,7 @@ impl App {
         let title = Self::device_title_bar(Self::device_title_row(
             "Synth",
             track_color,
-            Some(Message::RemoveTrackInstrument(track_id)),
+            Some(Message::remove_track_instrument(track_id)),
         ));
 
         let descriptors = vibez_instruments::synth::SYNTH_PARAMS;
@@ -8949,7 +8664,7 @@ impl App {
                     .align_x(iced::Alignment::Center)
                     .color(if active { th::BG_DARK } else { th::TEXT_DIM }),
             )
-            .on_press(Message::SetInstrumentParam(track_id, 0, i as f32))
+            .on_press(Message::set_instrument_param(track_id, 0, i as f32))
             .padding([3, 4])
             .style(move |_theme: &Theme, _status| button::Style {
                 background: Some(if active { th::ACCENT } else { th::BG_DARK }.into()),
@@ -9032,7 +8747,7 @@ impl App {
         let title = Self::device_title_bar(Self::device_title_row(
             "Sampler",
             track_color,
-            Some(Message::RemoveTrackInstrument(track_id)),
+            Some(Message::remove_track_instrument(track_id)),
         ));
 
         let descriptors = vibez_instruments::sampler::SAMPLER_PARAMS;
@@ -9169,7 +8884,7 @@ impl App {
         let title = Self::device_title_bar(Self::device_title_row(
             "Drum Rack",
             track_color,
-            Some(Message::RemoveTrackInstrument(track_id)),
+            Some(Message::remove_track_instrument(track_id)),
         ));
 
         let mut grid = column![].spacing(4);
@@ -9263,7 +8978,7 @@ impl App {
             });
 
         let clear_btn = button(text("Clear").size(9).color(th::TEXT_DIM))
-            .on_press(Message::ClearDrumRackPad(track_id, selected_pad))
+            .on_press(Message::clear_drum_rack_pad(track_id, selected_pad))
             .padding([2, 8])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
@@ -9373,11 +9088,13 @@ impl App {
         } else {
             th::TEXT_DIM
         }))
-        .on_press(Message::SetDrumPadOneShot {
-            track_id,
-            pad_index: selected_pad,
-            one_shot: !one_shot_active,
-        })
+        .on_press(Message::Devices(
+            crate::domains::devices::DevicesMsg::SetDrumPadOneShot {
+                track_id,
+                pad_index: selected_pad,
+                one_shot: !one_shot_active,
+            },
+        ))
         .padding([2, 6])
         .style(move |_theme: &Theme, _status| button::Style {
             background: Some(
@@ -9422,11 +9139,13 @@ impl App {
                         .size(9)
                         .color(if active { th::ACCENT } else { th::TEXT_DIM }),
                 )
-                .on_press(Message::SetDrumPadChokeGroup {
-                    track_id,
-                    pad_index: selected_pad,
-                    choke_group: group,
-                })
+                .on_press(Message::Devices(
+                    crate::domains::devices::DevicesMsg::SetDrumPadChokeGroup {
+                        track_id,
+                        pad_index: selected_pad,
+                        choke_group: group,
+                    },
+                ))
                 .padding([2, 6])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
@@ -9495,7 +9214,7 @@ impl App {
     fn view_device_context_menu_overlay(&self) -> Element<'_, Message> {
         use crate::state::DeviceMenuCategory;
 
-        let menu = self.state.device_context_menu.as_ref().unwrap();
+        let menu = self.state.devices.context_menu.as_ref().unwrap();
         let track_id = menu.track_id;
         let is_midi = self
             .state
@@ -9512,7 +9231,7 @@ impl App {
                 (th::BG_ELEVATED, th::TEXT_DIM)
             };
             let inst_tab = button(text("Instruments").size(11).color(tc))
-                .on_press(Message::SetDeviceMenuCategory(
+                .on_press(Message::set_device_menu_category(
                     DeviceMenuCategory::Instruments,
                 ))
                 .padding([4, 10])
@@ -9539,7 +9258,9 @@ impl App {
             (th::BG_ELEVATED, th::TEXT_DIM)
         };
         let fx_tab = button(text("Effects").size(11).color(tc))
-            .on_press(Message::SetDeviceMenuCategory(DeviceMenuCategory::Effects))
+            .on_press(Message::set_device_menu_category(
+                DeviceMenuCategory::Effects,
+            ))
             .padding([4, 10])
             .style(move |_theme: &Theme, _status| button::Style {
                 background: Some(bg.into()),
@@ -9565,7 +9286,9 @@ impl App {
             (th::BG_ELEVATED, th::TEXT_DIM)
         };
         let plugins_tab = button(text("Plugins").size(11).color(tc))
-            .on_press(Message::SetDeviceMenuCategory(DeviceMenuCategory::Plugins))
+            .on_press(Message::set_device_menu_category(
+                DeviceMenuCategory::Plugins,
+            ))
             .padding([4, 10])
             .style(move |_theme: &Theme, _status| button::Style {
                 background: Some(bg.into()),
@@ -9585,7 +9308,7 @@ impl App {
 
         // Search input
         let search_input = text_input("Search...", &menu.search)
-            .on_input(Message::DeviceMenuSearch)
+            .on_input(Message::device_menu_search)
             .size(12)
             .width(Length::Fill);
 
@@ -9606,7 +9329,7 @@ impl App {
                         continue;
                     }
                     let btn = button(text(name).size(12).color(th::TEXT))
-                        .on_press(Message::SetTrackInstrument(track_id, kind))
+                        .on_press(Message::set_track_instrument(track_id, kind))
                         .padding([6, 10])
                         .width(Length::Fill)
                         .style(|_theme: &Theme, status| {
@@ -9704,7 +9427,7 @@ impl App {
                         continue;
                     }
                     let btn = button(text(name).size(12).color(th::TEXT))
-                        .on_press(Message::AddEffect(track_id, et))
+                        .on_press(Message::add_effect(track_id, et))
                         .padding([6, 10])
                         .width(Length::Fill)
                         .style(|_theme: &Theme, status| {
@@ -9773,7 +9496,7 @@ impl App {
         ];
 
         mouse_area(container(padded).width(Length::Fill).height(Length::Fill))
-            .on_press(Message::DismissDeviceContextMenu)
+            .on_press(Message::dismiss_device_menu())
             .into()
     }
 
@@ -11293,13 +11016,4 @@ fn is_supported_audio_file(path: &PathBuf) -> bool {
             )
         })
         .unwrap_or(false)
-}
-
-fn default_instrument_params(kind: InstrumentKind, sample_rate: f32) -> Vec<f32> {
-    let instrument = vibez_instruments::create_instrument(kind, sample_rate);
-    instrument
-        .param_descriptors()
-        .iter()
-        .map(|descriptor| descriptor.default)
-        .collect()
 }

--- a/crates/vibez-ui/src/domains/devices.rs
+++ b/crates/vibez-ui/src/domains/devices.rs
@@ -1,0 +1,613 @@
+//! Devices domain: the per-track device chain. Built-in effects
+//! (add/remove/reorder/params/bypass), native instruments and their
+//! params, drum pad editing, note audition, and the device context
+//! menu.
+//!
+//! Follows the transport reference pattern with one addition: tracks
+//! are the shared model (like database entities), so `update`
+//! receives `&mut [UiTrack]` explicitly. The domain may touch the
+//! DEVICE fields of a track and nothing else; every dependency is
+//! visible in the signature, which is what keeps this testable with
+//! plain `Vec<UiTrack>` fixtures.
+//!
+//! Deliberately NOT here (async/infrastructure, future services
+//! tranche): plugin scanning and loading pipelines, plugin GUI window
+//! management, and file dialogs. Their cross-domain needs surface as
+//! [`DevicesAction`] fields instead.
+
+use vibez_core::effect::EffectType;
+use vibez_core::id::{EffectId, TrackId};
+use vibez_core::midi::InstrumentKind;
+use vibez_engine::commands::EngineCommand;
+use vibez_plugin_host::gui::PluginGuiKey;
+
+use super::EngineHandle;
+use crate::message::DrumPadParam;
+use crate::state::{DeviceContextMenu, DeviceMenuCategory, UiDrumPad, UiEffect, UiTrack};
+
+/// Messages the devices domain handles.
+#[derive(Debug, Clone)]
+pub enum DevicesMsg {
+    AddEffect(TrackId, EffectType),
+    RemoveEffect(TrackId, EffectId),
+    SetEffectParam(TrackId, EffectId, usize, f32),
+    ToggleEffectBypass(TrackId, EffectId),
+    MoveEffectUp(TrackId, EffectId),
+    MoveEffectDown(TrackId, EffectId),
+    SetTrackInstrument(TrackId, InstrumentKind),
+    RemoveTrackInstrument(TrackId),
+    SetInstrumentParam(TrackId, usize, f32),
+    SelectDrumRackPad(TrackId, usize),
+    ClearDrumRackPad(TrackId, usize),
+    SetDrumPadParam {
+        track_id: TrackId,
+        pad_index: usize,
+        param: DrumPadParam,
+        value: f32,
+    },
+    SetDrumPadOneShot {
+        track_id: TrackId,
+        pad_index: usize,
+        one_shot: bool,
+    },
+    SetDrumPadChokeGroup {
+        track_id: TrackId,
+        pad_index: usize,
+        choke_group: Option<u8>,
+    },
+    /// Preview a pitch on a track's instrument. `on: false` releases.
+    AuditionNote {
+        track_id: TrackId,
+        pitch: u8,
+        on: bool,
+    },
+    ShowContextMenu {
+        x: f32,
+        y: f32,
+        track_id: TrackId,
+    },
+    DismissContextMenu,
+    SetMenuCategory(DeviceMenuCategory),
+    MenuSearch(String),
+}
+
+impl DevicesMsg {
+    /// Whether this message edits the project (drives the dirty flag).
+    pub fn marks_dirty(&self) -> bool {
+        !matches!(
+            self,
+            DevicesMsg::AuditionNote { .. }
+                | DevicesMsg::SelectDrumRackPad(..)
+                | DevicesMsg::ShowContextMenu { .. }
+                | DevicesMsg::DismissContextMenu
+                | DevicesMsg::SetMenuCategory(_)
+                | DevicesMsg::MenuSearch(_)
+        )
+    }
+}
+
+/// Cross-domain effects requested by a devices update. A struct
+/// rather than an enum because several can occur at once.
+#[derive(Debug, Default, PartialEq)]
+pub struct DevicesAction {
+    /// A plugin GUI window (and its raw pointers) must be torn down.
+    pub close_gui: Option<PluginGuiKey>,
+    /// The interaction implies focusing this track.
+    pub select_track: Option<TrackId>,
+    /// Status bar text.
+    pub status: Option<String>,
+}
+
+/// Devices domain state slice: currently just the context menu; the
+/// device data itself lives on the shared track model.
+#[derive(Debug, Default)]
+pub struct DevicesState {
+    pub context_menu: Option<DeviceContextMenu>,
+}
+
+/// Default parameter values for a freshly added native instrument.
+pub fn default_instrument_params(kind: InstrumentKind, sample_rate: f32) -> Vec<f32> {
+    let instrument = vibez_instruments::create_instrument(kind, sample_rate);
+    instrument
+        .param_descriptors()
+        .iter()
+        .map(|descriptor| descriptor.default)
+        .collect()
+}
+
+fn find_track_mut(tracks: &mut [UiTrack], track_id: TrackId) -> Option<&mut UiTrack> {
+    tracks.iter_mut().find(|t| t.id == track_id)
+}
+
+/// Send the engine a pad's full state (single source of truth for
+/// pad edits).
+fn sync_pad(
+    tracks: &[UiTrack],
+    track_id: TrackId,
+    pad_index: usize,
+    engine: &mut impl EngineHandle,
+) {
+    let state = tracks
+        .iter()
+        .find(|t| t.id == track_id)
+        .and_then(|track| track.drum_rack_pads.get(pad_index))
+        .map(UiDrumPad::to_state);
+    if let Some(state) = state {
+        engine.send(EngineCommand::SetDrumRackPadState {
+            track_id,
+            pad_index,
+            state,
+        });
+    }
+}
+
+impl DevicesState {
+    pub fn update(
+        &mut self,
+        msg: DevicesMsg,
+        engine: &mut impl EngineHandle,
+        tracks: &mut [UiTrack],
+        sample_rate: u32,
+    ) -> DevicesAction {
+        let mut action = DevicesAction::default();
+        match msg {
+            DevicesMsg::AddEffect(track_id, effect_type) => {
+                let effect_id = EffectId::new();
+                let fx = vibez_dsp::factory::create_effect(effect_type, sample_rate as f32);
+                let descriptors = fx.param_descriptors();
+                let params: Vec<f32> = descriptors.iter().map(|d| d.default).collect();
+
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    track.effects.push(UiEffect {
+                        id: effect_id,
+                        effect_type,
+                        bypass: false,
+                        params,
+                        descriptors,
+                        plugin_name: None,
+                        has_plugin_gui: false,
+                        plugin_ref: None,
+                    });
+                }
+                engine.send(EngineCommand::AddEffect {
+                    track_id,
+                    effect_id,
+                    effect_type,
+                    position: None,
+                });
+                self.context_menu = None;
+                action.status = Some(format!("Added {} effect", effect_type.name()));
+            }
+            DevicesMsg::RemoveEffect(track_id, effect_id) => {
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    track.effects.retain(|e| e.id != effect_id);
+                }
+                engine.send(EngineCommand::RemoveEffect(track_id, effect_id));
+                action.close_gui = Some(PluginGuiKey::Effect {
+                    track_id,
+                    effect_id,
+                });
+                action.status = Some("Removed effect".to_string());
+            }
+            DevicesMsg::SetEffectParam(track_id, effect_id, param_index, value) => {
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if let Some(effect) = track.effects.iter_mut().find(|e| e.id == effect_id) {
+                        if param_index < effect.params.len() {
+                            let desc = &effect.descriptors[param_index];
+                            let clamped = value.clamp(desc.min, desc.max);
+                            effect.params[param_index] = clamped;
+                            engine.send(EngineCommand::SetEffectParam {
+                                track_id,
+                                effect_id,
+                                param_index,
+                                value: clamped,
+                            });
+                        }
+                    }
+                }
+            }
+            DevicesMsg::ToggleEffectBypass(track_id, effect_id) => {
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if let Some(effect) = track.effects.iter_mut().find(|e| e.id == effect_id) {
+                        effect.bypass = !effect.bypass;
+                        engine.send(EngineCommand::SetEffectBypass {
+                            track_id,
+                            effect_id,
+                            bypass: effect.bypass,
+                        });
+                    }
+                }
+            }
+            DevicesMsg::MoveEffectUp(track_id, effect_id) => {
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if let Some(idx) = track.effects.iter().position(|e| e.id == effect_id) {
+                        if idx > 0 {
+                            track.effects.swap(idx, idx - 1);
+                            engine.send(EngineCommand::MoveEffect {
+                                track_id,
+                                effect_id,
+                                new_index: idx - 1,
+                            });
+                        }
+                    }
+                }
+            }
+            DevicesMsg::MoveEffectDown(track_id, effect_id) => {
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if let Some(idx) = track.effects.iter().position(|e| e.id == effect_id) {
+                        if idx + 1 < track.effects.len() {
+                            track.effects.swap(idx, idx + 1);
+                            engine.send(EngineCommand::MoveEffect {
+                                track_id,
+                                effect_id,
+                                new_index: idx + 1,
+                            });
+                        }
+                    }
+                }
+            }
+            DevicesMsg::SetTrackInstrument(track_id, instrument_kind) => {
+                let instrument_params =
+                    default_instrument_params(instrument_kind, sample_rate as f32);
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    track.has_instrument = true;
+                    track.instrument_kind = Some(instrument_kind);
+                    track.sample_name = None;
+                    track.sample_source = None;
+                    track.sample_audio = None;
+                    track.instrument_params = instrument_params.clone();
+                    track.drum_rack_pads = (0..16).map(|_| UiDrumPad::default()).collect();
+                    track.selected_drum_pad = 0;
+                }
+                engine.send(EngineCommand::SetTrackInstrument(track_id, instrument_kind));
+                for (param_index, value) in instrument_params.into_iter().enumerate() {
+                    engine.send(EngineCommand::SetInstrumentParam {
+                        track_id,
+                        param_index,
+                        value,
+                    });
+                }
+                self.context_menu = None;
+                action.status = Some(format!("Added {}", instrument_kind.name()));
+            }
+            DevicesMsg::RemoveTrackInstrument(track_id) => {
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    track.has_instrument = false;
+                    track.instrument_kind = None;
+                    track.sample_name = None;
+                    track.sample_source = None;
+                    track.instrument_params.clear();
+                    track.drum_rack_pads = (0..16).map(|_| UiDrumPad::default()).collect();
+                    track.selected_drum_pad = 0;
+                    track.plugin_instrument_name = None;
+                    track.has_plugin_instrument_gui = false;
+                }
+                engine.send(EngineCommand::RemoveTrackInstrument(track_id));
+                action.close_gui = Some(PluginGuiKey::Instrument { track_id });
+                action.status = Some("Removed instrument".to_string());
+            }
+            DevicesMsg::SetInstrumentParam(track_id, param_index, value) => {
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if param_index < track.instrument_params.len() {
+                        track.instrument_params[param_index] = value;
+                    }
+                }
+                engine.send(EngineCommand::SetInstrumentParam {
+                    track_id,
+                    param_index,
+                    value,
+                });
+                action.status = Some(format!("Param {param_index} = {value:.2}"));
+            }
+            DevicesMsg::SelectDrumRackPad(track_id, pad_index) => {
+                // Audition the pad like Ableton: hear it on click.
+                let pitch = 36 + pad_index.min(127) as u8;
+                engine.send(EngineCommand::AuditionNote {
+                    track_id,
+                    pitch,
+                    velocity: 100,
+                    on: true,
+                });
+                engine.send(EngineCommand::AuditionNote {
+                    track_id,
+                    pitch,
+                    velocity: 100,
+                    on: false,
+                });
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    let max_index = track.drum_rack_pads.len().saturating_sub(1);
+                    track.selected_drum_pad = pad_index.min(max_index);
+                }
+                action.select_track = Some(track_id);
+            }
+            DevicesMsg::ClearDrumRackPad(track_id, pad_index) => {
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
+                        *pad = UiDrumPad::default();
+                    }
+                }
+                sync_pad(tracks, track_id, pad_index, engine);
+                engine.send(EngineCommand::ClearDrumRackPad {
+                    track_id,
+                    pad_index,
+                });
+                action.status = Some(format!("Cleared pad {}", pad_index + 1));
+            }
+            DevicesMsg::SetDrumPadParam {
+                track_id,
+                pad_index,
+                param,
+                value,
+            } => {
+                let mut changed = false;
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
+                        match param {
+                            DrumPadParam::Gain => pad.gain = value.clamp(0.0, 2.0),
+                            DrumPadParam::Pan => pad.pan = value.clamp(-1.0, 1.0),
+                            DrumPadParam::Start => pad.start = value.clamp(0.0, 1.0),
+                            DrumPadParam::End => pad.end = value.clamp(0.0, 1.0),
+                            DrumPadParam::CoarseTune => {
+                                pad.coarse_tune = value.clamp(-24.0, 24.0).round() as i8;
+                            }
+                            DrumPadParam::FineTune => {
+                                pad.fine_tune = value.clamp(-100.0, 100.0);
+                            }
+                        }
+                        changed = true;
+                    }
+                }
+                if changed {
+                    sync_pad(tracks, track_id, pad_index, engine);
+                    action.status = Some(format!("Pad {} updated", pad_index + 1));
+                }
+            }
+            DevicesMsg::SetDrumPadOneShot {
+                track_id,
+                pad_index,
+                one_shot,
+            } => {
+                let mut changed = false;
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
+                        pad.one_shot = one_shot;
+                        changed = true;
+                    }
+                }
+                if changed {
+                    sync_pad(tracks, track_id, pad_index, engine);
+                    action.status = Some(format!("Pad {} updated", pad_index + 1));
+                }
+            }
+            DevicesMsg::SetDrumPadChokeGroup {
+                track_id,
+                pad_index,
+                choke_group,
+            } => {
+                let mut changed = false;
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
+                        pad.choke_group = choke_group;
+                        changed = true;
+                    }
+                }
+                if changed {
+                    sync_pad(tracks, track_id, pad_index, engine);
+                    action.status = Some(format!("Pad {} updated", pad_index + 1));
+                }
+            }
+            DevicesMsg::AuditionNote {
+                track_id,
+                pitch,
+                on,
+            } => {
+                engine.send(EngineCommand::AuditionNote {
+                    track_id,
+                    pitch,
+                    velocity: 100,
+                    on,
+                });
+            }
+            DevicesMsg::ShowContextMenu { x, y, track_id } => {
+                let is_midi = tracks
+                    .iter()
+                    .find(|t| t.id == track_id)
+                    .is_some_and(|t| t.kind.is_midi());
+                self.context_menu = Some(DeviceContextMenu {
+                    x,
+                    y,
+                    track_id,
+                    category: Some(if is_midi {
+                        DeviceMenuCategory::Instruments
+                    } else {
+                        DeviceMenuCategory::Effects
+                    }),
+                    search: String::new(),
+                });
+            }
+            DevicesMsg::DismissContextMenu => {
+                self.context_menu = None;
+            }
+            DevicesMsg::SetMenuCategory(category) => {
+                if let Some(ref mut menu) = self.context_menu {
+                    menu.category = Some(category);
+                }
+            }
+            DevicesMsg::MenuSearch(query) => {
+                if let Some(ref mut menu) = self.context_menu {
+                    menu.search = query;
+                }
+            }
+        }
+        action
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::RecordingEngine;
+    use super::*;
+
+    fn midi_track_with_effect() -> (Vec<UiTrack>, TrackId, EffectId) {
+        let track_id = TrackId::new();
+        let mut track = UiTrack::new_instrument(
+            track_id,
+            "MIDI 1".to_string(),
+            vibez_core::midi::TrackKind::Midi,
+            0,
+        );
+        let effect_id = EffectId::new();
+        track.effects.push(UiEffect {
+            id: effect_id,
+            effect_type: EffectType::Gain,
+            bypass: false,
+            params: vec![1.0],
+            descriptors: vibez_dsp::factory::create_effect(EffectType::Gain, 44_100.0)
+                .param_descriptors(),
+            plugin_name: None,
+            has_plugin_gui: false,
+            plugin_ref: None,
+        });
+        (vec![track], track_id, effect_id)
+    }
+
+    #[test]
+    fn remove_effect_requests_gui_teardown() {
+        let (mut tracks, track_id, effect_id) = midi_track_with_effect();
+        let mut devices = DevicesState::default();
+        let mut engine = RecordingEngine::default();
+        let action = devices.update(
+            DevicesMsg::RemoveEffect(track_id, effect_id),
+            &mut engine,
+            &mut tracks,
+            44_100,
+        );
+        assert!(tracks[0].effects.is_empty());
+        assert_eq!(
+            action.close_gui,
+            Some(PluginGuiKey::Effect {
+                track_id,
+                effect_id
+            })
+        );
+        assert!(matches!(engine.0[0], EngineCommand::RemoveEffect(..)));
+    }
+
+    #[test]
+    fn effect_param_clamps_to_descriptor_range() {
+        let (mut tracks, track_id, effect_id) = midi_track_with_effect();
+        let mut devices = DevicesState::default();
+        let mut engine = RecordingEngine::default();
+        devices.update(
+            DevicesMsg::SetEffectParam(track_id, effect_id, 0, 9999.0),
+            &mut engine,
+            &mut tracks,
+            44_100,
+        );
+        let max = tracks[0].effects[0].descriptors[0].max;
+        assert_eq!(tracks[0].effects[0].params[0], max);
+    }
+
+    #[test]
+    fn move_effect_up_at_top_is_a_no_op() {
+        let (mut tracks, track_id, effect_id) = midi_track_with_effect();
+        let mut devices = DevicesState::default();
+        let mut engine = RecordingEngine::default();
+        devices.update(
+            DevicesMsg::MoveEffectUp(track_id, effect_id),
+            &mut engine,
+            &mut tracks,
+            44_100,
+        );
+        assert!(engine.0.is_empty());
+    }
+
+    #[test]
+    fn pad_click_auditions_and_selects_track() {
+        let (mut tracks, track_id, _) = midi_track_with_effect();
+        tracks[0].drum_rack_pads = (0..16).map(|_| UiDrumPad::default()).collect();
+        let mut devices = DevicesState::default();
+        let mut engine = RecordingEngine::default();
+        let action = devices.update(
+            DevicesMsg::SelectDrumRackPad(track_id, 3),
+            &mut engine,
+            &mut tracks,
+            44_100,
+        );
+        assert_eq!(tracks[0].selected_drum_pad, 3);
+        assert_eq!(action.select_track, Some(track_id));
+        assert!(matches!(
+            engine.0[0],
+            EngineCommand::AuditionNote {
+                pitch: 39,
+                on: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn pad_param_edit_syncs_full_pad_state() {
+        let (mut tracks, track_id, _) = midi_track_with_effect();
+        tracks[0].drum_rack_pads = (0..16).map(|_| UiDrumPad::default()).collect();
+        let mut devices = DevicesState::default();
+        let mut engine = RecordingEngine::default();
+        devices.update(
+            DevicesMsg::SetDrumPadParam {
+                track_id,
+                pad_index: 0,
+                param: DrumPadParam::Gain,
+                value: 5.0,
+            },
+            &mut engine,
+            &mut tracks,
+            44_100,
+        );
+        assert_eq!(tracks[0].drum_rack_pads[0].gain, 2.0); // clamped
+        assert!(matches!(
+            engine.0[0],
+            EngineCommand::SetDrumRackPadState { .. }
+        ));
+    }
+
+    #[test]
+    fn menu_lifecycle() {
+        let (mut tracks, track_id, _) = midi_track_with_effect();
+        let mut devices = DevicesState::default();
+        let mut engine = RecordingEngine::default();
+        devices.update(
+            DevicesMsg::ShowContextMenu {
+                x: 10.0,
+                y: 20.0,
+                track_id,
+            },
+            &mut engine,
+            &mut tracks,
+            44_100,
+        );
+        // MIDI track opens on the Instruments tab.
+        assert_eq!(
+            devices.context_menu.as_ref().and_then(|m| m.category),
+            Some(DeviceMenuCategory::Instruments)
+        );
+        devices.update(
+            DevicesMsg::DismissContextMenu,
+            &mut engine,
+            &mut tracks,
+            44_100,
+        );
+        assert!(devices.context_menu.is_none());
+    }
+
+    #[test]
+    fn dirty_classification() {
+        assert!(DevicesMsg::AddEffect(TrackId::new(), EffectType::Gain).marks_dirty());
+        assert!(!DevicesMsg::DismissContextMenu.marks_dirty());
+        assert!(!DevicesMsg::AuditionNote {
+            track_id: TrackId::new(),
+            pitch: 60,
+            on: true
+        }
+        .marks_dirty());
+    }
+}

--- a/crates/vibez-ui/src/domains/mod.rs
+++ b/crates/vibez-ui/src/domains/mod.rs
@@ -6,6 +6,7 @@
 //! app.rs shrinks to a router. TypeScript mental model: these are
 //! Redux slices; `EngineHandle` is an injected service interface.
 
+pub mod devices;
 pub mod transport;
 
 use vibez_engine::commands::EngineCommand;

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -12,8 +12,8 @@ use vibez_plugin_host::PluginId;
 use vibez_project::Project;
 
 use crate::state::{
-    ArrangementSelection, ContextMenuTarget, DetailPanelTab, DeviceMenuCategory,
-    SampleBrowserEntry, SettingsTab, SnapGrid, Workspace,
+    ArrangementSelection, ContextMenuTarget, DetailPanelTab, SampleBrowserEntry, SettingsTab,
+    SnapGrid, Workspace,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -151,6 +151,8 @@ pub struct ProjectLoadResult {
 pub enum Message {
     /// Transport domain (playback, tempo, arrangement loop).
     Transport(crate::domains::transport::TransportMsg),
+    /// Devices domain (effect chain, instruments, drum pads, menu).
+    Devices(crate::domains::devices::DevicesMsg),
 
     // Workspace
     SwitchWorkspace(Workspace),
@@ -186,16 +188,9 @@ pub enum Message {
     },
 
     // Effects
-    AddEffect(TrackId, EffectType),
-    RemoveEffect(TrackId, EffectId),
-    SetEffectParam(TrackId, EffectId, usize, f32),
-    ToggleEffectBypass(TrackId, EffectId),
-    MoveEffectUp(TrackId, EffectId),
-    MoveEffectDown(TrackId, EffectId),
 
     // Instrument tracks
     AddInstrumentTrack,
-    SetInstrumentParam(TrackId, usize, f32),
 
     // Sampler
     LoadSamplerSample(TrackId),
@@ -206,24 +201,6 @@ pub enum Message {
     DrumRackPadFileSelected(TrackId, usize, Option<PathBuf>),
     DrumRackPadSampleDecoded(TrackId, usize, Arc<DecodedAudio>, String, MediaSourceRef),
     DrumRackPadDecodeError(TrackId, usize, String),
-    ClearDrumRackPad(TrackId, usize),
-    SelectDrumRackPad(TrackId, usize),
-    SetDrumPadParam {
-        track_id: TrackId,
-        pad_index: usize,
-        param: DrumPadParam,
-        value: f32,
-    },
-    SetDrumPadOneShot {
-        track_id: TrackId,
-        pad_index: usize,
-        one_shot: bool,
-    },
-    SetDrumPadChokeGroup {
-        track_id: TrackId,
-        pad_index: usize,
-        choke_group: Option<u8>,
-    },
 
     // Zoom / scroll
     ZoomIn,
@@ -387,8 +364,6 @@ pub enum Message {
     AddMidiTrack,
 
     // Instrument attach/detach
-    SetTrackInstrument(TrackId, InstrumentKind),
-    RemoveTrackInstrument(TrackId),
 
     // Pattern halve
     HalveNoteClip(TrackId, ClipId),
@@ -397,25 +372,10 @@ pub enum Message {
     TogglePianoRollEditMode,
 
     // Device context menu
-    ShowDeviceContextMenu {
-        x: f32,
-        y: f32,
-        track_id: TrackId,
-    },
-    DismissDeviceContextMenu,
-    SetDeviceMenuCategory(DeviceMenuCategory),
-    DeviceMenuSearch(String),
 
     // Cursor tracking
     CursorMoved(f32, f32),
     DeleteKeyPressed,
-    /// Preview a pitch on a track's instrument (piano-roll key press
-    /// or drum pad click). `on: false` releases it.
-    AuditionNote {
-        track_id: TrackId,
-        pitch: u8,
-        on: bool,
-    },
     WindowResized(f32, f32),
     MouseReleased,
 
@@ -635,4 +595,68 @@ pub enum Message {
     DropboxPreviewReady(Result<Arc<DecodedAudio>, String>),
     DropboxImportToArrangement(DropboxEntry),
     DropboxImportToDevice(DropboxEntry),
+}
+
+/// Arity-preserving constructor helpers so call sites read cleanly
+/// and mechanical migrations stay parenthesis-balanced.
+impl Message {
+    pub fn add_effect(t: TrackId, e: EffectType) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::AddEffect(t, e))
+    }
+    pub fn remove_effect(t: TrackId, e: EffectId) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::RemoveEffect(t, e))
+    }
+    pub fn set_effect_param(t: TrackId, e: EffectId, i: usize, v: f32) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::SetEffectParam(
+            t, e, i, v,
+        ))
+    }
+    pub fn toggle_effect_bypass(t: TrackId, e: EffectId) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::ToggleEffectBypass(
+            t, e,
+        ))
+    }
+    pub fn move_effect_up(t: TrackId, e: EffectId) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::MoveEffectUp(t, e))
+    }
+    pub fn move_effect_down(t: TrackId, e: EffectId) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::MoveEffectDown(t, e))
+    }
+    pub fn set_track_instrument(t: TrackId, k: InstrumentKind) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::SetTrackInstrument(
+            t, k,
+        ))
+    }
+    pub fn remove_track_instrument(t: TrackId) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::RemoveTrackInstrument(
+            t,
+        ))
+    }
+    pub fn set_instrument_param(t: TrackId, i: usize, v: f32) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::SetInstrumentParam(
+            t, i, v,
+        ))
+    }
+    pub fn select_drum_rack_pad(t: TrackId, p: usize) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::SelectDrumRackPad(t, p))
+    }
+    pub fn clear_drum_rack_pad(t: TrackId, p: usize) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::ClearDrumRackPad(t, p))
+    }
+    pub fn audition_note(track_id: TrackId, pitch: u8, on: bool) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::AuditionNote {
+            track_id,
+            pitch,
+            on,
+        })
+    }
+    pub fn dismiss_device_menu() -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::DismissContextMenu)
+    }
+    pub fn set_device_menu_category(c: crate::state::DeviceMenuCategory) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::SetMenuCategory(c))
+    }
+    pub fn device_menu_search(q: String) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::MenuSearch(q))
+    }
 }

--- a/crates/vibez-ui/src/state.rs
+++ b/crates/vibez-ui/src/state.rs
@@ -566,7 +566,7 @@ pub struct AppState {
     pub piano_roll_edit_mode: PianoRollEditMode,
 
     // Device context menu
-    pub device_context_menu: Option<DeviceContextMenu>,
+    pub devices: crate::domains::devices::DevicesState,
 
     // File menu / Settings
     pub file_menu_open: bool,
@@ -645,7 +645,7 @@ impl Default for AppState {
             edit_name_text: String::new(),
             clip_bpm_edit: HashMap::new(),
             piano_roll_edit_mode: PianoRollEditMode::default(),
-            device_context_menu: None,
+            devices: crate::domains::devices::DevicesState::default(),
             file_menu_open: false,
             settings_open: false,
             settings_tab: SettingsTab::default(),

--- a/crates/vibez-ui/src/widgets/effect_knob.rs
+++ b/crates/vibez-ui/src/widgets/effect_knob.rs
@@ -121,17 +121,19 @@ impl EffectKnobWidget {
     fn set_value_message(&self, value: f32) -> Message {
         match self.target {
             KnobTarget::Effect(effect_id) => {
-                Message::SetEffectParam(self.track_id, effect_id, self.param_index, value)
+                Message::set_effect_param(self.track_id, effect_id, self.param_index, value)
             }
             KnobTarget::Instrument => {
-                Message::SetInstrumentParam(self.track_id, self.param_index, value)
+                Message::set_instrument_param(self.track_id, self.param_index, value)
             }
-            KnobTarget::DrumPad { pad_index, param } => Message::SetDrumPadParam {
-                track_id: self.track_id,
-                pad_index,
-                param,
-                value,
-            },
+            KnobTarget::DrumPad { pad_index, param } => {
+                Message::Devices(crate::domains::devices::DevicesMsg::SetDrumPadParam {
+                    track_id: self.track_id,
+                    pad_index,
+                    param,
+                    value,
+                })
+            }
         }
     }
 

--- a/crates/vibez-ui/src/widgets/effect_slot.rs
+++ b/crates/vibez-ui/src/widgets/effect_slot.rs
@@ -28,7 +28,7 @@ pub fn view_effect_slot<'a>(
 
     // ── Title bar: [●] Name …          [On] [▲] [▼] [×] ──
     let dot = button(text("\u{25CF}").size(9).color(dot_color))
-        .on_press(Message::ToggleEffectBypass(track_id, effect.id))
+        .on_press(Message::toggle_effect_bypass(track_id, effect.id))
         .padding([2, 3])
         .style(move |_theme: &Theme, status| {
             let bg = match status {
@@ -98,7 +98,7 @@ pub fn view_effect_slot<'a>(
     };
     let make_bypass = move || {
         button(text(bypass_label).size(9).color(bypass_color))
-            .on_press(Message::ToggleEffectBypass(track_id, effect.id))
+            .on_press(Message::toggle_effect_bypass(track_id, effect.id))
             .padding([2, 5])
             .style(move |_theme: &Theme, status| {
                 let bg = match status {
@@ -127,7 +127,7 @@ pub fn view_effect_slot<'a>(
             icons::CHEVRON_UP,
             th::TEXT_DIM,
             th::TEXT,
-            Message::MoveEffectUp(track_id, effect.id),
+            Message::move_effect_up(track_id, effect.id),
         )
         .into()
     };
@@ -136,7 +136,7 @@ pub fn view_effect_slot<'a>(
             icons::CHEVRON_DOWN,
             th::TEXT_DIM,
             th::TEXT,
-            Message::MoveEffectDown(track_id, effect.id),
+            Message::move_effect_down(track_id, effect.id),
         )
         .into()
     };
@@ -144,7 +144,7 @@ pub fn view_effect_slot<'a>(
         icons::X,
         th::TEXT_DIM,
         th::DANGER,
-        Message::RemoveEffect(track_id, effect.id),
+        Message::remove_effect(track_id, effect.id),
     )
     .into();
 

--- a/crates/vibez-ui/src/widgets/piano_roll.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll.rs
@@ -929,11 +929,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                             state.audition_pitch = Some(pitch);
                             return (
                                 canvas::event::Status::Captured,
-                                Some(Message::AuditionNote {
-                                    track_id: self.track_id,
-                                    pitch,
-                                    on: true,
-                                }),
+                                Some(Message::audition_note(self.track_id, pitch, true)),
                             );
                         }
                         return (canvas::event::Status::Ignored, None);
@@ -1257,11 +1253,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                 if let Some(pitch) = state.audition_pitch.take() {
                     return (
                         canvas::event::Status::Captured,
-                        Some(Message::AuditionNote {
-                            track_id: self.track_id,
-                            pitch,
-                            on: false,
-                        }),
+                        Some(Message::audition_note(self.track_id, pitch, false)),
                     );
                 }
                 if let Some(drag) = state.drag.take() {


### PR DESCRIPTION
The hairiest tranche: the per-track device chain moves into domains/devices.rs following the transport reference pattern from #16.

- 19 Message variants become DevicesMsg; app.rs handler arms collapse into one router arm.
- Tracks are handed to the domain explicitly as the shared model (&mut [UiTrack]); every dependency is visible in the update() signature, which is what makes the domain testable with plain Vec<UiTrack> fixtures.
- DevicesAction carries cross-domain effects (plugin GUI teardown, track focus, status text) back to the router.
- The undo-dirty classification for device edits now lives with the domain (marks_dirty()), not in an app.rs list.
- Seven unit tests cover the previously untestable logic: GUI teardown on effect removal, descriptor-range param clamping, reorder edges, pad-click audition, pad state sync, menu lifecycle.

Async plugin pipelines (scanning, loading, GUI windows) intentionally remain in app.rs; they are the services tranche.

Test plan: cargo test (domains::devices), then in-app: add/remove/reorder effects, tweak synth/sampler knobs, drum pad editing and clicking, right-click device menu, remove a plugin effect with its GUI open.