### PR TITLE
feat: automation lanes (core, engine, UI)

### DIFF
--- a/crates/vibez-core/src/automation.rs
+++ b/crates/vibez-core/src/automation.rs
@@ -16,6 +16,25 @@ use crate::id::{EffectId, LaneId};
 pub struct AutomationPoint {
     pub beat: f64,
     pub value: f32,
+    /// Shape of the segment LEAVING this point: 0 is linear,
+    /// positive bends toward the destination late (ease-in),
+    /// negative early (ease-out). Range -1..1.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub curve: f32,
+}
+
+fn is_zero(v: &f32) -> bool {
+    *v == 0.0
+}
+
+/// Apply a segment's curve shaping to linear progress `t` (0..1).
+pub fn shape(t: f32, curve: f32) -> f32 {
+    if curve == 0.0 {
+        return t;
+    }
+    // Exponent sweep: curve -1 -> t^(1/8) (early), +1 -> t^8 (late).
+    let exp = 2.0_f32.powf(curve * 3.0);
+    t.powf(exp)
 }
 
 /// What a lane drives.
@@ -77,7 +96,7 @@ impl AutomationLane {
         if span <= f64::EPSILON {
             return Some(b.value);
         }
-        let t = ((beat - a.beat) / span) as f32;
+        let t = shape(((beat - a.beat) / span) as f32, a.curve);
         Some(a.value + (b.value - a.value) * t)
     }
 
@@ -109,6 +128,7 @@ mod tests {
             l.insert_point(AutomationPoint {
                 beat: *beat,
                 value: *value,
+                curve: 0.0,
             });
         }
         l
@@ -141,6 +161,7 @@ mod tests {
         l.insert_point(AutomationPoint {
             beat: 4.0,
             value: 0.9,
+            curve: 0.0,
         });
         assert_eq!(l.points.len(), 3);
         assert_eq!(l.value_at(4.0), Some(0.9));
@@ -152,5 +173,44 @@ mod tests {
         let json = serde_json::to_string(&l).unwrap();
         let back: AutomationLane = serde_json::from_str(&json).unwrap();
         assert_eq!(l, back);
+    }
+}
+
+#[cfg(test)]
+mod curve_tests {
+    use super::*;
+
+    #[test]
+    fn curve_bends_interpolation() {
+        let mut l = AutomationLane::new(AutomationTarget::TrackGain);
+        l.insert_point(AutomationPoint {
+            beat: 0.0,
+            value: 0.0,
+            curve: 1.0, // strong ease-in: stays low, rises late
+        });
+        l.insert_point(AutomationPoint {
+            beat: 8.0,
+            value: 1.0,
+            curve: 0.0,
+        });
+        let mid = l.value_at(4.0).unwrap();
+        assert!(mid < 0.05, "eased-in midpoint should hug the start: {mid}");
+        // Linear again once the curve resets.
+        l.points[0].curve = 0.0;
+        assert_eq!(l.value_at(4.0), Some(0.5));
+    }
+
+    #[test]
+    fn zero_curve_serializes_compactly_and_loads_back() {
+        let mut l = AutomationLane::new(AutomationTarget::TrackPan);
+        l.insert_point(AutomationPoint {
+            beat: 0.0,
+            value: 0.5,
+            curve: 0.0,
+        });
+        let json = serde_json::to_string(&l).unwrap();
+        assert!(!json.contains("curve"));
+        let back: AutomationLane = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.points[0].curve, 0.0);
     }
 }

--- a/crates/vibez-core/src/automation.rs
+++ b/crates/vibez-core/src/automation.rs
@@ -1,0 +1,156 @@
+//! Automation lanes: parameter values drawn over time.
+//!
+//! A lane targets one parameter and holds points sorted by beat.
+//! Evaluation is linear interpolation between points, holding the
+//! first value before the first point and the last value after the
+//! last point. Block-rate evaluation (once per render segment) is
+//! the v1 contract; no sample-accurate ramps yet.
+
+use serde::{Deserialize, Serialize};
+
+use crate::id::{EffectId, LaneId};
+
+/// One breakpoint on a lane. `value` is in the target parameter's
+/// native unit (gain multiplier, pan 0..1, effect param range).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct AutomationPoint {
+    pub beat: f64,
+    pub value: f32,
+}
+
+/// What a lane drives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AutomationTarget {
+    TrackGain,
+    TrackPan,
+    EffectParam {
+        effect_id: EffectId,
+        param_index: usize,
+    },
+    InstrumentParam {
+        param_index: usize,
+    },
+    /// Third-party plugin parameter. `effect_id` is `None` for the
+    /// track's plugin instrument.
+    PluginParam {
+        effect_id: Option<EffectId>,
+        param_id: u32,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationLane {
+    pub id: LaneId,
+    pub target: AutomationTarget,
+    /// Sorted by beat. Editing code must keep this invariant;
+    /// [`AutomationLane::insert_point`] does.
+    pub points: Vec<AutomationPoint>,
+}
+
+impl AutomationLane {
+    pub fn new(target: AutomationTarget) -> Self {
+        Self {
+            id: LaneId::new(),
+            target,
+            points: Vec::new(),
+        }
+    }
+
+    /// Evaluate the lane at `beat`. `None` when the lane is empty.
+    pub fn value_at(&self, beat: f64) -> Option<f32> {
+        let points = &self.points;
+        if points.is_empty() {
+            return None;
+        }
+        if beat <= points[0].beat {
+            return Some(points[0].value);
+        }
+        let last = points[points.len() - 1];
+        if beat >= last.beat {
+            return Some(last.value);
+        }
+        // partition_point: first index whose beat is > beat.
+        let idx = points.partition_point(|p| p.beat <= beat);
+        let a = points[idx - 1];
+        let b = points[idx];
+        let span = b.beat - a.beat;
+        if span <= f64::EPSILON {
+            return Some(b.value);
+        }
+        let t = ((beat - a.beat) / span) as f32;
+        Some(a.value + (b.value - a.value) * t)
+    }
+
+    /// Insert keeping beat order. Replaces an existing point on the
+    /// same beat (within a hair) instead of stacking duplicates.
+    pub fn insert_point(&mut self, point: AutomationPoint) {
+        const EPS: f64 = 1e-9;
+        match self
+            .points
+            .iter()
+            .position(|p| (p.beat - point.beat).abs() < EPS)
+        {
+            Some(i) => self.points[i] = point,
+            None => {
+                let idx = self.points.partition_point(|p| p.beat < point.beat);
+                self.points.insert(idx, point);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lane(points: &[(f64, f32)]) -> AutomationLane {
+        let mut l = AutomationLane::new(AutomationTarget::TrackGain);
+        for (beat, value) in points {
+            l.insert_point(AutomationPoint {
+                beat: *beat,
+                value: *value,
+            });
+        }
+        l
+    }
+
+    #[test]
+    fn empty_lane_has_no_value() {
+        assert_eq!(lane(&[]).value_at(4.0), None);
+    }
+
+    #[test]
+    fn holds_first_and_last_values_outside_range() {
+        let l = lane(&[(4.0, 0.2), (8.0, 0.8)]);
+        assert_eq!(l.value_at(0.0), Some(0.2));
+        assert_eq!(l.value_at(100.0), Some(0.8));
+    }
+
+    #[test]
+    fn interpolates_linearly_between_points() {
+        let l = lane(&[(0.0, 0.0), (8.0, 1.0)]);
+        assert_eq!(l.value_at(4.0), Some(0.5));
+        assert_eq!(l.value_at(2.0), Some(0.25));
+    }
+
+    #[test]
+    fn insert_keeps_order_and_replaces_same_beat() {
+        let mut l = lane(&[(8.0, 0.8), (0.0, 0.1), (4.0, 0.4)]);
+        let beats: Vec<f64> = l.points.iter().map(|p| p.beat).collect();
+        assert_eq!(beats, vec![0.0, 4.0, 8.0]);
+        l.insert_point(AutomationPoint {
+            beat: 4.0,
+            value: 0.9,
+        });
+        assert_eq!(l.points.len(), 3);
+        assert_eq!(l.value_at(4.0), Some(0.9));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let l = lane(&[(0.0, 0.0), (16.0, 1.0)]);
+        let json = serde_json::to_string(&l).unwrap();
+        let back: AutomationLane = serde_json::from_str(&json).unwrap();
+        assert_eq!(l, back);
+    }
+}

--- a/crates/vibez-core/src/id.rs
+++ b/crates/vibez-core/src/id.rs
@@ -49,6 +49,7 @@ macro_rules! typed_id {
 typed_id!(TrackId);
 typed_id!(ClipId);
 typed_id!(EffectId);
+typed_id!(LaneId);
 
 #[cfg(test)]
 mod tests {

--- a/crates/vibez-core/src/lib.rs
+++ b/crates/vibez-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio_buffer;
+pub mod automation;
 pub mod constants;
 pub mod effect;
 pub mod id;

--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -88,6 +88,9 @@ pub struct TrackInfo {
     /// Third-party plugin instrument on this track, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugin_instrument: Option<crate::effect::PluginDeviceInfo>,
+    /// Automation lanes on this track.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub automation: Vec<crate::automation::AutomationLane>,
 }
 
 impl TrackInfo {
@@ -105,6 +108,7 @@ impl TrackInfo {
             instrument: None,
             native_instrument: None,
             plugin_instrument: None,
+            automation: Vec::new(),
         }
     }
 }

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -71,6 +71,16 @@ pub enum EngineCommand {
     },
     /// Set the gain for a track.
     SetTrackGain(TrackId, f32),
+    /// Upsert one automation lane (whole-lane replace; points are
+    /// built on the UI thread).
+    SetAutomationLane {
+        track_id: TrackId,
+        lane: vibez_core::automation::AutomationLane,
+    },
+    RemoveAutomationLane {
+        track_id: TrackId,
+        lane_id: vibez_core::id::LaneId,
+    },
     /// Set the pan for a track (0.0 = left, 0.5 = center, 1.0 = right).
     SetTrackPan(TrackId, f32),
     /// Set the mute state for a track.

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -159,6 +159,10 @@ impl AudioEngine {
     }
 
     /// Read the tracks (for inspection / testing).
+    pub fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
     pub fn tracks(&self) -> &[EngineTrack] {
         &self.tracks
     }
@@ -246,6 +250,20 @@ impl AudioEngine {
                 continue;
             }
 
+            // Block-rate automation: evaluate every lane at the
+            // segment-start beat. Effect/instrument params apply in
+            // place; gain/pan come back as overrides for the sum
+            // stage below.
+            let beat = {
+                let bpm = self.transport.bpm();
+                if bpm > 0.0 {
+                    pos as f64 * bpm / (self.sample_rate as f64 * 60.0)
+                } else {
+                    0.0
+                }
+            };
+            let (auto_gain, auto_pan) = track.apply_automation(beat);
+
             let loop_region = self.transport.active_loop_region();
             let rendered = if track.instrument.is_some() {
                 let tempo_map = TempoMap::new(self.transport.bpm(), self.sample_rate);
@@ -267,8 +285,8 @@ impl AudioEngine {
                 continue;
             }
 
-            let gain = track.gain;
-            let (pan_l, pan_r) = equal_power_pan(track.pan);
+            let gain = auto_gain.unwrap_or(track.gain);
+            let (pan_l, pan_r) = equal_power_pan(auto_pan.unwrap_or(track.pan));
             let track_id = track.id;
             let buf_size = frames * channels;
 
@@ -505,6 +523,19 @@ impl AudioEngine {
                 EngineCommand::SetTrackGain(id, gain) => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == id) {
                         track.gain = gain;
+                    }
+                }
+                EngineCommand::SetAutomationLane { track_id, lane } => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                        match track.automation.iter_mut().find(|l| l.id == lane.id) {
+                            Some(existing) => *existing = lane,
+                            None => track.automation.push(lane),
+                        }
+                    }
+                }
+                EngineCommand::RemoveAutomationLane { track_id, lane_id } => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                        track.automation.retain(|l| l.id != lane_id);
                     }
                 }
                 EngineCommand::SetTrackPan(id, pan) => {

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -928,11 +928,24 @@ impl AudioEngine {
     fn render_idle_instruments(&mut self, output: &mut [f32], frames: usize, channels: usize) {
         let has_solo = any_solo(&self.tracks);
         for track in &mut self.tracks {
-            if track.instrument.is_none() || track.mute || (has_solo && !track.solo) {
+            if track.mute || (has_solo && !track.solo) {
                 continue;
             }
-            if !track.render_instrument_idle(frames, channels) {
+            // Instruments render so auditioned notes sound; every
+            // effect chain keeps processing while stopped so delay
+            // and reverb tails ring out and queued plugin parameter
+            // changes (knob edits, automation) actually reach the
+            // plugin instead of waiting for play.
+            let has_signal = if track.instrument.is_some() {
+                track.render_instrument_idle(frames, channels)
+            } else {
+                false
+            };
+            if !has_signal && track.effects.is_empty() {
                 continue;
+            }
+            if !has_signal && track.instrument.is_none() {
+                track.clear_buffer(frames, channels);
             }
             track.process_effects(frames, channels);
             let gain = track.gain;

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -1035,10 +1035,12 @@ fn gain_lane_ramps_track_volume_down() {
     lane.insert_point(AutomationPoint {
         beat: 0.0,
         value: 1.0,
+        curve: 0.0,
     });
     lane.insert_point(AutomationPoint {
         beat: 2.0,
         value: 0.0,
+        curve: 0.0,
     });
     cmd_tx
         .push(EngineCommand::SetAutomationLane {
@@ -1092,14 +1094,17 @@ fn pan_lane_moves_signal_between_channels() {
     lane.insert_point(AutomationPoint {
         beat: 0.0,
         value: 0.0,
+        curve: 0.0,
     });
     lane.insert_point(AutomationPoint {
         beat: 1.0,
         value: 0.0,
+        curve: 0.0,
     });
     lane.insert_point(AutomationPoint {
         beat: 1.01,
         value: 1.0,
+        curve: 0.0,
     });
     cmd_tx
         .push(EngineCommand::SetAutomationLane {
@@ -1140,6 +1145,7 @@ fn removing_a_lane_restores_the_knob_value() {
     lane.insert_point(AutomationPoint {
         beat: 0.0,
         value: 0.0,
+        curve: 0.0,
     });
     let lane_id = lane.id;
     cmd_tx

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -989,3 +989,181 @@ fn note_clip_loop_renders() {
         "Expected synth audio in looped region (beat 2-3)"
     );
 }
+
+// ---- Automation ----
+
+fn rms(buf: &[f32]) -> f32 {
+    (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt()
+}
+
+fn constant_clip_track(
+    cmd_tx: &mut rtrb::Producer<EngineCommand>,
+    frames: usize,
+) -> (TrackId, ClipId) {
+    let tid = TrackId::new();
+    let cid = ClipId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(tid, "Track".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddClip {
+            track_id: tid,
+            clip_id: cid,
+            audio: make_constant_audio(frames, 0.5),
+            position: 0,
+            source_offset: 0,
+            duration: frames as u64,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+    (tid, cid)
+}
+
+#[test]
+fn gain_lane_ramps_track_volume_down() {
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let sr = engine.sample_rate();
+    let frames_total = sr as usize; // one second of audio
+    let (tid, _cid) = constant_clip_track(&mut cmd_tx, frames_total);
+
+    // 120 BPM: one second = 2 beats. Ramp 1.0 -> 0.0 across it.
+    let mut lane = AutomationLane::new(AutomationTarget::TrackGain);
+    lane.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 1.0,
+    });
+    lane.insert_point(AutomationPoint {
+        beat: 2.0,
+        value: 0.0,
+    });
+    cmd_tx
+        .push(EngineCommand::SetAutomationLane {
+            track_id: tid,
+            lane,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let block = 512usize;
+    let mut buf = vec![0.0f32; block * 2];
+    let mut first_rms = None;
+    let mut mid_rms = None;
+    let blocks = frames_total / block;
+    for i in 0..blocks {
+        buf.fill(0.0);
+        engine.process(&mut buf, 2);
+        if i == 0 {
+            first_rms = Some(rms(&buf));
+        }
+        if i == blocks / 2 {
+            mid_rms = Some(rms(&buf));
+        }
+    }
+    let last_rms = rms(&buf);
+    let (first, mid) = (first_rms.unwrap(), mid_rms.unwrap());
+
+    // 0.5 amplitude through center equal-power pan = ~0.354 RMS.
+    assert!(first > 0.3, "start should be near full volume: {first}");
+    assert!(
+        mid < first * 0.7 && mid > first * 0.3,
+        "midpoint should be roughly half: first {first}, mid {mid}"
+    );
+    assert!(
+        last_rms < first * 0.1,
+        "end should be near silent: first {first}, last {last_rms}"
+    );
+}
+
+#[test]
+fn pan_lane_moves_signal_between_channels() {
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let sr = engine.sample_rate();
+    let frames_total = sr as usize;
+    let (tid, _cid) = constant_clip_track(&mut cmd_tx, frames_total);
+
+    // Hard left for the first beat, hard right after.
+    let mut lane = AutomationLane::new(AutomationTarget::TrackPan);
+    lane.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 0.0,
+    });
+    lane.insert_point(AutomationPoint {
+        beat: 1.0,
+        value: 0.0,
+    });
+    lane.insert_point(AutomationPoint {
+        beat: 1.01,
+        value: 1.0,
+    });
+    cmd_tx
+        .push(EngineCommand::SetAutomationLane {
+            track_id: tid,
+            lane,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let block = 512usize;
+    let mut buf = vec![0.0f32; block * 2];
+    engine.process(&mut buf, 2); // first block: hard left
+    let l: f32 = buf.iter().step_by(2).map(|s| s.abs()).sum();
+    let r: f32 = buf.iter().skip(1).step_by(2).map(|s| s.abs()).sum();
+    assert!(l > 1.0 && r < 0.01, "expected hard left: l {l}, r {r}");
+
+    // Jump past beat 1 and render again.
+    let one_beat_samples = (sr as f64 * 60.0 / 120.0) as u64;
+    cmd_tx
+        .push(EngineCommand::Seek(one_beat_samples + 4096))
+        .unwrap();
+    buf.fill(0.0);
+    engine.process(&mut buf, 2);
+    let l: f32 = buf.iter().step_by(2).map(|s| s.abs()).sum();
+    let r: f32 = buf.iter().skip(1).step_by(2).map(|s| s.abs()).sum();
+    assert!(r > 1.0 && l < 0.01, "expected hard right: l {l}, r {r}");
+}
+
+#[test]
+fn removing_a_lane_restores_the_knob_value() {
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let sr = engine.sample_rate();
+    let (tid, _cid) = constant_clip_track(&mut cmd_tx, sr as usize);
+
+    let mut lane = AutomationLane::new(AutomationTarget::TrackGain);
+    lane.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 0.0,
+    });
+    let lane_id = lane.id;
+    cmd_tx
+        .push(EngineCommand::SetAutomationLane {
+            track_id: tid,
+            lane,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut buf = vec![0.0f32; 1024];
+    engine.process(&mut buf, 2);
+    assert!(rms(&buf) < 1e-6, "lane at zero should silence the track");
+
+    cmd_tx
+        .push(EngineCommand::RemoveAutomationLane {
+            track_id: tid,
+            lane_id,
+        })
+        .unwrap();
+    buf.fill(0.0);
+    engine.process(&mut buf, 2);
+    assert!(
+        rms(&buf) > 0.2,
+        "removing the lane should restore the track gain"
+    );
+}

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -1167,3 +1167,46 @@ fn removing_a_lane_restores_the_knob_value() {
         "removing the lane should restore the track gain"
     );
 }
+
+#[test]
+fn effect_tails_ring_out_after_stop() {
+    // A delay tail must keep sounding after the transport stops:
+    // effect chains process while stopped. (This is also what
+    // delivers queued plugin param changes without pressing play.)
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let sr = engine.sample_rate() as usize;
+    let (tid, _cid) = constant_clip_track(&mut cmd_tx, sr);
+
+    let effect_id = vibez_core::id::EffectId::new();
+    cmd_tx
+        .push(EngineCommand::AddEffect {
+            track_id: tid,
+            effect_id,
+            effect_type: vibez_core::effect::EffectType::Delay,
+            position: None,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    // Delay time defaults to 500 ms: play well past it so echoes
+    // exist, then listen for them after stop.
+    let mut buf = vec![0.0f32; 1024];
+    for _ in 0..60 {
+        buf.fill(0.0);
+        engine.process(&mut buf, 2);
+    }
+    cmd_tx.push(EngineCommand::Stop).unwrap();
+    buf.fill(0.0);
+    engine.process(&mut buf, 2); // drains Stop, first stopped block
+
+    let mut tail = 0.0f32;
+    for _ in 0..40 {
+        buf.fill(0.0);
+        engine.process(&mut buf, 2);
+        tail += buf.iter().map(|s| s.abs()).sum::<f32>();
+    }
+    assert!(
+        tail > 0.01,
+        "delay tail should ring out after stop, got {tail}"
+    );
+}

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -140,12 +140,22 @@ impl EngineTrack {
                     param_index,
                 } => {
                     if let Some(slot) = self.effects.iter_mut().find(|e| e.id == effect_id) {
-                        slot.effect.set_param(param_index, value);
+                        // Lanes are normalized 0..1; parameters live in
+                        // their native descriptor range.
+                        let native = match slot.effect.param_descriptors().get(param_index) {
+                            Some(d) => d.min + value * (d.max - d.min),
+                            None => value,
+                        };
+                        slot.effect.set_param(param_index, native);
                     }
                 }
                 AutomationTarget::InstrumentParam { param_index } => {
                     if let Some(instrument) = self.instrument.as_mut() {
-                        instrument.set_param(param_index, value);
+                        let native = match instrument.param_descriptors().get(param_index) {
+                            Some(d) => d.min + value * (d.max - d.min),
+                            None => value,
+                        };
+                        instrument.set_param(param_index, native);
                     }
                 }
                 AutomationTarget::PluginParam { .. } => {}

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -164,6 +164,17 @@ impl EngineTrack {
         (gain, pan)
     }
 
+    /// Zero the mix buffer: an idle block for a track with no source
+    /// signal, so the effect chain can still run (tails, queued
+    /// plugin param changes).
+    pub fn clear_buffer(&mut self, frames: usize, channels: usize) {
+        let buf_size = frames * channels;
+        self.ensure_buffer(buf_size);
+        for s in self.mix_buffer[..buf_size].iter_mut() {
+            *s = 0.0;
+        }
+    }
+
     /// Render the instrument with no clip events (transport stopped):
     /// lets auditioned/held notes sound and plugin event queues drain.
     /// Returns true when the buffer has signal.

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -83,6 +83,8 @@ pub struct EngineTrack {
     pub mix_buffer: Vec<f32>,
     pub effects: Vec<EffectSlot>,
     pub note_clips: Vec<EngineNoteClip>,
+    /// Automation lanes, evaluated once per render segment.
+    pub automation: Vec<vibez_core::automation::AutomationLane>,
     pub instrument: Option<Box<dyn Instrument>>,
     /// Scratch storage for batch rendering: (frame_offset, pitch, velocity)
     timed_note_ons: Vec<(u32, u8, u8)>,
@@ -109,11 +111,47 @@ impl EngineTrack {
             mix_buffer: Vec::new(),
             effects: Vec::new(),
             note_clips: Vec::new(),
+            automation: Vec::new(),
             instrument: None,
             timed_note_ons: Vec::new(),
             timed_note_offs: Vec::new(),
             active_notes: 0,
         }
+    }
+
+    /// Evaluate every automation lane at `beat` (block-rate): effect
+    /// and instrument parameters are applied in place; gain and pan
+    /// come back as overrides for the mix stage. Plugin parameter
+    /// lanes are handled by the plugin event path, not here.
+    pub fn apply_automation(&mut self, beat: f64) -> (Option<f32>, Option<f32>) {
+        use vibez_core::automation::AutomationTarget;
+        let mut gain = None;
+        let mut pan = None;
+        for lane_idx in 0..self.automation.len() {
+            let lane = &self.automation[lane_idx];
+            let Some(value) = lane.value_at(beat) else {
+                continue;
+            };
+            match lane.target {
+                AutomationTarget::TrackGain => gain = Some(value),
+                AutomationTarget::TrackPan => pan = Some(value),
+                AutomationTarget::EffectParam {
+                    effect_id,
+                    param_index,
+                } => {
+                    if let Some(slot) = self.effects.iter_mut().find(|e| e.id == effect_id) {
+                        slot.effect.set_param(param_index, value);
+                    }
+                }
+                AutomationTarget::InstrumentParam { param_index } => {
+                    if let Some(instrument) = self.instrument.as_mut() {
+                        instrument.set_param(param_index, value);
+                    }
+                }
+                AutomationTarget::PluginParam { .. } => {}
+            }
+        }
+        (gain, pan)
     }
 
     /// Render the instrument with no clip events (transport stopped):

--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -306,6 +306,7 @@ mod tests {
             instrument: None,
             native_instrument: None,
             plugin_instrument: None,
+            automation: Vec::new(),
         }
     }
 
@@ -524,6 +525,7 @@ mod tests {
             instrument: Some(InstrumentKind::SubtractiveSynth),
             native_instrument: Some(InstrumentStateInfo::SubtractiveSynth { params: Vec::new() }),
             plugin_instrument: None,
+            automation: Vec::new(),
         };
         let note_clip = NoteClipInfo {
             id: cid,
@@ -573,6 +575,7 @@ mod tests {
             instrument: None,
             native_instrument: None,
             plugin_instrument: None,
+            automation: Vec::new(),
         };
         let req = BounceRequest {
             tracks: vec![track],

--- a/crates/vibez-instruments/src/lib.rs
+++ b/crates/vibez-instruments/src/lib.rs
@@ -15,6 +15,17 @@ use sampler::Sampler;
 use synth::SubtractiveSynth;
 
 /// Trait implemented by all instruments (synths, samplers, etc.).
+/// Parameter descriptors for an instrument kind, without building
+/// an instance (UI pickers, automation lane labels).
+pub fn descriptors_for(kind: InstrumentKind) -> &'static [ParamDescriptor] {
+    match kind {
+        InstrumentKind::SubtractiveSynth => synth::SYNTH_PARAMS,
+        InstrumentKind::Sampler => sampler::SAMPLER_PARAMS,
+        // The drum rack has per-pad state, no top-level params.
+        InstrumentKind::DrumRack => &[],
+    }
+}
+
 pub trait Instrument: Send {
     fn instrument_kind(&self) -> InstrumentKind;
     fn param_descriptors(&self) -> &'static [ParamDescriptor];

--- a/crates/vibez-plugin-host/src/clap_host/instance.rs
+++ b/crates/vibez-plugin-host/src/clap_host/instance.rs
@@ -22,6 +22,12 @@ pub struct ClapPluginInstance {
     _lib: libloading::Library,
     param_descriptors: Vec<ParamDescriptor>,
     param_values: Vec<f32>,
+    /// CLAP param ids and cookies, index-aligned with the
+    /// descriptors (cookies stored as usize to stay Send).
+    param_ids: Vec<u32>,
+    param_cookies: Vec<usize>,
+    /// (id, cookie, native value) queued for the next process block.
+    pending_params: Vec<(u32, usize, f64)>,
     buffer_adapter: AudioBufferAdapter,
     note_events: Vec<NoteEvent>,
     sample_rate: f64,
@@ -182,7 +188,7 @@ impl ClapPluginInstance {
             return Err("Plugin init() failed".into());
         }
 
-        let (param_descriptors, param_values) = query_params(plugin_ptr);
+        let (param_descriptors, param_values, param_ids, param_cookies) = query_params(plugin_ptr);
         let buffer_adapter = AudioBufferAdapter::new(2, max_buffer_size as usize);
 
         let mut instance = Self {
@@ -192,6 +198,9 @@ impl ClapPluginInstance {
             _lib: partial.lib,
             param_descriptors,
             param_values,
+            param_ids,
+            param_cookies,
+            pending_params: Vec::new(),
             buffer_adapter,
             note_events: Vec::new(),
             sample_rate,
@@ -219,7 +228,10 @@ impl ClapPluginInstance {
     }
 }
 
-fn query_params(plugin_ptr: *const clap_plugin) -> (Vec<ParamDescriptor>, Vec<f32>) {
+#[allow(clippy::type_complexity)]
+fn query_params(
+    plugin_ptr: *const clap_plugin,
+) -> (Vec<ParamDescriptor>, Vec<f32>, Vec<u32>, Vec<usize>) {
     let plugin_ref = unsafe { &*plugin_ptr };
 
     let ext_ptr =
@@ -227,7 +239,7 @@ fn query_params(plugin_ptr: *const clap_plugin) -> (Vec<ParamDescriptor>, Vec<f3
             as *const clap_plugin_params;
 
     if ext_ptr.is_null() {
-        return (Vec::new(), Vec::new());
+        return (Vec::new(), Vec::new(), Vec::new(), Vec::new());
     }
 
     let params_ext = unsafe { &*ext_ptr };
@@ -235,6 +247,8 @@ fn query_params(plugin_ptr: *const clap_plugin) -> (Vec<ParamDescriptor>, Vec<f3
 
     let mut descriptors = Vec::with_capacity(count);
     let mut values = Vec::with_capacity(count);
+    let mut ids = Vec::with_capacity(count);
+    let mut cookies = Vec::with_capacity(count);
 
     for i in 0..count {
         let mut info = clap_sys::ext::params::clap_param_info {
@@ -275,9 +289,11 @@ fn query_params(plugin_ptr: *const clap_plugin) -> (Vec<ParamDescriptor>, Vec<f3
             unit: "",
         });
         values.push(value as f32);
+        ids.push(info.id);
+        cookies.push(info.cookie as usize);
     }
 
-    (descriptors, values)
+    (descriptors, values, ids, cookies)
 }
 
 impl PluginInstance for ClapPluginInstance {
@@ -304,6 +320,12 @@ impl PluginInstance for ClapPluginInstance {
     fn set_param(&mut self, index: usize, value: f32) -> bool {
         if index < self.param_values.len() {
             self.param_values[index] = value;
+            // Deliver as a CLAP param event on the next process block.
+            self.pending_params.push((
+                self.param_ids[index],
+                self.param_cookies[index],
+                value as f64,
+            ));
             true
         } else {
             false
@@ -352,9 +374,45 @@ impl PluginInstance for ClapPluginInstance {
             input_events_storage.push(ClapNoteEventWrapper(event));
         }
 
+        // Param events (automation): delivered at block start.
+        let param_events_storage: Vec<clap_sys::events::clap_event_param_value> = self
+            .pending_params
+            .drain(..)
+            .map(
+                |(id, cookie, value)| clap_sys::events::clap_event_param_value {
+                    header: clap_event_header {
+                        size: std::mem::size_of::<clap_sys::events::clap_event_param_value>()
+                            as u32,
+                        time: 0,
+                        space_id: CLAP_CORE_EVENT_SPACE_ID,
+                        type_: clap_sys::events::CLAP_EVENT_PARAM_VALUE,
+                        flags: 0,
+                    },
+                    param_id: id,
+                    cookie: cookie as *mut std::ffi::c_void,
+                    note_id: -1,
+                    port_index: -1,
+                    channel: -1,
+                    key: -1,
+                    value,
+                },
+            )
+            .collect();
+
+        // Merge into one header list: params first (time 0), then the
+        // time-sorted notes.
+        let mut event_headers: Vec<*const clap_event_header> =
+            Vec::with_capacity(param_events_storage.len() + input_events_storage.len());
+        for pe in &param_events_storage {
+            event_headers.push(&pe.header as *const clap_event_header);
+        }
+        for ne in &input_events_storage {
+            event_headers.push(&ne.0.header as *const clap_event_header);
+        }
+
         // Create input/output event lists
         let input_events = ClapInputEvents {
-            events: &input_events_storage,
+            events: &event_headers,
         };
         let input_events_clap = clap_input_events {
             ctx: &input_events as *const ClapInputEvents as *const std::ffi::c_void
@@ -498,7 +556,9 @@ impl Drop for ClapPluginInstance {
 struct ClapNoteEventWrapper(clap_event_note);
 
 struct ClapInputEvents<'a> {
-    events: &'a [ClapNoteEventWrapper],
+    /// Type-erased event headers (notes and param values), sorted by
+    /// time. The pointed-to storage outlives the process() call.
+    events: &'a [*const clap_event_header],
 }
 
 unsafe extern "C" fn input_events_size(list: *const clap_input_events) -> u32 {
@@ -512,7 +572,7 @@ unsafe extern "C" fn input_events_get(
 ) -> *const clap_event_header {
     let events = &*((*list).ctx as *const ClapInputEvents);
     if (index as usize) < events.events.len() {
-        &events.events[index as usize].0.header as *const clap_event_header
+        events.events[index as usize]
     } else {
         std::ptr::null()
     }

--- a/crates/vibez-plugin-host/src/vst3_host/instance.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/instance.rs
@@ -26,6 +26,10 @@ pub struct Vst3PluginInstance {
     controller_is_separate: bool,
     param_descriptors: Vec<ParamDescriptor>,
     param_values: Vec<f32>,
+    /// VST3 ParamIDs, index-aligned with the descriptors.
+    param_ids: Vec<u32>,
+    /// (id, normalized value) queued for the next process block.
+    pending_params: Vec<(u32, f64)>,
     buffer_adapter: AudioBufferAdapter,
     /// Separate output buffers: VST3 process() is out-of-place by
     /// default and JUCE plugins do not reliably write in-place.
@@ -187,6 +191,144 @@ static PARAM_CHANGES_STUB: ParamChangesStub = ParamChangesStub {
 
 fn param_changes_stub() -> *mut std::ffi::c_void {
     &PARAM_CHANGES_STUB as *const ParamChangesStub as *mut std::ffi::c_void
+}
+
+// ── Live IParameterChanges (input) ──
+// Stack-allocated per process() call; spec-compliant plugins do not
+// retain the pointer past the call.
+
+#[repr(C)]
+struct LiveParamQueue {
+    vtbl: *const ParamQueueVtbl,
+    id: u32,
+    value: f64,
+}
+
+unsafe extern "system" fn lpq_parameter_id(this: *mut std::ffi::c_void) -> u32 {
+    unsafe { (*(this as *const LiveParamQueue)).id }
+}
+unsafe extern "system" fn lpq_point_count(_this: *mut std::ffi::c_void) -> i32 {
+    1
+}
+unsafe extern "system" fn lpq_get_point(
+    this: *mut std::ffi::c_void,
+    index: i32,
+    offset: *mut i32,
+    value: *mut f64,
+) -> i32 {
+    if index != 0 {
+        return 1; // kResultFalse
+    }
+    unsafe {
+        if !offset.is_null() {
+            *offset = 0;
+        }
+        if !value.is_null() {
+            *value = (*(this as *const LiveParamQueue)).value;
+        }
+    }
+    0
+}
+
+static LIVE_PARAM_QUEUE_VTBL: ParamQueueVtbl = ParamQueueVtbl {
+    query_interface: pc_query_interface,
+    add_ref: pc_add_ref,
+    release: pc_release,
+    get_parameter_id: lpq_parameter_id,
+    get_point_count: lpq_point_count,
+    get_point: lpq_get_point,
+    add_point: pq_add_point,
+};
+
+#[repr(C)]
+struct LiveParamChanges {
+    vtbl: *const ParamChangesVtbl,
+    queues: *const LiveParamQueue,
+    len: usize,
+}
+
+unsafe extern "system" fn lpc_count(this: *mut std::ffi::c_void) -> i32 {
+    unsafe { (*(this as *const LiveParamChanges)).len as i32 }
+}
+unsafe extern "system" fn lpc_get_data(
+    this: *mut std::ffi::c_void,
+    index: i32,
+) -> *mut std::ffi::c_void {
+    let changes = unsafe { &*(this as *const LiveParamChanges) };
+    if index < 0 || index as usize >= changes.len {
+        return std::ptr::null_mut();
+    }
+    unsafe { changes.queues.add(index as usize) as *mut std::ffi::c_void }
+}
+
+static LIVE_PARAM_CHANGES_VTBL: ParamChangesVtbl = ParamChangesVtbl {
+    query_interface: pc_query_interface,
+    add_ref: pc_add_ref,
+    release: pc_release,
+    get_parameter_count: lpc_count,
+    get_parameter_data: lpc_get_data,
+    add_parameter_data: pc_add_data,
+};
+
+/// Enumerate parameters via IEditController.
+/// Vtable slots: FUnknown 0-2, IPluginBase 3-4, then
+/// setComponentState(5) setState(6) getState(7) getParameterCount(8)
+/// getParameterInfo(9) ... getParamNormalized(14).
+fn query_vst3_params(
+    controller: *mut std::ffi::c_void,
+) -> (Vec<ParamDescriptor>, Vec<f32>, Vec<u32>) {
+    type GetCountFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> i32;
+    type GetInfoFn = unsafe extern "system" fn(
+        *mut std::ffi::c_void,
+        i32,
+        *mut vst3::Steinberg::Vst::ParameterInfo,
+    ) -> i32;
+    type GetNormalizedFn = unsafe extern "system" fn(*mut std::ffi::c_void, u32) -> f64;
+
+    let mut descriptors = Vec::new();
+    let mut values = Vec::new();
+    let mut ids = Vec::new();
+
+    unsafe {
+        let vtbl = *(controller as *const *const *const std::ffi::c_void);
+        let get_count: GetCountFn = std::mem::transmute(*vtbl.add(8));
+        let get_info: GetInfoFn = std::mem::transmute(*vtbl.add(9));
+        let get_normalized: GetNormalizedFn = std::mem::transmute(*vtbl.add(14));
+
+        let count = get_count(controller).max(0);
+        for i in 0..count {
+            let mut info: vst3::Steinberg::Vst::ParameterInfo = std::mem::zeroed();
+            if get_info(controller, i, &mut info) != 0 {
+                continue;
+            }
+            // Skip read-only / hidden params.
+            const CAN_AUTOMATE: i32 = 1 << 0;
+            const IS_READ_ONLY: i32 = 1 << 1;
+            if info.flags & IS_READ_ONLY != 0 {
+                continue;
+            }
+            if info.flags & CAN_AUTOMATE == 0 {
+                continue;
+            }
+            let title: String = char16_to_string(&info.title);
+            let name_static: &'static str = Box::leak(title.into_boxed_str());
+            descriptors.push(ParamDescriptor {
+                name: name_static,
+                min: 0.0,
+                max: 1.0,
+                default: info.defaultNormalizedValue as f32,
+                unit: "",
+            });
+            values.push(get_normalized(controller, info.id) as f32);
+            ids.push(info.id);
+        }
+    }
+    (descriptors, values, ids)
+}
+
+fn char16_to_string(chars: &[u16]) -> String {
+    let units: Vec<u16> = chars.iter().take_while(|&&c| c != 0).copied().collect();
+    String::from_utf16_lossy(&units)
 }
 
 /// Output of [`Vst3PluginInstance::load_partial`]: a dlopen'd module
@@ -548,6 +690,8 @@ impl Vst3PluginInstance {
             controller_is_separate,
             param_descriptors: Vec::new(),
             param_values: Vec::new(),
+            param_ids: Vec::new(),
+            pending_params: Vec::new(),
             buffer_adapter,
             out_adapter,
             audio_in_buses,
@@ -557,6 +701,15 @@ impl Vst3PluginInstance {
             sample_rate,
             active: false,
         };
+
+        // Enumerate parameters from the edit controller (VST3 params
+        // are always normalized 0..1).
+        if !instance.controller.is_null() {
+            let (descriptors, values, ids) = query_vst3_params(instance.controller);
+            instance.param_descriptors = descriptors;
+            instance.param_values = values;
+            instance.param_ids = ids;
+        }
 
         instance.prepare(sample_rate, max_buffer_size);
         instance.activate();
@@ -627,6 +780,8 @@ impl PluginInstance for Vst3PluginInstance {
     fn set_param(&mut self, index: usize, value: f32) -> bool {
         if index < self.param_values.len() {
             self.param_values[index] = value;
+            self.pending_params
+                .push((self.param_ids[index], value.clamp(0.0, 1.0) as f64));
             true
         } else {
             false
@@ -706,6 +861,23 @@ impl PluginInstance for Vst3PluginInstance {
             })
             .collect();
 
+        // Automation param changes for this block; storage must
+        // outlive the process() call below.
+        let live_queues: Vec<LiveParamQueue> = self
+            .pending_params
+            .drain(..)
+            .map(|(id, value)| LiveParamQueue {
+                vtbl: &LIVE_PARAM_QUEUE_VTBL,
+                id,
+                value,
+            })
+            .collect();
+        let live_changes = LiveParamChanges {
+            vtbl: &LIVE_PARAM_CHANGES_VTBL,
+            queues: live_queues.as_ptr(),
+            len: live_queues.len(),
+        };
+
         let mut process_data = ProcessDataRaw {
             process_mode: 0,
             symbolic_sample_size: 0,
@@ -714,7 +886,11 @@ impl PluginInstance for Vst3PluginInstance {
             num_outputs,
             inputs: input_buses.as_mut_ptr(),
             outputs: output_buses.as_mut_ptr(),
-            input_parameter_changes: param_changes_stub(),
+            input_parameter_changes: if live_queues.is_empty() {
+                param_changes_stub()
+            } else {
+                &live_changes as *const LiveParamChanges as *mut std::ffi::c_void
+            },
             output_parameter_changes: param_changes_stub(),
             input_events: std::ptr::null_mut(),
             output_events: std::ptr::null_mut(),

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -344,3 +344,50 @@ mod tests {
         ));
     }
 }
+
+#[cfg(test)]
+mod automation_persistence_tests {
+    use super::*;
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+    use vibez_core::track::TrackInfo;
+
+    #[test]
+    fn lanes_survive_a_save_load_roundtrip() {
+        let mut track = TrackInfo::new("T1");
+        let mut lane = AutomationLane::new(AutomationTarget::TrackGain);
+        lane.insert_point(AutomationPoint {
+            beat: 0.0,
+            value: 1.0,
+        });
+        lane.insert_point(AutomationPoint {
+            beat: 8.0,
+            value: 0.25,
+        });
+        track.automation.push(lane.clone());
+
+        let project = Project {
+            name: "roundtrip".to_string(),
+            tracks: vec![track],
+            ..Default::default()
+        };
+
+        let dir = std::env::temp_dir().join("vibez-lane-roundtrip-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("p.vibez");
+        project.save_to_file(&path).unwrap();
+        let loaded = Project::load_from_file(&path).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(loaded.tracks[0].automation, vec![lane]);
+    }
+
+    #[test]
+    fn projects_without_lanes_still_load() {
+        // Backcompat: pre-automation files have no `automation` key.
+        let json = r#"{"name":"old","bpm":120.0,"sample_rate":48000,
+            "tracks":[{"id":1,"name":"T","gain":1.0,"pan":0.5,
+            "mute":false,"solo":false}],"clips":[]}"#;
+        let project: Project = serde_json::from_str(json).unwrap();
+        assert!(project.tracks[0].automation.is_empty());
+    }
+}

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -358,10 +358,12 @@ mod automation_persistence_tests {
         lane.insert_point(AutomationPoint {
             beat: 0.0,
             value: 1.0,
+            curve: 0.0,
         });
         lane.insert_point(AutomationPoint {
             beat: 8.0,
             value: 0.25,
+            curve: 0.5,
         });
         track.automation.push(lane.clone());
 

--- a/crates/vibez-ui/examples/make_demo.rs
+++ b/crates/vibez-ui/examples/make_demo.rs
@@ -29,6 +29,7 @@ fn track(name: &str, kind: InstrumentKind, color_index: u8) -> TrackInfo {
         instrument: Some(kind),
         native_instrument: None,
         plugin_instrument: None,
+        automation: Vec::new(),
     }
 }
 

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -226,13 +226,17 @@ impl App {
             }
 
             if let Some(track) = self.state.find_track_mut(track_id) {
-                let descriptors: &'static [vibez_core::effect::ParamDescriptor] =
-                    Box::leak(Vec::new().into_boxed_slice());
+                // Real plugin parameters (already leaked 'static by the
+                // wrapper): drives the knob strip and automation picker.
+                let descriptors = effect.param_descriptors();
+                let params: Vec<f32> = (0..descriptors.len())
+                    .map(|i| effect.get_param(i))
+                    .collect();
                 let ui_effect = UiEffect {
                     id: effect_id,
                     effect_type: EffectType::Gain,
                     bypass: false,
-                    params: Vec::new(),
+                    params,
                     descriptors,
                     plugin_name: Some(plugin_name.clone()),
                     has_plugin_gui: has_gui,
@@ -284,6 +288,7 @@ impl App {
                 track.has_instrument = true;
                 track.plugin_instrument_name = Some(plugin_name.clone());
                 track.plugin_instrument_ref = Some(result.device_ref.clone());
+                track.plugin_instrument_descriptors = instrument.param_descriptors();
                 track.has_plugin_instrument_gui = has_gui;
             }
             self.send_command(EngineCommand::SetPluginInstrument {

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -215,7 +215,16 @@ impl App {
             )
         };
 
-        (app, startup_task)
+        // `vibez <project.vibez>` opens a project straight from the
+        // command line (also how file-manager associations launch us).
+        let open_task = std::env::args()
+            .nth(1)
+            .map(std::path::PathBuf::from)
+            .filter(|p| p.is_file())
+            .map(|p| Task::done(Message::ProjectOpenPathSelected(Some(p))))
+            .unwrap_or_else(Task::none);
+
+        (app, Task::batch([startup_task, open_task]))
     }
 
     fn send_command(&mut self, cmd: EngineCommand) {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -280,6 +280,7 @@ impl App {
             track.pan = track_info.pan;
             track.mute = track_info.mute;
             track.solo = track_info.solo;
+            track.automation = track_info.automation.clone();
             track.instrument_kind = track_info.instrument;
             track.has_instrument = track_info.instrument.is_some();
             if let Some(dev) = &track_info.plugin_instrument {
@@ -346,6 +347,13 @@ impl App {
                         }
                     }
                 }
+            }
+
+            for lane in &track_info.automation {
+                self.send_command(EngineCommand::SetAutomationLane {
+                    track_id: track_info.id,
+                    lane: lane.clone(),
+                });
             }
 
             for (chain_pos, effect_info) in track_info.effects.iter().enumerate() {
@@ -682,6 +690,13 @@ impl App {
                 }
                 InstrumentKind::SubtractiveSynth => {}
             }
+        }
+
+        for lane in &track.automation {
+            self.send_command(EngineCommand::SetAutomationLane {
+                track_id: track.id,
+                lane: lane.clone(),
+            });
         }
 
         for effect in &track.effects {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -146,6 +146,7 @@ impl App {
             instrument: track.instrument_kind,
             native_instrument,
             plugin_instrument,
+            automation: track.automation.clone(),
         }
     }
 

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -98,7 +98,8 @@ impl App {
                 | Message::ClipAutoWarpReady { .. }
         ) || matches!(&message, Message::Devices(m) if m.marks_dirty())
             || matches!(&message, Message::Arrangement(m) if m.marks_dirty())
-            || matches!(&message, Message::PianoRoll(m) if m.marks_dirty());
+            || matches!(&message, Message::PianoRoll(m) if m.marks_dirty())
+            || matches!(&message, Message::Automation(m) if m.marks_dirty());
         if should_mark_dirty {
             self.push_undo_snapshot();
             self.mark_project_dirty();
@@ -177,6 +178,19 @@ impl App {
                 let action = self.state.browser.update(msg);
                 return self.apply_browser_action(action);
             }
+            Message::Automation(msg) => {
+                let action = {
+                    let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+                    self.state.automation_ui.update(
+                        msg,
+                        &mut engine,
+                        &mut self.state.arrangement.tracks,
+                    )
+                };
+                if let Some(status) = action.status {
+                    self.state.status_text = status;
+                }
+            }
             Message::View(msg) => {
                 let ctx = crate::domains::view::ViewCtx {
                     total_beats: self.state.total_beats(),
@@ -224,7 +238,13 @@ impl App {
                 {
                     return Task::none();
                 }
-                // Priority 1: selected notes in the open piano roll.
+                // Priority 1: a selected automation point.
+                if self.state.automation_ui.selected.is_some() {
+                    return self.update(Message::Automation(
+                        crate::domains::automation::AutomationMsg::DeleteSelectedPoint,
+                    ));
+                }
+                // Priority 2: selected notes in the open piano roll.
                 if let Some((track_id, clip_id)) = self.state.arrangement.selected_note_clip {
                     let has_selection = self
                         .state
@@ -237,7 +257,7 @@ impl App {
                         )));
                     }
                 }
-                // Priority 2: selected arrangement clips.
+                // Priority 3: selected arrangement clips.
                 if !self.state.arrangement.selected_clips.is_empty() {
                     return self.update(Message::Arrangement(ArrangementMsg::DeleteSelectedClip));
                 }

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -388,8 +388,14 @@ impl App {
 
             // Track header (iced widgets)
             let editing = self.state.view.editing_track_name == Some(track.id);
-            let header =
-                view_track_header(track, selected, editing, &self.state.view.edit_name_text);
+            let automation_open = self.state.automation_ui.expanded.contains(&track.id);
+            let header = view_track_header(
+                track,
+                selected,
+                editing,
+                &self.state.view.edit_name_text,
+                automation_open,
+            );
 
             // Clip canvas for this track
             let clip_canvas_widget = TrackClipCanvas::from_track(
@@ -425,6 +431,10 @@ impl App {
             let track_row = row![header, clip_canvas].height(Length::Fixed(70.0));
 
             track_rows = track_rows.push(track_row);
+
+            if automation_open {
+                track_rows = self.push_automation_lanes(track_rows, track, track_color);
+            }
         }
 
         let content = column![ruler_row, minimap_row, track_rows];
@@ -720,5 +730,143 @@ impl App {
                 ..Default::default()
             })
             .into()
+    }
+
+    /// Lane strip under an expanded track: one row per lane plus the
+    /// add-lane picker.
+    fn push_automation_lanes<'a>(
+        &'a self,
+        mut rows: iced::widget::Column<'a, Message>,
+        track: &'a crate::state::UiTrack,
+        track_color: iced::Color,
+    ) -> iced::widget::Column<'a, Message> {
+        use crate::domains::automation::{target_label, AutomationMsg};
+        use crate::widgets::automation_lane::{AutomationLaneWidget, LANE_HEIGHT};
+
+        for lane in &track.automation {
+            let label = target_label(&lane.target, track);
+            let remove = button(icons::icon(icons::TRASH_2).size(9).color(th::TEXT_DIM))
+                .on_press(Message::Automation(AutomationMsg::RemoveLane {
+                    track_id: track.id,
+                    lane_id: lane.id,
+                }))
+                .padding([1, 4])
+                .style(|_theme: &Theme, _status| button::Style {
+                    background: None,
+                    text_color: th::TEXT_DIM,
+                    border: iced::Border::default(),
+                    ..Default::default()
+                });
+            let lane_header = container(
+                row![
+                    text(label).size(11).color(th::TEXT_DIM),
+                    horizontal_space(),
+                    remove
+                ]
+                .spacing(4)
+                .align_y(iced::Alignment::Center),
+            )
+            .padding([0, 10])
+            .width(Length::Fixed(
+                crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH,
+            ))
+            .height(Length::Fixed(LANE_HEIGHT))
+            .align_y(iced::alignment::Vertical::Center)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::BG_SURFACE.into()),
+                ..Default::default()
+            });
+
+            let selected = match self.state.automation_ui.selected {
+                Some((t, l, i)) if t == track.id && l == lane.id => Some(i),
+                _ => None,
+            };
+            let widget = AutomationLaneWidget {
+                track_id: track.id,
+                lane_id: lane.id,
+                points: lane.points.clone(),
+                color: track_color,
+                zoom_level: self.state.view.zoom_level,
+                scroll_offset_beats: self.state.view.scroll_offset_beats,
+                selected,
+            };
+            let lane_canvas: Element<'_, Message> = canvas(widget)
+                .width(Length::Fill)
+                .height(Length::Fixed(LANE_HEIGHT))
+                .into();
+            rows = rows.push(row![lane_header, lane_canvas].height(Length::Fixed(LANE_HEIGHT)));
+        }
+
+        // Add-lane picker: gain/pan plus every built-in effect param.
+        let mut choices: Vec<LaneChoice> = vec![
+            LaneChoice {
+                label: "Volume".to_string(),
+                target: vibez_core::automation::AutomationTarget::TrackGain,
+            },
+            LaneChoice {
+                label: "Pan".to_string(),
+                target: vibez_core::automation::AutomationTarget::TrackPan,
+            },
+        ];
+        for effect in &track.effects {
+            for (param_index, d) in effect.descriptors.iter().enumerate() {
+                let effect_name = effect
+                    .plugin_name
+                    .clone()
+                    .unwrap_or_else(|| format!("{:?}", effect.effect_type));
+                choices.push(LaneChoice {
+                    label: format!("{effect_name}: {}", d.name),
+                    target: vibez_core::automation::AutomationTarget::EffectParam {
+                        effect_id: effect.id,
+                        param_index,
+                    },
+                });
+            }
+        }
+        choices.retain(|c| !track.automation.iter().any(|l| l.target == c.target));
+
+        let track_id = track.id;
+        let picker = iced::widget::pick_list(choices, None::<LaneChoice>, move |choice| {
+            Message::Automation(AutomationMsg::AddLane {
+                track_id,
+                target: choice.target,
+            })
+        })
+        .placeholder("+ Add automation")
+        .text_size(11)
+        .padding([2, 8]);
+
+        let picker_row = row![
+            container(picker)
+                .padding([2, 10])
+                .width(Length::Fixed(
+                    crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH,
+                ))
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(th::BG_SURFACE.into()),
+                    ..Default::default()
+                }),
+            container(text(""))
+                .width(Length::Fill)
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.18).into()),
+                    ..Default::default()
+                })
+        ]
+        .height(Length::Fixed(26.0));
+        rows.push(picker_row)
+    }
+}
+
+/// One option in the add-lane picker.
+#[derive(Debug, Clone, PartialEq)]
+struct LaneChoice {
+    label: String,
+    target: vibez_core::automation::AutomationTarget,
+}
+
+impl std::fmt::Display for LaneChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.label)
     }
 }

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -789,6 +789,7 @@ impl App {
                 color: track_color,
                 zoom_level: self.state.view.zoom_level,
                 scroll_offset_beats: self.state.view.scroll_offset_beats,
+                snap: self.state.view.snap_grid,
                 selected,
                 reference,
                 min_label,
@@ -808,6 +809,7 @@ impl App {
             Some((tid, q)) if *tid == track.id => Some(q.clone()),
             _ => None,
         };
+        let picker_open = picker_query.is_some();
 
         let panel: Element<'_, Message> = if let Some(query) = picker_query {
             let mut choices: Vec<LaneChoice> = vec![
@@ -976,6 +978,7 @@ impl App {
             container(
                 button(text("+ Add automation").size(11).color(th::TEXT_DIM))
                     .on_press(Message::Automation(AutomationMsg::OpenLanePicker(track_id)))
+                    .width(Length::Fill)
                     .padding([3, 10])
                     .style(|_theme: &Theme, status| {
                         let bg = match status {
@@ -1000,22 +1003,22 @@ impl App {
             .into()
         };
 
-        let filler = container(text(""))
-            .width(Length::Fill)
-            .style(|_theme: &Theme| container::Style {
-                background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.18).into()),
-                ..Default::default()
-            });
+        // Collapsed: the button sits inside the header column like a
+        // lane header. Open: the search panel widens over the lane
+        // area like a dropdown.
+        let panel_width = if picker_open {
+            crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH + 300.0
+        } else {
+            crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH
+        };
         let picker_row = row![
             container(panel)
-                .width(Length::Fixed(
-                    crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH + 220.0,
-                ))
+                .width(Length::Fixed(panel_width))
                 .style(|_theme: &Theme| container::Style {
                     background: Some(th::BG_SURFACE.into()),
                     ..Default::default()
                 }),
-            filler
+            iced::widget::horizontal_space()
         ];
         rows.push(picker_row)
     }

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -808,6 +808,35 @@ impl App {
                 target: vibez_core::automation::AutomationTarget::TrackPan,
             },
         ];
+        if !track.plugin_instrument_descriptors.is_empty() {
+            let name = track
+                .plugin_instrument_name
+                .clone()
+                .unwrap_or_else(|| "Plugin".to_string());
+            for (param_index, d) in track.plugin_instrument_descriptors.iter().enumerate() {
+                choices.push(LaneChoice {
+                    label: format!("{name}: {}", d.name),
+                    target: vibez_core::automation::AutomationTarget::InstrumentParam {
+                        param_index,
+                    },
+                });
+            }
+        }
+        if let Some(kind) = track.instrument_kind {
+            let instrument_name = match kind {
+                vibez_core::midi::InstrumentKind::SubtractiveSynth => "Synth",
+                vibez_core::midi::InstrumentKind::Sampler => "Sampler",
+                vibez_core::midi::InstrumentKind::DrumRack => "Drum Rack",
+            };
+            for (param_index, d) in vibez_instruments::descriptors_for(kind).iter().enumerate() {
+                choices.push(LaneChoice {
+                    label: format!("{instrument_name}: {}", d.name),
+                    target: vibez_core::automation::AutomationTarget::InstrumentParam {
+                        param_index,
+                    },
+                });
+            }
+        }
         for effect in &track.effects {
             for (param_index, d) in effect.descriptors.iter().enumerate() {
                 let effect_name = effect

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -781,6 +781,7 @@ impl App {
                 Some((t, l, i)) if t == track.id && l == lane.id => Some(i),
                 _ => None,
             };
+            let (reference, min_label, max_label, ref_label) = lane_scale(track, &lane.target);
             let widget = AutomationLaneWidget {
                 track_id: track.id,
                 lane_id: lane.id,
@@ -789,6 +790,10 @@ impl App {
                 zoom_level: self.state.view.zoom_level,
                 scroll_offset_beats: self.state.view.scroll_offset_beats,
                 selected,
+                reference,
+                min_label,
+                max_label,
+                ref_label,
             };
             let lane_canvas: Element<'_, Message> = canvas(widget)
                 .width(Length::Fill)
@@ -797,93 +802,281 @@ impl App {
             rows = rows.push(row![lane_header, lane_canvas].height(Length::Fixed(LANE_HEIGHT)));
         }
 
-        // Add-lane picker: gain/pan plus every built-in effect param.
-        let mut choices: Vec<LaneChoice> = vec![
-            LaneChoice {
-                label: "Volume".to_string(),
-                target: vibez_core::automation::AutomationTarget::TrackGain,
-            },
-            LaneChoice {
-                label: "Pan".to_string(),
-                target: vibez_core::automation::AutomationTarget::TrackPan,
-            },
-        ];
-        if !track.plugin_instrument_descriptors.is_empty() {
-            let name = track
-                .plugin_instrument_name
-                .clone()
-                .unwrap_or_else(|| "Plugin".to_string());
-            for (param_index, d) in track.plugin_instrument_descriptors.iter().enumerate() {
-                choices.push(LaneChoice {
-                    label: format!("{name}: {}", d.name),
-                    target: vibez_core::automation::AutomationTarget::InstrumentParam {
-                        param_index,
-                    },
-                });
-            }
-        }
-        if let Some(kind) = track.instrument_kind {
-            let instrument_name = match kind {
-                vibez_core::midi::InstrumentKind::SubtractiveSynth => "Synth",
-                vibez_core::midi::InstrumentKind::Sampler => "Sampler",
-                vibez_core::midi::InstrumentKind::DrumRack => "Drum Rack",
-            };
-            for (param_index, d) in vibez_instruments::descriptors_for(kind).iter().enumerate() {
-                choices.push(LaneChoice {
-                    label: format!("{instrument_name}: {}", d.name),
-                    target: vibez_core::automation::AutomationTarget::InstrumentParam {
-                        param_index,
-                    },
-                });
-            }
-        }
-        for effect in &track.effects {
-            for (param_index, d) in effect.descriptors.iter().enumerate() {
-                let effect_name = effect
-                    .plugin_name
+        // Add-lane entry: a button that opens a searchable picker
+        // panel (plugins can expose hundreds of parameters).
+        let picker_query = match &self.state.automation_ui.picker {
+            Some((tid, q)) if *tid == track.id => Some(q.clone()),
+            _ => None,
+        };
+
+        let panel: Element<'_, Message> = if let Some(query) = picker_query {
+            let mut choices: Vec<LaneChoice> = vec![
+                LaneChoice {
+                    label: "Volume".to_string(),
+                    target: vibez_core::automation::AutomationTarget::TrackGain,
+                },
+                LaneChoice {
+                    label: "Pan".to_string(),
+                    target: vibez_core::automation::AutomationTarget::TrackPan,
+                },
+            ];
+            if !track.plugin_instrument_descriptors.is_empty() {
+                let name = track
+                    .plugin_instrument_name
                     .clone()
-                    .unwrap_or_else(|| format!("{:?}", effect.effect_type));
-                choices.push(LaneChoice {
-                    label: format!("{effect_name}: {}", d.name),
-                    target: vibez_core::automation::AutomationTarget::EffectParam {
-                        effect_id: effect.id,
-                        param_index,
-                    },
-                });
+                    .unwrap_or_else(|| "Plugin".to_string());
+                for (param_index, d) in track.plugin_instrument_descriptors.iter().enumerate() {
+                    choices.push(LaneChoice {
+                        label: format!("{name}: {}", d.name),
+                        target: vibez_core::automation::AutomationTarget::InstrumentParam {
+                            param_index,
+                        },
+                    });
+                }
             }
-        }
-        choices.retain(|c| !track.automation.iter().any(|l| l.target == c.target));
+            if let Some(kind) = track.instrument_kind {
+                let instrument_name = match kind {
+                    vibez_core::midi::InstrumentKind::SubtractiveSynth => "Synth",
+                    vibez_core::midi::InstrumentKind::Sampler => "Sampler",
+                    vibez_core::midi::InstrumentKind::DrumRack => "Drum Rack",
+                };
+                for (param_index, d) in vibez_instruments::descriptors_for(kind).iter().enumerate()
+                {
+                    choices.push(LaneChoice {
+                        label: format!("{instrument_name}: {}", d.name),
+                        target: vibez_core::automation::AutomationTarget::InstrumentParam {
+                            param_index,
+                        },
+                    });
+                }
+            }
+            for effect in &track.effects {
+                for (param_index, d) in effect.descriptors.iter().enumerate() {
+                    let effect_name = effect
+                        .plugin_name
+                        .clone()
+                        .unwrap_or_else(|| format!("{:?}", effect.effect_type));
+                    choices.push(LaneChoice {
+                        label: format!("{effect_name}: {}", d.name),
+                        target: vibez_core::automation::AutomationTarget::EffectParam {
+                            effect_id: effect.id,
+                            param_index,
+                        },
+                    });
+                }
+            }
+            choices.retain(|c| !track.automation.iter().any(|l| l.target == c.target));
 
-        let track_id = track.id;
-        let picker = iced::widget::pick_list(choices, None::<LaneChoice>, move |choice| {
-            Message::Automation(AutomationMsg::AddLane {
-                track_id,
-                target: choice.target,
+            let needle = query.to_lowercase();
+            let total_before = choices.len();
+            if !needle.is_empty() {
+                choices.retain(|c| c.label.to_lowercase().contains(&needle));
+            }
+            let shown = choices.len().min(MAX_PICKER_RESULTS);
+            let hidden = choices.len() - shown;
+
+            let search = iced::widget::text_input("Search parameters\u{2026}", &query)
+                .on_input(|q| Message::Automation(AutomationMsg::LanePickerQuery(q)))
+                .size(11)
+                .padding([4, 8])
+                .style(|_theme: &Theme, _status| iced::widget::text_input::Style {
+                    background: th::BG_DARK.into(),
+                    border: iced::Border {
+                        color: th::BORDER,
+                        width: 1.0,
+                        radius: 3.0.into(),
+                    },
+                    icon: th::TEXT_DIM,
+                    placeholder: th::TEXT_DIM,
+                    value: th::TEXT,
+                    selection: th::ACCENT,
+                });
+            let close = button(icons::icon(icons::X).size(10).color(th::TEXT_DIM))
+                .on_press(Message::Automation(AutomationMsg::CloseLanePicker))
+                .padding([3, 6])
+                .style(|_theme: &Theme, _status| button::Style {
+                    background: None,
+                    text_color: th::TEXT_DIM,
+                    border: iced::Border::default(),
+                    ..Default::default()
+                });
+
+            let mut list = column![].spacing(1);
+            for choice in choices.into_iter().take(MAX_PICKER_RESULTS) {
+                let target = choice.target;
+                let track_id = track.id;
+                list = list.push(
+                    button(text(choice.label).size(11).color(th::TEXT))
+                        .on_press(Message::Automation(AutomationMsg::AddLane {
+                            track_id,
+                            target,
+                        }))
+                        .width(Length::Fill)
+                        .padding([3, 10])
+                        .style(|_theme: &Theme, status| {
+                            let bg = match status {
+                                button::Status::Hovered | button::Status::Pressed => {
+                                    Some(th::BG_HOVER.into())
+                                }
+                                _ => None,
+                            };
+                            button::Style {
+                                background: bg,
+                                text_color: th::TEXT,
+                                border: iced::Border::default(),
+                                ..Default::default()
+                            }
+                        }),
+                );
+            }
+            if hidden > 0 {
+                list = list.push(
+                    container(
+                        text(format!("{hidden} more \u{2014} refine the search"))
+                            .size(10)
+                            .color(th::TEXT_DIM),
+                    )
+                    .padding([3, 10]),
+                );
+            }
+            if total_before == 0 {
+                list = list.push(
+                    container(
+                        text("Everything is already automated")
+                            .size(10)
+                            .color(th::TEXT_DIM),
+                    )
+                    .padding([3, 10]),
+                );
+            }
+
+            container(
+                column![
+                    row![search, close]
+                        .spacing(6)
+                        .align_y(iced::Alignment::Center),
+                    iced::widget::scrollable(list).height(Length::Fixed(150.0)),
+                ]
+                .spacing(6),
+            )
+            .padding(8)
+            .width(Length::Fill)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::BG_SURFACE.into()),
+                border: iced::Border {
+                    color: th::BORDER,
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                ..Default::default()
             })
-        })
-        .placeholder("+ Add automation")
-        .text_size(11)
-        .padding([2, 8]);
+            .into()
+        } else {
+            let track_id = track.id;
+            container(
+                button(text("+ Add automation").size(11).color(th::TEXT_DIM))
+                    .on_press(Message::Automation(AutomationMsg::OpenLanePicker(track_id)))
+                    .padding([3, 10])
+                    .style(|_theme: &Theme, status| {
+                        let bg = match status {
+                            button::Status::Hovered | button::Status::Pressed => {
+                                Some(th::BG_HOVER.into())
+                            }
+                            _ => Some(th::BG_ELEVATED.into()),
+                        };
+                        button::Style {
+                            background: bg,
+                            text_color: th::TEXT_DIM,
+                            border: iced::Border {
+                                color: th::BORDER,
+                                width: 1.0,
+                                radius: 3.0.into(),
+                            },
+                            ..Default::default()
+                        }
+                    }),
+            )
+            .padding([2, 10])
+            .into()
+        };
 
+        let filler = container(text(""))
+            .width(Length::Fill)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.18).into()),
+                ..Default::default()
+            });
         let picker_row = row![
-            container(picker)
-                .padding([2, 10])
+            container(panel)
                 .width(Length::Fixed(
-                    crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH,
+                    crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH + 220.0,
                 ))
                 .style(|_theme: &Theme| container::Style {
                     background: Some(th::BG_SURFACE.into()),
                     ..Default::default()
                 }),
-            container(text(""))
-                .width(Length::Fill)
-                .style(|_theme: &Theme| container::Style {
-                    background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.18).into()),
-                    ..Default::default()
-                })
-        ]
-        .height(Length::Fixed(26.0));
+            filler
+        ];
         rows.push(picker_row)
+    }
+}
+
+const MAX_PICKER_RESULTS: usize = 40;
+
+/// Reference value plus scale labels for a lane's target.
+fn lane_scale(
+    track: &crate::state::UiTrack,
+    target: &vibez_core::automation::AutomationTarget,
+) -> (Option<f32>, String, String, String) {
+    use crate::domains::automation::{normalized_target_value, target_descriptor};
+    use vibez_core::automation::AutomationTarget;
+
+    let reference = normalized_target_value(target, track);
+    match target {
+        AutomationTarget::TrackGain => {
+            let r = reference
+                .map(|n| fmt_value(n * 2.0, ""))
+                .unwrap_or_default();
+            (reference, "0".into(), "2.0".into(), r)
+        }
+        AutomationTarget::TrackPan => {
+            let r = match reference {
+                Some(n) if (n - 0.5).abs() < 0.01 => "C".to_string(),
+                Some(n) => fmt_value(n * 2.0 - 1.0, ""),
+                None => String::new(),
+            };
+            (reference, "L".into(), "R".into(), r)
+        }
+        _ => match target_descriptor(target, track) {
+            Some(d) => {
+                let r = reference
+                    .map(|n| fmt_value(d.min + n * (d.max - d.min), d.unit))
+                    .unwrap_or_default();
+                (
+                    reference,
+                    fmt_value(d.min, d.unit),
+                    fmt_value(d.max, d.unit),
+                    r,
+                )
+            }
+            None => (reference, String::new(), String::new(), String::new()),
+        },
+    }
+}
+
+fn fmt_value(v: f32, unit: &str) -> String {
+    let num = if v.abs() >= 1000.0 {
+        format!("{:.0}k", v / 1000.0)
+    } else if v.abs() >= 100.0 {
+        format!("{v:.0}")
+    } else {
+        let s = format!("{v:.2}");
+        s.trim_end_matches('0').trim_end_matches('.').to_string()
+    };
+    if unit.is_empty() {
+        num
+    } else {
+        format!("{num} {unit}")
     }
 }
 

--- a/crates/vibez-ui/src/domains/automation.rs
+++ b/crates/vibez-ui/src/domains/automation.rs
@@ -126,7 +126,26 @@ pub fn target_label(target: &AutomationTarget, track: &UiTrack) -> String {
                 None => format!("{effect_name}: P{param_index}"),
             }
         }
-        AutomationTarget::InstrumentParam { param_index } => format!("Instrument P{param_index}"),
+        AutomationTarget::InstrumentParam { param_index } => {
+            let (name, descriptors) = if !track.plugin_instrument_descriptors.is_empty() {
+                (
+                    track.plugin_instrument_name.as_deref().unwrap_or("Plugin"),
+                    track.plugin_instrument_descriptors,
+                )
+            } else {
+                (
+                    "Instrument",
+                    track
+                        .instrument_kind
+                        .map(vibez_instruments::descriptors_for)
+                        .unwrap_or(&[]),
+                )
+            };
+            match descriptors.get(*param_index) {
+                Some(d) => format!("{name}: {}", d.name),
+                None => format!("{name} P{param_index}"),
+            }
+        }
         AutomationTarget::PluginParam { .. } => "Plugin param".to_string(),
     }
 }

--- a/crates/vibez-ui/src/domains/automation.rs
+++ b/crates/vibez-ui/src/domains/automation.rs
@@ -1,0 +1,442 @@
+//! Automation domain: lane and point editing.
+//!
+//! Lanes live on [`UiTrack`] (the shared model) and mirror to the
+//! engine as whole-lane upserts: every edit clones the lane's points
+//! into a [`EngineCommand::SetAutomationLane`], so the allocation
+//! happens here on the UI thread and the audio thread only swaps
+//! vectors.
+
+use std::collections::HashSet;
+
+use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+use vibez_core::id::{LaneId, TrackId};
+use vibez_engine::commands::EngineCommand;
+
+use super::EngineHandle;
+use crate::state::UiTrack;
+
+/// Messages the automation domain handles.
+#[derive(Debug, Clone)]
+pub enum AutomationMsg {
+    /// Show/hide the lane strip under a track (view-only).
+    ToggleTrackLanes(TrackId),
+    AddLane {
+        track_id: TrackId,
+        target: AutomationTarget,
+    },
+    RemoveLane {
+        track_id: TrackId,
+        lane_id: LaneId,
+    },
+    AddPoint {
+        track_id: TrackId,
+        lane_id: LaneId,
+        beat: f64,
+        value: f32,
+    },
+    /// Move an existing point (drag release). The point keeps beat
+    /// order, so its index may change; selection follows it.
+    MovePoint {
+        track_id: TrackId,
+        lane_id: LaneId,
+        index: usize,
+        beat: f64,
+        value: f32,
+    },
+    RemovePoint {
+        track_id: TrackId,
+        lane_id: LaneId,
+        index: usize,
+    },
+    SelectPoint {
+        track_id: TrackId,
+        lane_id: LaneId,
+        index: Option<usize>,
+    },
+    /// Delete-key routing (higher priority than clip deletion when a
+    /// point is selected).
+    DeleteSelectedPoint,
+}
+
+impl AutomationMsg {
+    /// Whether this message edits the project (drives the dirty flag).
+    pub fn marks_dirty(&self) -> bool {
+        !matches!(
+            self,
+            AutomationMsg::ToggleTrackLanes(_) | AutomationMsg::SelectPoint { .. }
+        )
+    }
+}
+
+/// Cross-domain effects requested by an automation update.
+#[derive(Debug, Default, PartialEq)]
+pub struct AutomationAction {
+    /// Status bar text.
+    pub status: Option<String>,
+}
+
+/// Automation domain slice.
+#[derive(Debug, Default)]
+pub struct AutomationState {
+    /// Tracks whose lane strip is expanded.
+    pub expanded: HashSet<TrackId>,
+    /// The selected point: (track, lane, point index).
+    pub selected: Option<(TrackId, LaneId, usize)>,
+}
+
+fn find_lane_mut(
+    tracks: &mut [UiTrack],
+    track_id: TrackId,
+    lane_id: LaneId,
+) -> Option<&mut AutomationLane> {
+    tracks
+        .iter_mut()
+        .find(|t| t.id == track_id)?
+        .automation
+        .iter_mut()
+        .find(|l| l.id == lane_id)
+}
+
+fn sync_lane(engine: &mut impl EngineHandle, track_id: TrackId, lane: &AutomationLane) {
+    engine.send(EngineCommand::SetAutomationLane {
+        track_id,
+        lane: lane.clone(),
+    });
+}
+
+/// Human-readable name for a lane target, for lane headers and the
+/// add-lane picker.
+pub fn target_label(target: &AutomationTarget, track: &UiTrack) -> String {
+    match target {
+        AutomationTarget::TrackGain => "Volume".to_string(),
+        AutomationTarget::TrackPan => "Pan".to_string(),
+        AutomationTarget::EffectParam {
+            effect_id,
+            param_index,
+        } => {
+            let Some(effect) = track.effects.iter().find(|e| e.id == *effect_id) else {
+                return "Missing effect".to_string();
+            };
+            let effect_name = effect
+                .plugin_name
+                .clone()
+                .unwrap_or_else(|| format!("{:?}", effect.effect_type));
+            match effect.descriptors.get(*param_index) {
+                Some(d) => format!("{effect_name}: {}", d.name),
+                None => format!("{effect_name}: P{param_index}"),
+            }
+        }
+        AutomationTarget::InstrumentParam { param_index } => format!("Instrument P{param_index}"),
+        AutomationTarget::PluginParam { .. } => "Plugin param".to_string(),
+    }
+}
+
+impl AutomationState {
+    pub fn update(
+        &mut self,
+        msg: AutomationMsg,
+        engine: &mut impl EngineHandle,
+        tracks: &mut [UiTrack],
+    ) -> AutomationAction {
+        let mut action = AutomationAction::default();
+        match msg {
+            AutomationMsg::ToggleTrackLanes(track_id) => {
+                if !self.expanded.remove(&track_id) {
+                    self.expanded.insert(track_id);
+                }
+            }
+            AutomationMsg::AddLane { track_id, target } => {
+                let Some(track) = tracks.iter_mut().find(|t| t.id == track_id) else {
+                    return action;
+                };
+                if track.automation.iter().any(|l| l.target == target) {
+                    action.status = Some("That parameter already has a lane".to_string());
+                    return action;
+                }
+                let lane = AutomationLane::new(target);
+                sync_lane(engine, track_id, &lane);
+                let label = target_label(&target, track);
+                track.automation.push(lane);
+                self.expanded.insert(track_id);
+                action.status = Some(format!("Added automation lane: {label}"));
+            }
+            AutomationMsg::RemoveLane { track_id, lane_id } => {
+                if let Some(track) = tracks.iter_mut().find(|t| t.id == track_id) {
+                    track.automation.retain(|l| l.id != lane_id);
+                }
+                engine.send(EngineCommand::RemoveAutomationLane { track_id, lane_id });
+                if matches!(self.selected, Some((t, l, _)) if t == track_id && l == lane_id) {
+                    self.selected = None;
+                }
+                action.status = Some("Removed automation lane".to_string());
+            }
+            AutomationMsg::AddPoint {
+                track_id,
+                lane_id,
+                beat,
+                value,
+            } => {
+                let Some(lane) = find_lane_mut(tracks, track_id, lane_id) else {
+                    return action;
+                };
+                let point = AutomationPoint {
+                    beat: beat.max(0.0),
+                    value: value.clamp(0.0, 1.0),
+                };
+                lane.insert_point(point);
+                let index = lane
+                    .points
+                    .iter()
+                    .position(|p| p.beat == point.beat)
+                    .unwrap_or(0);
+                let lane = lane.clone();
+                sync_lane(engine, track_id, &lane);
+                self.selected = Some((track_id, lane_id, index));
+            }
+            AutomationMsg::MovePoint {
+                track_id,
+                lane_id,
+                index,
+                beat,
+                value,
+            } => {
+                let Some(lane) = find_lane_mut(tracks, track_id, lane_id) else {
+                    return action;
+                };
+                if index >= lane.points.len() {
+                    return action;
+                }
+                lane.points.remove(index);
+                let point = AutomationPoint {
+                    beat: beat.max(0.0),
+                    value: value.clamp(0.0, 1.0),
+                };
+                lane.insert_point(point);
+                let new_index = lane
+                    .points
+                    .iter()
+                    .position(|p| p.beat == point.beat)
+                    .unwrap_or(0);
+                let lane = lane.clone();
+                sync_lane(engine, track_id, &lane);
+                self.selected = Some((track_id, lane_id, new_index));
+            }
+            AutomationMsg::RemovePoint {
+                track_id,
+                lane_id,
+                index,
+            } => {
+                let Some(lane) = find_lane_mut(tracks, track_id, lane_id) else {
+                    return action;
+                };
+                if index >= lane.points.len() {
+                    return action;
+                }
+                lane.points.remove(index);
+                let lane = lane.clone();
+                sync_lane(engine, track_id, &lane);
+                if matches!(self.selected, Some((t, l, i)) if t == track_id && l == lane_id && i == index)
+                {
+                    self.selected = None;
+                }
+            }
+            AutomationMsg::SelectPoint {
+                track_id,
+                lane_id,
+                index,
+            } => {
+                self.selected = index.map(|i| (track_id, lane_id, i));
+            }
+            AutomationMsg::DeleteSelectedPoint => {
+                if let Some((track_id, lane_id, index)) = self.selected.take() {
+                    return self.update(
+                        AutomationMsg::RemovePoint {
+                            track_id,
+                            lane_id,
+                            index,
+                        },
+                        engine,
+                        tracks,
+                    );
+                }
+            }
+        }
+        action
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::RecordingEngine;
+    use super::*;
+
+    fn track() -> Vec<UiTrack> {
+        vec![UiTrack::new(TrackId::new(), "T1".to_string(), 0)]
+    }
+
+    #[test]
+    fn add_lane_syncs_and_expands() {
+        let mut a = AutomationState::default();
+        let mut engine = RecordingEngine::default();
+        let mut tracks = track();
+        let tid = tracks[0].id;
+        a.update(
+            AutomationMsg::AddLane {
+                track_id: tid,
+                target: AutomationTarget::TrackGain,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        assert_eq!(tracks[0].automation.len(), 1);
+        assert!(a.expanded.contains(&tid));
+        assert!(matches!(
+            engine.0[0],
+            EngineCommand::SetAutomationLane { .. }
+        ));
+
+        // Duplicate target refused.
+        let action = a.update(
+            AutomationMsg::AddLane {
+                track_id: tid,
+                target: AutomationTarget::TrackGain,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        assert_eq!(tracks[0].automation.len(), 1);
+        assert!(action.status.unwrap().contains("already"));
+    }
+
+    #[test]
+    fn point_lifecycle_add_move_delete() {
+        let mut a = AutomationState::default();
+        let mut engine = RecordingEngine::default();
+        let mut tracks = track();
+        let tid = tracks[0].id;
+        a.update(
+            AutomationMsg::AddLane {
+                track_id: tid,
+                target: AutomationTarget::TrackGain,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let lane_id = tracks[0].automation[0].id;
+
+        a.update(
+            AutomationMsg::AddPoint {
+                track_id: tid,
+                lane_id,
+                beat: 8.0,
+                value: 0.25,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        a.update(
+            AutomationMsg::AddPoint {
+                track_id: tid,
+                lane_id,
+                beat: 0.0,
+                value: 1.0,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let beats: Vec<f64> = tracks[0].automation[0]
+            .points
+            .iter()
+            .map(|p| p.beat)
+            .collect();
+        assert_eq!(beats, vec![0.0, 8.0]);
+        assert_eq!(a.selected, Some((tid, lane_id, 0)));
+
+        // Drag point 0 past point 1: selection follows to the end.
+        a.update(
+            AutomationMsg::MovePoint {
+                track_id: tid,
+                lane_id,
+                index: 0,
+                beat: 16.0,
+                value: 0.5,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let beats: Vec<f64> = tracks[0].automation[0]
+            .points
+            .iter()
+            .map(|p| p.beat)
+            .collect();
+        assert_eq!(beats, vec![8.0, 16.0]);
+        assert_eq!(a.selected, Some((tid, lane_id, 1)));
+
+        // Delete key removes the selected point.
+        a.update(AutomationMsg::DeleteSelectedPoint, &mut engine, &mut tracks);
+        assert_eq!(tracks[0].automation[0].points.len(), 1);
+        assert_eq!(a.selected, None);
+    }
+
+    #[test]
+    fn remove_lane_clears_engine_and_selection() {
+        let mut a = AutomationState::default();
+        let mut engine = RecordingEngine::default();
+        let mut tracks = track();
+        let tid = tracks[0].id;
+        a.update(
+            AutomationMsg::AddLane {
+                track_id: tid,
+                target: AutomationTarget::TrackPan,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let lane_id = tracks[0].automation[0].id;
+        a.selected = Some((tid, lane_id, 0));
+        a.update(
+            AutomationMsg::RemoveLane {
+                track_id: tid,
+                lane_id,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        assert!(tracks[0].automation.is_empty());
+        assert_eq!(a.selected, None);
+        assert!(matches!(
+            engine.0.last(),
+            Some(EngineCommand::RemoveAutomationLane { .. })
+        ));
+    }
+
+    #[test]
+    fn values_clamp_to_unit_range() {
+        let mut a = AutomationState::default();
+        let mut engine = RecordingEngine::default();
+        let mut tracks = track();
+        let tid = tracks[0].id;
+        a.update(
+            AutomationMsg::AddLane {
+                track_id: tid,
+                target: AutomationTarget::TrackGain,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let lane_id = tracks[0].automation[0].id;
+        a.update(
+            AutomationMsg::AddPoint {
+                track_id: tid,
+                lane_id,
+                beat: -3.0,
+                value: 7.0,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let p = tracks[0].automation[0].points[0];
+        assert_eq!(p.beat, 0.0);
+        assert_eq!(p.value, 1.0);
+    }
+}

--- a/crates/vibez-ui/src/domains/automation.rs
+++ b/crates/vibez-ui/src/domains/automation.rs
@@ -56,6 +56,24 @@ pub enum AutomationMsg {
     /// Delete-key routing (higher priority than clip deletion when a
     /// point is selected).
     DeleteSelectedPoint,
+    /// Set the curve of the segment leaving point `index` (drag
+    /// release of an alt-drag; -1..1, 0 = linear).
+    SetCurve {
+        track_id: TrackId,
+        lane_id: LaneId,
+        index: usize,
+        curve: f32,
+    },
+    /// Remove every point in a beat range (ctrl-drag erase).
+    RemovePointsInRange {
+        track_id: TrackId,
+        lane_id: LaneId,
+        start_beat: f64,
+        end_beat: f64,
+    },
+    OpenLanePicker(TrackId),
+    LanePickerQuery(String),
+    CloseLanePicker,
 }
 
 impl AutomationMsg {
@@ -63,7 +81,11 @@ impl AutomationMsg {
     pub fn marks_dirty(&self) -> bool {
         !matches!(
             self,
-            AutomationMsg::ToggleTrackLanes(_) | AutomationMsg::SelectPoint { .. }
+            AutomationMsg::ToggleTrackLanes(_)
+                | AutomationMsg::SelectPoint { .. }
+                | AutomationMsg::OpenLanePicker(_)
+                | AutomationMsg::LanePickerQuery(_)
+                | AutomationMsg::CloseLanePicker
         )
     }
 }
@@ -82,6 +104,8 @@ pub struct AutomationState {
     pub expanded: HashSet<TrackId>,
     /// The selected point: (track, lane, point index).
     pub selected: Option<(TrackId, LaneId, usize)>,
+    /// The open add-lane picker, with its search query.
+    pub picker: Option<(TrackId, String)>,
 }
 
 fn find_lane_mut(
@@ -102,6 +126,73 @@ fn sync_lane(engine: &mut impl EngineHandle, track_id: TrackId, lane: &Automatio
         track_id,
         lane: lane.clone(),
     });
+}
+
+/// The target's CURRENT (un-automated) value, normalized 0..1.
+/// This seeds new lanes and draws the reference line. Track gain's
+/// native range is 0..2 (see the arrangement domain clamp).
+pub fn normalized_target_value(target: &AutomationTarget, track: &UiTrack) -> Option<f32> {
+    match target {
+        AutomationTarget::TrackGain => Some((track.gain / 2.0).clamp(0.0, 1.0)),
+        AutomationTarget::TrackPan => Some(track.pan.clamp(0.0, 1.0)),
+        AutomationTarget::EffectParam {
+            effect_id,
+            param_index,
+        } => {
+            let effect = track.effects.iter().find(|e| e.id == *effect_id)?;
+            let d = effect.descriptors.get(*param_index)?;
+            let v = effect
+                .params
+                .get(*param_index)
+                .copied()
+                .unwrap_or(d.default);
+            Some(((v - d.min) / (d.max - d.min).max(f32::EPSILON)).clamp(0.0, 1.0))
+        }
+        AutomationTarget::InstrumentParam { param_index } => {
+            if !track.plugin_instrument_descriptors.is_empty() {
+                let d = track.plugin_instrument_descriptors.get(*param_index)?;
+                // Plugin values are not mirrored UI-side; use the default.
+                Some(((d.default - d.min) / (d.max - d.min).max(f32::EPSILON)).clamp(0.0, 1.0))
+            } else {
+                let kind = track.instrument_kind?;
+                let d = vibez_instruments::descriptors_for(kind).get(*param_index)?;
+                let v = track
+                    .instrument_params
+                    .get(*param_index)
+                    .copied()
+                    .unwrap_or(d.default);
+                Some(((v - d.min) / (d.max - d.min).max(f32::EPSILON)).clamp(0.0, 1.0))
+            }
+        }
+        AutomationTarget::PluginParam { .. } => None,
+    }
+}
+
+/// The static descriptor behind a target, when one exists (effect
+/// and instrument params). Gain/pan have implicit ranges.
+pub fn target_descriptor(
+    target: &AutomationTarget,
+    track: &UiTrack,
+) -> Option<&'static vibez_core::effect::ParamDescriptor> {
+    match target {
+        AutomationTarget::EffectParam {
+            effect_id,
+            param_index,
+        } => track
+            .effects
+            .iter()
+            .find(|e| e.id == *effect_id)?
+            .descriptors
+            .get(*param_index),
+        AutomationTarget::InstrumentParam { param_index } => {
+            if !track.plugin_instrument_descriptors.is_empty() {
+                track.plugin_instrument_descriptors.get(*param_index)
+            } else {
+                vibez_instruments::descriptors_for(track.instrument_kind?).get(*param_index)
+            }
+        }
+        _ => None,
+    }
 }
 
 /// Human-readable name for a lane target, for lane headers and the
@@ -172,11 +263,20 @@ impl AutomationState {
                     action.status = Some("That parameter already has a lane".to_string());
                     return action;
                 }
-                let lane = AutomationLane::new(target);
+                let mut lane = AutomationLane::new(target);
+                // Start where the knob already is.
+                if let Some(value) = normalized_target_value(&target, track) {
+                    lane.insert_point(AutomationPoint {
+                        beat: 0.0,
+                        value,
+                        curve: 0.0,
+                    });
+                }
                 sync_lane(engine, track_id, &lane);
                 let label = target_label(&target, track);
                 track.automation.push(lane);
                 self.expanded.insert(track_id);
+                self.picker = None;
                 action.status = Some(format!("Added automation lane: {label}"));
             }
             AutomationMsg::RemoveLane { track_id, lane_id } => {
@@ -201,6 +301,7 @@ impl AutomationState {
                 let point = AutomationPoint {
                     beat: beat.max(0.0),
                     value: value.clamp(0.0, 1.0),
+                    curve: 0.0,
                 };
                 lane.insert_point(point);
                 let index = lane
@@ -225,10 +326,12 @@ impl AutomationState {
                 if index >= lane.points.len() {
                     return action;
                 }
+                let curve = lane.points[index].curve;
                 lane.points.remove(index);
                 let point = AutomationPoint {
                     beat: beat.max(0.0),
                     value: value.clamp(0.0, 1.0),
+                    curve,
                 };
                 lane.insert_point(point);
                 let new_index = lane
@@ -265,6 +368,58 @@ impl AutomationState {
                 index,
             } => {
                 self.selected = index.map(|i| (track_id, lane_id, i));
+            }
+            AutomationMsg::SetCurve {
+                track_id,
+                lane_id,
+                index,
+                curve,
+            } => {
+                let Some(lane) = find_lane_mut(tracks, track_id, lane_id) else {
+                    return action;
+                };
+                if index >= lane.points.len() {
+                    return action;
+                }
+                lane.points[index].curve = curve.clamp(-1.0, 1.0);
+                let lane = lane.clone();
+                sync_lane(engine, track_id, &lane);
+            }
+            AutomationMsg::RemovePointsInRange {
+                track_id,
+                lane_id,
+                start_beat,
+                end_beat,
+            } => {
+                let (lo, hi) = if start_beat <= end_beat {
+                    (start_beat, end_beat)
+                } else {
+                    (end_beat, start_beat)
+                };
+                let Some(lane) = find_lane_mut(tracks, track_id, lane_id) else {
+                    return action;
+                };
+                let before = lane.points.len();
+                lane.points.retain(|p| p.beat < lo || p.beat > hi);
+                if lane.points.len() != before {
+                    let lane = lane.clone();
+                    sync_lane(engine, track_id, &lane);
+                    if matches!(self.selected, Some((t, l, _)) if t == track_id && l == lane_id) {
+                        self.selected = None;
+                    }
+                    action.status = Some(format!("Erased {} point(s)", before - lane.points.len()));
+                }
+            }
+            AutomationMsg::OpenLanePicker(track_id) => {
+                self.picker = Some((track_id, String::new()));
+            }
+            AutomationMsg::LanePickerQuery(query) => {
+                if let Some((_, q)) = &mut self.picker {
+                    *q = query;
+                }
+            }
+            AutomationMsg::CloseLanePicker => {
+                self.picker = None;
             }
             AutomationMsg::DeleteSelectedPoint => {
                 if let Some((track_id, lane_id, index)) = self.selected.take() {

--- a/crates/vibez-ui/src/domains/mod.rs
+++ b/crates/vibez-ui/src/domains/mod.rs
@@ -7,6 +7,7 @@
 //! Redux slices; `EngineHandle` is an injected service interface.
 
 pub mod arrangement;
+pub mod automation;
 pub mod browser;
 pub mod devices;
 pub mod piano_roll;

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -155,6 +155,7 @@ pub enum Message {
     PianoRoll(crate::domains::piano_roll::PianoRollMsg),
     Browser(crate::domains::browser::BrowserMsg),
     Project(crate::domains::project::ProjectMsg),
+    Automation(crate::domains::automation::AutomationMsg),
     View(crate::domains::view::ViewMsg),
 
     // Workspace

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -361,6 +361,9 @@ pub struct AppState {
     /// Minimum BPM-detect confidence required to auto-warp. Mirrored
     /// from `UiSettings::warp_confidence_threshold`.
     pub warp_confidence_threshold: f32,
+    // Automation domain slice (lane expansion, point selection).
+    pub automation_ui: crate::domains::automation::AutomationState,
+
     // Browser domain slice (sample library, Dropbox, drag-drop).
     pub browser: BrowserState,
 
@@ -394,6 +397,7 @@ impl Default for AppState {
             project: ProjectState::default(),
             auto_warp_on_import: false,
             warp_confidence_threshold: 0.6,
+            automation_ui: crate::domains::automation::AutomationState::default(),
             browser: BrowserState::default(),
             plugin_settings: PluginSettings::load(),
             plugin_scan_in_progress: false,

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -183,6 +183,9 @@ pub struct UiTrack {
     pub plugin_instrument_name: Option<String>,
     /// Persistent identity of the plugin instrument, if any.
     pub plugin_instrument_ref: Option<vibez_core::effect::PluginDeviceInfo>,
+    /// Parameters of the plugin instrument (leaked 'static by the
+    /// wrapper); empty for built-in instruments.
+    pub plugin_instrument_descriptors: &'static [vibez_core::effect::ParamDescriptor],
     /// Whether the plugin instrument has a native GUI.
     pub has_plugin_instrument_gui: bool,
 }
@@ -214,6 +217,7 @@ impl UiTrack {
             selected_drum_pad: 0,
             plugin_instrument_name: None,
             plugin_instrument_ref: None,
+            plugin_instrument_descriptors: &[],
             has_plugin_instrument_gui: false,
         }
     }
@@ -248,6 +252,7 @@ impl UiTrack {
             selected_drum_pad: 0,
             plugin_instrument_name: None,
             plugin_instrument_ref: None,
+            plugin_instrument_descriptors: &[],
             has_plugin_instrument_gui: false,
         }
     }

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -176,6 +176,8 @@ pub struct UiTrack {
     pub sample_audio: Option<Arc<DecodedAudio>>,
     pub instrument_params: Vec<f32>,
     pub drum_rack_pads: Vec<UiDrumPad>,
+    /// Automation lanes (mirrored to the engine like note clips).
+    pub automation: Vec<vibez_core::automation::AutomationLane>,
     pub selected_drum_pad: usize,
     /// Display name for external plugin instruments (e.g. "Dexed", "Surge XT").
     pub plugin_instrument_name: Option<String>,
@@ -208,6 +210,7 @@ impl UiTrack {
             sample_audio: None,
             instrument_params: Vec::new(),
             drum_rack_pads: default_drum_rack_pads(),
+            automation: Vec::new(),
             selected_drum_pad: 0,
             plugin_instrument_name: None,
             plugin_instrument_ref: None,
@@ -241,6 +244,7 @@ impl UiTrack {
             sample_audio: None,
             instrument_params: Vec::new(),
             drum_rack_pads: default_drum_rack_pads(),
+            automation: Vec::new(),
             selected_drum_pad: 0,
             plugin_instrument_name: None,
             plugin_instrument_ref: None,

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -1,0 +1,295 @@
+//! Automation lane canvas: breakpoints over time, aligned with the
+//! arrangement timeline (same pixels-per-beat and scroll offset).
+//!
+//! Interactions: double-click adds a point, drag moves one (the
+//! move commits on release; a ghost renders during the drag), click
+//! selects, Delete removes via the global delete-key priority.
+
+use std::time::Instant;
+
+use iced::widget::canvas;
+use iced::{mouse, Color, Point, Rectangle, Renderer, Theme};
+use vibez_core::automation::AutomationPoint;
+use vibez_core::id::{LaneId, TrackId};
+
+use crate::domains::automation::AutomationMsg;
+use crate::message::Message;
+use crate::theme as th;
+
+pub const LANE_HEIGHT: f32 = 56.0;
+const HANDLE_RADIUS: f32 = 5.0;
+const HIT_RADIUS: f32 = 9.0;
+const PAD_TOP: f32 = 8.0;
+const PAD_BOTTOM: f32 = 8.0;
+
+pub struct AutomationLaneWidget {
+    pub track_id: TrackId,
+    pub lane_id: LaneId,
+    pub points: Vec<AutomationPoint>,
+    pub color: Color,
+    pub zoom_level: f32,
+    pub scroll_offset_beats: f64,
+    pub selected: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LaneInteraction {
+    /// Point index being dragged and its current ghost position.
+    drag: Option<(usize, f64, f32)>,
+    /// Last left press, for double-click detection.
+    last_click: Option<(Instant, Point)>,
+}
+
+impl AutomationLaneWidget {
+    fn pixels_per_beat(&self) -> f32 {
+        20.0 * self.zoom_level
+    }
+
+    fn beat_to_x(&self, beat: f64) -> f32 {
+        ((beat - self.scroll_offset_beats) * self.pixels_per_beat() as f64) as f32
+    }
+
+    fn x_to_beat(&self, x: f32) -> f64 {
+        (x as f64 / self.pixels_per_beat() as f64 + self.scroll_offset_beats).max(0.0)
+    }
+
+    fn value_to_y(&self, value: f32, height: f32) -> f32 {
+        let usable = height - PAD_TOP - PAD_BOTTOM;
+        PAD_TOP + (1.0 - value.clamp(0.0, 1.0)) * usable
+    }
+
+    fn y_to_value(&self, y: f32, height: f32) -> f32 {
+        let usable = height - PAD_TOP - PAD_BOTTOM;
+        (1.0 - (y - PAD_TOP) / usable).clamp(0.0, 1.0)
+    }
+
+    fn hit_point(&self, pos: Point, height: f32) -> Option<usize> {
+        self.points.iter().position(|p| {
+            let px = self.beat_to_x(p.beat);
+            let py = self.value_to_y(p.value, height);
+            (px - pos.x).powi(2) + (py - pos.y).powi(2) <= HIT_RADIUS * HIT_RADIUS
+        })
+    }
+}
+
+impl canvas::Program<Message> for AutomationLaneWidget {
+    type State = LaneInteraction;
+
+    fn draw(
+        &self,
+        state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let h = bounds.height;
+
+        // Ground and midline.
+        frame.fill_rectangle(
+            Point::ORIGIN,
+            bounds.size(),
+            Color::from_rgba(0.0, 0.0, 0.0, 0.18),
+        );
+        let mid = self.value_to_y(0.5, h);
+        frame.stroke(
+            &canvas::Path::line(Point::new(0.0, mid), Point::new(bounds.width, mid)),
+            canvas::Stroke::default()
+                .with_color(Color::from_rgba(1.0, 1.0, 1.0, 0.06))
+                .with_width(1.0),
+        );
+
+        // The curve, with the dragged point replaced by its ghost.
+        let mut pts: Vec<AutomationPoint> = self.points.clone();
+        if let Some((idx, beat, value)) = state.drag {
+            if idx < pts.len() {
+                pts.remove(idx);
+                let insert_at = pts.partition_point(|p| p.beat < beat);
+                pts.insert(insert_at, AutomationPoint { beat, value });
+            }
+        }
+
+        let curve_color = self.color;
+        if !pts.is_empty() {
+            let mut path = canvas::path::Builder::new();
+            let first_y = self.value_to_y(pts[0].value, h);
+            path.move_to(Point::new(0.0, first_y));
+            path.line_to(Point::new(self.beat_to_x(pts[0].beat), first_y));
+            for p in &pts {
+                path.line_to(Point::new(
+                    self.beat_to_x(p.beat),
+                    self.value_to_y(p.value, h),
+                ));
+            }
+            let last = pts[pts.len() - 1];
+            let last_y = self.value_to_y(last.value, h);
+            path.line_to(Point::new(bounds.width, last_y));
+            frame.stroke(
+                &path.build(),
+                canvas::Stroke::default()
+                    .with_color(curve_color)
+                    .with_width(2.0),
+            );
+
+            for (i, p) in pts.iter().enumerate() {
+                let center = Point::new(self.beat_to_x(p.beat), self.value_to_y(p.value, h));
+                let selected = state.drag.map(|(d, _, _)| d == i).unwrap_or(false)
+                    || (state.drag.is_none() && self.selected == Some(i));
+                let handle = canvas::Path::circle(center, HANDLE_RADIUS);
+                if selected {
+                    frame.fill(&handle, th::ACCENT);
+                } else {
+                    frame.fill(&handle, Color::from_rgba(0.09, 0.09, 0.1, 1.0));
+                    frame.stroke(
+                        &handle,
+                        canvas::Stroke::default()
+                            .with_color(curve_color)
+                            .with_width(2.0),
+                    );
+                }
+            }
+        } else {
+            frame.stroke(
+                &canvas::Path::line(
+                    Point::new(0.0, self.value_to_y(1.0, h)),
+                    Point::new(bounds.width, self.value_to_y(1.0, h)),
+                ),
+                canvas::Stroke::default()
+                    .with_color(Color {
+                        a: 0.35,
+                        ..curve_color
+                    })
+                    .with_width(1.5),
+            );
+        }
+
+        vec![frame.into_geometry()]
+    }
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: canvas::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<Message>) {
+        let Some(pos) = cursor.position_in(bounds) else {
+            // Commit an in-flight drag even if the release lands
+            // outside the lane.
+            if let canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) = event {
+                if let Some((index, beat, value)) = state.drag.take() {
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::Automation(AutomationMsg::MovePoint {
+                            track_id: self.track_id,
+                            lane_id: self.lane_id,
+                            index,
+                            beat,
+                            value,
+                        })),
+                    );
+                }
+            }
+            return (canvas::event::Status::Ignored, None);
+        };
+        let h = bounds.height;
+
+        match event {
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                if let Some(index) = self.hit_point(pos, h) {
+                    let p = self.points[index];
+                    state.drag = Some((index, p.beat, p.value));
+                    state.last_click = None;
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::Automation(AutomationMsg::SelectPoint {
+                            track_id: self.track_id,
+                            lane_id: self.lane_id,
+                            index: Some(index),
+                        })),
+                    );
+                }
+                // Double-click on empty lane space adds a point.
+                let now = Instant::now();
+                if let Some((t, p)) = state.last_click {
+                    let close = (p.x - pos.x).abs() < 6.0 && (p.y - pos.y).abs() < 6.0;
+                    if close && now.duration_since(t).as_millis() < 400 {
+                        state.last_click = None;
+                        return (
+                            canvas::event::Status::Captured,
+                            Some(Message::Automation(AutomationMsg::AddPoint {
+                                track_id: self.track_id,
+                                lane_id: self.lane_id,
+                                beat: self.x_to_beat(pos.x),
+                                value: self.y_to_value(pos.y, h),
+                            })),
+                        );
+                    }
+                }
+                state.last_click = Some((now, pos));
+                (
+                    canvas::event::Status::Captured,
+                    Some(Message::Automation(AutomationMsg::SelectPoint {
+                        track_id: self.track_id,
+                        lane_id: self.lane_id,
+                        index: None,
+                    })),
+                )
+            }
+            canvas::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                if let Some((index, _, _)) = state.drag {
+                    state.drag = Some((index, self.x_to_beat(pos.x), self.y_to_value(pos.y, h)));
+                    return (canvas::event::Status::Captured, None);
+                }
+                (canvas::event::Status::Ignored, None)
+            }
+            canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                if let Some((index, beat, value)) = state.drag.take() {
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::Automation(AutomationMsg::MovePoint {
+                            track_id: self.track_id,
+                            lane_id: self.lane_id,
+                            index,
+                            beat,
+                            value,
+                        })),
+                    );
+                }
+                (canvas::event::Status::Ignored, None)
+            }
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Right)) => {
+                if let Some(index) = self.hit_point(pos, h) {
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::Automation(AutomationMsg::RemovePoint {
+                            track_id: self.track_id,
+                            lane_id: self.lane_id,
+                            index,
+                        })),
+                    );
+                }
+                (canvas::event::Status::Ignored, None)
+            }
+            _ => (canvas::event::Status::Ignored, None),
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if state.drag.is_some() {
+            return mouse::Interaction::Grabbing;
+        }
+        if let Some(pos) = cursor.position_in(bounds) {
+            if self.hit_point(pos, bounds.height).is_some() {
+                return mouse::Interaction::Grab;
+            }
+        }
+        mouse::Interaction::default()
+    }
+}

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -1,15 +1,22 @@
 //! Automation lane canvas: breakpoints over time, aligned with the
 //! arrangement timeline (same pixels-per-beat and scroll offset).
 //!
-//! Interactions: double-click adds a point, drag moves one (the
-//! move commits on release; a ghost renders during the drag), click
-//! selects, Delete removes via the global delete-key priority.
+//! Interactions:
+//! - double-click adds a point; drag moves one (ghost while
+//!   dragging, commit on release); right-click or Delete removes
+//! - alt-drag a segment bends its curve (alt-double-click resets it
+//!   straight); the cursor switches to a vertical-resize arrow
+//! - ctrl-drag sweeps a beat range and erases every point inside
+//!   (crosshair cursor)
+//!
+//! The dotted line is the parameter's current (un-automated) value;
+//! min/max labels give the scale.
 
 use std::time::Instant;
 
 use iced::widget::canvas;
 use iced::{mouse, Color, Point, Rectangle, Renderer, Theme};
-use vibez_core::automation::AutomationPoint;
+use vibez_core::automation::{shape, AutomationPoint};
 use vibez_core::id::{LaneId, TrackId};
 
 use crate::domains::automation::AutomationMsg;
@@ -19,8 +26,11 @@ use crate::theme as th;
 pub const LANE_HEIGHT: f32 = 56.0;
 const HANDLE_RADIUS: f32 = 5.0;
 const HIT_RADIUS: f32 = 9.0;
+const SEGMENT_HIT: f32 = 10.0;
 const PAD_TOP: f32 = 8.0;
 const PAD_BOTTOM: f32 = 8.0;
+/// Vertical drag distance for a full curve sweep.
+const CURVE_DRAG_RANGE: f32 = 90.0;
 
 pub struct AutomationLaneWidget {
     pub track_id: TrackId,
@@ -30,14 +40,26 @@ pub struct AutomationLaneWidget {
     pub zoom_level: f32,
     pub scroll_offset_beats: f64,
     pub selected: Option<usize>,
+    /// The parameter's current un-automated value (normalized), for
+    /// the dotted reference line.
+    pub reference: Option<f32>,
+    pub min_label: String,
+    pub max_label: String,
+    pub ref_label: String,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct LaneInteraction {
     /// Point index being dragged and its current ghost position.
     drag: Option<(usize, f64, f32)>,
+    /// (segment index, original curve, press y, ghost curve).
+    curve_drag: Option<(usize, f32, f32, f32)>,
+    /// (start beat, current beat) of a ctrl-drag erase sweep.
+    erase_drag: Option<(f64, f64)>,
     /// Last left press, for double-click detection.
     last_click: Option<(Instant, Point)>,
+    alt: bool,
+    ctrl: bool,
 }
 
 impl AutomationLaneWidget {
@@ -70,6 +92,40 @@ impl AutomationLaneWidget {
             (px - pos.x).powi(2) + (py - pos.y).powi(2) <= HIT_RADIUS * HIT_RADIUS
         })
     }
+
+    /// The segment (index of its left point) under the cursor, if the
+    /// cursor is horizontally inside it and vertically near the curve.
+    fn hit_segment(&self, pos: Point, height: f32) -> Option<usize> {
+        for i in 0..self.points.len().saturating_sub(1) {
+            let a = self.points[i];
+            let b = self.points[i + 1];
+            let x0 = self.beat_to_x(a.beat);
+            let x1 = self.beat_to_x(b.beat);
+            if pos.x < x0 || pos.x > x1 || x1 - x0 < 2.0 {
+                continue;
+            }
+            let t = (pos.x - x0) / (x1 - x0);
+            let value = a.value + (b.value - a.value) * shape(t, a.curve);
+            let y = self.value_to_y(value, height);
+            if (y - pos.y).abs() <= SEGMENT_HIT {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    /// Ghost curve from a vertical drag, oriented so dragging down
+    /// always bulges the segment downward.
+    fn curve_from_drag(&self, index: usize, orig: f32, press_y: f32, y: f32) -> f32 {
+        let rising = self
+            .points
+            .get(index + 1)
+            .zip(self.points.get(index))
+            .map(|(b, a)| b.value >= a.value)
+            .unwrap_or(true);
+        let dir = if rising { 1.0 } else { -1.0 };
+        (orig + (y - press_y) / CURVE_DRAG_RANGE * dir).clamp(-1.0, 1.0)
+    }
 }
 
 impl canvas::Program<Message> for AutomationLaneWidget {
@@ -86,27 +142,71 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         let mut frame = canvas::Frame::new(renderer, bounds.size());
         let h = bounds.height;
 
-        // Ground and midline.
         frame.fill_rectangle(
             Point::ORIGIN,
             bounds.size(),
             Color::from_rgba(0.0, 0.0, 0.0, 0.18),
         );
-        let mid = self.value_to_y(0.5, h);
-        frame.stroke(
-            &canvas::Path::line(Point::new(0.0, mid), Point::new(bounds.width, mid)),
-            canvas::Stroke::default()
-                .with_color(Color::from_rgba(1.0, 1.0, 1.0, 0.06))
-                .with_width(1.0),
-        );
 
-        // The curve, with the dragged point replaced by its ghost.
+        // Dotted reference: where the knob sits without automation.
+        if let Some(reference) = self.reference {
+            let y = self.value_to_y(reference, h);
+            frame.stroke(
+                &canvas::Path::line(Point::new(0.0, y), Point::new(bounds.width, y)),
+                canvas::Stroke {
+                    line_dash: canvas::LineDash {
+                        segments: &[3.0, 5.0],
+                        offset: 0,
+                    },
+                    ..canvas::Stroke::default()
+                        .with_color(Color::from_rgba(0.85, 0.83, 0.78, 0.35))
+                        .with_width(1.0)
+                },
+            );
+        }
+
+        // Scale labels: max top-left, min bottom-left, reference value
+        // against the right edge on its line.
+        let label = |content: &str, position: Point, bottom: bool| canvas::Text {
+            content: content.to_string(),
+            position,
+            color: Color::from_rgba(0.75, 0.73, 0.68, 0.55),
+            size: iced::Pixels(9.0),
+            vertical_alignment: if bottom {
+                iced::alignment::Vertical::Bottom
+            } else {
+                iced::alignment::Vertical::Top
+            },
+            ..canvas::Text::default()
+        };
+        frame.fill_text(label(&self.max_label, Point::new(6.0, 2.0), false));
+        frame.fill_text(label(&self.min_label, Point::new(6.0, h - 2.0), true));
+        if let Some(reference) = self.reference {
+            if !self.ref_label.is_empty() {
+                let y = self.value_to_y(reference, h);
+                let mut t = label(
+                    &self.ref_label,
+                    Point::new(bounds.width - 6.0, y - 3.0),
+                    true,
+                );
+                t.horizontal_alignment = iced::alignment::Horizontal::Right;
+                frame.fill_text(t);
+            }
+        }
+
+        // Working copy with drag ghosts applied.
         let mut pts: Vec<AutomationPoint> = self.points.clone();
         if let Some((idx, beat, value)) = state.drag {
             if idx < pts.len() {
+                let curve = pts[idx].curve;
                 pts.remove(idx);
                 let insert_at = pts.partition_point(|p| p.beat < beat);
-                pts.insert(insert_at, AutomationPoint { beat, value });
+                pts.insert(insert_at, AutomationPoint { beat, value, curve });
+            }
+        }
+        if let Some((idx, _, _, ghost)) = state.curve_drag {
+            if idx < pts.len() {
+                pts[idx].curve = ghost;
             }
         }
 
@@ -116,11 +216,21 @@ impl canvas::Program<Message> for AutomationLaneWidget {
             let first_y = self.value_to_y(pts[0].value, h);
             path.move_to(Point::new(0.0, first_y));
             path.line_to(Point::new(self.beat_to_x(pts[0].beat), first_y));
-            for p in &pts {
-                path.line_to(Point::new(
-                    self.beat_to_x(p.beat),
-                    self.value_to_y(p.value, h),
-                ));
+            for i in 0..pts.len() - 1 {
+                let a = pts[i];
+                let b = pts[i + 1];
+                let x0 = self.beat_to_x(a.beat);
+                let x1 = self.beat_to_x(b.beat);
+                if a.curve == 0.0 {
+                    path.line_to(Point::new(x1, self.value_to_y(b.value, h)));
+                } else {
+                    const STEPS: usize = 24;
+                    for step in 1..=STEPS {
+                        let t = step as f32 / STEPS as f32;
+                        let v = a.value + (b.value - a.value) * shape(t, a.curve);
+                        path.line_to(Point::new(x0 + (x1 - x0) * t, self.value_to_y(v, h)));
+                    }
+                }
             }
             let last = pts[pts.len() - 1];
             let last_y = self.value_to_y(last.value, h);
@@ -149,19 +259,20 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                     );
                 }
             }
-        } else {
-            frame.stroke(
-                &canvas::Path::line(
-                    Point::new(0.0, self.value_to_y(1.0, h)),
-                    Point::new(bounds.width, self.value_to_y(1.0, h)),
-                ),
-                canvas::Stroke::default()
-                    .with_color(Color {
-                        a: 0.35,
-                        ..curve_color
-                    })
-                    .with_width(1.5),
-            );
+        }
+
+        // Erase sweep overlay.
+        if let Some((b0, b1)) = state.erase_drag {
+            let (lo, hi) = if b0 <= b1 { (b0, b1) } else { (b1, b0) };
+            let x0 = self.beat_to_x(lo).max(0.0);
+            let x1 = self.beat_to_x(hi).min(bounds.width);
+            if x1 > x0 {
+                frame.fill_rectangle(
+                    Point::new(x0, 0.0),
+                    iced::Size::new(x1 - x0, h),
+                    Color::from_rgba(0.9, 0.35, 0.25, 0.18),
+                );
+            }
         }
 
         vec![frame.into_geometry()]
@@ -174,21 +285,51 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> (canvas::event::Status, Option<Message>) {
+        // Modifier tracking works regardless of cursor position.
+        if let canvas::Event::Keyboard(iced::keyboard::Event::ModifiersChanged(m)) = event {
+            state.alt = m.alt();
+            state.ctrl = m.control();
+            return (canvas::event::Status::Ignored, None);
+        }
+
+        let commit_release = |state: &mut Self::State| -> Option<Message> {
+            if let Some((index, beat, value)) = state.drag.take() {
+                return Some(Message::Automation(AutomationMsg::MovePoint {
+                    track_id: self.track_id,
+                    lane_id: self.lane_id,
+                    index,
+                    beat,
+                    value,
+                }));
+            }
+            if let Some((index, orig, _, ghost)) = state.curve_drag.take() {
+                if (ghost - orig).abs() > 0.001 {
+                    return Some(Message::Automation(AutomationMsg::SetCurve {
+                        track_id: self.track_id,
+                        lane_id: self.lane_id,
+                        index,
+                        curve: ghost,
+                    }));
+                }
+                return None;
+            }
+            if let Some((b0, b1)) = state.erase_drag.take() {
+                if (b1 - b0).abs() > 0.01 {
+                    return Some(Message::Automation(AutomationMsg::RemovePointsInRange {
+                        track_id: self.track_id,
+                        lane_id: self.lane_id,
+                        start_beat: b0,
+                        end_beat: b1,
+                    }));
+                }
+            }
+            None
+        };
+
         let Some(pos) = cursor.position_in(bounds) else {
-            // Commit an in-flight drag even if the release lands
-            // outside the lane.
             if let canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) = event {
-                if let Some((index, beat, value)) = state.drag.take() {
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(Message::Automation(AutomationMsg::MovePoint {
-                            track_id: self.track_id,
-                            lane_id: self.lane_id,
-                            index,
-                            beat,
-                            value,
-                        })),
-                    );
+                if let Some(msg) = commit_release(state) {
+                    return (canvas::event::Status::Captured, Some(msg));
                 }
             }
             return (canvas::event::Status::Ignored, None);
@@ -197,6 +338,40 @@ impl canvas::Program<Message> for AutomationLaneWidget {
 
         match event {
             canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                // Ctrl: sweep-erase.
+                if state.ctrl {
+                    let beat = self.x_to_beat(pos.x);
+                    state.erase_drag = Some((beat, beat));
+                    state.last_click = None;
+                    return (canvas::event::Status::Captured, None);
+                }
+                // Alt: bend a segment (alt-double-click resets it).
+                if state.alt {
+                    if let Some(index) = self.hit_segment(pos, h) {
+                        let now = Instant::now();
+                        if let Some((t, p)) = state.last_click {
+                            let close = (p.x - pos.x).abs() < 6.0 && (p.y - pos.y).abs() < 6.0;
+                            if close && now.duration_since(t).as_millis() < 400 {
+                                state.last_click = None;
+                                state.curve_drag = None;
+                                return (
+                                    canvas::event::Status::Captured,
+                                    Some(Message::Automation(AutomationMsg::SetCurve {
+                                        track_id: self.track_id,
+                                        lane_id: self.lane_id,
+                                        index,
+                                        curve: 0.0,
+                                    })),
+                                );
+                            }
+                        }
+                        state.last_click = Some((now, pos));
+                        let orig = self.points[index].curve;
+                        state.curve_drag = Some((index, orig, pos.y, orig));
+                        return (canvas::event::Status::Captured, None);
+                    }
+                    return (canvas::event::Status::Ignored, None);
+                }
                 if let Some(index) = self.hit_point(pos, h) {
                     let p = self.points[index];
                     state.drag = Some((index, p.beat, p.value));
@@ -242,22 +417,22 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                     state.drag = Some((index, self.x_to_beat(pos.x), self.y_to_value(pos.y, h)));
                     return (canvas::event::Status::Captured, None);
                 }
+                if let Some((index, orig, press_y, _)) = state.curve_drag {
+                    let ghost = self.curve_from_drag(index, orig, press_y, pos.y);
+                    state.curve_drag = Some((index, orig, press_y, ghost));
+                    return (canvas::event::Status::Captured, None);
+                }
+                if let Some((b0, _)) = state.erase_drag {
+                    state.erase_drag = Some((b0, self.x_to_beat(pos.x)));
+                    return (canvas::event::Status::Captured, None);
+                }
                 (canvas::event::Status::Ignored, None)
             }
             canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
-                if let Some((index, beat, value)) = state.drag.take() {
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(Message::Automation(AutomationMsg::MovePoint {
-                            track_id: self.track_id,
-                            lane_id: self.lane_id,
-                            index,
-                            beat,
-                            value,
-                        })),
-                    );
+                match commit_release(state) {
+                    Some(msg) => (canvas::event::Status::Captured, Some(msg)),
+                    None => (canvas::event::Status::Ignored, None),
                 }
-                (canvas::event::Status::Ignored, None)
             }
             canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Right)) => {
                 if let Some(index) = self.hit_point(pos, h) {
@@ -285,7 +460,22 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         if state.drag.is_some() {
             return mouse::Interaction::Grabbing;
         }
+        if state.curve_drag.is_some() {
+            return mouse::Interaction::ResizingVertically;
+        }
+        if state.erase_drag.is_some() {
+            return mouse::Interaction::Crosshair;
+        }
         if let Some(pos) = cursor.position_in(bounds) {
+            if state.ctrl {
+                return mouse::Interaction::Crosshair;
+            }
+            if state.alt {
+                if self.hit_segment(pos, bounds.height).is_some() {
+                    return mouse::Interaction::ResizingVertically;
+                }
+                return mouse::Interaction::default();
+            }
             if self.hit_point(pos, bounds.height).is_some() {
                 return mouse::Interaction::Grab;
             }

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -21,6 +21,7 @@ use vibez_core::id::{LaneId, TrackId};
 
 use crate::domains::automation::AutomationMsg;
 use crate::message::Message;
+use crate::state::SnapGrid;
 use crate::theme as th;
 
 pub const LANE_HEIGHT: f32 = 56.0;
@@ -39,6 +40,8 @@ pub struct AutomationLaneWidget {
     pub color: Color,
     pub zoom_level: f32,
     pub scroll_offset_beats: f64,
+    /// Grid for beat snapping (hold shift to bypass).
+    pub snap: SnapGrid,
     pub selected: Option<usize>,
     /// The parameter's current un-automated value (normalized), for
     /// the dotted reference line.
@@ -60,6 +63,7 @@ pub struct LaneInteraction {
     last_click: Option<(Instant, Point)>,
     alt: bool,
     ctrl: bool,
+    shift: bool,
 }
 
 impl AutomationLaneWidget {
@@ -73,6 +77,16 @@ impl AutomationLaneWidget {
 
     fn x_to_beat(&self, x: f32) -> f64 {
         (x as f64 / self.pixels_per_beat() as f64 + self.scroll_offset_beats).max(0.0)
+    }
+
+    /// Cursor x to beat, snapped to the grid unless shift is held.
+    fn x_to_snapped_beat(&self, x: f32, state: &LaneInteraction) -> f64 {
+        let beat = self.x_to_beat(x);
+        if state.shift {
+            beat
+        } else {
+            self.snap.snap_beat(beat).max(0.0)
+        }
     }
 
     fn value_to_y(&self, value: f32, height: f32) -> f32 {
@@ -289,6 +303,7 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         if let canvas::Event::Keyboard(iced::keyboard::Event::ModifiersChanged(m)) = event {
             state.alt = m.alt();
             state.ctrl = m.control();
+            state.shift = m.shift();
             return (canvas::event::Status::Ignored, None);
         }
 
@@ -340,7 +355,7 @@ impl canvas::Program<Message> for AutomationLaneWidget {
             canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 // Ctrl: sweep-erase.
                 if state.ctrl {
-                    let beat = self.x_to_beat(pos.x);
+                    let beat = self.x_to_snapped_beat(pos.x, state);
                     state.erase_drag = Some((beat, beat));
                     state.last_click = None;
                     return (canvas::event::Status::Captured, None);
@@ -396,7 +411,7 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                             Some(Message::Automation(AutomationMsg::AddPoint {
                                 track_id: self.track_id,
                                 lane_id: self.lane_id,
-                                beat: self.x_to_beat(pos.x),
+                                beat: self.x_to_snapped_beat(pos.x, state),
                                 value: self.y_to_value(pos.y, h),
                             })),
                         );
@@ -414,7 +429,11 @@ impl canvas::Program<Message> for AutomationLaneWidget {
             }
             canvas::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
                 if let Some((index, _, _)) = state.drag {
-                    state.drag = Some((index, self.x_to_beat(pos.x), self.y_to_value(pos.y, h)));
+                    state.drag = Some((
+                        index,
+                        self.x_to_snapped_beat(pos.x, state),
+                        self.y_to_value(pos.y, h),
+                    ));
                     return (canvas::event::Status::Captured, None);
                 }
                 if let Some((index, orig, press_y, _)) = state.curve_drag {
@@ -423,7 +442,7 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                     return (canvas::event::Status::Captured, None);
                 }
                 if let Some((b0, _)) = state.erase_drag {
-                    state.erase_drag = Some((b0, self.x_to_beat(pos.x)));
+                    state.erase_drag = Some((b0, self.x_to_snapped_beat(pos.x, state)));
                     return (canvas::event::Status::Captured, None);
                 }
                 (canvas::event::Status::Ignored, None)

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -1,4 +1,5 @@
 pub mod audio_clip_detail;
+pub mod automation_lane;
 pub mod effect_knob;
 pub mod effect_slot;
 pub mod fader;

--- a/crates/vibez-ui/src/widgets/track_header.rs
+++ b/crates/vibez-ui/src/widgets/track_header.rs
@@ -3,6 +3,7 @@ use iced::widget::{
 };
 use iced::{Element, Length, Theme};
 
+use crate::domains::automation::AutomationMsg;
 use crate::domains::piano_roll::PianoRollMsg;
 use crate::domains::view::ViewMsg;
 use crate::icons;
@@ -25,6 +26,7 @@ pub fn view_track_header<'a>(
     selected: bool,
     editing_name: bool,
     edit_text: &'a str,
+    automation_open: bool,
 ) -> Element<'a, Message> {
     let track_color = th::track_color(track.color_index);
 
@@ -94,10 +96,36 @@ pub fn view_track_header<'a>(
             }
         });
 
+    let auto_btn = {
+        let color = if automation_open {
+            th::ACCENT
+        } else {
+            th::TEXT_DIM
+        };
+        button(icons::icon(icons::SLIDERS_VERTICAL).size(10).color(color))
+            .on_press(Message::Automation(AutomationMsg::ToggleTrackLanes(
+                track.id,
+            )))
+            .padding([2, 4])
+            .style(|_theme: &Theme, status| {
+                let bg = match status {
+                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    _ => None,
+                };
+                button::Style {
+                    background: bg,
+                    text_color: th::TEXT_DIM,
+                    border: iced::Border::default(),
+                    ..Default::default()
+                }
+            })
+    };
+
     let name_row = row![
         type_icon,
         name_widget,
         horizontal_space(),
+        auto_btn,
         add_btn,
         delete_btn
     ]


### PR DESCRIPTION
Automation lanes end to end, all targets covered:

**Core** (vibez-core/automation.rs): AutomationLane/Point/Target, linear interpolation with hold semantics, sorted insert. Serialized on TrackInfo behind serde defaults.

**Engine**: lanes live on EngineTrack, synced by whole-lane upsert commands (allocation UI-side). render_multitrack_segment evaluates once per segment; lane values (0..1) denormalize into each parameter's native descriptor range; gain/pan as overrides at the sum stage. Three end-to-end tests (gain ramp RMS profile, pan sweep, lane removal restores the knob).

**Plugins (CLAP + VST3)**: plugin parameters are real automation targets.
- CLAP: param ids/cookies retained at load; CLAP_EVENT_PARAM_VALUE events merged with notes into each process block.
- VST3: params enumerated via IEditController (vtable slots verified against the vst3 crate; read-only/non-automatable skipped); a real stack-built IParameterChanges replaces the input stub.
- Plugin effects/instruments expose their real descriptors to the UI (the poll path stored an empty list before), so the picker lists e.g. all of Surge XT's params.

**UI**: automation toggle per track header expands a lane strip: canvas per lane (double-click add, drag with ghost, right-click/Delete remove), add-lane picker (Volume, Pan, built-in instrument params, built-in effect params, plugin params), delete-key priority, undo/save/load covered.

Also: vibez <project.vibez> opens a project from the command line.

**Deferred**: IComponentHandler (recording automation from plugin GUI knob moves).

Verified interactively in an Xvfb sandbox including a live Surge XT (CLAP) run: full param list in the picker, a Global Volume lane delivering param events during playback. Gate: 21 suites ok, clippy -D warnings clean.

Known UX debt: the picker is a flat list; Surge exposes hundreds of params so it needs search/grouping eventually.