### PR TITLE
feat(ci): release artifacts for Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x86_64
+            archive: tar.gz
+          - os: macos-latest
+            label: macos-arm64
+            archive: tar.gz
+          - os: macos-15-intel
+            label: macos-x86_64
+            archive: tar.gz
+          - os: windows-latest
+            label: windows-x86_64
+            archive: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev
+
+      - name: Build
+        run: cargo build --release -p vibez --bins
+
+      - name: Package
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then VERSION="dev-${GITHUB_SHA::7}"; fi
+          PKG="vibez-${VERSION}-${{ matrix.label }}"
+          mkdir -p "stage/${PKG}"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cp target/release/vibez.exe target/release/vibez-plugin-scan.exe "stage/${PKG}/"
+          else
+            cp target/release/vibez target/release/vibez-plugin-scan "stage/${PKG}/"
+          fi
+          cp README.md LICENSE assets/demo.vibez "stage/${PKG}/"
+          cd stage
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            7z a "../${PKG}.zip" "${PKG}" > /dev/null
+          else
+            tar czf "../${PKG}.tar.gz" "${PKG}"
+          fi
+          cd ..
+          ls -la vibez-*.*
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vibez-${{ matrix.label }}
+          path: |
+            vibez-*.tar.gz
+            vibez-*.zip
+          if-no-files-found: error
+
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            vibez-*.tar.gz
+            vibez-*.zip
+          draft: false
+          generate_release_notes: true

--- a/crates/vibez-plugin-host/src/scanner.rs
+++ b/crates/vibez-plugin-host/src/scanner.rs
@@ -124,9 +124,10 @@ fn helper_binary() -> Option<PathBuf> {
     let dir = exe.parent()?;
     // Same directory as the app binary; one level up covers cargo's
     // target/<profile>/examples/ layout.
+    let name = format!("vibez-plugin-scan{}", std::env::consts::EXE_SUFFIX);
     [dir, dir.parent()?]
         .iter()
-        .map(|d| d.join("vibez-plugin-scan"))
+        .map(|d| d.join(&name))
         .find(|p| p.is_file())
 }
 


### PR DESCRIPTION
Release workflow (tag push on v*, plus workflow_dispatch for dry-runs):

- Four targets: linux-x86_64, macos-arm64, macos-x86_64 (macos-15-intel runner), windows-x86_64
- Each archive contains vibez, the vibez-plugin-scan sandbox helper, README, LICENSE, and assets/demo.vibez
- Tag pushes attach archives to a GitHub Release with generated notes; dispatch runs only upload workflow artifacts

Also fixes a real Windows bug found while wiring this: helper_binary() searched for vibez-plugin-scan without EXE_SUFFIX, so Windows release builds would never find the sandbox scanner and silently fell back to in-process scanning.

Plan after merge: dry-run via workflow_dispatch to validate all four legs before cutting the first tag.