### PR TITLE
fix(ui): Ableton-style device strip and drum card geometry

### DIFF
--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8339,9 +8339,19 @@ impl App {
                 .into()
         };
 
+        // Ableton-style panel heights: the Devices tab is a FIXED
+        // strip that device cards are designed to fit exactly (the
+        // arrangement flexes instead); the Clip tab keeps flexible
+        // height for the piano roll. Window-fraction heights clipped
+        // cards or demanded ugly vertical scrollbars.
+        let panel_height = if self.state.detail_panel_tab == DetailPanelTab::Devices {
+            Length::Fixed(th::DEVICE_BODY_H + 96.0)
+        } else {
+            Length::FillPortion(2)
+        };
         container(detail_content)
             .width(Length::Fill)
-            .height(Length::FillPortion(2))
+            .height(panel_height)
             .style(|_theme: &Theme| container::Style {
                 background: Some(th::BG_DARK.into()),
                 border: iced::Border {
@@ -8418,19 +8428,15 @@ impl App {
             devices_row = devices_row.push(slot);
         }
 
-        let thin = || {
-            scrollable::Scrollbar::new()
-                .width(5)
-                .scroller_width(5)
-                .spacing(2)
-        };
-        // Both axes: on short windows the rack height exceeds the
-        // panel viewport and vertical scroll keeps every control
-        // reachable instead of amputated.
-        let scrollable_devices = scrollable(devices_row).direction(scrollable::Direction::Both {
-            horizontal: thin(),
-            vertical: thin(),
-        });
+        // Horizontal only: the panel is now a fixed-height strip the
+        // cards fit exactly, Ableton-style.
+        let scrollable_devices =
+            scrollable(devices_row).direction(scrollable::Direction::Horizontal(
+                scrollable::Scrollbar::new()
+                    .width(5)
+                    .scroller_width(5)
+                    .spacing(2),
+            ));
 
         let content = column![header, scrollable_devices]
             .spacing(6)

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -9203,8 +9203,22 @@ impl App {
         // Pads and the selected pad's editor sit side by side in
         // labeled sections; the panel scrolls horizontally so the
         // card grows sideways, never past the rack height.
+        // Ableton-style pad bank: the grid lives in its own fixed
+        // vertical viewport with a slim scrollbar; the card height
+        // never depends on the pad count.
+        let pads_view: Element<'a, Message> = scrollable(grid)
+            .direction(scrollable::Direction::Vertical(
+                scrollable::Scrollbar::new()
+                    .width(4)
+                    .scroller_width(4)
+                    .spacing(2),
+            ))
+            .height(Length::Fixed(132.0))
+            .width(Length::Fixed(232.0))
+            .into();
+
         let body = row![
-            Self::device_section("PADS", grid.into()),
+            Self::device_section("PADS", pads_view),
             Self::device_divider(),
             Self::device_section("PAD", editor.into()),
         ]

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8894,14 +8894,18 @@ impl App {
                 let pad_index = row_index * 4 + col_index;
                 let pad = &track.drum_rack_pads[pad_index];
                 let active = selected_pad == pad_index;
+                // Hard-truncated single line: wrapping names change
+                // the tile height and blow the card's height budget
+                // (clipped knobs, dogfood screenshot 2026-07-06).
                 let label = pad
                     .name
                     .as_deref()
                     .map(|name| {
-                        if name.len() > 7 {
-                            format!("{}..", &name[..7])
+                        let short: String = name.chars().take(6).collect();
+                        if name.chars().count() > 6 {
+                            format!("{short}..")
                         } else {
-                            name.to_string()
+                            short
                         }
                     })
                     .unwrap_or_else(|| format!("Pad {}", pad_index + 1));
@@ -8915,7 +8919,7 @@ impl App {
                             .size(9)
                             .color(if active { th::ACCENT } else { th::TEXT_DIM }),
                         text(label)
-                            .size(10)
+                            .size(8)
                             .color(if active { th::ACCENT } else { th::TEXT })
                     ]
                     .spacing(2)
@@ -8923,6 +8927,7 @@ impl App {
                 )
                 .padding([3, 4])
                 .width(Length::Fixed(52.0))
+                .height(Length::Fixed(30.0))
                 .style(move |_theme: &Theme| container::Style {
                     background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
                     text_color: Some(if active { th::ACCENT } else { th::TEXT }),
@@ -8998,8 +9003,12 @@ impl App {
             });
 
         let footer = column![
-            text(selected_name).size(10).color(th::TEXT),
-            text(source_hint).size(9).color(th::TEXT_DIM),
+            text(truncate_end(&selected_name, 22))
+                .size(10)
+                .color(th::TEXT),
+            text(truncate_end(&source_hint, 26))
+                .size(9)
+                .color(th::TEXT_DIM),
             row![load_btn, clear_btn]
                 .spacing(6)
                 .align_y(iced::Alignment::Center)
@@ -10176,6 +10185,16 @@ impl App {
                 _ => None,
             }),
         ])
+    }
+}
+
+/// One-line ellipsis truncation for fixed-budget card text.
+fn truncate_end(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        text.to_string()
+    } else {
+        let head: String = text.chars().take(max_chars.saturating_sub(2)).collect();
+        format!("{head}..")
     }
 }
 

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8418,13 +8418,19 @@ impl App {
             devices_row = devices_row.push(slot);
         }
 
-        let scrollable_devices =
-            scrollable(devices_row).direction(scrollable::Direction::Horizontal(
-                scrollable::Scrollbar::new()
-                    .width(5)
-                    .scroller_width(5)
-                    .spacing(4),
-            ));
+        let thin = || {
+            scrollable::Scrollbar::new()
+                .width(5)
+                .scroller_width(5)
+                .spacing(2)
+        };
+        // Both axes: on short windows the rack height exceeds the
+        // panel viewport and vertical scroll keeps every control
+        // reachable instead of amputated.
+        let scrollable_devices = scrollable(devices_row).direction(scrollable::Direction::Both {
+            horizontal: thin(),
+            vertical: thin(),
+        });
 
         let content = column![header, scrollable_devices]
             .spacing(6)

--- a/crates/vibez-ui/src/theme.rs
+++ b/crates/vibez-ui/src/theme.rs
@@ -337,4 +337,4 @@ pub fn vibez_theme() -> Theme {
 
 /// Uniform device-card body height across the device chain: the
 /// panel scrolls horizontally, so cards share one rack height.
-pub const DEVICE_BODY_H: f32 = 176.0;
+pub const DEVICE_BODY_H: f32 = 184.0;


### PR DESCRIPTION
Re-opened #18 (auto-closed when its stacked base merged). The drum-card/panel layout work, now based on main.

- Deterministic drum card heights: pad tiles pinned to 30px, hard single-line truncation everywhere wrapping text could change card height.
- Pad editor in two side-by-side columns so the 4x4 grid is the card's only height driver.
- Devices tab is an Ableton-style fixed-height strip that cards fit exactly; arrangement flexes; no vertical panel scrollbar. Clip tab keeps flexible height.
- Pad bank scrolls vertically inside its own fixed viewport (ready for 128-pad banks).