### PR TITLE
feat(mix): channel EQ always present, console zigzag layout

### DIFF
--- a/crates/vibez-core/src/id.rs
+++ b/crates/vibez-core/src/id.rs
@@ -47,6 +47,17 @@ macro_rules! typed_id {
 }
 
 typed_id!(TrackId);
+
+impl TrackId {
+    /// Reserved id for the master bus. The global counter starts at 1
+    /// and only moves up, so 0 can never collide with a minted id.
+    pub const MASTER: TrackId = TrackId(0);
+
+    pub fn is_master(self) -> bool {
+        self.0 == 0
+    }
+}
+
 typed_id!(ClipId);
 typed_id!(EffectId);
 typed_id!(LaneId);

--- a/crates/vibez-dsp/src/eq.rs
+++ b/crates/vibez-dsp/src/eq.rs
@@ -184,6 +184,19 @@ impl Biquad {
         self.a2 = a2 / a0;
     }
 
+    /// Magnitude of the transfer function at normalized angular
+    /// frequency `w` (radians/sample). Used for drawing the response
+    /// curve; never called on the audio thread.
+    fn magnitude_at(&self, w: f64) -> f64 {
+        let (cos_w, sin_w) = (w.cos(), w.sin());
+        let (cos_2w, sin_2w) = ((2.0 * w).cos(), (2.0 * w).sin());
+        let num_re = self.b0 + self.b1 * cos_w + self.b2 * cos_2w;
+        let num_im = -(self.b1 * sin_w + self.b2 * sin_2w);
+        let den_re = 1.0 + self.a1 * cos_w + self.a2 * cos_2w;
+        let den_im = -(self.a1 * sin_w + self.a2 * sin_2w);
+        ((num_re * num_re + num_im * num_im) / (den_re * den_re + den_im * den_im)).sqrt()
+    }
+
     fn process(&mut self, sample: f32, channel: usize) -> f32 {
         let x0 = sample as f64;
         let z = &mut self.z[channel];
@@ -234,6 +247,30 @@ impl EqEffect {
         };
         fx.recompute();
         fx
+    }
+
+    /// Build an EQ from a parameter vector without touching audio
+    /// state; the UI uses this to evaluate the response curve.
+    pub fn from_params(sample_rate: f32, params: &[f32]) -> Self {
+        let mut fx = Self::new(sample_rate);
+        for (i, v) in params.iter().copied().enumerate().take(12) {
+            if let Some(d) = EQ_PARAMS.get(i) {
+                fx.params[i] = v.clamp(d.min, d.max);
+            }
+        }
+        fx.recompute();
+        fx
+    }
+
+    /// Combined magnitude response of all four bands at `freq_hz`,
+    /// in dB. Drawing-time helper; not for the audio thread.
+    pub fn response_db(&self, freq_hz: f32) -> f32 {
+        let w = 2.0 * std::f64::consts::PI * freq_hz as f64 / self.sample_rate as f64;
+        let mag = self.lf.magnitude_at(w)
+            * self.lmf.magnitude_at(w)
+            * self.hmf.magnitude_at(w)
+            * self.hf.magnitude_at(w);
+        (20.0 * mag.max(1e-9).log10()) as f32
     }
 
     fn recompute(&mut self) {
@@ -312,6 +349,46 @@ mod tests {
         (0..n)
             .map(|i| ((i as f32 / sr) * freq * std::f32::consts::TAU).sin() * 0.2)
             .collect()
+    }
+
+    #[test]
+    fn response_curve_matches_the_settings() {
+        // Flat EQ: ~0 dB everywhere.
+        let flat = EqEffect::new(48_000.0);
+        for f in [30.0, 200.0, 1_000.0, 8_000.0, 18_000.0] {
+            assert!(
+                flat.response_db(f).abs() < 0.05,
+                "flat response at {f} Hz should be ~0 dB"
+            );
+        }
+
+        // LF shelf boost: +12 dB below the corner, ~0 dB well above.
+        let mut params: Vec<f32> = EQ_PARAMS.iter().map(|d| d.default).collect();
+        params[0] = 12.0; // LF gain
+        params[1] = 120.0; // LF freq
+        let boosted = EqEffect::from_params(48_000.0, &params);
+        assert!(
+            boosted.response_db(40.0) > 10.0,
+            "lows should read near +12 dB, got {}",
+            boosted.response_db(40.0)
+        );
+        assert!(
+            boosted.response_db(8_000.0).abs() < 0.5,
+            "highs should stay flat under an LF shelf, got {}",
+            boosted.response_db(8_000.0)
+        );
+
+        // HMF bell cut reads back at its center.
+        params[0] = 0.0;
+        params[6] = -9.0; // HMF gain
+        params[7] = 2_000.0; // HMF freq
+        params[8] = 1.5; // Q
+        let cut = EqEffect::from_params(48_000.0, &params);
+        assert!(
+            cut.response_db(2_000.0) < -8.0,
+            "bell center should read near -9 dB, got {}",
+            cut.response_db(2_000.0)
+        );
     }
 
     #[test]

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -90,6 +90,10 @@ pub enum EngineCommand {
 
     // -- Infrastructure --
     SetSampleRate(u32),
+    /// Select which track streams post-effects samples to the UI
+    /// spectrum analyser ring (`None` disables the tap).
+    /// `TrackId::MASTER` taps the summed master bus.
+    SetSpectrumTap(Option<TrackId>),
 
     // -- Effects --
     AddEffect {

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use rtrb::{Consumer, Producer, RingBuffer};
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::constants::RING_BUFFER_CAPACITY;
+use vibez_core::id::TrackId;
 
 use vibez_core::time::TempoMap;
 use vibez_dsp::factory::create_effect;
@@ -16,6 +17,10 @@ use crate::mixer::{
     EngineTrack,
 };
 use crate::transport::Transport;
+
+/// Capacity of the UI spectrum-analyser sample ring: roughly a third
+/// of a second of mono audio at 48 kHz, ample for a 60 fps drain.
+const SPECTRUM_RING_CAPACITY: usize = 16_384;
 
 /// The real-time audio engine.
 ///
@@ -39,6 +44,17 @@ pub struct AudioEngine {
     audio: Option<Arc<DecodedAudio>>,
     /// Multi-track state.
     tracks: Vec<EngineTrack>,
+    /// The master bus: a track-shaped channel (gain + effect chain,
+    /// no clips or instrument) applied to the summed mix. Addressed
+    /// by commands via [`TrackId::MASTER`].
+    master: EngineTrack,
+    /// Which track streams samples to the UI spectrum analyser.
+    spectrum_track: Option<TrackId>,
+    /// Producer side of the spectrum ring (mono samples).
+    spectrum_tx: Producer<f32>,
+    /// Consumer side, parked here until the UI takes it before the
+    /// engine moves to the audio thread.
+    spectrum_rx: Option<Consumer<f32>>,
     /// One-shot sample preview, bypasses transport and soloed/muted state.
     preview: Option<PreviewVoice>,
     sample_rate: u32,
@@ -67,11 +83,16 @@ impl AudioEngine {
     pub fn new() -> (Self, Producer<EngineCommand>, Consumer<EngineEvent>) {
         let (cmd_tx, cmd_rx) = RingBuffer::<EngineCommand>::new(RING_BUFFER_CAPACITY);
         let (event_tx, event_rx) = RingBuffer::<EngineEvent>::new(RING_BUFFER_CAPACITY);
+        let (spectrum_tx, spectrum_rx) = RingBuffer::<f32>::new(SPECTRUM_RING_CAPACITY);
 
         let engine = Self {
             transport: Transport::new(),
             audio: None,
             tracks: Vec::new(),
+            master: EngineTrack::new(TrackId::MASTER),
+            spectrum_track: None,
+            spectrum_tx,
+            spectrum_rx: Some(spectrum_rx),
             preview: None,
             sample_rate: 44100,
             cmd_rx,
@@ -80,6 +101,13 @@ impl AudioEngine {
         };
 
         (engine, cmd_tx, event_rx)
+    }
+
+    /// Take the consumer side of the spectrum-analyser ring. Must be
+    /// called on the UI thread before the engine moves to the audio
+    /// thread; returns `None` if already taken.
+    pub fn take_spectrum_consumer(&mut self) -> Option<Consumer<f32>> {
+        self.spectrum_rx.take()
     }
 
     /// Process one audio callback worth of data.
@@ -109,6 +137,23 @@ impl AudioEngine {
         } else {
             // ---- 4. Legacy single-audio path ----------------------------
             self.process_legacy(output, frames, channels);
+        }
+
+        // ---- 4.4 Master bus: effect chain + gain over the summed mix.
+        // Runs whether or not the transport is playing so queued
+        // plugin params are delivered and tails ring out, matching
+        // the per-track idle behavior.
+        for slot in &mut self.master.effects {
+            if !slot.bypass {
+                slot.effect.process(output, channels);
+            }
+        }
+        if (self.master.gain - 1.0).abs() > f32::EPSILON {
+            let gain = self.master.gain;
+            output.iter_mut().for_each(|s| *s *= gain);
+        }
+        if self.spectrum_track == Some(self.master.id) {
+            push_spectrum(&mut self.spectrum_tx, output, channels);
         }
 
         // ---- 4.5 Preview channel (bypasses transport) -------------------
@@ -170,6 +215,17 @@ impl AudioEngine {
     // ------------------------------------------------------------------
     // Private helpers
     // ------------------------------------------------------------------
+
+    /// Resolve a command's target channel: the master bus for
+    /// [`TrackId::MASTER`], otherwise the matching track. Only used
+    /// by commands that make sense on both (gain, effect chain).
+    fn channel_mut(&mut self, id: TrackId) -> Option<&mut EngineTrack> {
+        if id.is_master() {
+            Some(&mut self.master)
+        } else {
+            self.tracks.iter_mut().find(|t| t.id == id)
+        }
+    }
 
     /// Multi-track rendering: render each track, apply gain/pan, sum into output.
     ///
@@ -274,6 +330,13 @@ impl AudioEngine {
 
             if rendered {
                 track.process_effects(frames, channels);
+                if self.spectrum_track == Some(track.id) {
+                    push_spectrum(
+                        &mut self.spectrum_tx,
+                        &track.mix_buffer[..frames * channels],
+                        channels,
+                    );
+                }
             }
 
             if !rendered {
@@ -521,7 +584,7 @@ impl AudioEngine {
                     self.recalculate_audio_length();
                 }
                 EngineCommand::SetTrackGain(id, gain) => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == id) {
+                    if let Some(track) = self.channel_mut(id) {
                         track.gain = gain;
                     }
                 }
@@ -558,6 +621,9 @@ impl AudioEngine {
                 EngineCommand::SetSampleRate(sr) => {
                     self.sample_rate = sr;
                 }
+                EngineCommand::SetSpectrumTap(target) => {
+                    self.spectrum_track = target;
+                }
 
                 // -- Effects --
                 EngineCommand::AddEffect {
@@ -566,8 +632,8 @@ impl AudioEngine {
                     effect_type,
                     position,
                 } => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        let effect = create_effect(effect_type, self.sample_rate as f32);
+                    let effect = create_effect(effect_type, self.sample_rate as f32);
+                    if let Some(track) = self.channel_mut(track_id) {
                         let slot = EffectSlot {
                             id: effect_id,
                             effect,
@@ -582,11 +648,15 @@ impl AudioEngine {
                     }
                 }
                 EngineCommand::RemoveEffect(track_id, effect_id) => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(pos) = track.effects.iter().position(|e| e.id == effect_id) {
-                            let slot = track.effects.remove(pos);
-                            self.dispose_effect(slot.effect);
-                        }
+                    let removed = self.channel_mut(track_id).and_then(|track| {
+                        track
+                            .effects
+                            .iter()
+                            .position(|e| e.id == effect_id)
+                            .map(|pos| track.effects.remove(pos))
+                    });
+                    if let Some(slot) = removed {
+                        self.dispose_effect(slot.effect);
                     }
                 }
                 EngineCommand::SetEffectParam {
@@ -595,7 +665,7 @@ impl AudioEngine {
                     param_index,
                     value,
                 } => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                    if let Some(track) = self.channel_mut(track_id) {
                         if let Some(slot) = track.effects.iter_mut().find(|e| e.id == effect_id) {
                             slot.effect.set_param(param_index, value);
                         }
@@ -606,7 +676,7 @@ impl AudioEngine {
                     effect_id,
                     bypass,
                 } => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                    if let Some(track) = self.channel_mut(track_id) {
                         if let Some(slot) = track.effects.iter_mut().find(|e| e.id == effect_id) {
                             slot.bypass = bypass;
                         }
@@ -617,7 +687,7 @@ impl AudioEngine {
                     effect_id,
                     new_index,
                 } => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                    if let Some(track) = self.channel_mut(track_id) {
                         if let Some(old_idx) = track.effects.iter().position(|e| e.id == effect_id)
                         {
                             let slot = track.effects.remove(old_idx);
@@ -878,7 +948,7 @@ impl AudioEngine {
                     effect,
                     position,
                 } => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                    if let Some(track) = self.channel_mut(track_id) {
                         let slot = EffectSlot {
                             id: effect_id,
                             effect,
@@ -948,6 +1018,13 @@ impl AudioEngine {
                 track.clear_buffer(frames, channels);
             }
             track.process_effects(frames, channels);
+            if self.spectrum_track == Some(track.id) {
+                push_spectrum(
+                    &mut self.spectrum_tx,
+                    &track.mix_buffer[..frames * channels],
+                    channels,
+                );
+            }
             let gain = track.gain;
             let (pan_l, pan_r) = equal_power_pan(track.pan);
             let buf_size = frames * channels;
@@ -1007,6 +1084,22 @@ impl AudioEngine {
         } else if self.audio.is_none() {
             // Only clear audio length if no legacy audio is loaded
             self.transport.set_audio_length(None);
+        }
+    }
+}
+
+/// Stream a block to the UI spectrum analyser as mono samples.
+/// Lock-free and allocation-free; drops samples when the ring is
+/// full (the UI drains at 60 fps, so sustained overflow just means
+/// the analyser skips audio it would have averaged away anyway).
+fn push_spectrum(tx: &mut Producer<f32>, buffer: &[f32], channels: usize) {
+    if channels >= 2 {
+        for frame in buffer.chunks_exact(channels) {
+            let _ = tx.push((frame[0] + frame[1]) * 0.5);
+        }
+    } else {
+        for &s in buffer {
+            let _ = tx.push(s);
         }
     }
 }

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use vibez_core::audio_buffer::DecodedAudio;
-use vibez_core::id::{ClipId, TrackId};
+use vibez_core::id::{ClipId, EffectId, TrackId};
 
 /// Helper to create a simple stereo decoded audio with a known pattern.
 fn make_test_audio(frames: usize) -> Arc<DecodedAudio> {
@@ -1214,5 +1214,177 @@ fn effect_tails_ring_out_after_stop() {
     assert!(
         tail > 0.01,
         "delay tail should ring out after stop, got {tail}"
+    );
+}
+
+#[test]
+fn master_gain_scales_the_summed_mix() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let tid = TrackId::new();
+    let cid = ClipId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddClip {
+            track_id: tid,
+            clip_id: cid,
+            audio: make_constant_audio(100, 0.5),
+            position: 0,
+            source_offset: 0,
+            duration: 100,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetTrackGain(TrackId::MASTER, 0.5))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut buf = vec![0.0f32; 16];
+    engine.process(&mut buf, 2);
+
+    let expected = 0.5 * std::f32::consts::FRAC_1_SQRT_2 * 0.5;
+    assert!(
+        (buf[0] - expected).abs() < 1e-4,
+        "master gain 0.5 should halve the mix: expected {expected} got {}",
+        buf[0]
+    );
+}
+
+#[test]
+fn master_effect_chain_processes_the_summed_mix() {
+    use vibez_core::effect::EffectType;
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let tid = TrackId::new();
+    let cid = ClipId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddClip {
+            track_id: tid,
+            clip_id: cid,
+            audio: make_constant_audio(4_096, 0.5),
+            position: 0,
+            source_offset: 0,
+            duration: 4_096,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+    // A master EQ with the LF shelf slammed down should attenuate a
+    // constant (DC-heavy) signal relative to the flat default.
+    let eq_id = EffectId::new();
+    cmd_tx
+        .push(EngineCommand::AddEffect {
+            track_id: TrackId::MASTER,
+            effect_id: eq_id,
+            effect_type: EffectType::Eq,
+            position: None,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetEffectParam {
+            track_id: TrackId::MASTER,
+            effect_id: eq_id,
+            param_index: 0, // LF gain
+            value: -15.0,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetEffectParam {
+            track_id: TrackId::MASTER,
+            effect_id: eq_id,
+            param_index: 1, // LF freq up to make the cut obvious
+            value: 450.0,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut buf = vec![0.0f32; 2_048];
+    let mut last_rms = 0.0f32;
+    for _ in 0..3 {
+        buf.fill(0.0);
+        engine.process(&mut buf, 2);
+        last_rms = (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt();
+    }
+    let flat = 0.5 * std::f32::consts::FRAC_1_SQRT_2;
+    assert!(
+        last_rms < flat * 0.5,
+        "master LF cut should attenuate the constant mix well below {flat}, got {last_rms}"
+    );
+
+    // Bypassing the master EQ restores the flat mix.
+    cmd_tx
+        .push(EngineCommand::SetEffectBypass {
+            track_id: TrackId::MASTER,
+            effect_id: eq_id,
+            bypass: true,
+        })
+        .unwrap();
+    buf.fill(0.0);
+    engine.process(&mut buf, 2);
+    assert!(
+        (buf[0] - flat).abs() < 1e-3,
+        "bypassed master chain should pass the mix through, got {}",
+        buf[0]
+    );
+}
+
+#[test]
+fn spectrum_tap_streams_track_samples() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let mut spectrum_rx = engine.take_spectrum_consumer().unwrap();
+    let tid = TrackId::new();
+    let cid = ClipId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(tid, "T".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddClip {
+            track_id: tid,
+            clip_id: cid,
+            audio: make_constant_audio(10_000, 0.5),
+            position: 0,
+            source_offset: 0,
+            duration: 10_000,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetSpectrumTap(Some(tid)))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut buf = vec![0.0f32; 1024];
+    engine.process(&mut buf, 2);
+
+    let mut peak = 0.0f32;
+    let mut count = 0;
+    while let Ok(s) = spectrum_rx.pop() {
+        peak = peak.max(s.abs());
+        count += 1;
+    }
+    assert_eq!(count, 512, "one mono sample per frame");
+    assert!(peak > 0.4, "tap should carry the clip audio, got {peak}");
+
+    // Retarget to master: still streams (the summed mix).
+    cmd_tx
+        .push(EngineCommand::SetSpectrumTap(Some(TrackId::MASTER)))
+        .unwrap();
+    engine.process(&mut buf, 2);
+    let mut master_peak = 0.0f32;
+    while let Ok(s) = spectrum_rx.pop() {
+        master_peak = master_peak.max(s.abs());
+    }
+    assert!(
+        master_peak > 0.3,
+        "master tap should carry the mix, got {master_peak}"
     );
 }

--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -47,6 +47,9 @@ pub enum BounceMode {
 /// decoded audio for every asset referenced by the snapshot.
 pub struct BounceRequest {
     pub tracks: Vec<TrackInfo>,
+    /// Master bus (gain + effect chain), applied to the summed mix
+    /// in [`BounceMode::Master`] renders.
+    pub master: Option<TrackInfo>,
     pub audio_clips: Vec<ClipInfo>,
     pub note_clips: Vec<NoteClipInfo>,
     pub clip_audio: HashMap<ClipId, Arc<DecodedAudio>>,
@@ -196,6 +199,35 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
     let total_frames = end.saturating_sub(start) as usize;
     let has_solo = matches!(req.mode, BounceMode::Master) && any_solo(&tracks);
 
+    // Master bus chain + gain, applied to the summed mix so the
+    // export matches live playback. Only master-mode renders route
+    // through it (single-track/clip bounces are pre-master stems).
+    let mut master_fx: Vec<EffectSlot> = Vec::new();
+    let mut master_gain = 1.0f32;
+    if matches!(req.mode, BounceMode::Master) {
+        if let Some(info) = &req.master {
+            master_gain = info.gain;
+            for fx_info in &info.effects {
+                if fx_info.plugin.is_some() {
+                    warnings.push(format!(
+                        "Master plugin effect '{}' not rendered offline",
+                        fx_info
+                            .plugin
+                            .as_ref()
+                            .map(|d| d.name.as_str())
+                            .unwrap_or("?")
+                    ));
+                    continue;
+                }
+                master_fx.push(EffectSlot {
+                    id: fx_info.id,
+                    effect: create_effect_with_params(fx_info.effect_type, sr_f32, &fx_info.params),
+                    bypass: fx_info.bypass,
+                });
+            }
+        }
+    }
+
     let mut out_l = Vec::with_capacity(total_frames);
     let mut out_r = Vec::with_capacity(total_frames);
 
@@ -238,6 +270,15 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
                 scratch[idx] += track.mix_buffer[idx] * gain * pan_l;
                 scratch[idx + 1] += track.mix_buffer[idx + 1] * gain * pan_r;
             }
+        }
+
+        for slot in &mut master_fx {
+            if !slot.bypass {
+                slot.effect.process(scratch, CHANNELS);
+            }
+        }
+        if (master_gain - 1.0).abs() > f32::EPSILON {
+            scratch.iter_mut().for_each(|s| *s *= master_gain);
         }
 
         for frame in 0..block {
@@ -338,6 +379,7 @@ mod tests {
         clip_audio.insert(cid, audio);
 
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: vec![clip],
             note_clips: Vec::new(),
@@ -386,6 +428,7 @@ mod tests {
         clip_audio.insert(cid, audio);
 
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: vec![clip],
             note_clips: Vec::new(),
@@ -427,6 +470,7 @@ mod tests {
         let mut clip_audio = HashMap::new();
         clip_audio.insert(cid, audio);
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: vec![clip],
             note_clips: Vec::new(),
@@ -488,6 +532,7 @@ mod tests {
         clip_audio.insert(cid_b, audio_b);
 
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: vec![clip_a, clip_b],
             note_clips: Vec::new(),
@@ -544,6 +589,7 @@ mod tests {
             }],
         };
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: Vec::new(),
             note_clips: vec![note_clip],
@@ -578,6 +624,7 @@ mod tests {
             automation: Vec::new(),
         };
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: Vec::new(),
             note_clips: Vec::new(),
@@ -628,6 +675,7 @@ mod tests {
         clip_audio.insert(cid, audio);
 
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: vec![clip],
             note_clips: Vec::new(),

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -14,6 +14,10 @@ pub struct Project {
     pub clips: Vec<ClipInfo>,
     #[serde(default)]
     pub note_clips: Vec<NoteClipInfo>,
+    /// The master bus channel (gain + effect chain). Absent in
+    /// projects saved before the master was a real channel.
+    #[serde(default)]
+    pub master: Option<TrackInfo>,
 }
 
 impl Default for Project {
@@ -25,6 +29,7 @@ impl Default for Project {
             tracks: Vec::new(),
             clips: Vec::new(),
             note_clips: Vec::new(),
+            master: None,
         }
     }
 }
@@ -156,6 +161,7 @@ mod tests {
         let path = dir.path().join("test.vibez");
 
         let project = Project {
+            master: None,
             name: "Test Project".into(),
             bpm: 140.0,
             sample_rate: 48_000,
@@ -261,6 +267,7 @@ mod tests {
 
         let tid = TrackId::new();
         let project = Project {
+            master: None,
             name: "Note Test".into(),
             bpm: 128.0,
             sample_rate: 44_100,
@@ -323,6 +330,7 @@ mod tests {
         });
 
         let project = Project {
+            master: None,
             name: "FX Test".into(),
             bpm: 120.0,
             sample_rate: 44_100,
@@ -368,6 +376,7 @@ mod automation_persistence_tests {
         track.automation.push(lane.clone());
 
         let project = Project {
+            master: None,
             name: "roundtrip".to_string(),
             tracks: vec![track],
             ..Default::default()

--- a/crates/vibez-ui/examples/make_demo.rs
+++ b/crates/vibez-ui/examples/make_demo.rs
@@ -151,6 +151,7 @@ fn main() {
     note_clips.push(clip(lead.id, "Hook", 32.0, 16.0, notes));
 
     let project = Project {
+        master: None,
         name: "Neon Skyline".to_string(),
         bpm: 124.0,
         sample_rate: 48_000,

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -375,6 +375,9 @@ impl App {
                     EngineEvent::Metering { peak_l, peak_r, .. } => {
                         self.state.peak_l = peak_l.max(self.state.peak_l * 0.85);
                         self.state.peak_r = peak_r.max(self.state.peak_r * 0.85);
+                        // The master strip meters the same summed mix.
+                        self.state.arrangement.master.peak_l = self.state.peak_l;
+                        self.state.arrangement.master.peak_r = self.state.peak_r;
                     }
                     EngineEvent::PlaybackStopped => {
                         self.state.transport.playing = false;
@@ -397,10 +400,48 @@ impl App {
         }
     }
 
+    /// Keep the engine's spectrum tap on the selected track and pump
+    /// drained samples through the analyser.
+    fn poll_spectrum(&mut self) {
+        let wanted = self.state.arrangement.selected_track;
+        if wanted != self.spectrum_tap {
+            self.send_command(EngineCommand::SetSpectrumTap(wanted));
+            self.spectrum_tap = wanted;
+            self.state.spectrum.reset();
+        }
+        if let Some(ref mut rx) = self.spectrum_rx {
+            // Drain in slices; the ring holds well under a second.
+            let mut chunk = [0.0f32; 512];
+            loop {
+                let mut n = 0;
+                while n < chunk.len() {
+                    match rx.pop() {
+                        Ok(s) => {
+                            chunk[n] = s;
+                            n += 1;
+                        }
+                        Err(_) => break,
+                    }
+                }
+                if n == 0 {
+                    break;
+                }
+                self.state.spectrum.ingest(&chunk[..n]);
+                if n < chunk.len() {
+                    break;
+                }
+            }
+        }
+        self.state
+            .spectrum
+            .analyse(self.state.transport.sample_rate as f32);
+    }
+
     /// One frame of the 60fps subscription: drain engine events and
     /// pump every background service.
     pub(super) fn handle_tick(&mut self) -> Task<Message> {
         self.poll_engine_events();
+        self.poll_spectrum();
         self.poll_plugin_loads();
         self.poll_plugin_windows();
         self.poll_midi_input();

--- a/crates/vibez-ui/src/app/bounce.rs
+++ b/crates/vibez-ui/src/app/bounce.rs
@@ -96,6 +96,7 @@ impl App {
 
         let request = vibez_engine::render::BounceRequest {
             tracks: project.tracks,
+            master: project.master,
             audio_clips: project.clips,
             note_clips: project.note_clips,
             clip_audio: assets.clips,

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -35,6 +35,12 @@ struct App {
     state: AppState,
     cmd_tx: Option<Producer<EngineCommand>>,
     event_rx: Option<Consumer<EngineEvent>>,
+    /// Post-effects mono samples from the engine's spectrum tap,
+    /// feeding the EQ analyser.
+    spectrum_rx: Option<Consumer<f32>>,
+    /// Track the engine tap currently points at, so tick can retarget
+    /// it when the selection moves.
+    spectrum_tap: Option<vibez_core::id::TrackId>,
     _stream: Option<AudioOutputStream>,
     // Channels for receiving loaded plugins from background threads
     plugin_effect_rx: std::sync::mpsc::Receiver<PluginLoadResult>,
@@ -118,7 +124,8 @@ mod views_shell;
 
 impl App {
     fn new() -> (Self, Task<Message>) {
-        let (engine, cmd_tx, event_rx) = AudioEngine::new();
+        let (mut engine, cmd_tx, event_rx) = AudioEngine::new();
+        let spectrum_rx = engine.take_spectrum_consumer();
         let ui_settings = UiSettings::load();
 
         let (stream, sample_rate) = match AudioOutputStream::open(engine, Some(512)) {
@@ -187,6 +194,8 @@ impl App {
             state,
             cmd_tx: Some(cmd_tx),
             event_rx: Some(event_rx),
+            spectrum_rx,
+            spectrum_tap: None,
             _stream: stream,
             plugin_effect_rx,
             plugin_effect_tx,
@@ -204,6 +213,10 @@ impl App {
 
         // Inform the engine of the actual sample rate
         app.send_command(EngineCommand::SetBpm(app.state.transport.bpm));
+
+        // Console model: the master bus carries its channel EQ from
+        // the first frame.
+        app.ensure_master_eq();
 
         let startup_task = if app.state.browser.roots.is_empty() {
             Task::none()

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -35,6 +35,7 @@ impl App {
         }
 
         self.state.arrangement.tracks.clear();
+        self.reset_master_channel();
         // The engine drops all plugin instances with their tracks;
         // their GUI windows and stale raw pointers must go with them
         // (pumping a closed plugin's run-loop timers segfaults).
@@ -62,8 +63,47 @@ impl App {
         self.state.view.edit_name_text.clear();
     }
 
+    /// Tear the master bus back to a bare channel: engine chain
+    /// cleared, gain at unity, fresh UI model. Callers re-attach the
+    /// channel EQ (or load a saved chain) afterwards.
+    pub(super) fn reset_master_channel(&mut self) {
+        let effect_ids: Vec<EffectId> = self
+            .state
+            .arrangement
+            .master
+            .effects
+            .iter()
+            .map(|e| e.id)
+            .collect();
+        for effect_id in effect_ids {
+            self.send_command(EngineCommand::RemoveEffect(TrackId::MASTER, effect_id));
+        }
+        self.state.arrangement.master = crate::state::new_master_track();
+        self.send_command(EngineCommand::SetTrackGain(TrackId::MASTER, 1.0));
+    }
+
+    /// Console model: the master bus always carries its channel EQ.
+    /// Attaches a flat one when missing (fresh session, old project).
+    pub(super) fn ensure_master_eq(&mut self) {
+        let has_eq = self
+            .state
+            .arrangement
+            .master
+            .effects
+            .iter()
+            .any(|e| e.effect_type == EffectType::Eq && e.plugin_ref.is_none());
+        if !has_eq {
+            let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+            crate::domains::arrangement::attach_channel_eq(
+                &mut engine,
+                &mut self.state.arrangement.master,
+            );
+        }
+    }
+
     pub(super) fn reset_to_new_project(&mut self) {
         self.clear_project_runtime();
+        self.ensure_master_eq();
         self.state.transport.bpm = vibez_core::constants::DEFAULT_BPM;
         self.state.transport.bpm_text = format!("{:.0}", self.state.transport.bpm);
         self.send_command(EngineCommand::SetBpm(self.state.transport.bpm));
@@ -234,6 +274,7 @@ impl App {
             tracks,
             clips,
             note_clips,
+            master: Some(self.track_info_from_ui(&self.state.arrangement.master)),
         }
     }
 
@@ -252,6 +293,13 @@ impl App {
             .flat_map(|t| std::iter::once(t.id.raw()).chain(t.effects.iter().map(|e| e.id.raw())))
             .chain(loaded.project.clips.iter().map(|c| c.id.raw()))
             .chain(loaded.project.note_clips.iter().map(|c| c.id.raw()))
+            .chain(
+                loaded
+                    .project
+                    .master
+                    .iter()
+                    .flat_map(|m| m.effects.iter().map(|e| e.id.raw())),
+            )
             .max()
             .unwrap_or(0);
         vibez_core::id::ensure_ids_above(max_loaded_id);
@@ -443,6 +491,64 @@ impl App {
             self.state.arrangement.tracks.push(track);
         }
 
+        // Master bus: gain + effect chain from the file, then the
+        // channel-EQ backfill for projects saved before the master
+        // was a real channel. clear_project_runtime left it bare.
+        if let Some(master_info) = &loaded.project.master {
+            self.state.arrangement.master.gain = master_info.gain;
+            self.send_command(EngineCommand::SetTrackGain(
+                TrackId::MASTER,
+                master_info.gain,
+            ));
+            for (chain_pos, effect_info) in master_info.effects.iter().enumerate() {
+                if let Some(dev) = &effect_info.plugin {
+                    plugin_effect_requests.push((
+                        TrackId::MASTER,
+                        effect_info.id,
+                        chain_pos,
+                        dev.clone(),
+                    ));
+                    continue;
+                }
+                let fx = vibez_dsp::factory::create_effect_with_params(
+                    effect_info.effect_type,
+                    self.state.transport.sample_rate as f32,
+                    &effect_info.params,
+                );
+                let descriptors = fx.param_descriptors();
+                self.state.arrangement.master.effects.push(UiEffect {
+                    id: effect_info.id,
+                    effect_type: effect_info.effect_type,
+                    bypass: effect_info.bypass,
+                    params: effect_info.params.clone(),
+                    descriptors,
+                    plugin_name: None,
+                    has_plugin_gui: false,
+                    plugin_ref: None,
+                });
+                self.send_command(EngineCommand::AddEffect {
+                    track_id: TrackId::MASTER,
+                    effect_id: effect_info.id,
+                    effect_type: effect_info.effect_type,
+                    position: None,
+                });
+                for (idx, value) in effect_info.params.iter().copied().enumerate() {
+                    self.send_command(EngineCommand::SetEffectParam {
+                        track_id: TrackId::MASTER,
+                        effect_id: effect_info.id,
+                        param_index: idx,
+                        value,
+                    });
+                }
+                self.send_command(EngineCommand::SetEffectBypass {
+                    track_id: TrackId::MASTER,
+                    effect_id: effect_info.id,
+                    bypass: effect_info.bypass,
+                });
+            }
+        }
+        self.ensure_master_eq();
+
         for loaded_clip in loaded.clips {
             self.send_command(EngineCommand::AddClip {
                 track_id: loaded_clip.info.track_id,
@@ -589,6 +695,7 @@ impl App {
     pub(super) fn take_snapshot(&self) -> crate::state::ProjectSnapshot {
         crate::state::ProjectSnapshot {
             tracks: self.state.arrangement.tracks.clone(),
+            master: self.state.arrangement.master.clone(),
             bpm: self.state.transport.bpm,
             bpm_text: self.state.transport.bpm_text.clone(),
             loop_enabled: self.state.transport.loop_enabled,
@@ -634,7 +741,21 @@ impl App {
         for track_id in existing_track_ids {
             self.send_command(EngineCommand::RemoveTrack(track_id));
         }
+        // The master bus survives track teardown; clear its chain
+        // explicitly so the snapshot replay starts from bare.
+        let master_effect_ids: Vec<EffectId> = self
+            .state
+            .arrangement
+            .master
+            .effects
+            .iter()
+            .map(|e| e.id)
+            .collect();
+        for effect_id in master_effect_ids {
+            self.send_command(EngineCommand::RemoveEffect(TrackId::MASTER, effect_id));
+        }
 
+        self.state.arrangement.master = snapshot.master;
         self.state.arrangement.tracks = snapshot.tracks;
         self.state.transport.bpm = snapshot.bpm;
         self.state.transport.bpm_text = snapshot.bpm_text;
@@ -664,6 +785,8 @@ impl App {
         for track in &tracks {
             self.replay_track_to_engine(track);
         }
+        let master = self.state.arrangement.master.clone();
+        self.replay_track_to_engine(&master);
 
         // Reload plugin devices through the project-open pipeline;
         // they re-enter the chains at their recorded positions.
@@ -671,6 +794,13 @@ impl App {
     }
 
     pub(super) fn replay_track_to_engine(&mut self, track: &UiTrack) {
+        if track.id.is_master() {
+            // The master bus always exists in the engine: replay only
+            // its gain and effect chain.
+            self.send_command(EngineCommand::SetTrackGain(track.id, track.gain));
+            self.replay_effects_to_engine(track);
+            return;
+        }
         match track.kind {
             TrackKind::Audio => {
                 self.send_command(EngineCommand::AddTrack(track.id, track.name.clone()));
@@ -731,27 +861,7 @@ impl App {
             });
         }
 
-        for effect in &track.effects {
-            self.send_command(EngineCommand::AddEffect {
-                track_id: track.id,
-                effect_id: effect.id,
-                effect_type: effect.effect_type,
-                position: None,
-            });
-            for (idx, value) in effect.params.iter().copied().enumerate() {
-                self.send_command(EngineCommand::SetEffectParam {
-                    track_id: track.id,
-                    effect_id: effect.id,
-                    param_index: idx,
-                    value,
-                });
-            }
-            self.send_command(EngineCommand::SetEffectBypass {
-                track_id: track.id,
-                effect_id: effect.id,
-                bypass: effect.bypass,
-            });
-        }
+        self.replay_effects_to_engine(track);
 
         for clip in &track.clips {
             self.send_command(EngineCommand::AddClip {
@@ -787,6 +897,33 @@ impl App {
         }
     }
 
+    /// Replay a channel's built-in effect chain to the engine
+    /// (add, params, bypass). Plugin devices reload through the
+    /// async pipeline instead.
+    fn replay_effects_to_engine(&mut self, track: &UiTrack) {
+        for effect in &track.effects {
+            self.send_command(EngineCommand::AddEffect {
+                track_id: track.id,
+                effect_id: effect.id,
+                effect_type: effect.effect_type,
+                position: None,
+            });
+            for (idx, value) in effect.params.iter().copied().enumerate() {
+                self.send_command(EngineCommand::SetEffectParam {
+                    track_id: track.id,
+                    effect_id: effect.id,
+                    param_index: idx,
+                    value,
+                });
+            }
+            self.send_command(EngineCommand::SetEffectBypass {
+                track_id: track.id,
+                effect_id: effect.id,
+                bypass: effect.bypass,
+            });
+        }
+    }
+
     pub(super) fn handle_export_path_selected(&mut self, path: Option<PathBuf>) -> Task<Message> {
         let Some(mut path) = path else {
             return Task::none();
@@ -805,6 +942,7 @@ impl App {
         let bpm = self.state.transport.bpm;
         let request = vibez_engine::render::BounceRequest {
             tracks: project.tracks,
+            master: project.master,
             audio_clips: project.clips,
             note_clips: project.note_clips,
             clip_audio: assets.clips,

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
+use vibez_core::effect::EffectType;
 
 use iced::Task;
 
@@ -400,6 +401,37 @@ impl App {
                     track_id: track_info.id,
                     effect_id: effect_info.id,
                     bypass: effect_info.bypass,
+                });
+            }
+
+            // Console model: every channel has its EQ. Backfill for
+            // projects saved before the channel EQ existed.
+            if !track
+                .effects
+                .iter()
+                .any(|e| e.effect_type == EffectType::Eq && e.plugin_ref.is_none())
+            {
+                let effect_id = EffectId::new();
+                let fx = vibez_dsp::factory::create_effect(
+                    EffectType::Eq,
+                    self.state.transport.sample_rate as f32,
+                );
+                let descriptors = fx.param_descriptors();
+                track.effects.push(UiEffect {
+                    id: effect_id,
+                    effect_type: EffectType::Eq,
+                    bypass: false,
+                    params: descriptors.iter().map(|d| d.default).collect(),
+                    descriptors,
+                    plugin_name: None,
+                    has_plugin_gui: false,
+                    plugin_ref: None,
+                });
+                self.send_command(EngineCommand::AddEffect {
+                    track_id: track_info.id,
+                    effect_id,
+                    effect_type: EffectType::Eq,
+                    position: None,
                 });
             }
 

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -138,6 +138,7 @@ impl App {
                         msg,
                         &mut engine,
                         &mut self.state.arrangement.tracks,
+                        &mut self.state.arrangement.master,
                         sample_rate,
                     )
                 };
@@ -581,10 +582,9 @@ impl App {
                         .dropbox_client
                         .clone()
                         .map(|client| (client, self.dropbox_cache.clone()));
-                    return Task::perform(
-                        load_project_async(path, dropbox),
-                        Message::ProjectLoaded,
-                    );
+                    return Task::perform(load_project_async(path, dropbox), |result| {
+                        Message::ProjectLoaded(Box::new(result))
+                    });
                 }
             }
             Message::ProjectSavePathSelected(path) => {
@@ -596,7 +596,7 @@ impl App {
                     return Task::perform(save_project_async(path, project), Message::ProjectSaved);
                 }
             }
-            Message::ProjectLoaded(result) => match result {
+            Message::ProjectLoaded(result) => match *result {
                 Ok(loaded) => {
                     self.rebuild_from_loaded_project(loaded);
                 }
@@ -680,6 +680,12 @@ impl App {
                     let is_instrument = info.category.is_instrument();
                     let loading_name = info.name.clone();
 
+                    if is_instrument && track_id.is_master() {
+                        // The master bus hosts effects only.
+                        self.state.status_text =
+                            format!("{loading_name} is an instrument; Master takes effects only");
+                        return Task::none();
+                    }
                     if is_instrument {
                         let tx = self.plugin_instrument_tx.clone();
                         std::thread::spawn(move || {

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -68,7 +68,14 @@ impl App {
 
         // Effect cards
         for effect in &track.effects {
-            let slot = view_effect_slot(track_id, effect, track_color);
+            let custom = if effect.effect_type == vibez_core::effect::EffectType::Eq
+                && effect.plugin_ref.is_none()
+            {
+                Some(self.eq_device_body(track_id, effect))
+            } else {
+                None
+            };
+            let slot = view_effect_slot(track_id, effect, track_color, custom);
             devices_row = devices_row.push(slot);
         }
 
@@ -97,6 +104,142 @@ impl App {
                 },
             ))
             .into()
+    }
+
+    /// Channel EQ card body: response display over the live analyser
+    /// on the left, four color-coded band columns on the right. The
+    /// analyser follows the selected track, which is exactly the
+    /// track whose device chain is on screen.
+    fn eq_device_body<'a>(
+        &'a self,
+        track_id: TrackId,
+        effect: &'a crate::state::UiEffect,
+    ) -> (Element<'a, Message>, f32) {
+        use crate::widgets::effect_knob::{format_value, EffectKnobWidget};
+        use crate::widgets::eq_display::EqDisplayWidget;
+
+        const DISPLAY_W: f32 = 380.0;
+        const BAND_COL_W: f32 = 50.0;
+
+        let display = EqDisplayWidget {
+            track_id,
+            effect_id: effect.id,
+            params: effect.params.clone(),
+            descriptors: effect.descriptors,
+            bypass: effect.bypass,
+            sample_rate: self.state.transport.sample_rate as f32,
+            spectrum: self.state.spectrum.bins.clone(),
+            spectrum_active: self.state.spectrum.active,
+        };
+        let display_canvas: Element<'a, Message> = canvas(display)
+            .width(Length::Fixed(DISPLAY_W))
+            .height(Length::Fill)
+            .into();
+
+        // Band columns, left to right along the frequency axis:
+        // (label, gain idx, freq idx, third idx, bell?, color)
+        let bands: [(&str, usize, usize, usize, bool, Color); 4] = [
+            ("LF", 0, 1, 2, true, th::EQ_LF),
+            ("LMF", 3, 4, 5, false, th::EQ_LMF),
+            ("HMF", 6, 7, 8, false, th::EQ_HMF),
+            ("HF", 9, 10, 11, true, th::EQ_HF),
+        ];
+
+        let knob_color = if effect.bypass {
+            th::TEXT_MUTED
+        } else {
+            th::TEXT_DIM
+        };
+        let mut band_row = row![].spacing(4);
+        for (label, gain_i, freq_i, third_i, is_bell, color) in bands {
+            let band_color = if effect.bypass { knob_color } else { color };
+            let knob = |i: usize, size: f32| -> Element<'a, Message> {
+                let d = &effect.descriptors[i];
+                let w = EffectKnobWidget::new(
+                    track_id,
+                    effect.id,
+                    i,
+                    effect.params.get(i).copied().unwrap_or(d.default),
+                    d.min,
+                    d.max,
+                    d.default,
+                    band_color,
+                );
+                canvas(w)
+                    .width(Length::Fixed(size))
+                    .height(Length::Fixed(size))
+                    .into()
+            };
+            let gain_v = effect.params.get(gain_i).copied().unwrap_or(0.0);
+            let freq_v = effect.params.get(freq_i).copied().unwrap_or(0.0);
+
+            let mut col = column![
+                text(label).size(9).color(band_color),
+                knob(gain_i, 28.0),
+                text(format!("{gain_v:+.1}")).size(8).color(th::TEXT_DIM),
+                knob(freq_i, 24.0),
+                text(format_value(freq_v, "Hz")).size(8).color(th::TEXT_DIM),
+            ]
+            .spacing(2)
+            .width(Length::Fixed(BAND_COL_W))
+            .align_x(iced::Alignment::Center);
+
+            if is_bell {
+                let bell_on = effect.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
+                let bell = button(text("BELL").size(6).color(if bell_on {
+                    th::BG_DARK
+                } else {
+                    th::TEXT_DIM
+                }))
+                .on_press(Message::set_effect_param(
+                    track_id,
+                    effect.id,
+                    third_i,
+                    if bell_on { 0.0 } else { 1.0 },
+                ))
+                .padding([3, 6])
+                .style(move |_theme: &Theme, _status| button::Style {
+                    background: Some(if bell_on {
+                        band_color.into()
+                    } else {
+                        th::BG_ELEVATED.into()
+                    }),
+                    text_color: if bell_on { th::BG_DARK } else { th::TEXT_DIM },
+                    border: iced::Border {
+                        color: th::BORDER,
+                        width: 1.0,
+                        radius: 2.0.into(),
+                    },
+                    ..Default::default()
+                });
+                col = col.push(bell);
+            } else {
+                let q_v = effect.params.get(third_i).copied().unwrap_or(0.7);
+                col = col.push(
+                    row![
+                        text("Q").size(8).color(th::TEXT_DIM),
+                        knob(third_i, 20.0),
+                        text(format!("{q_v:.2}")).size(8).color(th::TEXT_DIM),
+                    ]
+                    .spacing(2)
+                    .align_y(iced::Alignment::Center),
+                );
+            }
+            band_row = band_row.push(col);
+        }
+
+        let body: Element<'a, Message> = row![
+            display_canvas,
+            Self::device_divider(),
+            container(band_row).padding([0, 2]),
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center)
+        .into();
+
+        // padding (20) + display + divider + bands + spacing
+        let card_w = DISPLAY_W + 4.0 * (BAND_COL_W + 4.0) + 48.0;
+        (body, card_w)
     }
 
     // ── Shared device card helpers ──────────────────────────────────

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -488,7 +488,8 @@ impl App {
         let mut strips = row![].spacing(4).padding(8).height(Length::Fill);
 
         for track in &self.state.arrangement.tracks {
-            let strip = view_mixer_strip(track);
+            let selected = self.state.arrangement.selected_track == Some(track.id);
+            let strip = view_mixer_strip(track, selected);
             strips = strips.push(strip);
         }
 

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -493,38 +493,17 @@ impl App {
             strips = strips.push(strip);
         }
 
-        // Master strip — pinned to far right
-        let master_label = text("Master").size(12).color(th::TEXT);
-        let master_meter = VuMeterWidget {
-            peak_l: self.state.peak_l,
-            peak_r: self.state.peak_r,
-        };
-        let master_meter_canvas: Element<'_, Message> = canvas(master_meter)
-            .width(Length::Fixed(32.0))
-            .height(Length::Fill)
-            .into();
+        // Master strip — a real channel, pinned to far right
+        let master_selected =
+            self.state.arrangement.selected_track == Some(vibez_core::id::TrackId::MASTER);
+        let master_strip = container(view_mixer_strip(
+            &self.state.arrangement.master,
+            master_selected,
+        ))
+        .padding(8)
+        .height(Length::Fill);
 
-        let master_col = column![master_label, master_meter_canvas]
-            .spacing(4)
-            .padding(8)
-            .width(Length::Fixed(100.0))
-            .height(Length::Fill)
-            .align_x(iced::Alignment::Center);
-
-        let master_container =
-            container(master_col)
-                .height(Length::Fill)
-                .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    border: iced::Border {
-                        color: th::BORDER,
-                        width: 1.0,
-                        radius: 2.0.into(),
-                    },
-                    ..Default::default()
-                });
-
-        let mixer_row = row![strips, horizontal_space(), master_container]
+        let mixer_row = row![strips, horizontal_space(), master_strip]
             .spacing(4)
             .padding([8, 4])
             .height(Length::Fill);

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -174,6 +174,31 @@ pub struct ArrangementCtx {
     pub playhead_beats: f64,
 }
 
+/// Every channel carries an SSL-style EQ, console style: create it
+/// flat (passthrough) alongside the track.
+fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut UiTrack) {
+    let effect_id = vibez_core::id::EffectId::new();
+    let effect_type = vibez_core::effect::EffectType::Eq;
+    let descriptors = vibez_dsp::factory::create_effect(effect_type, 48_000.0).param_descriptors();
+    let params: Vec<f32> = descriptors.iter().map(|d| d.default).collect();
+    track.effects.push(crate::state::UiEffect {
+        id: effect_id,
+        effect_type,
+        bypass: false,
+        params,
+        descriptors,
+        plugin_name: None,
+        has_plugin_gui: false,
+        plugin_ref: None,
+    });
+    engine.send(EngineCommand::AddEffect {
+        track_id: track.id,
+        effect_id,
+        effect_type,
+        position: None,
+    });
+}
+
 impl ArrangementState {
     fn find_track(&self, track_id: TrackId) -> Option<&UiTrack> {
         self.tracks.iter().find(|t| t.id == track_id)
@@ -228,7 +253,9 @@ impl ArrangementState {
                 let id = TrackId::new();
                 let name = format!("Track {track_num}");
                 engine.send(EngineCommand::AddTrack(id, name.clone()));
-                self.tracks.push(UiTrack::new(id, name, color_index));
+                let mut track = UiTrack::new(id, name, color_index);
+                attach_channel_eq(engine, &mut track);
+                self.tracks.push(track);
                 self.selected_track = Some(id);
                 action.status = Some(format!("{} tracks", self.tracks.len()));
             }
@@ -241,6 +268,7 @@ impl ArrangementState {
                 engine.send(EngineCommand::AddMidiTrack(id, name.clone()));
                 let mut track = UiTrack::new_instrument(id, name, TrackKind::Midi, color_index);
                 track.has_instrument = false;
+                attach_channel_eq(engine, &mut track);
                 self.tracks.push(track);
                 self.selected_track = Some(id);
                 action.status = Some(format!("{} tracks", self.tracks.len()));

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -175,8 +175,9 @@ pub struct ArrangementCtx {
 }
 
 /// Every channel carries an SSL-style EQ, console style: create it
-/// flat (passthrough) alongside the track.
-fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut UiTrack) {
+/// flat (passthrough) alongside the track. Also used for the master
+/// bus, which is why it is crate-visible.
+pub(crate) fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut UiTrack) {
     let effect_id = vibez_core::id::EffectId::new();
     let effect_type = vibez_core::effect::EffectType::Eq;
     let descriptors = vibez_dsp::factory::create_effect(effect_type, 48_000.0).param_descriptors();
@@ -201,6 +202,9 @@ fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut UiTrack) {
 
 impl ArrangementState {
     fn find_track(&self, track_id: TrackId) -> Option<&UiTrack> {
+        if track_id.is_master() {
+            return Some(&self.master);
+        }
         self.tracks.iter().find(|t| t.id == track_id)
     }
 
@@ -217,6 +221,9 @@ impl ArrangementState {
     }
 
     fn find_track_mut(&mut self, track_id: TrackId) -> Option<&mut UiTrack> {
+        if track_id.is_master() {
+            return Some(&mut self.master);
+        }
         self.tracks.iter_mut().find(|t| t.id == track_id)
     }
 
@@ -274,6 +281,10 @@ impl ArrangementState {
                 action.status = Some(format!("{} tracks", self.tracks.len()));
             }
             ArrangementMsg::RemoveTrack(track_id) => {
+                if track_id.is_master() {
+                    // The master bus cannot be deleted.
+                    return action;
+                }
                 let removed_name = self
                     .tracks
                     .iter()

--- a/crates/vibez-ui/src/domains/devices.rs
+++ b/crates/vibez-ui/src/domains/devices.rs
@@ -31,6 +31,9 @@ pub enum DevicesMsg {
     AddEffect(TrackId, EffectType),
     RemoveEffect(TrackId, EffectId),
     SetEffectParam(TrackId, EffectId, usize, f32),
+    /// Set several parameters of one effect atomically (the EQ
+    /// display drags frequency and gain together).
+    SetEffectParams(TrackId, EffectId, Vec<(usize, f32)>),
     ToggleEffectBypass(TrackId, EffectId),
     MoveEffectUp(TrackId, EffectId),
     MoveEffectDown(TrackId, EffectId),
@@ -115,7 +118,14 @@ pub fn default_instrument_params(kind: InstrumentKind, sample_rate: f32) -> Vec<
         .collect()
 }
 
-fn find_track_mut(tracks: &mut [UiTrack], track_id: TrackId) -> Option<&mut UiTrack> {
+fn find_track_mut<'a>(
+    tracks: &'a mut [UiTrack],
+    master: &'a mut UiTrack,
+    track_id: TrackId,
+) -> Option<&'a mut UiTrack> {
+    if track_id.is_master() {
+        return Some(master);
+    }
     tracks.iter_mut().find(|t| t.id == track_id)
 }
 
@@ -147,6 +157,7 @@ impl DevicesState {
         msg: DevicesMsg,
         engine: &mut impl EngineHandle,
         tracks: &mut [UiTrack],
+        master: &mut UiTrack,
         sample_rate: u32,
     ) -> DevicesAction {
         let mut action = DevicesAction::default();
@@ -157,7 +168,7 @@ impl DevicesState {
                 let descriptors = fx.param_descriptors();
                 let params: Vec<f32> = descriptors.iter().map(|d| d.default).collect();
 
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     track.effects.push(UiEffect {
                         id: effect_id,
                         effect_type,
@@ -179,7 +190,7 @@ impl DevicesState {
                 action.status = Some(format!("Added {} effect", effect_type.name()));
             }
             DevicesMsg::RemoveEffect(track_id, effect_id) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     track.effects.retain(|e| e.id != effect_id);
                 }
                 engine.send(EngineCommand::RemoveEffect(track_id, effect_id));
@@ -190,7 +201,7 @@ impl DevicesState {
                 action.status = Some("Removed effect".to_string());
             }
             DevicesMsg::SetEffectParam(track_id, effect_id, param_index, value) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(effect) = track.effects.iter_mut().find(|e| e.id == effect_id) {
                         if param_index < effect.params.len() {
                             let desc = &effect.descriptors[param_index];
@@ -206,8 +217,27 @@ impl DevicesState {
                     }
                 }
             }
+            DevicesMsg::SetEffectParams(track_id, effect_id, updates) => {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
+                    if let Some(effect) = track.effects.iter_mut().find(|e| e.id == effect_id) {
+                        for (param_index, value) in updates {
+                            if param_index < effect.params.len() {
+                                let desc = &effect.descriptors[param_index];
+                                let clamped = value.clamp(desc.min, desc.max);
+                                effect.params[param_index] = clamped;
+                                engine.send(EngineCommand::SetEffectParam {
+                                    track_id,
+                                    effect_id,
+                                    param_index,
+                                    value: clamped,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
             DevicesMsg::ToggleEffectBypass(track_id, effect_id) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(effect) = track.effects.iter_mut().find(|e| e.id == effect_id) {
                         effect.bypass = !effect.bypass;
                         engine.send(EngineCommand::SetEffectBypass {
@@ -219,7 +249,7 @@ impl DevicesState {
                 }
             }
             DevicesMsg::MoveEffectUp(track_id, effect_id) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(idx) = track.effects.iter().position(|e| e.id == effect_id) {
                         if idx > 0 {
                             track.effects.swap(idx, idx - 1);
@@ -233,7 +263,7 @@ impl DevicesState {
                 }
             }
             DevicesMsg::MoveEffectDown(track_id, effect_id) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(idx) = track.effects.iter().position(|e| e.id == effect_id) {
                         if idx + 1 < track.effects.len() {
                             track.effects.swap(idx, idx + 1);
@@ -247,9 +277,13 @@ impl DevicesState {
                 }
             }
             DevicesMsg::SetTrackInstrument(track_id, instrument_kind) => {
+                if track_id.is_master() {
+                    // The master bus hosts effects only.
+                    return action;
+                }
                 let instrument_params =
                     default_instrument_params(instrument_kind, sample_rate as f32);
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     track.has_instrument = true;
                     track.instrument_kind = Some(instrument_kind);
                     track.sample_name = None;
@@ -271,7 +305,7 @@ impl DevicesState {
                 action.status = Some(format!("Added {}", instrument_kind.name()));
             }
             DevicesMsg::RemoveTrackInstrument(track_id) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     track.has_instrument = false;
                     track.instrument_kind = None;
                     track.sample_name = None;
@@ -287,7 +321,7 @@ impl DevicesState {
                 action.status = Some("Removed instrument".to_string());
             }
             DevicesMsg::SetInstrumentParam(track_id, param_index, value) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if param_index < track.instrument_params.len() {
                         track.instrument_params[param_index] = value;
                     }
@@ -314,14 +348,14 @@ impl DevicesState {
                     velocity: 100,
                     on: false,
                 });
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     let max_index = track.drum_rack_pads.len().saturating_sub(1);
                     track.selected_drum_pad = pad_index.min(max_index);
                 }
                 action.select_track = Some(track_id);
             }
             DevicesMsg::ClearDrumRackPad(track_id, pad_index) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
                         *pad = UiDrumPad::default();
                     }
@@ -340,7 +374,7 @@ impl DevicesState {
                 value,
             } => {
                 let mut changed = false;
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
                         match param {
                             DrumPadParam::Gain => pad.gain = value.clamp(0.0, 2.0),
@@ -368,7 +402,7 @@ impl DevicesState {
                 one_shot,
             } => {
                 let mut changed = false;
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
                         pad.one_shot = one_shot;
                         changed = true;
@@ -385,7 +419,7 @@ impl DevicesState {
                 choke_group,
             } => {
                 let mut changed = false;
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
                         pad.choke_group = choke_group;
                         changed = true;
@@ -480,6 +514,7 @@ mod tests {
             DevicesMsg::RemoveEffect(track_id, effect_id),
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         assert!(tracks[0].effects.is_empty());
@@ -502,6 +537,7 @@ mod tests {
             DevicesMsg::SetEffectParam(track_id, effect_id, 0, 9999.0),
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         let max = tracks[0].effects[0].descriptors[0].max;
@@ -517,6 +553,7 @@ mod tests {
             DevicesMsg::MoveEffectUp(track_id, effect_id),
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         assert!(engine.0.is_empty());
@@ -532,6 +569,7 @@ mod tests {
             DevicesMsg::SelectDrumRackPad(track_id, 3),
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         assert_eq!(tracks[0].selected_drum_pad, 3);
@@ -561,6 +599,7 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         assert_eq!(tracks[0].drum_rack_pads[0].gain, 2.0); // clamped
@@ -583,6 +622,7 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         // MIDI track opens on the Instruments tab.
@@ -594,6 +634,7 @@ mod tests {
             DevicesMsg::DismissContextMenu,
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         assert!(devices.context_menu.is_none());

--- a/crates/vibez-ui/src/domains/project.rs
+++ b/crates/vibez-ui/src/domains/project.rs
@@ -98,7 +98,8 @@ pub fn collect_plugin_reload_requests(
     mut capture_state: impl FnMut(PluginGuiKey) -> Option<String>,
 ) -> PluginReloadRequests {
     let mut requests = PluginReloadRequests::default();
-    for track in &mut snapshot.tracks {
+    let (tracks, master) = (&mut snapshot.tracks, &mut snapshot.master);
+    for track in tracks.iter_mut().chain(std::iter::once(master)) {
         let track_id = track.id;
         for (chain_pos, effect) in track.effects.iter().enumerate() {
             if let Some(dev) = &effect.plugin_ref {
@@ -159,6 +160,7 @@ mod tests {
         track.effects = effects;
         ProjectSnapshot {
             tracks: vec![track],
+            master: crate::state::new_master_track(),
             bpm: 120.0,
             bpm_text: "120".to_string(),
             loop_enabled: false,

--- a/crates/vibez-ui/src/lib.rs
+++ b/crates/vibez-ui/src/lib.rs
@@ -4,6 +4,7 @@ pub mod icons;
 mod message;
 pub mod plugin_window;
 mod services;
+mod spectrum;
 mod state;
 mod theme;
 mod ui_settings;

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -221,7 +221,7 @@ pub enum Message {
     SaveProjectAs,
     ProjectOpenPathSelected(Option<PathBuf>),
     ProjectSavePathSelected(Option<PathBuf>),
-    ProjectLoaded(Result<ProjectLoadResult, String>),
+    ProjectLoaded(Box<Result<ProjectLoadResult, String>>),
     ProjectSaved(Result<PathBuf, String>),
     /// Settings: toggle auto-warp-on-import.
     ToggleAutoWarpOnImport,
@@ -391,6 +391,11 @@ impl Message {
     pub fn set_effect_param(t: TrackId, e: EffectId, i: usize, v: f32) -> Self {
         Self::Devices(crate::domains::devices::DevicesMsg::SetEffectParam(
             t, e, i, v,
+        ))
+    }
+    pub fn set_effect_params(t: TrackId, e: EffectId, updates: Vec<(usize, f32)>) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::SetEffectParams(
+            t, e, updates,
         ))
     }
     pub fn toggle_effect_bypass(t: TrackId, e: EffectId) -> Self {

--- a/crates/vibez-ui/src/spectrum.rs
+++ b/crates/vibez-ui/src/spectrum.rs
@@ -1,0 +1,251 @@
+//! Spectrum analyser for the channel EQ display.
+//!
+//! The engine streams post-effects mono samples for the tapped track
+//! through a lock-free ring; every UI tick the analyser ingests them
+//! into a sliding window, runs a Hann-windowed FFT, and folds the
+//! magnitudes into log-spaced display bins with fast-attack /
+//! slow-release smoothing (the familiar analyser ballistics).
+
+/// FFT window length (samples). Power of two for radix-2.
+const FFT_SIZE: usize = 2048;
+
+/// Number of log-spaced display bins between MIN_HZ and MAX_HZ.
+pub const DISPLAY_BINS: usize = 96;
+
+/// Display range, matching the EQ curve's frequency axis.
+pub const MIN_HZ: f32 = 20.0;
+pub const MAX_HZ: f32 = 20_000.0;
+
+/// Floor of the level axis in dB (0 dB = full scale).
+pub const FLOOR_DB: f32 = -66.0;
+
+/// Release rate in dB per tick (60 fps → ~1.6 s full-scale fall).
+const RELEASE_DB_PER_TICK: f32 = 0.66;
+
+#[derive(Debug, Clone)]
+pub struct SpectrumState {
+    /// Sliding window of the most recent mono samples.
+    window: Vec<f32>,
+    /// Smoothed display bins in dB (FLOOR_DB..0), ready to draw.
+    pub bins: Vec<f32>,
+    /// Anything above the floor to draw at all?
+    pub active: bool,
+}
+
+impl Default for SpectrumState {
+    fn default() -> Self {
+        Self {
+            window: Vec::with_capacity(FFT_SIZE),
+            bins: vec![FLOOR_DB; DISPLAY_BINS],
+            active: false,
+        }
+    }
+}
+
+impl SpectrumState {
+    /// Append freshly drained tap samples, keeping the last window.
+    pub fn ingest(&mut self, samples: &[f32]) {
+        self.window.extend_from_slice(samples);
+        let len = self.window.len();
+        if len > FFT_SIZE {
+            self.window.drain(..len - FFT_SIZE);
+        }
+    }
+
+    /// Drop all signal history (tap retargeted to another track).
+    pub fn reset(&mut self) {
+        self.window.clear();
+        self.bins.fill(FLOOR_DB);
+        self.active = false;
+    }
+
+    /// One tick of analysis: FFT the current window and update the
+    /// smoothed display bins.
+    pub fn analyse(&mut self, sample_rate: f32) {
+        let fresh = if self.window.len() >= FFT_SIZE {
+            compute_bins(&self.window[self.window.len() - FFT_SIZE..], sample_rate)
+        } else {
+            // No (or not enough) signal: release toward the floor.
+            vec![FLOOR_DB; DISPLAY_BINS]
+        };
+        let mut any = false;
+        for (cur, new) in self.bins.iter_mut().zip(fresh) {
+            if new > *cur {
+                *cur = new; // fast attack
+            } else {
+                *cur = (*cur - RELEASE_DB_PER_TICK).max(new).max(FLOOR_DB);
+            }
+            if *cur > FLOOR_DB + 0.5 {
+                any = true;
+            }
+        }
+        self.active = any;
+    }
+}
+
+/// Hann-window `input` (FFT_SIZE samples), FFT it, and fold the
+/// magnitude spectrum into DISPLAY_BINS log-spaced dB bins.
+fn compute_bins(input: &[f32], sample_rate: f32) -> Vec<f32> {
+    debug_assert_eq!(input.len(), FFT_SIZE);
+    let mut re: Vec<f32> = input
+        .iter()
+        .enumerate()
+        .map(|(i, &s)| {
+            let hann = 0.5 - 0.5 * (std::f32::consts::TAU * i as f32 / (FFT_SIZE - 1) as f32).cos();
+            s * hann
+        })
+        .collect();
+    let mut im = vec![0.0f32; FFT_SIZE];
+    fft_in_place(&mut re, &mut im);
+
+    // Coherent-gain normalization: a full-scale sine under a Hann
+    // window peaks at N/4 in the half-spectrum.
+    let norm = 4.0 / FFT_SIZE as f32;
+    let hz_per_fft_bin = sample_rate / FFT_SIZE as f32;
+    let log_min = MIN_HZ.ln();
+    let log_span = MAX_HZ.ln() - log_min;
+
+    let mut bins = vec![FLOOR_DB; DISPLAY_BINS];
+    for k in 1..FFT_SIZE / 2 {
+        let freq = k as f32 * hz_per_fft_bin;
+        if !(MIN_HZ..=MAX_HZ).contains(&freq) {
+            continue;
+        }
+        let pos = (freq.ln() - log_min) / log_span;
+        let bin = ((pos * DISPLAY_BINS as f32) as usize).min(DISPLAY_BINS - 1);
+        let mag = (re[k] * re[k] + im[k] * im[k]).sqrt() * norm;
+        let db = (20.0 * mag.max(1e-9).log10()).clamp(FLOOR_DB, 0.0);
+        if db > bins[bin] {
+            bins[bin] = db;
+        }
+    }
+    // Low display bins can be narrower than one FFT bin; fill gaps
+    // from the left neighbor so the trace stays continuous.
+    for i in 1..DISPLAY_BINS {
+        if bins[i] <= FLOOR_DB && bins[i - 1] > FLOOR_DB {
+            bins[i] = bins[i - 1] - 1.5;
+        }
+    }
+    bins
+}
+
+/// Iterative radix-2 Cooley-Tukey FFT, in place. `re.len()` must be a
+/// power of two and equal to `im.len()`.
+fn fft_in_place(re: &mut [f32], im: &mut [f32]) {
+    let n = re.len();
+    debug_assert!(n.is_power_of_two() && n == im.len());
+
+    // Bit-reversal permutation.
+    let bits = n.trailing_zeros();
+    for i in 0..n {
+        let j = (i as u32).reverse_bits() >> (32 - bits);
+        let j = j as usize;
+        if j > i {
+            re.swap(i, j);
+            im.swap(i, j);
+        }
+    }
+
+    let mut len = 2;
+    while len <= n {
+        let ang = -std::f32::consts::TAU / len as f32;
+        let (w_re, w_im) = (ang.cos(), ang.sin());
+        for start in (0..n).step_by(len) {
+            let (mut cur_re, mut cur_im) = (1.0f32, 0.0f32);
+            for k in 0..len / 2 {
+                let a = start + k;
+                let b = a + len / 2;
+                let t_re = re[b] * cur_re - im[b] * cur_im;
+                let t_im = re[b] * cur_im + im[b] * cur_re;
+                re[b] = re[a] - t_re;
+                im[b] = im[a] - t_im;
+                re[a] += t_re;
+                im[a] += t_im;
+                let next_re = cur_re * w_re - cur_im * w_im;
+                cur_im = cur_re * w_im + cur_im * w_re;
+                cur_re = next_re;
+            }
+        }
+        len <<= 1;
+    }
+}
+
+/// Normalized x position (0..1) of `freq` on the shared log axis.
+pub fn freq_to_norm(freq: f32) -> f32 {
+    ((freq.max(MIN_HZ).ln() - MIN_HZ.ln()) / (MAX_HZ.ln() - MIN_HZ.ln())).clamp(0.0, 1.0)
+}
+
+/// Inverse of [`freq_to_norm`].
+pub fn norm_to_freq(pos: f32) -> f32 {
+    (MIN_HZ.ln() + pos.clamp(0.0, 1.0) * (MAX_HZ.ln() - MIN_HZ.ln())).exp()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fft_finds_a_sine_peak() {
+        let sr = 48_000.0f32;
+        let freq = 1_000.0f32;
+        let samples: Vec<f32> = (0..FFT_SIZE)
+            .map(|i| (std::f32::consts::TAU * freq * i as f32 / sr).sin() * 0.8)
+            .collect();
+        let bins = compute_bins(&samples, sr);
+
+        // The display bin holding 1 kHz should carry the peak level.
+        let expect_bin =
+            ((freq_to_norm(freq) * DISPLAY_BINS as f32) as usize).min(DISPLAY_BINS - 1);
+        let peak = bins
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.total_cmp(b.1))
+            .unwrap();
+        assert!(
+            (peak.0 as i32 - expect_bin as i32).abs() <= 1,
+            "peak bin {} should sit at ~{expect_bin}",
+            peak.0
+        );
+        // 0.8 full scale ≈ -1.9 dB.
+        assert!(
+            (*peak.1 - (-1.9)).abs() < 1.5,
+            "peak level should read near -1.9 dB, got {}",
+            peak.1
+        );
+        // Far-away bins stay near the floor (100 Hz vs 1 kHz).
+        let far = bins[(freq_to_norm(100.0) * DISPLAY_BINS as f32) as usize];
+        assert!(far < -40.0, "off-peak bin should be quiet, got {far}");
+    }
+
+    #[test]
+    fn attack_is_instant_release_is_gradual() {
+        let sr = 48_000.0f32;
+        let mut state = SpectrumState::default();
+        let tone: Vec<f32> = (0..FFT_SIZE)
+            .map(|i| (std::f32::consts::TAU * 1_000.0 * i as f32 / sr).sin())
+            .collect();
+        state.ingest(&tone);
+        state.analyse(sr);
+        let peak_after_attack = state.bins.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!(peak_after_attack > -3.0, "attack should be instant");
+        assert!(state.active);
+
+        // Silence: the peak falls by the release rate per tick, not
+        // all at once.
+        state.window.clear();
+        state.analyse(sr);
+        let peak_after_release = state.bins.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!(
+            (peak_after_attack - peak_after_release - RELEASE_DB_PER_TICK).abs() < 1e-3,
+            "release should fall by exactly one tick's worth"
+        );
+    }
+
+    #[test]
+    fn freq_axis_roundtrips() {
+        for f in [20.0, 100.0, 1_000.0, 10_000.0, 20_000.0] {
+            let back = norm_to_freq(freq_to_norm(f));
+            assert!((back / f - 1.0).abs() < 1e-3, "{f} -> {back}");
+        }
+    }
+}

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -114,6 +114,7 @@ pub enum SettingsTab {
 #[derive(Debug, Clone)]
 pub struct ProjectSnapshot {
     pub tracks: Vec<UiTrack>,
+    pub master: UiTrack,
     pub bpm: f64,
     pub bpm_text: String,
     pub loop_enabled: bool,
@@ -303,11 +304,23 @@ impl Default for TransportState {
     }
 }
 
+/// The master bus as a track-shaped UI channel: gain plus an effect
+/// chain, no clips or instrument. Lives outside `tracks` so the
+/// arrangement never shows it, but `find_track` resolves it, so the
+/// mixer strip, device chain, and effect commands all work on it.
+pub fn new_master_track() -> UiTrack {
+    let mut master = UiTrack::new(TrackId::MASTER, "Master".to_string(), 0);
+    master.pan = 0.5;
+    master
+}
+
 /// Arrangement domain state: the track list (the shared model other
 /// domains receive explicitly), selection, and track numbering.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ArrangementState {
     pub tracks: Vec<UiTrack>,
+    /// The master bus channel (see [`new_master_track`]).
+    pub master: UiTrack,
     pub selected_track: Option<TrackId>,
     pub next_track_number: u32,
     pub selected_clips: HashSet<ArrangementSelection>,
@@ -326,6 +339,25 @@ pub struct ArrangementState {
     pub clip_bpm_edit: HashMap<ClipId, String>,
 }
 
+impl Default for ArrangementState {
+    fn default() -> Self {
+        Self {
+            tracks: Vec::new(),
+            master: new_master_track(),
+            selected_track: None,
+            next_track_number: 0,
+            selected_clips: HashSet::new(),
+            selected_note_clip: None,
+            time_selection_active: false,
+            selection_start_beats: 0.0,
+            selection_end_beats: 0.0,
+            time_selection_track: None,
+            drag_resize_active: false,
+            clip_bpm_edit: HashMap::new(),
+        }
+    }
+}
+
 pub struct AppState {
     // Transport domain slice (playback, tempo, arrangement loop).
     pub transport: TransportState,
@@ -333,6 +365,9 @@ pub struct AppState {
     // Metering (master)
     pub peak_l: f32,
     pub peak_r: f32,
+    /// Spectrum analyser fed by the engine's per-track tap (follows
+    /// the selected track); drawn behind the channel EQ curve.
+    pub spectrum: crate::spectrum::SpectrumState,
 
     // UI
     pub status_text: String,
@@ -383,6 +418,7 @@ impl Default for AppState {
             },
             peak_l: 0.0,
             peak_r: 0.0,
+            spectrum: crate::spectrum::SpectrumState::default(),
             status_text: "Ready — Add a track to get started".to_string(),
             view: ViewState::default(),
             piano_roll: PianoRollState::default(),
@@ -511,10 +547,16 @@ impl AppState {
     }
 
     pub fn find_track(&self, id: TrackId) -> Option<&UiTrack> {
+        if id.is_master() {
+            return Some(&self.arrangement.master);
+        }
         self.arrangement.tracks.iter().find(|t| t.id == id)
     }
 
     pub fn find_track_mut(&mut self, id: TrackId) -> Option<&mut UiTrack> {
+        if id.is_master() {
+            return Some(&mut self.arrangement.master);
+        }
         self.arrangement.tracks.iter_mut().find(|t| t.id == id)
     }
 

--- a/crates/vibez-ui/src/theme.rs
+++ b/crates/vibez-ui/src/theme.rs
@@ -258,6 +258,32 @@ pub fn track_color(index: u8) -> Color {
     TRACK_COLORS[index as usize % TRACK_COLORS.len()]
 }
 
+// ── Channel EQ band colors (console convention, muted) ──
+pub const EQ_HF: Color = Color {
+    r: 0.76,
+    g: 0.33,
+    b: 0.30,
+    a: 1.0,
+};
+pub const EQ_HMF: Color = Color {
+    r: 0.33,
+    g: 0.62,
+    b: 0.38,
+    a: 1.0,
+};
+pub const EQ_LMF: Color = Color {
+    r: 0.36,
+    g: 0.48,
+    b: 0.72,
+    a: 1.0,
+};
+pub const EQ_LF: Color = Color {
+    r: 0.65,
+    g: 0.46,
+    b: 0.28,
+    a: 1.0,
+};
+
 /// Darken a color by a factor (for borders, etc.)
 pub fn darken(color: Color, factor: f32) -> Color {
     Color {

--- a/crates/vibez-ui/src/widgets/effect_slot.rs
+++ b/crates/vibez-ui/src/widgets/effect_slot.rs
@@ -10,10 +10,15 @@ use vibez_core::id::TrackId;
 use vibez_plugin_host::gui::PluginGuiKey;
 
 /// Render an Ableton-style device card for the detail panel.
+///
+/// `custom_body` swaps the generic knob-row body for a purpose-built
+/// one (the channel EQ's display panel) while keeping the shared
+/// title-bar chrome; the second element is the card width.
 pub fn view_effect_slot<'a>(
     track_id: TrackId,
     effect: &'a UiEffect,
     track_color: Color,
+    custom_body: Option<(Element<'a, Message>, f32)>,
 ) -> Element<'a, Message> {
     let is_bypassed = effect.bypass;
     let has_params = !effect.descriptors.is_empty();
@@ -175,7 +180,13 @@ pub fn view_effect_slot<'a>(
         });
 
     // ── Body ─────────────────────────────────────────────────
-    let body: Element<'a, Message> = if has_params && !has_gui {
+    let custom_w = custom_body.as_ref().map(|(_, w)| *w);
+    let body: Element<'a, Message> = if let Some((custom, _)) = custom_body {
+        container(custom)
+            .padding([8, 10])
+            .height(Length::Fixed(th::DEVICE_BODY_H))
+            .into()
+    } else if has_params && !has_gui {
         let knob_color = if is_bypassed {
             th::TEXT_MUTED
         } else {
@@ -257,7 +268,9 @@ pub fn view_effect_slot<'a>(
     } else {
         0
     };
-    let card_w = if is_plugin {
+    let card_w = if let Some(w) = custom_w {
+        w
+    } else if is_plugin {
         190.0
     } else {
         (knob_count as f32 * 62.0 + 24.0).max(150.0)

--- a/crates/vibez-ui/src/widgets/eq_display.rs
+++ b/crates/vibez-ui/src/widgets/eq_display.rs
@@ -1,0 +1,449 @@
+//! Channel EQ display: frequency response curve over a live spectrum
+//! analyser, with draggable band handles (drag sets frequency and
+//! gain, scroll trims Q on the parametric mids, double-click zeroes
+//! the band).
+
+use std::time::Instant;
+
+use iced::mouse;
+use iced::widget::canvas;
+use iced::{Color, Point, Rectangle, Renderer, Theme};
+
+use crate::message::Message;
+use crate::spectrum::{freq_to_norm, norm_to_freq, DISPLAY_BINS, FLOOR_DB};
+use crate::theme as th;
+use vibez_core::effect::ParamDescriptor;
+use vibez_core::id::{EffectId, TrackId};
+
+/// Vertical range of the response axis in dB (curve clamps to it).
+const RANGE_DB: f32 = 18.0;
+/// Handle hit/draw radius.
+const HANDLE_R: f32 = 6.0;
+/// Double-click window in milliseconds.
+const DOUBLE_CLICK_MS: u128 = 300;
+/// Points sampled along the response curve.
+const CURVE_POINTS: usize = 128;
+
+/// One EQ band's parameter wiring: (gain index, freq index, Q index
+/// when the band has a sweepable Q).
+struct Band {
+    gain_i: usize,
+    freq_i: usize,
+    q_i: Option<usize>,
+    color: Color,
+}
+
+const BANDS: [Band; 4] = [
+    Band {
+        gain_i: 0,
+        freq_i: 1,
+        q_i: None,
+        color: th::EQ_LF,
+    },
+    Band {
+        gain_i: 3,
+        freq_i: 4,
+        q_i: Some(5),
+        color: th::EQ_LMF,
+    },
+    Band {
+        gain_i: 6,
+        freq_i: 7,
+        q_i: Some(8),
+        color: th::EQ_HMF,
+    },
+    Band {
+        gain_i: 9,
+        freq_i: 10,
+        q_i: Some(11),
+        color: th::EQ_HF,
+    },
+];
+
+pub struct EqDisplayWidget {
+    pub track_id: TrackId,
+    pub effect_id: EffectId,
+    pub params: Vec<f32>,
+    pub descriptors: &'static [ParamDescriptor],
+    pub bypass: bool,
+    pub sample_rate: f32,
+    /// Smoothed analyser bins in dB (FLOOR_DB..0), log-spaced.
+    pub spectrum: Vec<f32>,
+    pub spectrum_active: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct EqDisplayState {
+    drag: Option<usize>,
+    hover: Option<usize>,
+    last_click: Option<Instant>,
+}
+
+impl EqDisplayWidget {
+    fn param(&self, i: usize) -> f32 {
+        self.params
+            .get(i)
+            .copied()
+            .unwrap_or_else(|| self.descriptors.get(i).map(|d| d.default).unwrap_or(0.0))
+    }
+
+    fn db_to_y(&self, db: f32, h: f32) -> f32 {
+        let half = h / 2.0;
+        half - (db.clamp(-RANGE_DB, RANGE_DB) / RANGE_DB) * (half - 8.0)
+    }
+
+    fn y_to_db(&self, y: f32, h: f32) -> f32 {
+        let half = h / 2.0;
+        ((half - y) / (half - 8.0) * RANGE_DB).clamp(-RANGE_DB, RANGE_DB)
+    }
+
+    fn handle_pos(&self, band: &Band, bounds: Rectangle) -> Point {
+        let x = freq_to_norm(self.param(band.freq_i)) * bounds.width;
+        let y = self.db_to_y(self.param(band.gain_i), bounds.height);
+        Point::new(x, y)
+    }
+
+    /// Band index whose handle sits under `pos` (widget-local).
+    fn band_at(&self, pos: Point, bounds: Rectangle) -> Option<usize> {
+        BANDS
+            .iter()
+            .enumerate()
+            .map(|(i, b)| (i, self.handle_pos(b, bounds)))
+            .filter(|(_, hp)| {
+                let (dx, dy) = (hp.x - pos.x, hp.y - pos.y);
+                (dx * dx + dy * dy).sqrt() <= HANDLE_R + 3.0
+            })
+            .min_by(|a, b| {
+                let d = |hp: &Point| (hp.x - pos.x).powi(2) + (hp.y - pos.y).powi(2);
+                d(&a.1).total_cmp(&d(&b.1))
+            })
+            .map(|(i, _)| i)
+    }
+
+    fn drag_message(&self, band_idx: usize, pos: Point, bounds: Rectangle) -> Message {
+        let band = &BANDS[band_idx];
+        let freq = norm_to_freq((pos.x / bounds.width).clamp(0.0, 1.0));
+        let gain = self.y_to_db(pos.y, bounds.height);
+        // Descriptor clamps happen again in the domain; pre-clamp so
+        // the handle never visually detaches from the cursor's band.
+        let fd = &self.descriptors[band.freq_i];
+        let gd = &self.descriptors[band.gain_i];
+        Message::set_effect_params(
+            self.track_id,
+            self.effect_id,
+            vec![
+                (band.freq_i, freq.clamp(fd.min, fd.max)),
+                (band.gain_i, gain.clamp(gd.min, gd.max)),
+            ],
+        )
+    }
+}
+
+impl canvas::Program<Message> for EqDisplayWidget {
+    type State = EqDisplayState;
+
+    fn draw(
+        &self,
+        state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let (w, h) = (bounds.width, bounds.height);
+
+        // ── Panel ──
+        frame.fill(
+            &canvas::Path::rounded_rectangle(Point::ORIGIN, bounds.size(), 3.0.into()),
+            th::BG_DARK,
+        );
+
+        // ── Grid: decade frequency lines + dB lines ──
+        let grid = Color {
+            a: 0.35,
+            ..th::BORDER
+        };
+        let labeled: [(f32, &str); 3] = [(100.0, "100"), (1_000.0, "1k"), (10_000.0, "10k")];
+        for f in [
+            30.0, 50.0, 100.0, 200.0, 300.0, 500.0, 1e3, 2e3, 3e3, 5e3, 10e3,
+        ] {
+            let x = freq_to_norm(f) * w;
+            frame.stroke(
+                &canvas::Path::line(Point::new(x, 0.0), Point::new(x, h)),
+                canvas::Stroke::default().with_color(grid).with_width(1.0),
+            );
+        }
+        for (f, label) in labeled {
+            frame.fill_text(canvas::Text {
+                content: label.to_string(),
+                position: Point::new(freq_to_norm(f) * w + 3.0, h - 2.0),
+                color: th::TEXT_MUTED,
+                size: 8.0.into(),
+                vertical_alignment: iced::alignment::Vertical::Bottom,
+                ..canvas::Text::default()
+            });
+        }
+        for db in [-12.0f32, -6.0, 6.0, 12.0] {
+            let y = self.db_to_y(db, h);
+            frame.stroke(
+                &canvas::Path::line(Point::new(0.0, y), Point::new(w, y)),
+                canvas::Stroke::default().with_color(grid).with_width(1.0),
+            );
+        }
+        // Unity line, slightly brighter.
+        let y0 = self.db_to_y(0.0, h);
+        frame.stroke(
+            &canvas::Path::line(Point::new(0.0, y0), Point::new(w, y0)),
+            canvas::Stroke::default()
+                .with_color(Color {
+                    a: 0.8,
+                    ..th::BORDER
+                })
+                .with_width(1.0),
+        );
+
+        // ── Spectrum (behind the curve) ──
+        if self.spectrum_active && self.spectrum.len() == DISPLAY_BINS {
+            let bin_y = |db: f32| -> f32 { h - ((db - FLOOR_DB) / -FLOOR_DB) * h };
+            let path = canvas::Path::new(|b| {
+                b.move_to(Point::new(0.0, h));
+                for (i, &db) in self.spectrum.iter().enumerate() {
+                    let x = (i as f32 + 0.5) / DISPLAY_BINS as f32 * w;
+                    b.line_to(Point::new(x, bin_y(db)));
+                }
+                b.line_to(Point::new(w, h));
+                b.close();
+            });
+            frame.fill(
+                &path,
+                Color {
+                    a: 0.13,
+                    ..th::TEXT_DIM
+                },
+            );
+            frame.stroke(
+                &path,
+                canvas::Stroke::default()
+                    .with_color(Color {
+                        a: 0.30,
+                        ..th::TEXT_DIM
+                    })
+                    .with_width(1.0),
+            );
+        }
+
+        // ── Response curve ──
+        let eq = vibez_dsp::eq::EqEffect::from_params(self.sample_rate, &self.params);
+        let curve_pts: Vec<Point> = (0..CURVE_POINTS)
+            .map(|i| {
+                let pos = i as f32 / (CURVE_POINTS - 1) as f32;
+                let db = eq.response_db(norm_to_freq(pos));
+                Point::new(pos * w, self.db_to_y(db, h))
+            })
+            .collect();
+
+        if !self.bypass {
+            // Soft fill between the curve and unity.
+            let fill = canvas::Path::new(|b| {
+                b.move_to(Point::new(0.0, y0));
+                for p in &curve_pts {
+                    b.line_to(*p);
+                }
+                b.line_to(Point::new(w, y0));
+                b.close();
+            });
+            frame.fill(
+                &fill,
+                Color {
+                    a: 0.10,
+                    ..th::ACCENT
+                },
+            );
+        }
+
+        let curve = canvas::Path::new(|b| {
+            b.move_to(curve_pts[0]);
+            for p in &curve_pts[1..] {
+                b.line_to(*p);
+            }
+        });
+        let (curve_color, curve_w) = if self.bypass {
+            (th::TEXT_MUTED, 1.5)
+        } else {
+            (th::TEXT, 2.0)
+        };
+        frame.stroke(
+            &curve,
+            canvas::Stroke {
+                line_join: canvas::LineJoin::Round,
+                ..canvas::Stroke::default()
+            }
+            .with_color(curve_color)
+            .with_width(curve_w),
+        );
+
+        // ── Band handles ──
+        for (i, band) in BANDS.iter().enumerate() {
+            let p = self.handle_pos(band, bounds);
+            let engaged = state.drag == Some(i) || (state.drag.is_none() && state.hover == Some(i));
+            let color = if self.bypass {
+                th::TEXT_MUTED
+            } else {
+                band.color
+            };
+            frame.fill(&canvas::Path::circle(p, HANDLE_R), color);
+            frame.fill(&canvas::Path::circle(p, HANDLE_R - 2.5), th::BG_DARK);
+            if engaged {
+                frame.stroke(
+                    &canvas::Path::circle(p, HANDLE_R + 2.0),
+                    canvas::Stroke::default()
+                        .with_color(th::TEXT)
+                        .with_width(1.0),
+                );
+                // Readout: freq / gain / Q next to the handle.
+                let freq = self.param(band.freq_i);
+                let mut readout = format!(
+                    "{}  {:+.1} dB",
+                    crate::widgets::effect_knob::format_value(freq, "Hz"),
+                    self.param(band.gain_i),
+                );
+                if let Some(q_i) = band.q_i {
+                    readout.push_str(&format!("  Q {:.2}", self.param(q_i)));
+                }
+                let above = p.y > 24.0;
+                frame.fill_text(canvas::Text {
+                    content: readout,
+                    position: Point::new(
+                        p.x.clamp(60.0, w - 80.0),
+                        if above { p.y - 12.0 } else { p.y + 12.0 },
+                    ),
+                    color: th::TEXT,
+                    size: 9.0.into(),
+                    horizontal_alignment: iced::alignment::Horizontal::Center,
+                    vertical_alignment: if above {
+                        iced::alignment::Vertical::Bottom
+                    } else {
+                        iced::alignment::Vertical::Top
+                    },
+                    ..canvas::Text::default()
+                });
+            }
+        }
+
+        // ── Frame border ──
+        frame.stroke(
+            &canvas::Path::rounded_rectangle(Point::ORIGIN, bounds.size(), 3.0.into()),
+            canvas::Stroke::default()
+                .with_color(th::BORDER)
+                .with_width(1.0),
+        );
+
+        vec![frame.into_geometry()]
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if state.drag.is_some() {
+            mouse::Interaction::Grabbing
+        } else if cursor
+            .position_in(bounds)
+            .and_then(|p| self.band_at(p, bounds))
+            .is_some()
+        {
+            mouse::Interaction::Grab
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: canvas::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<Message>) {
+        let local = cursor.position_in(bounds);
+        match event {
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                if let Some(pos) = local {
+                    if let Some(band_idx) = self.band_at(pos, bounds) {
+                        let now = Instant::now();
+                        if let Some(last) = state.last_click {
+                            if now.duration_since(last).as_millis() < DOUBLE_CLICK_MS {
+                                // Double-click: zero the band's gain.
+                                state.last_click = None;
+                                state.drag = None;
+                                return (
+                                    canvas::event::Status::Captured,
+                                    Some(Message::set_effect_param(
+                                        self.track_id,
+                                        self.effect_id,
+                                        BANDS[band_idx].gain_i,
+                                        0.0,
+                                    )),
+                                );
+                            }
+                        }
+                        state.last_click = Some(now);
+                        state.drag = Some(band_idx);
+                        return (canvas::event::Status::Captured, None);
+                    }
+                }
+            }
+            canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                if state.drag.take().is_some() {
+                    return (canvas::event::Status::Captured, None);
+                }
+            }
+            canvas::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                if let Some(band_idx) = state.drag {
+                    // Track the cursor even slightly outside bounds.
+                    if let Some(abs) = cursor.position() {
+                        let pos = Point::new(abs.x - bounds.x, abs.y - bounds.y);
+                        return (
+                            canvas::event::Status::Captured,
+                            Some(self.drag_message(band_idx, pos, bounds)),
+                        );
+                    }
+                }
+                if let Some(pos) = local {
+                    state.hover = self.band_at(pos, bounds);
+                }
+            }
+            canvas::Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if let Some(pos) = local {
+                    if let Some(band_idx) = self.band_at(pos, bounds).or(state.drag) {
+                        if let Some(q_i) = BANDS[band_idx].q_i {
+                            let scroll_y = match delta {
+                                mouse::ScrollDelta::Lines { y, .. } => y,
+                                mouse::ScrollDelta::Pixels { y, .. } => y / 20.0,
+                            };
+                            let d = &self.descriptors[q_i];
+                            let q = (self.param(q_i) * 1.10f32.powf(scroll_y)).clamp(d.min, d.max);
+                            return (
+                                canvas::event::Status::Captured,
+                                Some(Message::set_effect_param(
+                                    self.track_id,
+                                    self.effect_id,
+                                    q_i,
+                                    q,
+                                )),
+                            );
+                        }
+                        // Bands without a Q swallow the scroll so the
+                        // panel underneath doesn't pan.
+                        return (canvas::event::Status::Captured, None);
+                    }
+                }
+            }
+            _ => {}
+        }
+        (canvas::event::Status::Ignored, None)
+    }
+}

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -351,7 +351,7 @@ fn view_eq_band<'a>(
             third_i,
             if bell_on { 0.0 } else { 1.0 },
         ))
-        .padding([2, 3])
+        .padding([3, 6])
         .style(move |_theme: &Theme, _status| button::Style {
             background: Some(if bell_on {
                 color.into()
@@ -368,7 +368,7 @@ fn view_eq_band<'a>(
         })
         .into()
     } else {
-        column![text("Q").size(7).color(dim), knob(third_i, 16.0)]
+        column![text("Q").size(7).color(dim), knob(third_i, 22.0)]
             .spacing(1)
             .align_x(iced::Alignment::Center)
             .into()

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -14,7 +14,7 @@ use crate::widgets::vu_meter::VuMeterWidget;
 use vibez_core::midi::TrackKind;
 
 /// Render a single mixer channel strip for a track.
-pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
+pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message> {
     let track_color = th::track_color(track.color_index);
 
     // Track name + type icon
@@ -156,17 +156,24 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
     .height(Length::Fill)
     .align_x(iced::Alignment::Center);
 
-    container(strip)
+    let body = container(strip)
         .height(Length::Fill)
         .style(move |_theme: &Theme| container::Style {
             background: Some(th::BG_SURFACE.into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: if selected { th::ACCENT } else { th::BORDER },
                 width: 1.0,
                 radius: 2.0.into(),
             },
             ..Default::default()
-        })
+        });
+
+    // Clicking anywhere on the strip chrome selects the track, so
+    // the detail panel follows the mixer like it follows the
+    // arrangement headers. Knobs, faders, and buttons still win
+    // their own clicks.
+    iced::widget::mouse_area(body)
+        .on_press(Message::select_track(track.id))
         .into()
 }
 

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -256,13 +256,12 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         (3, 4, 5, false, LMF, "LMF"),
         (0, 1, 2, true, LF, "LF"),
     ];
-    for (i, (gain_i, freq_i, third_i, is_bell_toggle, color, label)) in
-        rows.into_iter().enumerate()
+    for (i, (gain_i, freq_i, third_i, is_bell_toggle, color, label)) in rows.into_iter().enumerate()
     {
         if i > 0 {
             bands = bands.push(
                 container(text(""))
-                    .width(Length::Fixed(72.0))
+                    .width(Length::Fixed(88.0))
                     .height(Length::Fixed(1.0))
                     .style(|_theme: &Theme| container::Style {
                         background: Some(
@@ -341,11 +340,11 @@ fn view_eq_band<'a>(
 
     let third_el: Element<'a, Message> = if bell_toggle {
         let bell_on = eq.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
-        button(text("BELL").size(6).color(if bell_on {
-            th::BG_DARK
-        } else {
-            th::TEXT_DIM
-        }))
+        button(
+            text("BELL")
+                .size(6)
+                .color(if bell_on { th::BG_DARK } else { th::TEXT_DIM }),
+        )
         .on_press(Message::set_effect_param(
             track_id,
             eq.id,
@@ -376,9 +375,13 @@ fn view_eq_band<'a>(
     };
 
     let freq_col = column![
-        text(if freq_i == 10 || freq_i == 7 { "kHz" } else { "Hz" })
-            .size(7)
-            .color(dim),
+        text(if freq_i == 10 || freq_i == 7 {
+            "kHz"
+        } else {
+            "Hz"
+        })
+        .size(7)
+        .color(dim),
         knob(freq_i, 26.0),
     ]
     .spacing(1)
@@ -388,9 +391,11 @@ fn view_eq_band<'a>(
         column![gain_col, third_el]
             .spacing(3)
             .align_x(iced::Alignment::Center),
+        iced::widget::horizontal_space(),
         column![text("").size(10), freq_col].align_x(iced::Alignment::Center),
     ]
-    .spacing(8)
+    .width(Length::Fill)
+    .padding([0, 6])
     .align_y(iced::Alignment::Start)
     .into()
 }

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -152,7 +152,7 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
     ]
     .spacing(4)
     .padding(8)
-    .width(Length::Fixed(108.0))
+    .width(Length::Fixed(112.0))
     .height(Length::Fill)
     .align_x(iced::Alignment::Center);
 
@@ -215,7 +215,7 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
     const LMF: iced::Color = iced::Color::from_rgb(0.36, 0.48, 0.72);
     const LF: iced::Color = iced::Color::from_rgb(0.65, 0.46, 0.28);
 
-    let mut bands = column![].spacing(2).align_x(iced::Alignment::Center);
+    let mut bands = column![].spacing(4).align_x(iced::Alignment::Center);
 
     // Header: EQ label + IN (bypass) toggle.
     let in_btn = {
@@ -256,7 +256,26 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         (3, 4, 5, false, LMF, "LMF"),
         (0, 1, 2, true, LF, "LF"),
     ];
-    for (gain_i, freq_i, third_i, is_bell_toggle, color, label) in rows {
+    for (i, (gain_i, freq_i, third_i, is_bell_toggle, color, label)) in
+        rows.into_iter().enumerate()
+    {
+        if i > 0 {
+            bands = bands.push(
+                container(text(""))
+                    .width(Length::Fixed(72.0))
+                    .height(Length::Fixed(1.0))
+                    .style(|_theme: &Theme| container::Style {
+                        background: Some(
+                            iced::Color {
+                                a: 0.5,
+                                ..th::BORDER
+                            }
+                            .into(),
+                        ),
+                        ..Default::default()
+                    }),
+            );
+        }
         bands = bands.push(view_eq_band(
             track.id,
             eq,
@@ -283,7 +302,7 @@ fn view_eq_band<'a>(
     color: iced::Color,
     label: &'static str,
 ) -> Element<'a, Message> {
-    let knob = |i: usize| -> Element<'a, Message> {
+    let knob = |i: usize, size: f32| -> Element<'a, Message> {
         let d = &eq.descriptors[i];
         let w = EffectKnobWidget::new(
             track_id,
@@ -296,25 +315,44 @@ fn view_eq_band<'a>(
             color,
         );
         canvas(w)
-            .width(Length::Fixed(24.0))
-            .height(Length::Fixed(24.0))
+            .width(Length::Fixed(size))
+            .height(Length::Fixed(size))
             .into()
     };
 
-    let third: Element<'a, Message> = if bell_toggle {
+    // Console stagger: the gain knob rides high on the left, the
+    // frequency knob sits low on the right, Q (or the bell switch)
+    // tucks under the gain. The eye zig-zags down the strip.
+    let dim = iced::Color {
+        a: 0.75,
+        ..th::TEXT_DIM
+    };
+    let gain_col = column![
+        row![
+            text(label).size(8).color(color),
+            text("dB").size(7).color(dim)
+        ]
+        .spacing(3)
+        .align_y(iced::Alignment::Center),
+        knob(gain_i, 30.0),
+    ]
+    .spacing(1)
+    .align_x(iced::Alignment::Center);
+
+    let third_el: Element<'a, Message> = if bell_toggle {
         let bell_on = eq.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
-        button(
-            text("B")
-                .size(8)
-                .color(if bell_on { th::BG_DARK } else { th::TEXT_DIM }),
-        )
+        button(text("BELL").size(6).color(if bell_on {
+            th::BG_DARK
+        } else {
+            th::TEXT_DIM
+        }))
         .on_press(Message::set_effect_param(
             track_id,
             eq.id,
             third_i,
             if bell_on { 0.0 } else { 1.0 },
         ))
-        .padding([2, 4])
+        .padding([2, 3])
         .style(move |_theme: &Theme, _status| button::Style {
             background: Some(if bell_on {
                 color.into()
@@ -331,17 +369,29 @@ fn view_eq_band<'a>(
         })
         .into()
     } else {
-        knob(third_i)
+        column![text("Q").size(7).color(dim), knob(third_i, 20.0)]
+            .spacing(1)
+            .align_x(iced::Alignment::Center)
+            .into()
     };
 
-    column![
-        text(label).size(8).color(color),
-        row![knob(gain_i), knob(freq_i), third]
-            .spacing(3)
-            .align_y(iced::Alignment::Center),
+    let freq_col = column![
+        text(if freq_i == 10 || freq_i == 7 { "kHz" } else { "Hz" })
+            .size(7)
+            .color(dim),
+        knob(freq_i, 26.0),
     ]
     .spacing(1)
-    .align_x(iced::Alignment::Center)
+    .align_x(iced::Alignment::Center);
+
+    row![
+        column![gain_col, third_el]
+            .spacing(3)
+            .align_x(iced::Alignment::Center),
+        column![text("").size(10), freq_col].align_x(iced::Alignment::Center),
+    ]
+    .spacing(8)
+    .align_y(iced::Alignment::Start)
     .into()
 }
 

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -152,7 +152,7 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
     ]
     .spacing(4)
     .padding(8)
-    .width(Length::Fixed(112.0))
+    .width(Length::Fixed(94.0))
     .height(Length::Fill)
     .align_x(iced::Alignment::Center);
 
@@ -215,7 +215,7 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
     const LMF: iced::Color = iced::Color::from_rgb(0.36, 0.48, 0.72);
     const LF: iced::Color = iced::Color::from_rgb(0.65, 0.46, 0.28);
 
-    let mut bands = column![].spacing(4).align_x(iced::Alignment::Center);
+    let mut bands = column![].spacing(2).align_x(iced::Alignment::Center);
 
     // Header: EQ label + IN (bypass) toggle.
     let in_btn = {
@@ -261,7 +261,7 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         if i > 0 {
             bands = bands.push(
                 container(text(""))
-                    .width(Length::Fixed(88.0))
+                    .width(Length::Fixed(74.0))
                     .height(Length::Fixed(1.0))
                     .style(|_theme: &Theme| container::Style {
                         background: Some(
@@ -333,7 +333,7 @@ fn view_eq_band<'a>(
         ]
         .spacing(3)
         .align_y(iced::Alignment::Center),
-        knob(gain_i, 30.0),
+        knob(gain_i, 26.0),
     ]
     .spacing(1)
     .align_x(iced::Alignment::Center);
@@ -368,7 +368,7 @@ fn view_eq_band<'a>(
         })
         .into()
     } else {
-        column![text("Q").size(7).color(dim), knob(third_i, 20.0)]
+        column![text("Q").size(7).color(dim), knob(third_i, 16.0)]
             .spacing(1)
             .align_x(iced::Alignment::Center)
             .into()
@@ -382,20 +382,18 @@ fn view_eq_band<'a>(
         })
         .size(7)
         .color(dim),
-        knob(freq_i, 26.0),
+        knob(freq_i, 22.0),
     ]
     .spacing(1)
     .align_x(iced::Alignment::Center);
 
     row![
         column![gain_col, third_el]
-            .spacing(3)
+            .spacing(2)
             .align_x(iced::Alignment::Center),
-        iced::widget::horizontal_space(),
-        column![text("").size(10), freq_col].align_x(iced::Alignment::Center),
+        column![text("").size(6), freq_col].align_x(iced::Alignment::Center),
     ]
-    .width(Length::Fill)
-    .padding([0, 6])
+    .spacing(9)
     .align_y(iced::Alignment::Start)
     .into()
 }

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -143,9 +143,9 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
 
     let strip = column![
         name_row,
+        eq_section,
         knob_canvas,
         pan_label,
-        eq_section,
         fader_meter,
         gain_label,
         mute_solo_row,

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -13,17 +13,28 @@ use crate::widgets::knob::KnobWidget;
 use crate::widgets::vu_meter::VuMeterWidget;
 use vibez_core::midi::TrackKind;
 
-/// Render a single mixer channel strip for a track.
+/// Render a single mixer channel strip for a track. The master bus
+/// renders through the same strip: EQ, fader, and meter, minus the
+/// controls that make no sense on a sum (pan, mute, solo).
 pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message> {
-    let track_color = th::track_color(track.color_index);
+    let is_master = track.id.is_master();
+    let track_color = if is_master {
+        th::ACCENT
+    } else {
+        th::track_color(track.color_index)
+    };
 
     // Track name + type icon
-    let type_icon = match track.kind {
-        TrackKind::Audio => icons::icon(icons::AUDIO_WAVEFORM)
-            .size(10)
-            .color(track_color),
-        TrackKind::Instrument(_) | TrackKind::Midi => {
-            icons::icon(icons::MUSIC).size(10).color(track_color)
+    let type_icon = if is_master {
+        icons::icon(icons::VOLUME_2).size(10).color(track_color)
+    } else {
+        match track.kind {
+            TrackKind::Audio => icons::icon(icons::AUDIO_WAVEFORM)
+                .size(10)
+                .color(track_color),
+            TrackKind::Instrument(_) | TrackKind::Midi => {
+                icons::icon(icons::MUSIC).size(10).color(track_color)
+            }
         }
     };
 
@@ -141,15 +152,32 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
 
     let eq_section = view_strip_eq(track);
 
-    let strip = column![
-        name_row,
-        eq_section,
-        knob_canvas,
-        pan_label,
-        fader_meter,
-        gain_label,
-        mute_solo_row,
-    ]
+    let strip = if is_master {
+        // No pan, mute, or solo on the sum: a MASTER tag keeps the
+        // strip's vertical rhythm instead.
+        let badge = container(text("MASTER").size(8).color(th::ACCENT))
+            .padding([3, 8])
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::BG_ELEVATED.into()),
+                border: iced::Border {
+                    color: th::ACCENT_DIM,
+                    width: 1.0,
+                    radius: 2.0.into(),
+                },
+                ..Default::default()
+            });
+        column![name_row, eq_section, badge, fader_meter, gain_label]
+    } else {
+        column![
+            name_row,
+            eq_section,
+            knob_canvas,
+            pan_label,
+            fader_meter,
+            gain_label,
+            mute_solo_row,
+        ]
+    }
     .spacing(4)
     .padding(8)
     .width(Length::Fixed(94.0))
@@ -217,10 +245,10 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
     };
 
     // Console band colors, muted for the theme.
-    const HF: iced::Color = iced::Color::from_rgb(0.76, 0.33, 0.30);
-    const HMF: iced::Color = iced::Color::from_rgb(0.33, 0.62, 0.38);
-    const LMF: iced::Color = iced::Color::from_rgb(0.36, 0.48, 0.72);
-    const LF: iced::Color = iced::Color::from_rgb(0.65, 0.46, 0.28);
+    const HF: iced::Color = th::EQ_HF;
+    const HMF: iced::Color = th::EQ_HMF;
+    const LMF: iced::Color = th::EQ_LMF;
+    const LF: iced::Color = th::EQ_LF;
 
     let mut bands = column![].spacing(2).align_x(iced::Alignment::Center);
 

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -2,6 +2,7 @@ pub mod audio_clip_detail;
 pub mod automation_lane;
 pub mod effect_knob;
 pub mod effect_slot;
+pub mod eq_display;
 pub mod fader;
 pub mod knob;
 pub mod mini_waveform;


### PR DESCRIPTION
Follow-up to #41 per Alex's review:

- **No more '+ EQ' button**: every track carries its channel EQ from creation (flat = neutral), and project load backfills older tracks. Strip order is console-style with the EQ front and center at the top.
- **Zigzag band layout** like the 611E: bigger gain knob high-left (dB), frequency knob offset low-right (kHz/Hz), Q or BELL under the gain, hairline separators between bands.

Verified in the sandbox: the pre-EQ demo project opens straight into full console strips with the staggered layout.