### PR TITLE
docs: successor handoff (refactoring playbook + automation and mix-desk specs)

### DIFF
--- a/.notes/REFACTORING-GUIDE.md
+++ b/.notes/REFACTORING-GUIDE.md
@@ -1,0 +1,88 @@
+# The domain-extraction playbook
+
+Written 2026-07-07 after extracting three domains (transport,
+devices, arrangement-tracks) in PRs #16, #17, #20. Follow this recipe
+to finish the remaining tranches. Read `domains/transport.rs` (small)
+and `domains/devices.rs` (shared-model style) as the worked examples.
+
+## The pattern
+
+Each domain in `crates/vibez-ui/src/domains/` owns:
+- a state slice struct (defined in `state.rs`, field on `AppState`),
+- a `XMsg` enum (variants moved out of the top-level `Message`),
+- `update(&mut self, msg, engine: &mut impl EngineHandle, ...) -> XAction`,
+- unit tests against `test_support::RecordingEngine`.
+
+Cross-domain rules:
+- Read-only facts other domains must provide come in via a small
+  `XCtx` struct computed by the router (see transport's).
+- Effects the domain cannot perform (GUI teardown, selection focus,
+  status text) go OUT via the `XAction` struct; app.rs applies them
+  in `apply_x_action`.
+- Tracks are the shared model: domains that edit track-owned data
+  receive `&mut [UiTrack]` explicitly (devices) or own the list
+  (arrangement).
+- `XMsg::marks_dirty()` classifies undo-worthy edits; app.rs's dirty
+  check calls it instead of enumerating variants.
+
+## The recipe (per tranche)
+
+1. Branch off main. Move fields into the slice struct in `state.rs`.
+   Build: the compiler enumerates every usage site.
+2. Sweep usages: sed the single-line `self.state.field` patterns,
+   then a MULTILINE regex for `self.state\n.field` chains (fmt splits
+   them), then hand-fix init literals. Commit when green.
+3. Write the domain module: move handler bodies verbatim from app.rs
+   arms into `update`, converting `self.state.*` to slice fields and
+   `self.send_command` to `engine.send`. Port cross-domain touches to
+   Ctx/Action. Write tests.
+4. `Message` migration:
+   - Remove the variants; add `X(XMsg)`.
+   - For TUPLE variants add arity-preserving constructor helpers on
+     `Message` (e.g. `Message::set_track_gain(t, g)`) and sed call
+     sites to the helper names: this stays parenthesis-balanced.
+     Unit variants sed directly to `Message::X(XMsg::Variant)`.
+   - Struct-literal variants (`Msg::Foo { .. }` construction sites):
+     few sites; convert by hand.
+5. Delete the old app.rs arms with a brace-matcher script; REQUIRE
+   the start line to contain `=>` or you will eat an innocent
+   multi-line construction argument (this happened; audit deletions
+   against `git show HEAD:...` if the count is off by one).
+6. Install the router arm + `apply_x_action`, fix the keep-menu and
+   dirty `matches!` lists (add `|| matches!(&message, Message::X(m)
+   if m.marks_dirty())`).
+7. Verify HONESTLY: `cargo test --workspace` must show the expected
+   COUNT of `test result: ok` lines AND zero `test result: FAILED`.
+   Grepping only for FAILED reads zero when a test target fails to
+   COMPILE. Then clippy (zero errors, zero unused warnings), fmt,
+   release build, in-app smoke test.
+
+## Known traps (all hit tonight)
+
+- iced: `Length::Fill` child inside a shrink-width parent collapses
+  the container (backgrounds/borders vanish). Cards use computed
+  fixed widths.
+- Never blind-regex Rust: a `\bKEY_WIDTH\b` sweep once rewrote a
+  constant inside its own accessor method into infinite recursion
+  (silent stack-overflow crash, no panic output).
+- Tuple-variant regex rewrites leave unbalanced parens at every call
+  site; use the constructor-helper trick instead.
+- Panel/viewport geometry: fix the CONTAINER first, then content.
+  Device strip is fixed-height (Ableton model); text that can wrap
+  inside fixed-height cards must be hard-truncated to one line.
+
+## Remaining tranches
+
+- 3b arrangement clips: audio clip add/move/resize/split/join/
+  duplicate/delete, time selection, ToggleClipLoop/SetClipLoopRegion,
+  warp orchestration messages (WarpClipToProject, ClipWarpReady,
+  ClearClipWarp, quantize, nominal BPM). Task-returning handlers can
+  stay in app.rs calling domain fns for the state math if Tasks prove
+  awkward (see devices' async note).
+- 4 piano roll: note clip CRUD, note editing/selection/nudge,
+  loop-region messages, HalveNoteClip/DoubleNoteClip/CropNoteClip.
+- 5 browser: sample browser, preview, Dropbox, drag-drop dispatch.
+- 6 project: save/load/undo/export/snapshots (also fix: snapshots
+  drop plugin devices; see dogfood #22 note).
+- 7 services: plugin load pipeline (poll_plugin_loads + bg loaders),
+  scanning, plugin window manager glue behind channel interfaces.

--- a/.notes/design-automation.md
+++ b/.notes/design-automation.md
@@ -1,0 +1,79 @@
+# Design: automation + LFOs
+
+Target: Ableton-style automation lanes on tracks, writing parameter
+changes over time, for built-in devices AND plugins. Written as an
+implementation spec for a successor session; engine constraints are
+the part that must not be guessed.
+
+## Data model (vibez-core)
+
+```rust
+pub struct AutomationLane {
+    pub id: LaneId,                  // typed_id! like the others
+    pub target: AutomationTarget,
+    pub points: Vec<AutomationPoint>, // sorted by beat
+}
+pub enum AutomationTarget {
+    TrackGain, TrackPan,
+    EffectParam { effect_id: EffectId, param_index: usize },
+    InstrumentParam { param_index: usize },
+    PluginParam { effect_id: Option<EffectId>, param_id: u32 }, // see plugin section
+}
+pub struct AutomationPoint { pub beat: f64, pub value: f32 }
+// Linear interpolation between points; hold value past the last.
+```
+Lanes live on `TrackInfo` (serde `#[serde(default)]` for backcompat,
+same trick as PluginDeviceInfo). UI mirror on `UiTrack`.
+
+## Engine evaluation (the RT-critical part)
+
+Per render block, per track, per lane: evaluate the lane at the
+block-start beat (samples_per_beat already available via TempoMap)
+and apply. NO allocation in the callback: lanes are Vec-stored on
+EngineTrack, updated via commands like note clips (Add/Remove/
+SetPoint commands, mirrored UI->engine like EngineNoteClip is).
+
+Granularity: block-rate (512 samples ~ 11ms) is fine for v1; do NOT
+attempt sample-accurate ramps first pass. Evaluate ONCE per block:
+`lane.value_at(current_beat)` (binary search; points sorted).
+
+Built-in application is trivial (set_param paths already exist on
+EffectSlot/instrument). The split render at the arrangement loop
+boundary (engine.rs process_multitrack) means evaluation must happen
+per SEGMENT, not per callback: hook inside render_multitrack_segment.
+
+## Plugin parameters (the hard 40%)
+
+- CLAP: param events (CLAP_EVENT_PARAM_VALUE) pushed into the input
+  event list per process() call. The wrapper already builds an event
+  list for notes: extend it. Param ids come from clap_plugin_params
+  (host currently answers `clap.params` with null: implement the host
+  ext minimally: rescan callbacks can be no-ops v1).
+- VST3: IParameterChanges input queues. A stub already exists
+  (PARAM_CHANGES_STUB in vst3_host/instance.rs): replace with a real
+  implementation: one queue per changed param per block, point at
+  sample offset 0. Param ids/ranges enumerate via IEditController
+  (getParameterCount/getParameterInfo: not yet wired: needed for the
+  UI to list automatable params).
+- IComponentHandler: implement it (currently missing: DPF plugins
+  assert). beginEdit/performEdit/endEdit callbacks are how plugin GUI
+  knob moves become recordable automation. Route to a pending queue
+  like the GUI resize requests (same pattern, host_context.rs).
+
+## UI
+
+- Lane display under the track (collapsible), canvas like the
+  timeline widgets; points draggable, double-click adds, Delete
+  removes (route through DeleteKeyPressed context priority).
+- Domain: extend arrangement (lanes are track data) or a new
+  `automation` domain following REFACTORING-GUIDE.md.
+- Record-arm from plugin GUIs comes later via IComponentHandler.
+
+## Order of work
+
+1. Core model + engine eval for TrackGain (audible end-to-end proof).
+2. Built-in effect/instrument params.
+3. UI lane editor.
+4. CLAP param events, then VST3 queues + param enumeration.
+5. IComponentHandler + write-from-GUI recording.
+Each step has an engine test analog to stuck_note_tests (spy/RMS).

--- a/.notes/design-mix-desk.md
+++ b/.notes/design-mix-desk.md
@@ -1,0 +1,65 @@
+# Design: mix desk (buses, sends, per-strip parametric EQ)
+
+Extends `.notes/feature-mix-desk.md` (the original idea) into an
+implementation spec. Alex's vision: the Mix view is a mixing desk;
+every strip has a parametric EQ; deep tools stay third-party plugins.
+
+## Open questions for Alex before building
+
+1. "The parametric EQ can send to busses": per-BAND sends (unusual,
+   powerful: e.g. send only the highs to reverb) or normal per-strip
+   sends alongside the EQ? Assume per-strip sends v1 unless he says
+   otherwise.
+2. Performance view: clip launcher (Ableton session view) or a
+   performance-oriented mixer layout? Do not guess: ask.
+
+## Engine: bus graph
+
+```rust
+// EngineTrack gains:
+pub output: OutputTarget,          // Master | Bus(BusId)
+pub sends: Vec<Send>,              // post-fader taps
+pub struct Send { pub bus: BusId, pub gain: f32, pub enabled: bool }
+```
+Buses are EngineTracks of a new kind (no clips/instrument; effects +
+gain/pan yes), summed AFTER regular tracks in process order:
+1. render regular tracks -> accumulate into their target bus buffer
+   (or master) AND into each enabled send's bus buffer at send gain.
+2. render buses in index order (bus->bus sends only allowed to
+   HIGHER-index buses to keep the graph acyclic and one-pass).
+3. buses sum to master.
+RT constraints: bus buffers preallocated on AddBus; no allocation in
+the callback; commands mirror track commands (AddBus, SetSend...).
+
+Serialization: TrackInfo gains `output` + `sends`; a `buses:
+Vec<BusInfo>` lands on Project (serde defaults for backcompat, with
+a roundtrip + pre-bus schema test like plugin_devices_roundtrip).
+
+## Parametric EQ (vibez-dsp)
+
+Per-strip built-in, NOT an effect slot: 4 bands v1, each band:
+biquad (RBJ cookbook), types low-shelf / bell / high-shelf (band 1
+LP/HP option), freq/gain/Q. State: [Biquad; 4] per channel,
+recompute coefficients on param change (command), process in chain
+position 0 before effect slots. dsp tests: white-noise spectrum
+before/after (FFT via existing onset tooling or plain goertzel at
+band centers).
+
+## UI (Mix workspace exists already)
+
+- Strip: input meter, 4-band EQ mini-display (reuse the AdsrScope
+  drawing approach: curve = sum of band responses, log-x), sends
+  knobs (param_column), fader, pan, mute/solo, output selector.
+- EQ detail: click the mini-display opens a large editor in the
+  detail strip: draggable band handles on the curve (the piano-roll
+  canvas interaction patterns apply).
+- New `mix` domain module per REFACTORING-GUIDE.md.
+
+## Order of work
+
+1. Engine buses + sends + tests (RMS through a bus == direct).
+2. TrackInfo/Project schema + persistence tests.
+3. Mix strips get output selector + send knobs.
+4. Biquad EQ in dsp + engine wiring + tests.
+5. Strip mini-curve + detail editor.
+6. Per-band sends only if Alex confirms (question 1).


### PR DESCRIPTION
The knowledge transfer package: the proven domain-extraction recipe with every trap documented, and implementation-grade specs for the two biggest ambiguous roadmap items so successor sessions implement instead of guessing (especially the RT-engine constraints). Includes the open questions only Alex can answer (per-band vs per-strip sends; what the performance view is).