### PR TITLE
style: cargo fmt on the make_demo example

### DIFF
--- a/crates/vibez-ui/examples/make_demo.rs
+++ b/crates/vibez-ui/examples/make_demo.rs
@@ -146,10 +146,7 @@ fn main() {
         (74, 11.5, 0.5),
         (69, 12.0, 3.5),
     ];
-    let notes = hook
-        .iter()
-        .map(|(p, s, d)| note(*p, 92, *s, *d))
-        .collect();
+    let notes = hook.iter().map(|(p, s, d)| note(*p, 92, *s, *d)).collect();
     note_clips.push(clip(lead.id, "Hook", 32.0, 16.0, notes));
 
     let project = Project {


### PR DESCRIPTION
The demo generator example missed a fmt pass; would fail the Format CI job. (Main's red run after #32 was a GitHub infra failure - all 8 jobs died in 2s before any step ran - but this was a real latent failure behind it.)