### PR TITLE
refactor(ui): domain architecture, tranche 3a: arrangement tracks

### DIFF
--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -264,12 +264,13 @@ impl App {
         self.send_command(EngineCommand::Stop);
         self.send_command(EngineCommand::Seek(0));
 
-        let existing_track_ids: Vec<TrackId> = self.state.tracks.iter().map(|t| t.id).collect();
+        let existing_track_ids: Vec<TrackId> =
+            self.state.arrangement.tracks.iter().map(|t| t.id).collect();
         for track_id in existing_track_ids {
             self.send_command(EngineCommand::RemoveTrack(track_id));
         }
 
-        self.state.tracks.clear();
+        self.state.arrangement.tracks.clear();
         // The engine drops all plugin instances with their tracks;
         // their GUI windows and stale raw pointers must go with them
         // (pumping a closed plugin's run-loop timers segfaults).
@@ -278,10 +279,10 @@ impl App {
         }
         self.plugin_gui_raw_ptrs.clear();
         self.plugin_state_ptrs.clear();
-        self.state.selected_track = None;
-        self.state.next_track_number = 1;
-        self.state.selected_note_clip = None;
-        self.state.selected_clips.clear();
+        self.state.arrangement.selected_track = None;
+        self.state.arrangement.next_track_number = 1;
+        self.state.arrangement.selected_note_clip = None;
+        self.state.arrangement.selected_clips.clear();
         self.state.transport.loop_enabled = false;
         self.state.transport.loop_start_beats = 0.0;
         self.state.transport.loop_end_beats = 4.0;
@@ -332,6 +333,7 @@ impl App {
     fn selected_browser_device_target(&self) -> Option<BrowserImportTarget> {
         let track = self
             .state
+            .arrangement
             .selected_track
             .and_then(|track_id| self.state.find_track(track_id))?;
         match track.instrument_kind {
@@ -412,13 +414,13 @@ impl App {
     /// deletes, or undo chains.
     fn next_unique_track_number(&mut self, prefix: &str) -> u32 {
         loop {
-            let candidate = self.state.next_track_number;
+            let candidate = self.state.arrangement.next_track_number;
             let name = format!("{prefix} {candidate}");
-            let clash = self.state.tracks.iter().any(|t| t.name == name);
+            let clash = self.state.arrangement.tracks.iter().any(|t| t.name == name);
             if !clash {
                 return candidate;
             }
-            self.state.next_track_number += 1;
+            self.state.arrangement.next_track_number += 1;
         }
     }
 
@@ -434,14 +436,17 @@ impl App {
         }
 
         let track_num = self.next_unique_track_number("Audio");
-        self.state.next_track_number = track_num + 1;
+        self.state.arrangement.next_track_number = track_num + 1;
         let id = TrackId::new();
         let color_index = ((track_num - 1) % 8) as u8;
         let name = format!("Audio {track_num}");
 
         self.send_command(EngineCommand::AddTrack(id, name.clone()));
-        self.state.tracks.push(UiTrack::new(id, name, color_index));
-        self.state.selected_track = Some(id);
+        self.state
+            .arrangement
+            .tracks
+            .push(UiTrack::new(id, name, color_index));
+        self.state.arrangement.selected_track = Some(id);
         id
     }
 
@@ -498,7 +503,7 @@ impl App {
             });
         }
 
-        self.state.selected_track = Some(track_id);
+        self.state.arrangement.selected_track = Some(track_id);
         self.state.status_text = format!("Added clip: {name}");
         self.schedule_auto_warp_if_enabled(track_id, clip_id, audio)
     }
@@ -591,7 +596,7 @@ impl App {
                 original_audio: None,
             });
         }
-        self.state.selected_track = Some(track_id);
+        self.state.arrangement.selected_track = Some(track_id);
         self.state.status_text = format!("Dropped '{name}' on {track_name}");
         self.schedule_auto_warp_if_enabled(track_id, clip_id, audio)
     }
@@ -747,6 +752,7 @@ impl App {
     fn project_from_state(&self) -> Project {
         let tracks = self
             .state
+            .arrangement
             .tracks
             .iter()
             .map(|track| self.track_info_from_ui(track))
@@ -754,6 +760,7 @@ impl App {
 
         let clips = self
             .state
+            .arrangement
             .tracks
             .iter()
             .flat_map(|track| {
@@ -781,6 +788,7 @@ impl App {
 
         let note_clips = self
             .state
+            .arrangement
             .tracks
             .iter()
             .flat_map(|track| {
@@ -976,11 +984,12 @@ impl App {
                 });
             }
 
-            self.state.next_track_number = self
+            self.state.arrangement.next_track_number = self
                 .state
+                .arrangement
                 .next_track_number
-                .max(self.state.tracks.len() as u32 + 1);
-            self.state.tracks.push(track);
+                .max(self.state.arrangement.tracks.len() as u32 + 1);
+            self.state.arrangement.tracks.push(track);
         }
 
         for loaded_clip in loaded.clips {
@@ -1082,7 +1091,8 @@ impl App {
             });
         }
 
-        self.state.selected_track = self.state.tracks.first().map(|track| track.id);
+        self.state.arrangement.selected_track =
+            self.state.arrangement.tracks.first().map(|track| track.id);
         self.state.current_project_path = Some(loaded.path.clone());
         self.state.project_dirty = false;
         self.state.status_text = if loaded.warnings.is_empty() {
@@ -1187,7 +1197,7 @@ impl App {
         let mut clips = std::collections::HashMap::new();
         let mut samplers = std::collections::HashMap::new();
         let mut pads = std::collections::HashMap::new();
-        for track in &self.state.tracks {
+        for track in &self.state.arrangement.tracks {
             for clip in &track.clips {
                 clips.insert(clip.id, Arc::clone(&clip.audio));
             }
@@ -1271,13 +1281,14 @@ impl App {
 
     fn finalize_bounce(&mut self, outcome: crate::message::BounceOutcome) {
         let track_num = self.next_unique_track_number("Bounce");
-        self.state.next_track_number = track_num + 1;
+        self.state.arrangement.next_track_number = track_num + 1;
         let color_index = (track_num.wrapping_sub(1) % 8) as u8;
         let track_id = TrackId::new();
         let track_name = format!("Bounce {track_num}");
 
         self.send_command(EngineCommand::AddTrack(track_id, track_name.clone()));
         self.state
+            .arrangement
             .tracks
             .push(UiTrack::new(track_id, track_name, color_index));
 
@@ -1314,9 +1325,10 @@ impl App {
             });
         }
 
-        self.state.selected_track = Some(track_id);
-        self.state.selected_clips.clear();
+        self.state.arrangement.selected_track = Some(track_id);
+        self.state.arrangement.selected_clips.clear();
         self.state
+            .arrangement
             .selected_clips
             .insert(ArrangementSelection::AudioClip { track_id, clip_id });
         self.mark_project_dirty();
@@ -1336,16 +1348,16 @@ impl App {
 
     fn take_snapshot(&self) -> crate::state::ProjectSnapshot {
         crate::state::ProjectSnapshot {
-            tracks: self.state.tracks.clone(),
+            tracks: self.state.arrangement.tracks.clone(),
             bpm: self.state.transport.bpm,
             bpm_text: self.state.transport.bpm_text.clone(),
             loop_enabled: self.state.transport.loop_enabled,
             loop_start_beats: self.state.transport.loop_start_beats,
             loop_end_beats: self.state.transport.loop_end_beats,
-            selected_track: self.state.selected_track,
-            selected_clips: self.state.selected_clips.clone(),
-            selected_note_clip: self.state.selected_note_clip,
-            next_track_number: self.state.next_track_number,
+            selected_track: self.state.arrangement.selected_track,
+            selected_clips: self.state.arrangement.selected_clips.clone(),
+            selected_note_clip: self.state.arrangement.selected_note_clip,
+            next_track_number: self.state.arrangement.next_track_number,
         }
     }
 
@@ -1367,21 +1379,22 @@ impl App {
         self.plugin_state_ptrs.clear();
 
         // Tear down the engine side.
-        let existing_track_ids: Vec<TrackId> = self.state.tracks.iter().map(|t| t.id).collect();
+        let existing_track_ids: Vec<TrackId> =
+            self.state.arrangement.tracks.iter().map(|t| t.id).collect();
         for track_id in existing_track_ids {
             self.send_command(EngineCommand::RemoveTrack(track_id));
         }
 
-        self.state.tracks = snapshot.tracks;
+        self.state.arrangement.tracks = snapshot.tracks;
         self.state.transport.bpm = snapshot.bpm;
         self.state.transport.bpm_text = snapshot.bpm_text;
         self.state.transport.loop_enabled = snapshot.loop_enabled;
         self.state.transport.loop_start_beats = snapshot.loop_start_beats;
         self.state.transport.loop_end_beats = snapshot.loop_end_beats;
-        self.state.selected_track = snapshot.selected_track;
-        self.state.selected_clips = snapshot.selected_clips;
-        self.state.selected_note_clip = snapshot.selected_note_clip;
-        self.state.next_track_number = snapshot.next_track_number;
+        self.state.arrangement.selected_track = snapshot.selected_track;
+        self.state.arrangement.selected_clips = snapshot.selected_clips;
+        self.state.arrangement.selected_note_clip = snapshot.selected_note_clip;
+        self.state.arrangement.next_track_number = snapshot.next_track_number;
 
         self.send_command(EngineCommand::SetBpm(self.state.transport.bpm));
         self.send_command(EngineCommand::SetArrangementLoop(
@@ -1397,7 +1410,7 @@ impl App {
             self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
         }
 
-        let tracks = self.state.tracks.clone();
+        let tracks = self.state.arrangement.tracks.clone();
         for track in &tracks {
             self.replay_track_to_engine(track);
         }
@@ -1586,13 +1599,16 @@ impl App {
         if let Some(track) = self.state.find_track_mut(track_id) {
             track.clips.retain(|c| c.id != old_clip_id);
         }
-        self.state.selected_clips.retain(|sel| match sel {
-            ArrangementSelection::AudioClip {
-                clip_id: cid,
-                track_id: tid,
-            } => !(*tid == track_id && *cid == old_clip_id),
-            _ => true,
-        });
+        self.state
+            .arrangement
+            .selected_clips
+            .retain(|sel| match sel {
+                ArrangementSelection::AudioClip {
+                    clip_id: cid,
+                    track_id: tid,
+                } => !(*tid == track_id && *cid == old_clip_id),
+                _ => true,
+            });
 
         self.send_command(EngineCommand::AddClip {
             track_id,
@@ -1624,6 +1640,7 @@ impl App {
             });
         }
         self.state
+            .arrangement
             .selected_clips
             .insert(ArrangementSelection::AudioClip {
                 track_id,
@@ -1675,7 +1692,7 @@ impl App {
             self.plugin_state_ptrs.remove(&key);
         }
         if let Some(track_id) = action.select_track {
-            self.state.selected_track = Some(track_id);
+            self.state.arrangement.selected_track = Some(track_id);
         }
         if let Some(status) = action.status {
             self.state.status_text = status;
@@ -1712,7 +1729,7 @@ impl App {
         let mut warped: Vec<(TrackId, ClipId)> = Vec::new();
         let mut moves: Vec<(TrackId, ClipId, u64)> = Vec::new();
 
-        for track in &mut self.state.tracks {
+        for track in &mut self.state.arrangement.tracks {
             for clip in &mut track.clips {
                 if !clip.warped {
                     continue;
@@ -2142,9 +2159,12 @@ impl App {
                 let sample_rate = self.state.transport.sample_rate;
                 let action = {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
-                    self.state
-                        .devices
-                        .update(msg, &mut engine, &mut self.state.tracks, sample_rate)
+                    self.state.devices.update(
+                        msg,
+                        &mut engine,
+                        &mut self.state.arrangement.tracks,
+                        sample_rate,
+                    )
                 };
                 self.apply_devices_action(action);
             }
@@ -2239,14 +2259,17 @@ impl App {
             Message::AddTrack => {
                 let track_num = self.next_unique_track_number("Track");
                 let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-                self.state.next_track_number = track_num + 1;
+                self.state.arrangement.next_track_number = track_num + 1;
                 let id = TrackId::new();
                 let name = format!("Track {track_num}");
 
                 self.send_command(EngineCommand::AddTrack(id, name.clone()));
-                self.state.tracks.push(UiTrack::new(id, name, color_index));
-                self.state.selected_track = Some(id);
-                self.state.status_text = format!("{} tracks", self.state.tracks.len());
+                self.state
+                    .arrangement
+                    .tracks
+                    .push(UiTrack::new(id, name, color_index));
+                self.state.arrangement.selected_track = Some(id);
+                self.state.status_text = format!("{} tracks", self.state.arrangement.tracks.len());
             }
             Message::RemoveTrack(track_id) => {
                 // Capture identity before mutating so we can report exactly
@@ -2272,18 +2295,19 @@ impl App {
                 });
 
                 self.send_command(EngineCommand::RemoveTrack(track_id));
-                self.state.tracks.retain(|t| t.id != track_id);
-                if self.state.selected_track == Some(track_id) {
-                    self.state.selected_track = self.state.tracks.first().map(|t| t.id);
+                self.state.arrangement.tracks.retain(|t| t.id != track_id);
+                if self.state.arrangement.selected_track == Some(track_id) {
+                    self.state.arrangement.selected_track =
+                        self.state.arrangement.tracks.first().map(|t| t.id);
                 }
                 // Clear note clip selection if track removed
-                if let Some((tid, _)) = self.state.selected_note_clip {
+                if let Some((tid, _)) = self.state.arrangement.selected_note_clip {
                     if tid == track_id {
-                        self.state.selected_note_clip = None;
+                        self.state.arrangement.selected_note_clip = None;
                     }
                 }
                 // Clear arrangement selections for removed track
-                self.state.selected_clips.retain(|sel| {
+                self.state.arrangement.selected_clips.retain(|sel| {
                     let sel_track = match sel {
                         ArrangementSelection::AudioClip { track_id: t, .. } => *t,
                         ArrangementSelection::NoteClip { track_id: t, .. } => *t,
@@ -2292,7 +2316,7 @@ impl App {
                 });
                 self.state.status_text = format!(
                     "Removed {removed_name}. {} track(s) remain.",
-                    self.state.tracks.len()
+                    self.state.arrangement.tracks.len()
                 );
             }
             Message::DeleteKeyPressed => {
@@ -2303,7 +2327,7 @@ impl App {
                     return Task::none();
                 }
                 // Priority 1: selected notes in the open piano roll.
-                if let Some((track_id, clip_id)) = self.state.selected_note_clip {
+                if let Some((track_id, clip_id)) = self.state.arrangement.selected_note_clip {
                     let has_selection = self
                         .state
                         .find_track(track_id)
@@ -2314,12 +2338,12 @@ impl App {
                     }
                 }
                 // Priority 2: selected arrangement clips.
-                if !self.state.selected_clips.is_empty() {
+                if !self.state.arrangement.selected_clips.is_empty() {
                     return self.update(Message::DeleteSelectedClip);
                 }
             }
             Message::SelectTrack(track_id) => {
-                self.state.selected_track = Some(track_id);
+                self.state.arrangement.selected_track = Some(track_id);
             }
             Message::AddClipToTrack(track_id) => {
                 // Guard: only audio tracks can have audio clips
@@ -2422,6 +2446,7 @@ impl App {
                 }
                 // Clear from multi-selection if this clip was selected
                 self.state
+                    .arrangement
                     .selected_clips
                     .remove(&ArrangementSelection::AudioClip { track_id, clip_id });
             }
@@ -2470,7 +2495,7 @@ impl App {
             Message::AddInstrumentTrack => {
                 let track_num = self.next_unique_track_number("MIDI");
                 let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-                self.state.next_track_number = track_num + 1;
+                self.state.arrangement.next_track_number = track_num + 1;
                 let id = TrackId::new();
                 let name = format!("MIDI {track_num}");
                 let kind = TrackKind::Midi;
@@ -2478,9 +2503,9 @@ impl App {
                 self.send_command(EngineCommand::AddMidiTrack(id, name.clone()));
                 let mut track = UiTrack::new_instrument(id, name, kind, color_index);
                 track.has_instrument = false;
-                self.state.tracks.push(track);
-                self.state.selected_track = Some(id);
-                self.state.status_text = format!("{} tracks", self.state.tracks.len());
+                self.state.arrangement.tracks.push(track);
+                self.state.arrangement.selected_track = Some(id);
+                self.state.status_text = format!("{} tracks", self.state.arrangement.tracks.len());
             }
 
             // -- Sampler --
@@ -2521,7 +2546,7 @@ impl App {
                 self.apply_sampler_sample_loaded(track_id, audio, name, source);
             }
             Message::SamplerDecodeError(track_id, err) => {
-                self.state.selected_track = Some(track_id);
+                self.state.arrangement.selected_track = Some(track_id);
                 self.state.status_text = format!("Sample load error: {err}");
             }
             Message::LoadDrumRackPadSample(track_id, pad_index) => {
@@ -2562,7 +2587,7 @@ impl App {
                 self.apply_drum_rack_pad_loaded(track_id, pad_index, audio, name, source);
             }
             Message::DrumRackPadDecodeError(track_id, _pad_index, err) => {
-                self.state.selected_track = Some(track_id);
+                self.state.arrangement.selected_track = Some(track_id);
                 self.state.status_text = format!("Drum pad load error: {err}");
             }
 
@@ -2699,12 +2724,12 @@ impl App {
                     loop_end_beats: duration_beats,
                 });
                 // Auto-select the new note clip for piano roll editing
-                self.state.selected_note_clip = Some((track_id, clip_id));
+                self.state.arrangement.selected_note_clip = Some((track_id, clip_id));
                 self.state.status_text = "Added note clip".to_string();
             }
             Message::SelectNoteClip(track_id, clip_id) => {
-                self.state.selected_note_clip = Some((track_id, clip_id));
-                self.state.selected_track = Some(track_id);
+                self.state.arrangement.selected_note_clip = Some((track_id, clip_id));
+                self.state.arrangement.selected_track = Some(track_id);
             }
             Message::AddNote {
                 track_id,
@@ -2945,7 +2970,7 @@ impl App {
                             note: *note,
                         });
                     }
-                    self.state.selected_note_clip = Some((track_id, new_clip_id));
+                    self.state.arrangement.selected_note_clip = Some((track_id, new_clip_id));
                     self.state.status_text = "Duplicated clip".to_string();
                 }
             }
@@ -3069,25 +3094,25 @@ impl App {
             } => {
                 if shift_held {
                     // Toggle in/out of selection set
-                    if !self.state.selected_clips.remove(&selection) {
-                        self.state.selected_clips.insert(selection);
+                    if !self.state.arrangement.selected_clips.remove(&selection) {
+                        self.state.arrangement.selected_clips.insert(selection);
                     }
                 } else {
                     // Replace selection
-                    self.state.selected_clips.clear();
-                    self.state.selected_clips.insert(selection);
+                    self.state.arrangement.selected_clips.clear();
+                    self.state.arrangement.selected_clips.insert(selection);
                 }
                 self.state.detail_panel_tab = DetailPanelTab::Clip;
                 // Also update track selection and note clip selection for detail panel
                 match selection {
                     ArrangementSelection::AudioClip { track_id, .. } => {
-                        self.state.selected_track = Some(track_id);
+                        self.state.arrangement.selected_track = Some(track_id);
                         // Clear note clip selection when an audio clip is selected
-                        self.state.selected_note_clip = None;
+                        self.state.arrangement.selected_note_clip = None;
                     }
                     ArrangementSelection::NoteClip { track_id, clip_id } => {
-                        self.state.selected_track = Some(track_id);
-                        self.state.selected_note_clip = Some((track_id, clip_id));
+                        self.state.arrangement.selected_track = Some(track_id);
+                        self.state.arrangement.selected_note_clip = Some((track_id, clip_id));
                     }
                 }
             }
@@ -3305,20 +3330,20 @@ impl App {
                             track.note_clips.push(clip);
                         }
                         // Update selection
-                        self.state
-                            .selected_clips
-                            .remove(&ArrangementSelection::NoteClip {
+                        self.state.arrangement.selected_clips.remove(
+                            &ArrangementSelection::NoteClip {
                                 track_id: source_track,
                                 clip_id,
-                            });
-                        self.state
-                            .selected_clips
-                            .insert(ArrangementSelection::NoteClip {
+                            },
+                        );
+                        self.state.arrangement.selected_clips.insert(
+                            ArrangementSelection::NoteClip {
                                 track_id: target_track,
                                 clip_id,
-                            });
-                        self.state.selected_track = Some(target_track);
-                        self.state.selected_note_clip = Some((target_track, clip_id));
+                            },
+                        );
+                        self.state.arrangement.selected_track = Some(target_track);
+                        self.state.arrangement.selected_note_clip = Some((target_track, clip_id));
                     }
                 } else {
                     // Move audio clip between audio tracks
@@ -3348,19 +3373,19 @@ impl App {
                             track.clips.push(clip);
                         }
                         // Update selection
-                        self.state
-                            .selected_clips
-                            .remove(&ArrangementSelection::AudioClip {
+                        self.state.arrangement.selected_clips.remove(
+                            &ArrangementSelection::AudioClip {
                                 track_id: source_track,
                                 clip_id,
-                            });
-                        self.state
-                            .selected_clips
-                            .insert(ArrangementSelection::AudioClip {
+                            },
+                        );
+                        self.state.arrangement.selected_clips.insert(
+                            ArrangementSelection::AudioClip {
                                 track_id: target_track,
                                 clip_id,
-                            });
-                        self.state.selected_track = Some(target_track);
+                            },
+                        );
+                        self.state.arrangement.selected_track = Some(target_track);
                     }
                 }
             }
@@ -3478,9 +3503,11 @@ impl App {
 
                     // Update selection: remove original, add left half
                     self.state
+                        .arrangement
                         .selected_clips
                         .remove(&ArrangementSelection::AudioClip { track_id, clip_id });
                     self.state
+                        .arrangement
                         .selected_clips
                         .insert(ArrangementSelection::AudioClip {
                             track_id,
@@ -3612,21 +3639,23 @@ impl App {
 
                     // Update selection: remove original, add left half
                     self.state
+                        .arrangement
                         .selected_clips
                         .remove(&ArrangementSelection::NoteClip { track_id, clip_id });
                     self.state
+                        .arrangement
                         .selected_clips
                         .insert(ArrangementSelection::NoteClip {
                             track_id,
                             clip_id: left_id,
                         });
-                    self.state.selected_note_clip = Some((track_id, left_id));
+                    self.state.arrangement.selected_note_clip = Some((track_id, left_id));
                     self.state.status_text = "Split note clip".to_string();
                 }
             }
 
             Message::DeleteSelectedClip => {
-                let selections: Vec<_> = self.state.selected_clips.drain().collect();
+                let selections: Vec<_> = self.state.arrangement.selected_clips.drain().collect();
                 if !selections.is_empty() {
                     for selection in &selections {
                         match selection {
@@ -3645,10 +3674,11 @@ impl App {
                                 }
                                 if self
                                     .state
+                                    .arrangement
                                     .selected_note_clip
                                     .is_some_and(|(tid, cid)| tid == *track_id && cid == *clip_id)
                                 {
-                                    self.state.selected_note_clip = None;
+                                    self.state.arrangement.selected_note_clip = None;
                                 }
                             }
                         }
@@ -3663,7 +3693,13 @@ impl App {
             }
 
             Message::DuplicateSelectedClip => {
-                let selections: Vec<_> = self.state.selected_clips.iter().copied().collect();
+                let selections: Vec<_> = self
+                    .state
+                    .arrangement
+                    .selected_clips
+                    .iter()
+                    .copied()
+                    .collect();
                 if !selections.is_empty() {
                     let mut new_selections = HashSet::new();
                     for selection in &selections {
@@ -3785,7 +3821,7 @@ impl App {
                         }
                     }
                     // Select the new copies
-                    self.state.selected_clips = new_selections;
+                    self.state.arrangement.selected_clips = new_selections;
                     let count = selections.len();
                     self.state.status_text = if count == 1 {
                         "Duplicated clip".to_string()
@@ -3809,7 +3845,13 @@ impl App {
                     });
                 }
 
-                let clips: Vec<_> = self.state.selected_clips.iter().copied().collect();
+                let clips: Vec<_> = self
+                    .state
+                    .arrangement
+                    .selected_clips
+                    .iter()
+                    .copied()
+                    .collect();
                 for selection in clips {
                     match selection {
                         ArrangementSelection::AudioClip { track_id, clip_id } => {
@@ -3832,7 +3874,13 @@ impl App {
 
             // -- Join selected clips (Ctrl+J) --
             Message::JoinSelectedClips => {
-                let clips: Vec<_> = self.state.selected_clips.iter().copied().collect();
+                let clips: Vec<_> = self
+                    .state
+                    .arrangement
+                    .selected_clips
+                    .iter()
+                    .copied()
+                    .collect();
                 if clips.len() < 2 {
                     return Task::none();
                 }
@@ -3870,7 +3918,7 @@ impl App {
                 self.state.time_selection_active = true;
                 self.state.time_selection_track = track_id;
                 if let Some(tid) = track_id {
-                    self.state.selected_track = Some(tid);
+                    self.state.arrangement.selected_track = Some(tid);
                 }
             }
             Message::SetSelectionAsLoop => {
@@ -3932,11 +3980,11 @@ impl App {
                             clip_id: *clip_id,
                         }
                     };
-                    if !self.state.selected_clips.contains(&selection) {
-                        self.state.selected_clips.clear();
-                        self.state.selected_clips.insert(selection);
+                    if !self.state.arrangement.selected_clips.contains(&selection) {
+                        self.state.arrangement.selected_clips.clear();
+                        self.state.arrangement.selected_clips.insert(selection);
                     }
-                    self.state.selected_track = Some(*track_id);
+                    self.state.arrangement.selected_track = Some(*track_id);
                 }
                 self.state.context_menu = Some(crate::state::ContextMenu {
                     x: menu_x,
@@ -3961,7 +4009,7 @@ impl App {
                 // Collect clip IDs to remove
                 let mut audio_removals: Vec<(TrackId, ClipId)> = Vec::new();
                 let mut note_removals: Vec<(TrackId, ClipId)> = Vec::new();
-                for track in &self.state.tracks {
+                for track in &self.state.arrangement.tracks {
                     if let Some(tid) = target_track {
                         if track.id != tid {
                             continue;
@@ -3995,8 +4043,8 @@ impl App {
                         track.note_clips.retain(|c| c.id != *cid);
                     }
                 }
-                self.state.selected_clips.clear();
-                self.state.selected_note_clip = None;
+                self.state.arrangement.selected_clips.clear();
+                self.state.arrangement.selected_note_clip = None;
                 self.state.time_selection_active = false;
                 let count = audio_removals.len() + note_removals.len();
                 self.state.status_text = format!("Deleted {count} clips in region");
@@ -4025,6 +4073,7 @@ impl App {
                     // on a single lane.
                     let audio_hits: Vec<(TrackId, ClipId)> = if spb > 0.0 {
                         self.state
+                            .arrangement
                             .tracks
                             .iter()
                             .filter(|t| target_track.is_none_or(|tid| t.id == tid))
@@ -4046,6 +4095,7 @@ impl App {
 
                     let note_hits: Vec<(TrackId, ClipId)> = self
                         .state
+                        .arrangement
                         .tracks
                         .iter()
                         .filter(|t| target_track.is_none_or(|tid| t.id == tid))
@@ -4087,7 +4137,7 @@ impl App {
 
             // -- Clip creation from region --
             Message::CreateClipFromSelection => {
-                if let Some(tid) = self.state.selected_track {
+                if let Some(tid) = self.state.arrangement.selected_track {
                     if let Some(track) = self.state.find_track(tid) {
                         if track.kind.is_midi() {
                             return self.update(Message::CreateNoteClipFromSelection(tid));
@@ -4141,9 +4191,10 @@ impl App {
                     loop_start_beats: 0.0,
                     loop_end_beats: 0.0,
                 });
-                self.state.selected_note_clip = Some((track_id, clip_id));
-                self.state.selected_clips.clear();
+                self.state.arrangement.selected_note_clip = Some((track_id, clip_id));
+                self.state.arrangement.selected_clips.clear();
                 self.state
+                    .arrangement
                     .selected_clips
                     .insert(ArrangementSelection::NoteClip { track_id, clip_id });
                 self.state.status_text = "Created note clip from selection".to_string();
@@ -4151,30 +4202,44 @@ impl App {
 
             // -- Track reordering --
             Message::MoveTrackUp(track_id) => {
-                if let Some(idx) = self.state.tracks.iter().position(|t| t.id == track_id) {
+                if let Some(idx) = self
+                    .state
+                    .arrangement
+                    .tracks
+                    .iter()
+                    .position(|t| t.id == track_id)
+                {
                     if idx > 0 {
-                        self.state.tracks.swap(idx, idx - 1);
-                        let order: Vec<TrackId> = self.state.tracks.iter().map(|t| t.id).collect();
+                        self.state.arrangement.tracks.swap(idx, idx - 1);
+                        let order: Vec<TrackId> =
+                            self.state.arrangement.tracks.iter().map(|t| t.id).collect();
                         self.send_command(EngineCommand::ReorderTracks(order));
                     }
                 }
             }
             Message::MoveTrackDown(track_id) => {
-                if let Some(idx) = self.state.tracks.iter().position(|t| t.id == track_id) {
-                    if idx + 1 < self.state.tracks.len() {
-                        self.state.tracks.swap(idx, idx + 1);
-                        let order: Vec<TrackId> = self.state.tracks.iter().map(|t| t.id).collect();
+                if let Some(idx) = self
+                    .state
+                    .arrangement
+                    .tracks
+                    .iter()
+                    .position(|t| t.id == track_id)
+                {
+                    if idx + 1 < self.state.arrangement.tracks.len() {
+                        self.state.arrangement.tracks.swap(idx, idx + 1);
+                        let order: Vec<TrackId> =
+                            self.state.arrangement.tracks.iter().map(|t| t.id).collect();
                         self.send_command(EngineCommand::ReorderTracks(order));
                     }
                 }
             }
             Message::MoveSelectedTrackUp => {
-                if let Some(tid) = self.state.selected_track {
+                if let Some(tid) = self.state.arrangement.selected_track {
                     return self.update(Message::MoveTrackUp(tid));
                 }
             }
             Message::MoveSelectedTrackDown => {
-                if let Some(tid) = self.state.selected_track {
+                if let Some(tid) = self.state.arrangement.selected_track {
                     return self.update(Message::MoveTrackDown(tid));
                 }
             }
@@ -4249,7 +4314,7 @@ impl App {
             Message::AddMidiTrack => {
                 let track_num = self.next_unique_track_number("MIDI");
                 let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-                self.state.next_track_number = track_num + 1;
+                self.state.arrangement.next_track_number = track_num + 1;
                 let id = TrackId::new();
                 let name = format!("MIDI {track_num}");
                 let kind = TrackKind::Midi;
@@ -4257,9 +4322,9 @@ impl App {
                 self.send_command(EngineCommand::AddMidiTrack(id, name.clone()));
                 let mut track = UiTrack::new_instrument(id, name, kind, color_index);
                 track.has_instrument = false;
-                self.state.tracks.push(track);
-                self.state.selected_track = Some(id);
-                self.state.status_text = format!("{} tracks", self.state.tracks.len());
+                self.state.arrangement.tracks.push(track);
+                self.state.arrangement.selected_track = Some(id);
+                self.state.status_text = format!("{} tracks", self.state.arrangement.tracks.len());
             }
 
             // -- Instrument attach/detach --
@@ -4343,6 +4408,7 @@ impl App {
                 // Collect targets first so we don't hold a borrow across dispatch.
                 let targets: Vec<(TrackId, ClipId)> = self
                     .state
+                    .arrangement
                     .tracks
                     .iter()
                     .flat_map(|track| {
@@ -4606,7 +4672,7 @@ impl App {
             Message::ImportSelectedBrowserSampleToArrangement => {
                 if let Some(entry) = self.selected_sample_browser_entry().cloned() {
                     let target = BrowserImportTarget::ArrangementClip(
-                        self.state.selected_track.filter(|track_id| {
+                        self.state.arrangement.selected_track.filter(|track_id| {
                             self.state
                                 .find_track(*track_id)
                                 .is_some_and(|track| matches!(track.kind, TrackKind::Audio))
@@ -5380,7 +5446,8 @@ impl App {
                     return Task::none();
                 };
                 let cache = self.dropbox_cache.clone();
-                let target = BrowserImportTarget::ArrangementClip(self.state.selected_track);
+                let target =
+                    BrowserImportTarget::ArrangementClip(self.state.arrangement.selected_track);
                 self.state.status_text = format!("Importing {}...", entry.name);
                 return Task::perform(
                     fetch_dropbox_sample_async(client, cache, entry),
@@ -5531,8 +5598,9 @@ impl App {
             });
         }
 
-        self.state.selected_clips.clear();
+        self.state.arrangement.selected_clips.clear();
         self.state
+            .arrangement
             .selected_clips
             .insert(ArrangementSelection::AudioClip {
                 track_id,
@@ -5625,14 +5693,15 @@ impl App {
             });
         }
 
-        self.state.selected_clips.clear();
+        self.state.arrangement.selected_clips.clear();
         self.state
+            .arrangement
             .selected_clips
             .insert(ArrangementSelection::NoteClip {
                 track_id,
                 clip_id: new_id,
             });
-        self.state.selected_note_clip = Some((track_id, new_id));
+        self.state.arrangement.selected_note_clip = Some((track_id, new_id));
         self.state.status_text = "Joined note clips".to_string();
     }
 
@@ -5891,7 +5960,7 @@ impl App {
         if events.is_empty() {
             return;
         }
-        let Some(track_id) = self.state.selected_track else {
+        let Some(track_id) = self.state.arrangement.selected_track else {
             return;
         };
         let has_instrument = self
@@ -6855,7 +6924,7 @@ impl App {
                 let mut col = column![].spacing(0).width(Length::Fixed(200.0));
 
                 // "Create Note Clip" if track is an instrument track
-                let effective_track = track_id.or(self.state.selected_track);
+                let effective_track = track_id.or(self.state.arrangement.selected_track);
                 if let Some(tid) = effective_track {
                     if let Some(track) = self.state.find_track(tid) {
                         if track.kind.is_midi() {
@@ -7929,7 +7998,7 @@ impl App {
     // ── Arrangement view ──
 
     fn view_arrangement(&self) -> Element<'_, Message> {
-        if self.state.tracks.is_empty() {
+        if self.state.arrangement.tracks.is_empty() {
             let prompt = text("Right-click or Ctrl+T to add a track")
                 .size(16)
                 .color(th::TEXT_DIM);
@@ -8009,6 +8078,7 @@ impl App {
             loop_end_beats: self.state.transport.loop_end_beats,
             tracks: self
                 .state
+                .arrangement
                 .tracks
                 .iter()
                 .map(|t| {
@@ -8043,20 +8113,27 @@ impl App {
         let minimap_row = row![minimap_spacer, minimap_canvas];
 
         // Collect track IDs and kinds for cross-track drag
-        let track_ids: Vec<TrackId> = self.state.tracks.iter().map(|t| t.id).collect();
-        let track_kinds: Vec<bool> = self.state.tracks.iter().map(|t| t.kind.is_midi()).collect();
-        let total_track_count = self.state.tracks.len();
+        let track_ids: Vec<TrackId> = self.state.arrangement.tracks.iter().map(|t| t.id).collect();
+        let track_kinds: Vec<bool> = self
+            .state
+            .arrangement
+            .tracks
+            .iter()
+            .map(|t| t.kind.is_midi())
+            .collect();
+        let total_track_count = self.state.arrangement.tracks.len();
 
         // Track rows: header widgets + clip canvas
         let mut track_rows = column![].spacing(0);
 
-        for (track_index, track) in self.state.tracks.iter().enumerate() {
-            let selected = self.state.selected_track == Some(track.id);
+        for (track_index, track) in self.state.arrangement.tracks.iter().enumerate() {
+            let selected = self.state.arrangement.selected_track == Some(track.id);
             let track_color = th::track_color(track.color_index);
 
             // Collect selected clip IDs for this track
             let selected_clips: HashSet<ClipId> = self
                 .state
+                .arrangement
                 .selected_clips
                 .iter()
                 .filter_map(|sel| match sel {
@@ -8144,7 +8221,7 @@ impl App {
     // ── Mixer view ──
 
     fn view_mixer(&self) -> Element<'_, Message> {
-        if self.state.tracks.is_empty() {
+        if self.state.arrangement.tracks.is_empty() {
             let prompt = text("Add a track to get started")
                 .size(16)
                 .color(th::TEXT_DIM);
@@ -8164,7 +8241,7 @@ impl App {
         // ── Channel strips + pinned master ──
         let mut strips = row![].spacing(4).padding(8).height(Length::Fill);
 
-        for track in &self.state.tracks {
+        for track in &self.state.arrangement.tracks {
             let strip = view_mixer_strip(track);
             strips = strips.push(strip);
         }
@@ -8231,6 +8308,7 @@ impl App {
     fn view_detail_panel(&self) -> Element<'_, Message> {
         let detail_content: Element<'_, Message> = if let Some(track) = self
             .state
+            .arrangement
             .selected_track
             .and_then(|id| self.state.find_track(id))
         {
@@ -8296,10 +8374,11 @@ impl App {
                     let is_midi = track.kind.is_midi();
                     // Check for note clip selection on this MIDI track
                     let has_note_clip = is_midi
-                        && (self.state.selected_clips.iter().any(|s| {
+                        && (self.state.arrangement.selected_clips.iter().any(|s| {
                             matches!(s, ArrangementSelection::NoteClip { track_id: tid, .. } if *tid == track_id)
                         }) || self
                             .state
+                            .arrangement
                             .selected_note_clip
                             .is_some_and(|(tid, _)| tid == track_id));
 
@@ -8307,13 +8386,18 @@ impl App {
                         self.view_piano_roll_panel(track_id, track_color)
                     } else {
                         // Find a single selected audio clip on this track
-                        let audio_sel = self.state.selected_clips.iter().find_map(|s| match s {
-                            ArrangementSelection::AudioClip {
-                                track_id: tid,
-                                clip_id: cid,
-                            } if *tid == track_id => Some(*cid),
-                            _ => None,
-                        });
+                        let audio_sel =
+                            self.state
+                                .arrangement
+                                .selected_clips
+                                .iter()
+                                .find_map(|s| match s {
+                                    ArrangementSelection::AudioClip {
+                                        track_id: tid,
+                                        clip_id: cid,
+                                    } if *tid == track_id => Some(*cid),
+                                    _ => None,
+                                });
                         if let Some(sel_cid) = audio_sel {
                             if let Some(clip) = track.clips.iter().find(|c| c.id == sel_cid) {
                                 self.view_audio_clip_panel(track_id, clip, track_color)
@@ -9543,9 +9627,10 @@ impl App {
 
         // Extract clip data as owned values (avoids lifetime conflicts with widget construction)
         let clip_data: Option<(String, f64, f64, bool, TrackId, ClipId)> =
-            if let Some((tid, cid)) = self.state.selected_note_clip {
+            if let Some((tid, cid)) = self.state.arrangement.selected_note_clip {
                 if tid == track_id {
                     self.state
+                        .arrangement
                         .tracks
                         .iter()
                         .find(|t| t.id == track_id)

--- a/crates/vibez-ui/src/app.rs
+++ b/crates/vibez-ui/src/app.rs
@@ -8,6 +8,7 @@ use iced::widget::{
 };
 use iced::{Color, Element, Length, Subscription, Task, Theme};
 
+use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::transport::TransportMsg;
 use rtrb::{Consumer, Producer};
 use vibez_audio_io::audio_stream::AudioOutputStream;
@@ -1682,6 +1683,26 @@ impl App {
         })
     }
 
+    /// Route cross-domain effects requested by the arrangement domain.
+    fn apply_arrangement_action(&mut self, action: crate::domains::arrangement::ArrangementAction) {
+        if let Some(track_id) = action.close_track_guis {
+            if let Some(ref mut mgr) = self.plugin_window_manager {
+                mgr.close_track_effects(track_id);
+            }
+            self.plugin_gui_raw_ptrs.retain(|k, _| match k {
+                PluginGuiKey::Effect { track_id: tid, .. } => *tid != track_id,
+                PluginGuiKey::Instrument { track_id: tid } => *tid != track_id,
+            });
+            self.plugin_state_ptrs.retain(|k, _| match k {
+                PluginGuiKey::Effect { track_id: tid, .. } => *tid != track_id,
+                PluginGuiKey::Instrument { track_id: tid } => *tid != track_id,
+            });
+        }
+        if let Some(status) = action.status {
+            self.state.status_text = status;
+        }
+    }
+
     /// Route cross-domain effects requested by the devices domain.
     fn apply_devices_action(&mut self, action: crate::domains::devices::DevicesAction) {
         if let Some(key) = action.close_gui {
@@ -2023,7 +2044,7 @@ impl App {
                     | Message::Transport(TransportMsg::EnginePosition(_))
                     | Message::EngineMetering { .. }
                     | Message::Transport(TransportMsg::EngineStopped)
-                    | Message::EngineTrackMeter { .. }
+                    | Message::Arrangement(ArrangementMsg::EngineTrackMeter { .. })
                     | Message::ShowContextMenu { .. }
                     | Message::DismissContextMenu
                     | Message::DeleteClipsInRegion { .. }
@@ -2066,15 +2087,10 @@ impl App {
         let should_mark_dirty = matches!(
             &message,
             Message::Transport(TransportMsg::BpmSubmit)
-                | Message::AddTrack
-                | Message::RemoveTrack(_)
+                | Message::Arrangement(ArrangementMsg::AddTrack)
                 | Message::ClipAudioDecoded(..)
                 | Message::RemoveClip(..)
-                | Message::SetTrackGain(..)
-                | Message::SetTrackPan(..)
-                | Message::SetTrackMute(_)
-                | Message::SetTrackSolo(_)
-                | Message::AddInstrumentTrack
+                | Message::Arrangement(ArrangementMsg::AddInstrumentTrack)
                 | Message::SamplerSampleDecoded(..)
                 | Message::DrumRackPadSampleDecoded(..)
                 | Message::BrowserSampleDecoded(..)
@@ -2109,13 +2125,9 @@ impl App {
                 | Message::SplitClipsAtRegion { .. }
                 | Message::CreateClipFromSelection
                 | Message::CreateNoteClipFromSelection(_)
-                | Message::MoveTrackUp(_)
-                | Message::MoveTrackDown(_)
-                | Message::MoveSelectedTrackUp
-                | Message::MoveSelectedTrackDown
-                | Message::RenameTrack(..)
-                | Message::RenameClip(..)
-                | Message::AddMidiTrack
+                | Message::Arrangement(ArrangementMsg::MoveSelectedTrackUp)
+                | Message::Arrangement(ArrangementMsg::MoveSelectedTrackDown)
+                | Message::Arrangement(ArrangementMsg::AddMidiTrack)
                 | Message::HalveNoteClip(..)
                 | Message::QuantizeNoteClip { .. }
                 | Message::AudioQuantizeReady { .. }
@@ -2124,7 +2136,8 @@ impl App {
                 | Message::ClipWarpReady { .. }
                 | Message::ClearClipWarp { .. }
                 | Message::ClipAutoWarpReady { .. }
-        ) || matches!(&message, Message::Devices(m) if m.marks_dirty());
+        ) || matches!(&message, Message::Devices(m) if m.marks_dirty())
+            || matches!(&message, Message::Arrangement(m) if m.marks_dirty());
         if should_mark_dirty {
             self.push_undo_snapshot();
             self.mark_project_dirty();
@@ -2167,6 +2180,13 @@ impl App {
                     )
                 };
                 self.apply_devices_action(action);
+            }
+            Message::Arrangement(msg) => {
+                let action = {
+                    let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+                    self.state.arrangement.update(msg, &mut engine)
+                };
+                self.apply_arrangement_action(action);
             }
 
             // -- Workspace --
@@ -2256,69 +2276,6 @@ impl App {
             }
 
             // -- Multi-track messages --
-            Message::AddTrack => {
-                let track_num = self.next_unique_track_number("Track");
-                let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-                self.state.arrangement.next_track_number = track_num + 1;
-                let id = TrackId::new();
-                let name = format!("Track {track_num}");
-
-                self.send_command(EngineCommand::AddTrack(id, name.clone()));
-                self.state
-                    .arrangement
-                    .tracks
-                    .push(UiTrack::new(id, name, color_index));
-                self.state.arrangement.selected_track = Some(id);
-                self.state.status_text = format!("{} tracks", self.state.arrangement.tracks.len());
-            }
-            Message::RemoveTrack(track_id) => {
-                // Capture identity before mutating so we can report exactly
-                // which track was removed. Helps diagnose the "deleted the
-                // wrong track" reports.
-                let removed_name = self
-                    .state
-                    .find_track(track_id)
-                    .map(|t| t.name.clone())
-                    .unwrap_or_else(|| format!("{track_id}"));
-
-                // Close all plugin GUI windows for this track
-                if let Some(ref mut mgr) = self.plugin_window_manager {
-                    mgr.close_track_effects(track_id);
-                }
-                self.plugin_gui_raw_ptrs.retain(|k, _| match k {
-                    PluginGuiKey::Effect { track_id: tid, .. } => *tid != track_id,
-                    PluginGuiKey::Instrument { track_id: tid } => *tid != track_id,
-                });
-                self.plugin_state_ptrs.retain(|k, _| match k {
-                    PluginGuiKey::Effect { track_id: tid, .. } => *tid != track_id,
-                    PluginGuiKey::Instrument { track_id: tid } => *tid != track_id,
-                });
-
-                self.send_command(EngineCommand::RemoveTrack(track_id));
-                self.state.arrangement.tracks.retain(|t| t.id != track_id);
-                if self.state.arrangement.selected_track == Some(track_id) {
-                    self.state.arrangement.selected_track =
-                        self.state.arrangement.tracks.first().map(|t| t.id);
-                }
-                // Clear note clip selection if track removed
-                if let Some((tid, _)) = self.state.arrangement.selected_note_clip {
-                    if tid == track_id {
-                        self.state.arrangement.selected_note_clip = None;
-                    }
-                }
-                // Clear arrangement selections for removed track
-                self.state.arrangement.selected_clips.retain(|sel| {
-                    let sel_track = match sel {
-                        ArrangementSelection::AudioClip { track_id: t, .. } => *t,
-                        ArrangementSelection::NoteClip { track_id: t, .. } => *t,
-                    };
-                    sel_track != track_id
-                });
-                self.state.status_text = format!(
-                    "Removed {removed_name}. {} track(s) remain.",
-                    self.state.arrangement.tracks.len()
-                );
-            }
             Message::DeleteKeyPressed => {
                 // Never delete anything while a text field is being
                 // edited; backspace belongs to the text there.
@@ -2341,9 +2298,6 @@ impl App {
                 if !self.state.arrangement.selected_clips.is_empty() {
                     return self.update(Message::DeleteSelectedClip);
                 }
-            }
-            Message::SelectTrack(track_id) => {
-                self.state.arrangement.selected_track = Some(track_id);
             }
             Message::AddClipToTrack(track_id) => {
                 // Guard: only audio tracks can have audio clips
@@ -2450,63 +2404,10 @@ impl App {
                     .selected_clips
                     .remove(&ArrangementSelection::AudioClip { track_id, clip_id });
             }
-            Message::SetTrackGain(track_id, gain) => {
-                let gain = gain.clamp(0.0, 2.0);
-                self.send_command(EngineCommand::SetTrackGain(track_id, gain));
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    track.gain = gain;
-                }
-            }
-            Message::SetTrackPan(track_id, pan) => {
-                let pan = pan.clamp(0.0, 1.0);
-                self.send_command(EngineCommand::SetTrackPan(track_id, pan));
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    track.pan = pan;
-                }
-            }
-            Message::SetTrackMute(track_id) => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    track.mute = !track.mute;
-                    let mute = track.mute;
-                    self.send_command(EngineCommand::SetTrackMute(track_id, mute));
-                }
-            }
-            Message::SetTrackSolo(track_id) => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    track.solo = !track.solo;
-                    let solo = track.solo;
-                    self.send_command(EngineCommand::SetTrackSolo(track_id, solo));
-                }
-            }
-            Message::EngineTrackMeter {
-                track_id,
-                peak_l,
-                peak_r,
-            } => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    track.peak_l = peak_l.max(track.peak_l * 0.85);
-                    track.peak_r = peak_r.max(track.peak_r * 0.85);
-                }
-            }
 
             // -- Effects --
 
             // -- Instrument tracks --
-            Message::AddInstrumentTrack => {
-                let track_num = self.next_unique_track_number("MIDI");
-                let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-                self.state.arrangement.next_track_number = track_num + 1;
-                let id = TrackId::new();
-                let name = format!("MIDI {track_num}");
-                let kind = TrackKind::Midi;
-
-                self.send_command(EngineCommand::AddMidiTrack(id, name.clone()));
-                let mut track = UiTrack::new_instrument(id, name, kind, color_index);
-                track.has_instrument = false;
-                self.state.arrangement.tracks.push(track);
-                self.state.arrangement.selected_track = Some(id);
-                self.state.status_text = format!("{} tracks", self.state.arrangement.tracks.len());
-            }
 
             // -- Sampler --
             Message::LoadSamplerSample(track_id) => {
@@ -4201,48 +4102,6 @@ impl App {
             }
 
             // -- Track reordering --
-            Message::MoveTrackUp(track_id) => {
-                if let Some(idx) = self
-                    .state
-                    .arrangement
-                    .tracks
-                    .iter()
-                    .position(|t| t.id == track_id)
-                {
-                    if idx > 0 {
-                        self.state.arrangement.tracks.swap(idx, idx - 1);
-                        let order: Vec<TrackId> =
-                            self.state.arrangement.tracks.iter().map(|t| t.id).collect();
-                        self.send_command(EngineCommand::ReorderTracks(order));
-                    }
-                }
-            }
-            Message::MoveTrackDown(track_id) => {
-                if let Some(idx) = self
-                    .state
-                    .arrangement
-                    .tracks
-                    .iter()
-                    .position(|t| t.id == track_id)
-                {
-                    if idx + 1 < self.state.arrangement.tracks.len() {
-                        self.state.arrangement.tracks.swap(idx, idx + 1);
-                        let order: Vec<TrackId> =
-                            self.state.arrangement.tracks.iter().map(|t| t.id).collect();
-                        self.send_command(EngineCommand::ReorderTracks(order));
-                    }
-                }
-            }
-            Message::MoveSelectedTrackUp => {
-                if let Some(tid) = self.state.arrangement.selected_track {
-                    return self.update(Message::MoveTrackUp(tid));
-                }
-            }
-            Message::MoveSelectedTrackDown => {
-                if let Some(tid) = self.state.arrangement.selected_track {
-                    return self.update(Message::MoveTrackDown(tid));
-                }
-            }
 
             // -- Renaming --
             Message::StartEditingTrackName(track_id) => {
@@ -4279,12 +4138,12 @@ impl App {
                 let new_name = self.state.edit_name_text.clone();
                 if let Some(track_id) = self.state.editing_track_name.take() {
                     if !new_name.is_empty() {
-                        return self.update(Message::RenameTrack(track_id, new_name));
+                        return self.update(Message::rename_track(track_id, new_name));
                     }
                 }
                 if let Some((track_id, clip_id)) = self.state.editing_clip_name.take() {
                     if !new_name.is_empty() {
-                        return self.update(Message::RenameClip(track_id, clip_id, new_name));
+                        return self.update(Message::rename_clip(track_id, clip_id, new_name));
                     }
                 }
             }
@@ -4294,38 +4153,8 @@ impl App {
                 self.state.edit_name_text.clear();
                 self.state.devices.context_menu = None;
             }
-            Message::RenameTrack(track_id, new_name) => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    track.name = new_name;
-                }
-            }
-            Message::RenameClip(track_id, clip_id, new_name) => {
-                if let Some(track) = self.state.find_track_mut(track_id) {
-                    if let Some(c) = track.clips.iter_mut().find(|c| c.id == clip_id) {
-                        c.name = new_name.clone();
-                    }
-                    if let Some(c) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
-                        c.name = new_name;
-                    }
-                }
-            }
 
             // -- MIDI track (no auto-synth) --
-            Message::AddMidiTrack => {
-                let track_num = self.next_unique_track_number("MIDI");
-                let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-                self.state.arrangement.next_track_number = track_num + 1;
-                let id = TrackId::new();
-                let name = format!("MIDI {track_num}");
-                let kind = TrackKind::Midi;
-
-                self.send_command(EngineCommand::AddMidiTrack(id, name.clone()));
-                let mut track = UiTrack::new_instrument(id, name, kind, color_index);
-                track.has_instrument = false;
-                self.state.arrangement.tracks.push(track);
-                self.state.arrangement.selected_track = Some(id);
-                self.state.status_text = format!("{} tracks", self.state.arrangement.tracks.len());
-            }
 
             // -- Instrument attach/detach --
 
@@ -6972,12 +6801,12 @@ impl App {
                 menu_btn(
                     icons::AUDIO_WAVEFORM,
                     "Add Audio Track".into(),
-                    Message::AddTrack,
+                    Message::Arrangement(ArrangementMsg::AddTrack),
                 ),
                 menu_btn(
                     icons::MUSIC,
                     "Add MIDI Track".into(),
-                    Message::AddInstrumentTrack,
+                    Message::Arrangement(ArrangementMsg::AddInstrumentTrack),
                 ),
             ]
             .spacing(0)
@@ -10483,14 +10312,18 @@ fn global_key_handler(
         return None;
     }
     match key {
-        iced::keyboard::Key::Named(Named::ArrowUp) => Some(Message::MoveSelectedTrackUp),
-        iced::keyboard::Key::Named(Named::ArrowDown) => Some(Message::MoveSelectedTrackDown),
+        iced::keyboard::Key::Named(Named::ArrowUp) => {
+            Some(Message::Arrangement(ArrangementMsg::MoveSelectedTrackUp))
+        }
+        iced::keyboard::Key::Named(Named::ArrowDown) => {
+            Some(Message::Arrangement(ArrangementMsg::MoveSelectedTrackDown))
+        }
         iced::keyboard::Key::Character(ref c) => match c.as_str() {
             "t" | "T" => {
                 if modifiers.shift() {
-                    Some(Message::AddInstrumentTrack)
+                    Some(Message::Arrangement(ArrangementMsg::AddInstrumentTrack))
                 } else {
-                    Some(Message::AddTrack)
+                    Some(Message::Arrangement(ArrangementMsg::AddTrack))
                 }
             }
             "m" => Some(Message::CreateClipFromSelection),

--- a/crates/vibez-ui/src/domains/arrangement.rs
+++ b/crates/vibez-ui/src/domains/arrangement.rs
@@ -1,0 +1,308 @@
+//! Arrangement domain, tranche one: track lifecycle and mixing
+//! basics. Owns the track list (the shared model other domains
+//! receive explicitly), selection, and track numbering.
+//!
+//! Clip operations (moves, splits, warp orchestration) are the next
+//! tranche; they follow this same pattern.
+
+use vibez_core::id::TrackId;
+use vibez_core::midi::TrackKind;
+use vibez_engine::commands::EngineCommand;
+
+use super::EngineHandle;
+use crate::state::{ArrangementSelection, ArrangementState, UiTrack};
+
+/// Messages the arrangement domain handles (track tranche).
+#[derive(Debug, Clone)]
+pub enum ArrangementMsg {
+    AddTrack,
+    AddMidiTrack,
+    AddInstrumentTrack,
+    RemoveTrack(TrackId),
+    SelectTrack(TrackId),
+    RenameTrack(TrackId, String),
+    RenameClip(TrackId, vibez_core::id::ClipId, String),
+    MoveTrackUp(TrackId),
+    MoveTrackDown(TrackId),
+    MoveSelectedTrackUp,
+    MoveSelectedTrackDown,
+    SetTrackGain(TrackId, f32),
+    SetTrackPan(TrackId, f32),
+    SetTrackMute(TrackId),
+    SetTrackSolo(TrackId),
+    EngineTrackMeter {
+        track_id: TrackId,
+        peak_l: f32,
+        peak_r: f32,
+    },
+}
+
+impl ArrangementMsg {
+    /// Whether this message edits the project (drives the dirty flag).
+    pub fn marks_dirty(&self) -> bool {
+        !matches!(
+            self,
+            ArrangementMsg::SelectTrack(_) | ArrangementMsg::EngineTrackMeter { .. }
+        )
+    }
+}
+
+/// Cross-domain effects requested by an arrangement update.
+#[derive(Debug, Default, PartialEq)]
+pub struct ArrangementAction {
+    /// All plugin GUI windows and raw pointers of this track must go
+    /// (the track's devices are being destroyed).
+    pub close_track_guis: Option<TrackId>,
+    /// Status bar text.
+    pub status: Option<String>,
+}
+
+impl ArrangementState {
+    /// First track number with no name clash for the given prefix.
+    pub fn next_unique_track_number(&mut self, prefix: &str) -> u32 {
+        loop {
+            let candidate = self.next_track_number;
+            let name = format!("{prefix} {candidate}");
+            if !self.tracks.iter().any(|t| t.name == name) {
+                return candidate;
+            }
+            self.next_track_number += 1;
+        }
+    }
+
+    fn find_track_mut(&mut self, track_id: TrackId) -> Option<&mut UiTrack> {
+        self.tracks.iter_mut().find(|t| t.id == track_id)
+    }
+
+    fn move_track(&mut self, track_id: TrackId, up: bool, engine: &mut impl EngineHandle) {
+        if let Some(idx) = self.tracks.iter().position(|t| t.id == track_id) {
+            let target = if up {
+                idx.checked_sub(1)
+            } else if idx + 1 < self.tracks.len() {
+                Some(idx + 1)
+            } else {
+                None
+            };
+            if let Some(target) = target {
+                self.tracks.swap(idx, target);
+                let order: Vec<TrackId> = self.tracks.iter().map(|t| t.id).collect();
+                engine.send(EngineCommand::ReorderTracks(order));
+            }
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        msg: ArrangementMsg,
+        engine: &mut impl EngineHandle,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        match msg {
+            ArrangementMsg::AddTrack => {
+                let track_num = self.next_unique_track_number("Track");
+                let color_index = (track_num.wrapping_sub(1) % 8) as u8;
+                self.next_track_number = track_num + 1;
+                let id = TrackId::new();
+                let name = format!("Track {track_num}");
+                engine.send(EngineCommand::AddTrack(id, name.clone()));
+                self.tracks.push(UiTrack::new(id, name, color_index));
+                self.selected_track = Some(id);
+                action.status = Some(format!("{} tracks", self.tracks.len()));
+            }
+            ArrangementMsg::AddMidiTrack | ArrangementMsg::AddInstrumentTrack => {
+                let track_num = self.next_unique_track_number("MIDI");
+                let color_index = (track_num.wrapping_sub(1) % 8) as u8;
+                self.next_track_number = track_num + 1;
+                let id = TrackId::new();
+                let name = format!("MIDI {track_num}");
+                engine.send(EngineCommand::AddMidiTrack(id, name.clone()));
+                let mut track = UiTrack::new_instrument(id, name, TrackKind::Midi, color_index);
+                track.has_instrument = false;
+                self.tracks.push(track);
+                self.selected_track = Some(id);
+                action.status = Some(format!("{} tracks", self.tracks.len()));
+            }
+            ArrangementMsg::RemoveTrack(track_id) => {
+                let removed_name = self
+                    .tracks
+                    .iter()
+                    .find(|t| t.id == track_id)
+                    .map(|t| t.name.clone())
+                    .unwrap_or_else(|| format!("{track_id}"));
+
+                engine.send(EngineCommand::RemoveTrack(track_id));
+                self.tracks.retain(|t| t.id != track_id);
+                if self.selected_track == Some(track_id) {
+                    self.selected_track = self.tracks.first().map(|t| t.id);
+                }
+                if let Some((tid, _)) = self.selected_note_clip {
+                    if tid == track_id {
+                        self.selected_note_clip = None;
+                    }
+                }
+                self.selected_clips.retain(|sel| {
+                    let sel_track = match sel {
+                        ArrangementSelection::AudioClip { track_id: t, .. } => *t,
+                        ArrangementSelection::NoteClip { track_id: t, .. } => *t,
+                    };
+                    sel_track != track_id
+                });
+                action.close_track_guis = Some(track_id);
+                action.status = Some(format!(
+                    "Removed {removed_name}. {} track(s) remain.",
+                    self.tracks.len()
+                ));
+            }
+            ArrangementMsg::SelectTrack(track_id) => {
+                self.selected_track = Some(track_id);
+            }
+            ArrangementMsg::RenameTrack(track_id, new_name) => {
+                if let Some(track) = self.find_track_mut(track_id) {
+                    track.name = new_name;
+                }
+            }
+            ArrangementMsg::RenameClip(track_id, clip_id, new_name) => {
+                if let Some(track) = self.find_track_mut(track_id) {
+                    if let Some(c) = track.clips.iter_mut().find(|c| c.id == clip_id) {
+                        c.name = new_name.clone();
+                    }
+                    if let Some(c) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
+                        c.name = new_name;
+                    }
+                }
+            }
+            ArrangementMsg::MoveTrackUp(track_id) => self.move_track(track_id, true, engine),
+            ArrangementMsg::MoveTrackDown(track_id) => self.move_track(track_id, false, engine),
+            ArrangementMsg::MoveSelectedTrackUp => {
+                if let Some(tid) = self.selected_track {
+                    self.move_track(tid, true, engine);
+                }
+            }
+            ArrangementMsg::MoveSelectedTrackDown => {
+                if let Some(tid) = self.selected_track {
+                    self.move_track(tid, false, engine);
+                }
+            }
+            ArrangementMsg::SetTrackGain(track_id, gain) => {
+                let gain = gain.clamp(0.0, 2.0);
+                engine.send(EngineCommand::SetTrackGain(track_id, gain));
+                if let Some(track) = self.find_track_mut(track_id) {
+                    track.gain = gain;
+                }
+            }
+            ArrangementMsg::SetTrackPan(track_id, pan) => {
+                let pan = pan.clamp(0.0, 1.0);
+                engine.send(EngineCommand::SetTrackPan(track_id, pan));
+                if let Some(track) = self.find_track_mut(track_id) {
+                    track.pan = pan;
+                }
+            }
+            ArrangementMsg::SetTrackMute(track_id) => {
+                if let Some(track) = self.find_track_mut(track_id) {
+                    track.mute = !track.mute;
+                    let mute = track.mute;
+                    engine.send(EngineCommand::SetTrackMute(track_id, mute));
+                }
+            }
+            ArrangementMsg::SetTrackSolo(track_id) => {
+                if let Some(track) = self.find_track_mut(track_id) {
+                    track.solo = !track.solo;
+                    let solo = track.solo;
+                    engine.send(EngineCommand::SetTrackSolo(track_id, solo));
+                }
+            }
+            ArrangementMsg::EngineTrackMeter {
+                track_id,
+                peak_l,
+                peak_r,
+            } => {
+                if let Some(track) = self.find_track_mut(track_id) {
+                    track.peak_l = peak_l.max(track.peak_l * 0.85);
+                    track.peak_r = peak_r.max(track.peak_r * 0.85);
+                }
+            }
+        }
+        action
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::RecordingEngine;
+    use super::*;
+
+    fn arrangement_with_tracks(n: usize) -> ArrangementState {
+        let mut a = ArrangementState {
+            next_track_number: 1,
+            ..Default::default()
+        };
+        let mut engine = RecordingEngine::default();
+        for _ in 0..n {
+            a.update(ArrangementMsg::AddTrack, &mut engine);
+        }
+        a
+    }
+
+    #[test]
+    fn add_track_selects_it_and_names_uniquely() {
+        let a = arrangement_with_tracks(2);
+        assert_eq!(a.tracks.len(), 2);
+        assert_eq!(a.tracks[1].name, "Track 2");
+        assert_eq!(a.selected_track, Some(a.tracks[1].id));
+    }
+
+    #[test]
+    fn remove_track_clears_its_selections_and_requests_gui_teardown() {
+        let mut a = arrangement_with_tracks(2);
+        let victim = a.tracks[1].id;
+        let survivor = a.tracks[0].id;
+        a.selected_note_clip = Some((victim, vibez_core::id::ClipId::new()));
+        let mut engine = RecordingEngine::default();
+        let action = a.update(ArrangementMsg::RemoveTrack(victim), &mut engine);
+        assert_eq!(a.tracks.len(), 1);
+        assert_eq!(a.selected_track, Some(survivor));
+        assert_eq!(a.selected_note_clip, None);
+        assert_eq!(action.close_track_guis, Some(victim));
+    }
+
+    #[test]
+    fn reorder_sends_full_order_and_respects_bounds() {
+        let mut a = arrangement_with_tracks(2);
+        let first = a.tracks[0].id;
+        let mut engine = RecordingEngine::default();
+        // Top track cannot move further up: no command.
+        a.update(ArrangementMsg::MoveTrackUp(first), &mut engine);
+        assert!(engine.0.is_empty());
+        a.update(ArrangementMsg::MoveTrackDown(first), &mut engine);
+        assert_eq!(a.tracks[1].id, first);
+        assert!(matches!(engine.0[0], EngineCommand::ReorderTracks(_)));
+    }
+
+    #[test]
+    fn gain_and_pan_clamp() {
+        let mut a = arrangement_with_tracks(1);
+        let id = a.tracks[0].id;
+        let mut engine = RecordingEngine::default();
+        a.update(ArrangementMsg::SetTrackGain(id, 99.0), &mut engine);
+        a.update(ArrangementMsg::SetTrackPan(id, -5.0), &mut engine);
+        assert_eq!(a.tracks[0].gain, 2.0);
+        assert_eq!(a.tracks[0].pan, 0.0);
+    }
+
+    #[test]
+    fn meter_decays_instead_of_snapping() {
+        let mut a = arrangement_with_tracks(1);
+        let id = a.tracks[0].id;
+        a.tracks[0].peak_l = 1.0;
+        let mut engine = RecordingEngine::default();
+        a.update(
+            ArrangementMsg::EngineTrackMeter {
+                track_id: id,
+                peak_l: 0.0,
+                peak_r: 0.0,
+            },
+            &mut engine,
+        );
+        assert!((a.tracks[0].peak_l - 0.85).abs() < 1e-6);
+    }
+}

--- a/crates/vibez-ui/src/domains/mod.rs
+++ b/crates/vibez-ui/src/domains/mod.rs
@@ -6,6 +6,7 @@
 //! app.rs shrinks to a router. TypeScript mental model: these are
 //! Redux slices; `EngineHandle` is an injected service interface.
 
+pub mod arrangement;
 pub mod devices;
 pub mod transport;
 

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -153,6 +153,8 @@ pub enum Message {
     Transport(crate::domains::transport::TransportMsg),
     /// Devices domain (effect chain, instruments, drum pads, menu).
     Devices(crate::domains::devices::DevicesMsg),
+    /// Arrangement domain (tracks, selection; clips arriving next).
+    Arrangement(crate::domains::arrangement::ArrangementMsg),
 
     // Workspace
     SwitchWorkspace(Workspace),
@@ -165,9 +167,6 @@ pub enum Message {
     },
 
     // Multi-track
-    AddTrack,
-    RemoveTrack(TrackId),
-    SelectTrack(TrackId),
     AddClipToTrack(TrackId),
     ClipFileSelected(TrackId, Option<PathBuf>),
     ClipAudioDecoded(TrackId, ClipId, Arc<DecodedAudio>, String, MediaSourceRef),
@@ -175,22 +174,12 @@ pub enum Message {
     RemoveClip(TrackId, ClipId),
 
     // Track controls
-    SetTrackGain(TrackId, f32),
-    SetTrackPan(TrackId, f32),
-    SetTrackMute(TrackId),
-    SetTrackSolo(TrackId),
 
     // Per-track metering
-    EngineTrackMeter {
-        track_id: TrackId,
-        peak_l: f32,
-        peak_r: f32,
-    },
 
     // Effects
 
     // Instrument tracks
-    AddInstrumentTrack,
 
     // Sampler
     LoadSamplerSample(TrackId),
@@ -346,14 +335,8 @@ pub enum Message {
     CreateNoteClipFromSelection(TrackId),
 
     // Track reordering
-    MoveTrackUp(TrackId),
-    MoveTrackDown(TrackId),
-    MoveSelectedTrackUp,
-    MoveSelectedTrackDown,
 
     // Renaming
-    RenameTrack(TrackId, String),
-    RenameClip(TrackId, ClipId, String),
     StartEditingTrackName(TrackId),
     StartEditingClipName(TrackId, ClipId),
     EditNameText(String),
@@ -361,7 +344,6 @@ pub enum Message {
     CancelEditing,
 
     // MIDI track (no auto-synth)
-    AddMidiTrack,
 
     // Instrument attach/detach
 
@@ -658,5 +640,48 @@ impl Message {
     }
     pub fn device_menu_search(q: String) -> Self {
         Self::Devices(crate::domains::devices::DevicesMsg::MenuSearch(q))
+    }
+}
+
+impl Message {
+    pub fn select_track(t: TrackId) -> Self {
+        Self::Arrangement(crate::domains::arrangement::ArrangementMsg::SelectTrack(t))
+    }
+    pub fn remove_track(t: TrackId) -> Self {
+        Self::Arrangement(crate::domains::arrangement::ArrangementMsg::RemoveTrack(t))
+    }
+    pub fn rename_track(t: TrackId, n: String) -> Self {
+        Self::Arrangement(crate::domains::arrangement::ArrangementMsg::RenameTrack(
+            t, n,
+        ))
+    }
+    pub fn rename_clip(t: TrackId, c: ClipId, n: String) -> Self {
+        Self::Arrangement(crate::domains::arrangement::ArrangementMsg::RenameClip(
+            t, c, n,
+        ))
+    }
+    pub fn move_track_up(t: TrackId) -> Self {
+        Self::Arrangement(crate::domains::arrangement::ArrangementMsg::MoveTrackUp(t))
+    }
+    pub fn move_track_down(t: TrackId) -> Self {
+        Self::Arrangement(crate::domains::arrangement::ArrangementMsg::MoveTrackDown(
+            t,
+        ))
+    }
+    pub fn set_track_gain(t: TrackId, g: f32) -> Self {
+        Self::Arrangement(crate::domains::arrangement::ArrangementMsg::SetTrackGain(
+            t, g,
+        ))
+    }
+    pub fn set_track_pan(t: TrackId, p: f32) -> Self {
+        Self::Arrangement(crate::domains::arrangement::ArrangementMsg::SetTrackPan(
+            t, p,
+        ))
+    }
+    pub fn set_track_mute(t: TrackId) -> Self {
+        Self::Arrangement(crate::domains::arrangement::ArrangementMsg::SetTrackMute(t))
+    }
+    pub fn set_track_solo(t: TrackId) -> Self {
+        Self::Arrangement(crate::domains::arrangement::ArrangementMsg::SetTrackSolo(t))
     }
 }

--- a/crates/vibez-ui/src/state.rs
+++ b/crates/vibez-ui/src/state.rs
@@ -495,6 +495,17 @@ impl Default for TransportState {
     }
 }
 
+/// Arrangement domain state: the track list (the shared model other
+/// domains receive explicitly), selection, and track numbering.
+#[derive(Debug, Default)]
+pub struct ArrangementState {
+    pub tracks: Vec<UiTrack>,
+    pub selected_track: Option<TrackId>,
+    pub next_track_number: u32,
+    pub selected_clips: HashSet<ArrangementSelection>,
+    pub selected_note_clip: Option<(TrackId, ClipId)>,
+}
+
 pub struct AppState {
     // Transport domain slice (playback, tempo, arrangement loop).
     pub transport: TransportState,
@@ -515,16 +526,8 @@ pub struct AppState {
     pub snap_grid: SnapGrid,
     pub piano_roll_scroll_y: f32,
 
-    // Multi-track
-    pub tracks: Vec<UiTrack>,
-    pub selected_track: Option<TrackId>,
-    pub next_track_number: u32,
-
-    // Detail panel: which note clip is selected for piano roll editing
-    pub selected_note_clip: Option<(TrackId, ClipId)>,
-
-    // Arrangement clip selection (multi-select)
-    pub selected_clips: HashSet<ArrangementSelection>,
+    // Arrangement domain slice (tracks, selection, numbering).
+    pub arrangement: ArrangementState,
 
     // Detail panel tab
     pub detail_panel_tab: DetailPanelTab,
@@ -624,11 +627,10 @@ impl Default for AppState {
             scroll_offset_beats: 0.0,
             snap_grid: SnapGrid::Eighth,
             piano_roll_scroll_y: crate::widgets::piano_roll::default_scroll_y(200.0),
-            tracks: Vec::new(),
-            selected_track: None,
-            next_track_number: 1,
-            selected_note_clip: None,
-            selected_clips: HashSet::new(),
+            arrangement: ArrangementState {
+                next_track_number: 1,
+                ..ArrangementState::default()
+            },
             detail_panel_tab: DetailPanelTab::Clip,
             time_selection_active: false,
             selection_start_beats: 0.0,
@@ -762,7 +764,7 @@ impl AppState {
     /// Check if a clip is in the multi-selection set.
     #[allow(dead_code)]
     pub fn is_clip_selected(&self, clip_id: ClipId) -> bool {
-        self.selected_clips.iter().any(|sel| match sel {
+        self.arrangement.selected_clips.iter().any(|sel| match sel {
             ArrangementSelection::AudioClip { clip_id: cid, .. } => *cid == clip_id,
             ArrangementSelection::NoteClip { clip_id: cid, .. } => *cid == clip_id,
         })
@@ -771,24 +773,25 @@ impl AppState {
     /// Returns the single selected clip if exactly one is selected.
     #[allow(dead_code)]
     pub fn single_selected_clip(&self) -> Option<ArrangementSelection> {
-        if self.selected_clips.len() == 1 {
-            self.selected_clips.iter().next().copied()
+        if self.arrangement.selected_clips.len() == 1 {
+            self.arrangement.selected_clips.iter().next().copied()
         } else {
             None
         }
     }
 
     pub fn find_track(&self, id: TrackId) -> Option<&UiTrack> {
-        self.tracks.iter().find(|t| t.id == id)
+        self.arrangement.tracks.iter().find(|t| t.id == id)
     }
 
     pub fn find_track_mut(&mut self, id: TrackId) -> Option<&mut UiTrack> {
-        self.tracks.iter_mut().find(|t| t.id == id)
+        self.arrangement.tracks.iter_mut().find(|t| t.id == id)
     }
 
     /// Total duration in samples across all tracks (max clip end position).
     pub fn total_duration_samples(&self) -> u64 {
         let audio_max = self
+            .arrangement
             .tracks
             .iter()
             .flat_map(|t| t.clips.iter())
@@ -803,7 +806,8 @@ impl AppState {
             0.0
         };
         let note_max = if spb > 0.0 {
-            self.tracks
+            self.arrangement
+                .tracks
                 .iter()
                 .flat_map(|t| t.note_clips.iter())
                 .map(|c| ((c.position_beats + c.duration_beats) * spb) as u64)

--- a/crates/vibez-ui/src/state.rs
+++ b/crates/vibez-ui/src/state.rs
@@ -827,10 +827,9 @@ mod tests {
     use vibez_core::id::TrackId;
 
     fn make_state_with(tracks: Vec<UiTrack>) -> AppState {
-        AppState {
-            tracks,
-            ..Default::default()
-        }
+        let mut state = AppState::default();
+        state.arrangement.tracks = tracks;
+        state
     }
 
     fn make_two_tracks() -> Vec<UiTrack> {
@@ -843,68 +842,68 @@ mod tests {
     #[test]
     fn move_track_up() {
         let mut state = make_state_with(make_two_tracks());
-        let id0 = state.tracks[0].id;
-        let id1 = state.tracks[1].id;
+        let id0 = state.arrangement.tracks[0].id;
+        let id1 = state.arrangement.tracks[1].id;
 
-        if let Some(idx) = state.tracks.iter().position(|t| t.id == id1) {
+        if let Some(idx) = state.arrangement.tracks.iter().position(|t| t.id == id1) {
             if idx > 0 {
-                state.tracks.swap(idx, idx - 1);
+                state.arrangement.tracks.swap(idx, idx - 1);
             }
         }
-        assert_eq!(state.tracks[0].id, id1);
-        assert_eq!(state.tracks[1].id, id0);
+        assert_eq!(state.arrangement.tracks[0].id, id1);
+        assert_eq!(state.arrangement.tracks[1].id, id0);
     }
 
     #[test]
     fn move_track_down() {
         let mut state = make_state_with(make_two_tracks());
-        let id0 = state.tracks[0].id;
-        let id1 = state.tracks[1].id;
+        let id0 = state.arrangement.tracks[0].id;
+        let id1 = state.arrangement.tracks[1].id;
 
-        if let Some(idx) = state.tracks.iter().position(|t| t.id == id0) {
-            if idx + 1 < state.tracks.len() {
-                state.tracks.swap(idx, idx + 1);
+        if let Some(idx) = state.arrangement.tracks.iter().position(|t| t.id == id0) {
+            if idx + 1 < state.arrangement.tracks.len() {
+                state.arrangement.tracks.swap(idx, idx + 1);
             }
         }
-        assert_eq!(state.tracks[0].id, id1);
-        assert_eq!(state.tracks[1].id, id0);
+        assert_eq!(state.arrangement.tracks[0].id, id1);
+        assert_eq!(state.arrangement.tracks[1].id, id0);
     }
 
     #[test]
     fn move_first_track_up_noop() {
         let mut state = make_state_with(vec![UiTrack::new(TrackId::new(), "Track 1".into(), 0)]);
-        let id0 = state.tracks[0].id;
+        let id0 = state.arrangement.tracks[0].id;
 
-        if let Some(idx) = state.tracks.iter().position(|t| t.id == id0) {
+        if let Some(idx) = state.arrangement.tracks.iter().position(|t| t.id == id0) {
             if idx > 0 {
-                state.tracks.swap(idx, idx - 1);
+                state.arrangement.tracks.swap(idx, idx - 1);
             }
         }
-        assert_eq!(state.tracks[0].id, id0);
+        assert_eq!(state.arrangement.tracks[0].id, id0);
     }
 
     #[test]
     fn move_last_track_down_noop() {
         let mut state = make_state_with(vec![UiTrack::new(TrackId::new(), "Track 1".into(), 0)]);
-        let id0 = state.tracks[0].id;
+        let id0 = state.arrangement.tracks[0].id;
 
-        if let Some(idx) = state.tracks.iter().position(|t| t.id == id0) {
-            if idx + 1 < state.tracks.len() {
-                state.tracks.swap(idx, idx + 1);
+        if let Some(idx) = state.arrangement.tracks.iter().position(|t| t.id == id0) {
+            if idx + 1 < state.arrangement.tracks.len() {
+                state.arrangement.tracks.swap(idx, idx + 1);
             }
         }
-        assert_eq!(state.tracks[0].id, id0);
+        assert_eq!(state.arrangement.tracks[0].id, id0);
     }
 
     #[test]
     fn rename_track() {
         let mut state = make_state_with(vec![UiTrack::new(TrackId::new(), "Track 1".into(), 0)]);
-        let id = state.tracks[0].id;
+        let id = state.arrangement.tracks[0].id;
 
         if let Some(track) = state.find_track_mut(id) {
             track.name = "My Custom Track".into();
         }
-        assert_eq!(state.tracks[0].name, "My Custom Track");
+        assert_eq!(state.arrangement.tracks[0].name, "My Custom Track");
     }
 
     #[test]
@@ -935,7 +934,10 @@ mod tests {
                 c.name = "Intro Pattern".into();
             }
         }
-        assert_eq!(state.tracks[0].note_clips[0].name, "Intro Pattern");
+        assert_eq!(
+            state.arrangement.tracks[0].note_clips[0].name,
+            "Intro Pattern"
+        );
     }
 
     #[test]
@@ -964,7 +966,7 @@ mod tests {
     #[test]
     fn rename_empty_rejected() {
         let mut state = make_state_with(vec![UiTrack::new(TrackId::new(), "Track 1".into(), 0)]);
-        let id = state.tracks[0].id;
+        let id = state.arrangement.tracks[0].id;
 
         // Simulate the FinishEditing guard: empty name doesn't rename
         let new_name = "";
@@ -973,6 +975,6 @@ mod tests {
                 track.name = new_name.to_string();
             }
         }
-        assert_eq!(state.tracks[0].name, "Track 1");
+        assert_eq!(state.arrangement.tracks[0].name, "Track 1");
     }
 }

--- a/crates/vibez-ui/src/widgets/fader.rs
+++ b/crates/vibez-ui/src/widgets/fader.rs
@@ -145,7 +145,7 @@ impl canvas::Program<Message> for HorizontalFaderWidget {
 
                         return (
                             canvas::event::Status::Captured,
-                            Some(Message::SetTrackGain(self.track_id, new_gain)),
+                            Some(Message::set_track_gain(self.track_id, new_gain)),
                         );
                     }
                 }
@@ -296,7 +296,7 @@ impl canvas::Program<Message> for FaderWidget {
 
                         return (
                             canvas::event::Status::Captured,
-                            Some(Message::SetTrackGain(self.track_id, new_gain)),
+                            Some(Message::set_track_gain(self.track_id, new_gain)),
                         );
                     }
                 }

--- a/crates/vibez-ui/src/widgets/knob.rs
+++ b/crates/vibez-ui/src/widgets/knob.rs
@@ -190,7 +190,7 @@ impl canvas::Program<Message> for KnobWidget {
                             state.last_click = None;
                             return (
                                 canvas::event::Status::Captured,
-                                Some(Message::SetTrackPan(self.track_id, 0.5)),
+                                Some(Message::set_track_pan(self.track_id, 0.5)),
                             );
                         }
                     }
@@ -230,7 +230,7 @@ impl canvas::Program<Message> for KnobWidget {
 
                         return (
                             canvas::event::Status::Captured,
-                            Some(Message::SetTrackPan(self.track_id, new_pan)),
+                            Some(Message::set_track_pan(self.track_id, new_pan)),
                         );
                     }
                 }
@@ -254,7 +254,7 @@ impl canvas::Program<Message> for KnobWidget {
 
                     return (
                         canvas::event::Status::Captured,
-                        Some(Message::SetTrackPan(self.track_id, new_pan)),
+                        Some(Message::set_track_pan(self.track_id, new_pan)),
                     );
                 }
             }

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -68,7 +68,7 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
         let label = text("M").size(11);
         if track.mute {
             button(label.color(th::BG_DARK))
-                .on_press(Message::SetTrackMute(track.id))
+                .on_press(Message::set_track_mute(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: Some(th::MUTE_ACTIVE.into()),
@@ -81,7 +81,7 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
                 })
         } else {
             button(label.color(th::TEXT_DIM))
-                .on_press(Message::SetTrackMute(track.id))
+                .on_press(Message::set_track_mute(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: Some(th::BG_ELEVATED.into()),
@@ -101,7 +101,7 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
         let label = text("S").size(11);
         if track.solo {
             button(label.color(th::BG_DARK))
-                .on_press(Message::SetTrackSolo(track.id))
+                .on_press(Message::set_track_solo(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: Some(th::SOLO_ACTIVE.into()),
@@ -114,7 +114,7 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
                 })
         } else {
             button(label.color(th::TEXT_DIM))
-                .on_press(Message::SetTrackSolo(track.id))
+                .on_press(Message::set_track_solo(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: Some(th::BG_ELEVATED.into()),

--- a/crates/vibez-ui/src/widgets/timeline.rs
+++ b/crates/vibez-ui/src/widgets/timeline.rs
@@ -4,6 +4,7 @@ use iced::mouse;
 use iced::widget::canvas;
 use iced::{Color, Rectangle, Renderer, Theme};
 
+use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::transport::TransportMsg;
 use crate::message::Message;
 use crate::state::{ArrangementSelection, ContextMenuTarget, UiTrack};
@@ -1516,7 +1517,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                         });
                         return (
                             canvas::event::Status::Captured,
-                            Some(Message::SelectTrack(track_id)),
+                            Some(Message::select_track(track_id)),
                         );
                     }
                 }
@@ -1864,10 +1865,13 @@ impl canvas::Program<Message> for TrackClipCanvas {
                             if modifiers.shift() {
                                 return (
                                     canvas::event::Status::Captured,
-                                    Some(Message::AddInstrumentTrack),
+                                    Some(Message::Arrangement(ArrangementMsg::AddInstrumentTrack)),
                                 );
                             } else {
-                                return (canvas::event::Status::Captured, Some(Message::AddTrack));
+                                return (
+                                    canvas::event::Status::Captured,
+                                    Some(Message::Arrangement(ArrangementMsg::AddTrack)),
+                                );
                             }
                         }
                         _ => {}

--- a/crates/vibez-ui/src/widgets/track_header.rs
+++ b/crates/vibez-ui/src/widgets/track_header.rs
@@ -49,7 +49,7 @@ pub fn view_track_header<'a>(
         let msg = if selected {
             Message::StartEditingTrackName(track.id)
         } else {
-            Message::SelectTrack(track.id)
+            Message::select_track(track.id)
         };
         button(text(&track.name).size(13).color(name_color))
             .on_press(msg)
@@ -75,7 +75,7 @@ pub fn view_track_header<'a>(
     };
 
     let delete_btn = button(icons::icon(icons::TRASH_2).size(10).color(th::TEXT_DIM))
-        .on_press(Message::RemoveTrack(track.id))
+        .on_press(Message::remove_track(track.id))
         .padding([2, 4])
         .style(|_theme: &Theme, status| {
             let bg = match status {
@@ -105,7 +105,7 @@ pub fn view_track_header<'a>(
         let label = text("M").size(11);
         if track.mute {
             button(label.color(th::BG_DARK))
-                .on_press(Message::SetTrackMute(track.id))
+                .on_press(Message::set_track_mute(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: Some(th::MUTE_ACTIVE.into()),
@@ -118,7 +118,7 @@ pub fn view_track_header<'a>(
                 })
         } else {
             button(label.color(th::TEXT_DIM))
-                .on_press(Message::SetTrackMute(track.id))
+                .on_press(Message::set_track_mute(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: Some(th::BG_ELEVATED.into()),
@@ -137,7 +137,7 @@ pub fn view_track_header<'a>(
         let label = text("S").size(11);
         if track.solo {
             button(label.color(th::BG_DARK))
-                .on_press(Message::SetTrackSolo(track.id))
+                .on_press(Message::set_track_solo(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: Some(th::SOLO_ACTIVE.into()),
@@ -150,7 +150,7 @@ pub fn view_track_header<'a>(
                 })
         } else {
             button(label.color(th::TEXT_DIM))
-                .on_press(Message::SetTrackSolo(track.id))
+                .on_press(Message::set_track_solo(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: Some(th::BG_ELEVATED.into()),
@@ -218,6 +218,6 @@ pub fn view_track_header<'a>(
     // (name, M/S, add, delete, fader) capture their own clicks first,
     // so this only fires on otherwise-dead header space.
     mouse_area(card)
-        .on_press(Message::SelectTrack(track.id))
+        .on_press(Message::select_track(track.id))
         .into()
 }


### PR DESCRIPTION
Track lifecycle and mixing basics move into domains/arrangement.rs following the established pattern (#16, #17).

- ArrangementState owns the track list, selection, and numbering; 16 Message variants routed; RemoveTrack's plugin-GUI teardown returns as an action.
- Five unit tests: unique naming/auto-select, remove cleanup + teardown request, reorder bounds + ReorderTracks command, gain/pan clamps, meter decay.
- Process note: the verification gate was hardened after catching that a failing-to-compile test target reads as zero FAILED greps; gates now assert the green-suite count too.

Clip operations are tranche 3b and follow the identical recipe; domains/transport.rs and this PR together are the worked examples for successors.

Test plan: cargo test (domains::arrangement); in-app: add/remove/rename/reorder tracks, gain/pan/mute/solo from header and mixer, meters decay smoothly, removing a track with plugin GUIs open closes them.