### PR TITLE
feat(mix): SSL-style four-band channel EQ

### DIFF
--- a/crates/vibez-dsp/src/eq.rs
+++ b/crates/vibez-dsp/src/eq.rs
@@ -3,39 +3,99 @@ use vibez_core::effect::{EffectType, ParamDescriptor};
 use crate::effect::AudioEffect;
 
 static EQ_PARAMS: &[ParamDescriptor] = &[
+    // ── LF band ──
     ParamDescriptor {
-        name: "Low",
-        min: -18.0,
-        max: 18.0,
+        name: "LF Gain",
+        min: -15.0,
+        max: 15.0,
         default: 0.0,
         unit: "dB",
     },
     ParamDescriptor {
-        name: "Mid Freq",
-        min: 200.0,
-        max: 4000.0,
-        default: 1000.0,
+        name: "LF Freq",
+        min: 30.0,
+        max: 450.0,
+        default: 80.0,
         unit: "Hz",
     },
     ParamDescriptor {
-        name: "Mid",
-        min: -18.0,
-        max: 18.0,
+        name: "LF Bell",
+        min: 0.0,
+        max: 1.0,
+        default: 0.0,
+        unit: "",
+    },
+    // ── LMF band ──
+    ParamDescriptor {
+        name: "LMF Gain",
+        min: -15.0,
+        max: 15.0,
         default: 0.0,
         unit: "dB",
     },
     ParamDescriptor {
-        name: "High",
-        min: -18.0,
-        max: 18.0,
+        name: "LMF Freq",
+        min: 200.0,
+        max: 2500.0,
+        default: 700.0,
+        unit: "Hz",
+    },
+    ParamDescriptor {
+        name: "LMF Q",
+        min: 0.3,
+        max: 4.0,
+        default: 0.7,
+        unit: "",
+    },
+    // ── HMF band ──
+    ParamDescriptor {
+        name: "HMF Gain",
+        min: -15.0,
+        max: 15.0,
         default: 0.0,
         unit: "dB",
     },
+    ParamDescriptor {
+        name: "HMF Freq",
+        min: 600.0,
+        max: 7000.0,
+        default: 2500.0,
+        unit: "Hz",
+    },
+    ParamDescriptor {
+        name: "HMF Q",
+        min: 0.3,
+        max: 4.0,
+        default: 0.7,
+        unit: "",
+    },
+    // ── HF band ──
+    ParamDescriptor {
+        name: "HF Gain",
+        min: -15.0,
+        max: 15.0,
+        default: 0.0,
+        unit: "dB",
+    },
+    ParamDescriptor {
+        name: "HF Freq",
+        min: 1500.0,
+        max: 16000.0,
+        default: 8000.0,
+        unit: "Hz",
+    },
+    ParamDescriptor {
+        name: "HF Bell",
+        min: 0.0,
+        max: 1.0,
+        default: 0.0,
+        unit: "",
+    },
 ];
 
-const LOW_SHELF_HZ: f32 = 150.0;
-const HIGH_SHELF_HZ: f32 = 4_000.0;
-const MID_Q: f32 = 0.707;
+/// Fixed bell width for the LF/HF bands when switched out of shelf
+/// mode, matching the console's fairly broad bell.
+const SHELF_BELL_Q: f32 = 0.85;
 
 #[derive(Default)]
 struct Biquad {
@@ -144,41 +204,53 @@ impl Biquad {
     }
 }
 
-/// 3-band EQ: low shelf @ 150Hz, peaking mid (sweepable), high shelf @ 4kHz.
+/// SSL E-series style four-band parametric EQ.
+///
+/// LF and HF are shelves with a bell option; LMF and HMF are fully
+/// parametric bells with sweepable Q. Parameter indices follow
+/// [`EQ_PARAMS`].
 pub struct EqEffect {
-    low_db: f32,
-    mid_hz: f32,
-    mid_db: f32,
-    high_db: f32,
+    params: [f32; 12],
     sample_rate: f32,
-    low: Biquad,
-    mid: Biquad,
-    high: Biquad,
+    lf: Biquad,
+    lmf: Biquad,
+    hmf: Biquad,
+    hf: Biquad,
 }
 
 impl EqEffect {
     pub fn new(sample_rate: f32) -> Self {
+        let mut params = [0.0_f32; 12];
+        for (i, d) in EQ_PARAMS.iter().enumerate() {
+            params[i] = d.default;
+        }
         let mut fx = Self {
-            low_db: 0.0,
-            mid_hz: 1000.0,
-            mid_db: 0.0,
-            high_db: 0.0,
+            params,
             sample_rate,
-            low: Biquad::identity(),
-            mid: Biquad::identity(),
-            high: Biquad::identity(),
+            lf: Biquad::identity(),
+            lmf: Biquad::identity(),
+            hmf: Biquad::identity(),
+            hf: Biquad::identity(),
         };
         fx.recompute();
         fx
     }
 
     fn recompute(&mut self) {
-        self.low
-            .set_low_shelf(LOW_SHELF_HZ, self.low_db, self.sample_rate);
-        self.mid
-            .set_peaking(self.mid_hz, MID_Q, self.mid_db, self.sample_rate);
-        self.high
-            .set_high_shelf(HIGH_SHELF_HZ, self.high_db, self.sample_rate);
+        let p = &self.params;
+        let sr = self.sample_rate;
+        if p[2] >= 0.5 {
+            self.lf.set_peaking(p[1], SHELF_BELL_Q, p[0], sr);
+        } else {
+            self.lf.set_low_shelf(p[1], p[0], sr);
+        }
+        self.lmf.set_peaking(p[4], p[5], p[3], sr);
+        self.hmf.set_peaking(p[7], p[8], p[6], sr);
+        if p[11] >= 0.5 {
+            self.hf.set_peaking(p[10], SHELF_BELL_Q, p[9], sr);
+        } else {
+            self.hf.set_high_shelf(p[10], p[9], sr);
+        }
     }
 }
 
@@ -192,39 +264,16 @@ impl AudioEffect for EqEffect {
     }
 
     fn set_param(&mut self, index: usize, value: f32) -> bool {
-        match index {
-            0 => {
-                self.low_db = value.clamp(-18.0, 18.0);
-                self.recompute();
-                true
-            }
-            1 => {
-                self.mid_hz = value.clamp(200.0, 4000.0);
-                self.recompute();
-                true
-            }
-            2 => {
-                self.mid_db = value.clamp(-18.0, 18.0);
-                self.recompute();
-                true
-            }
-            3 => {
-                self.high_db = value.clamp(-18.0, 18.0);
-                self.recompute();
-                true
-            }
-            _ => false,
-        }
+        let Some(d) = EQ_PARAMS.get(index) else {
+            return false;
+        };
+        self.params[index] = value.clamp(d.min, d.max);
+        self.recompute();
+        true
     }
 
     fn get_param(&self, index: usize) -> f32 {
-        match index {
-            0 => self.low_db,
-            1 => self.mid_hz,
-            2 => self.mid_db,
-            3 => self.high_db,
-            _ => 0.0,
-        }
+        self.params.get(index).copied().unwrap_or(0.0)
     }
 
     fn process(&mut self, buffer: &mut [f32], channels: usize) {
@@ -234,24 +283,36 @@ impl AudioEffect for EqEffect {
             for c in 0..ch {
                 let idx = frame * ch + c;
                 let mut s = buffer[idx];
-                s = self.low.process(s, c);
-                s = self.mid.process(s, c);
-                s = self.high.process(s, c);
+                s = self.lf.process(s, c);
+                s = self.lmf.process(s, c);
+                s = self.hmf.process(s, c);
+                s = self.hf.process(s, c);
                 buffer[idx] = s;
             }
         }
     }
 
     fn reset(&mut self) {
-        self.low.reset();
-        self.mid.reset();
-        self.high.reset();
+        self.lf.reset();
+        self.lmf.reset();
+        self.hmf.reset();
+        self.hf.reset();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rms(buf: &[f32]) -> f32 {
+        (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt()
+    }
+
+    fn tone(freq: f32, sr: f32, n: usize) -> Vec<f32> {
+        (0..n)
+            .map(|i| ((i as f32 / sr) * freq * std::f32::consts::TAU).sin() * 0.2)
+            .collect()
+    }
 
     #[test]
     fn flat_eq_approximately_passthrough() {
@@ -269,16 +330,59 @@ mod tests {
     }
 
     #[test]
-    fn low_boost_amplifies_low_frequencies() {
+    fn lf_shelf_boost_amplifies_lows_only() {
         let mut fx = EqEffect::new(44_100.0);
-        fx.set_param(0, 12.0);
-        // 60 Hz tone
-        let mut buf: Vec<f32> = (0..4_410)
-            .map(|i| ((i as f32 / 44_100.0) * 60.0 * std::f32::consts::TAU).sin() * 0.2)
-            .collect();
-        let in_rms: f32 = (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt();
+        fx.set_param(0, 12.0); // LF gain
+        fx.set_param(1, 120.0); // LF freq
+        let mut low = tone(60.0, 44_100.0, 4_410);
+        let in_rms = rms(&low);
+        fx.process(&mut low, 1);
+        assert!(rms(&low) > in_rms * 1.5, "low should boost");
+
+        fx.reset();
+        let mut high = tone(5_000.0, 44_100.0, 4_410);
+        let in_rms = rms(&high);
+        fx.process(&mut high, 1);
+        assert!(
+            (rms(&high) / in_rms - 1.0).abs() < 0.15,
+            "highs should be untouched by an LF shelf"
+        );
+    }
+
+    #[test]
+    fn hmf_bell_cuts_at_its_center() {
+        let mut fx = EqEffect::new(44_100.0);
+        fx.set_param(6, -12.0); // HMF gain
+        fx.set_param(7, 2_000.0); // HMF freq
+        fx.set_param(8, 1.0); // Q
+        let mut buf = tone(2_000.0, 44_100.0, 8_820);
+        let in_rms = rms(&buf);
         fx.process(&mut buf, 1);
-        let out_rms: f32 = (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt();
-        assert!(out_rms > in_rms * 1.5, "in {in_rms} out {out_rms}");
+        assert!(rms(&buf) < in_rms * 0.5, "bell cut should attenuate center");
+    }
+
+    #[test]
+    fn hf_bell_mode_leaves_extreme_highs_alone() {
+        // Shelf boosts everything above the corner; a bell at the same
+        // spot returns to unity well above its center.
+        let sr = 96_000.0;
+        let mut shelf = EqEffect::new(sr);
+        shelf.set_param(9, 12.0); // HF gain
+        shelf.set_param(10, 4_000.0);
+        let mut bell = EqEffect::new(sr);
+        bell.set_param(9, 12.0);
+        bell.set_param(10, 4_000.0);
+        bell.set_param(11, 1.0); // bell mode
+
+        let mut a = tone(30_000.0, sr, 9_600);
+        let mut b = a.clone();
+        shelf.process(&mut a, 1);
+        bell.process(&mut b, 1);
+        assert!(
+            rms(&a) > rms(&b) * 1.3,
+            "shelf should lift extreme highs more than bell: shelf {} bell {}",
+            rms(&a),
+            rms(&b)
+        );
     }
 }

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -3,8 +3,11 @@ use iced::{Element, Length, Theme};
 
 use crate::icons;
 use crate::message::Message;
-use crate::state::UiTrack;
+use vibez_core::effect::EffectType;
+
+use crate::state::{UiEffect, UiTrack};
 use crate::theme as th;
+use crate::widgets::effect_knob::EffectKnobWidget;
 use crate::widgets::fader::FaderWidget;
 use crate::widgets::knob::KnobWidget;
 use crate::widgets::vu_meter::VuMeterWidget;
@@ -136,17 +139,20 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
         .spacing(2)
         .height(Length::Fill);
 
+    let eq_section = view_strip_eq(track);
+
     let strip = column![
         name_row,
         knob_canvas,
         pan_label,
+        eq_section,
         fader_meter,
         gain_label,
         mute_solo_row,
     ]
     .spacing(4)
     .padding(8)
-    .width(Length::Fixed(90.0))
+    .width(Length::Fixed(108.0))
     .height(Length::Fill)
     .align_x(iced::Alignment::Center);
 
@@ -162,6 +168,181 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
             ..Default::default()
         })
         .into()
+}
+
+/// SSL-style channel EQ: the strip renders the track's first
+/// built-in EQ effect as four color-coded bands (HF red, HMF green,
+/// LMF blue, LF brown, like the console), with bell toggles on the
+/// outer bands and an IN (bypass) button. The EQ is an ordinary
+/// device on the chain, so automation and persistence come free.
+fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
+    let eq = track
+        .effects
+        .iter()
+        .find(|e| e.effect_type == EffectType::Eq && e.plugin_ref.is_none());
+
+    let Some(eq) = eq else {
+        return container(
+            button(text("+ EQ").size(10).color(th::TEXT_DIM))
+                .on_press(Message::add_effect(track.id, EffectType::Eq))
+                .padding([2, 10])
+                .style(|_theme: &Theme, status| {
+                    let bg = match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::BG_HOVER.into())
+                        }
+                        _ => Some(th::BG_ELEVATED.into()),
+                    };
+                    button::Style {
+                        background: bg,
+                        text_color: th::TEXT_DIM,
+                        border: iced::Border {
+                            color: th::BORDER,
+                            width: 1.0,
+                            radius: 2.0.into(),
+                        },
+                        ..Default::default()
+                    }
+                }),
+        )
+        .padding([4, 0])
+        .into();
+    };
+
+    // Console band colors, muted for the theme.
+    const HF: iced::Color = iced::Color::from_rgb(0.76, 0.33, 0.30);
+    const HMF: iced::Color = iced::Color::from_rgb(0.33, 0.62, 0.38);
+    const LMF: iced::Color = iced::Color::from_rgb(0.36, 0.48, 0.72);
+    const LF: iced::Color = iced::Color::from_rgb(0.65, 0.46, 0.28);
+
+    let mut bands = column![].spacing(2).align_x(iced::Alignment::Center);
+
+    // Header: EQ label + IN (bypass) toggle.
+    let in_btn = {
+        let active = !eq.bypass;
+        let label = text("IN").size(8);
+        button(if active {
+            label.color(th::BG_DARK)
+        } else {
+            label.color(th::TEXT_DIM)
+        })
+        .on_press(Message::toggle_effect_bypass(track.id, eq.id))
+        .padding([1, 5])
+        .style(move |_theme: &Theme, _status| button::Style {
+            background: Some(if active {
+                th::ACCENT.into()
+            } else {
+                th::BG_ELEVATED.into()
+            }),
+            text_color: if active { th::BG_DARK } else { th::TEXT_DIM },
+            border: iced::Border {
+                color: th::BORDER,
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            ..Default::default()
+        })
+    };
+    bands = bands.push(
+        row![text("EQ").size(9).color(th::TEXT_DIM), in_btn]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+    );
+
+    // (gain idx, freq idx, q/bell idx, bell?, color, label)
+    let rows: [(usize, usize, usize, bool, iced::Color, &str); 4] = [
+        (9, 10, 11, true, HF, "HF"),
+        (6, 7, 8, false, HMF, "HMF"),
+        (3, 4, 5, false, LMF, "LMF"),
+        (0, 1, 2, true, LF, "LF"),
+    ];
+    for (gain_i, freq_i, third_i, is_bell_toggle, color, label) in rows {
+        bands = bands.push(view_eq_band(
+            track.id,
+            eq,
+            gain_i,
+            freq_i,
+            third_i,
+            is_bell_toggle,
+            color,
+            label,
+        ));
+    }
+
+    container(bands).padding([4, 0]).width(Length::Fill).into()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn view_eq_band<'a>(
+    track_id: vibez_core::id::TrackId,
+    eq: &'a UiEffect,
+    gain_i: usize,
+    freq_i: usize,
+    third_i: usize,
+    bell_toggle: bool,
+    color: iced::Color,
+    label: &'static str,
+) -> Element<'a, Message> {
+    let knob = |i: usize| -> Element<'a, Message> {
+        let d = &eq.descriptors[i];
+        let w = EffectKnobWidget::new(
+            track_id,
+            eq.id,
+            i,
+            eq.params.get(i).copied().unwrap_or(d.default),
+            d.min,
+            d.max,
+            d.default,
+            color,
+        );
+        canvas(w)
+            .width(Length::Fixed(24.0))
+            .height(Length::Fixed(24.0))
+            .into()
+    };
+
+    let third: Element<'a, Message> = if bell_toggle {
+        let bell_on = eq.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
+        button(
+            text("B")
+                .size(8)
+                .color(if bell_on { th::BG_DARK } else { th::TEXT_DIM }),
+        )
+        .on_press(Message::set_effect_param(
+            track_id,
+            eq.id,
+            third_i,
+            if bell_on { 0.0 } else { 1.0 },
+        ))
+        .padding([2, 4])
+        .style(move |_theme: &Theme, _status| button::Style {
+            background: Some(if bell_on {
+                color.into()
+            } else {
+                th::BG_ELEVATED.into()
+            }),
+            text_color: if bell_on { th::BG_DARK } else { th::TEXT_DIM },
+            border: iced::Border {
+                color: th::BORDER,
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
+    } else {
+        knob(third_i)
+    };
+
+    column![
+        text(label).size(8).color(color),
+        row![knob(gain_i), knob(freq_i), third]
+            .spacing(3)
+            .align_y(iced::Alignment::Center),
+    ]
+    .spacing(1)
+    .align_x(iced::Alignment::Center)
+    .into()
 }
 
 fn format_pan(pan: f32) -> String {


### PR DESCRIPTION
The mixer EQ, E-series style (per the reference Alex posted):

- **DSP**: EqEffect becomes a four-band parametric. LF/HF shelves with BELL toggles, LMF/HMF parametric bells with Q. RBJ biquads per channel; 12 descriptor-driven params, so automation lanes and project persistence come free through the effect system. Four DSP tests.
- **Mix view**: each strip renders its first built-in EQ as color-coded band rows (HF red / HMF green / LMF blue / LF brown, matching the console), bell toggles, an amber IN bypass, and a '+ EQ' button when absent.
- Skipped from the reference: the BLK button (E-series circuit-character switch, out of scope for a digital band).

Breaking note: old projects with the previous 3-band EQ load with default params (indices changed; format is alpha-unstable).

Verified in the Xvfb sandbox: add EQ from the strip, knob drag applies, bell toggle lights. Gate: 21 suites ok, clippy -D warnings clean.