### PR TITLE
Themes: 20 built-ins, .vzt user themes, .vzp project extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,6 +5078,7 @@ dependencies = [
  "rtrb",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "vibez-audio-io",
  "vibez-core",

--- a/crates/vibez-ui/Cargo.toml
+++ b/crates/vibez-ui/Cargo.toml
@@ -22,3 +22,6 @@ rfd = "0.15"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync"] }
 x11rb = "0.13"
 dirs = "5"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -159,7 +159,7 @@ impl App {
             ..Default::default()
         };
 
-        let state = AppState {
+        let mut state = AppState {
             transport: crate::state::TransportState {
                 sample_rate,
                 ..Default::default()
@@ -174,6 +174,27 @@ impl App {
             },
             ..Default::default()
         };
+
+        // Themes: scan the user's .vzt collection, then restore the
+        // saved selection (built-in name or user theme name).
+        let (user_themes, theme_warnings) = crate::themes::scan_user_themes();
+        for warning in theme_warnings {
+            eprintln!("vibez: theme scan: {warning}");
+        }
+        state.user_themes = user_themes;
+        if let Some(name) = &ui_settings.theme {
+            let palette = crate::themes::builtin_by_name(name).or_else(|| {
+                state
+                    .user_themes
+                    .iter()
+                    .find(|t| t.palette.name == *name)
+                    .map(|t| t.palette.clone())
+            });
+            if let Some(palette) = palette {
+                th::set_theme(palette);
+                state.current_theme_name = name.clone();
+            }
+        }
 
         let (plugin_effect_tx, plugin_effect_rx) = std::sync::mpsc::channel();
         let (plugin_instrument_tx, plugin_instrument_rx) = std::sync::mpsc::channel();
@@ -228,8 +249,9 @@ impl App {
             )
         };
 
-        // `vibez <project.vibez>` opens a project straight from the
-        // command line (also how file-manager associations launch us).
+        // `vibez <project.vzp>` opens a project straight from the
+        // command line (also how file-manager associations launch
+        // us). Legacy `.vibez` files load the same way.
         let open_task = std::env::args()
             .nth(1)
             .map(std::path::PathBuf::from)
@@ -238,6 +260,18 @@ impl App {
             .unwrap_or_else(Task::none);
 
         (app, Task::batch([startup_task, open_task]))
+    }
+
+    /// Find a theme by name: built-ins first, then the scanned user
+    /// collection.
+    pub(crate) fn resolve_theme(&self, name: &str) -> Option<crate::theme::ThemePalette> {
+        crate::themes::builtin_by_name(name).or_else(|| {
+            self.state
+                .user_themes
+                .iter()
+                .find(|t| t.palette.name == name)
+                .map(|t| t.palette.clone())
+        })
     }
 
     fn send_command(&mut self, cmd: EngineCommand) {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -120,6 +120,7 @@ impl App {
             auto_warp_on_import: self.state.auto_warp_on_import,
             warp_confidence_threshold: self.state.warp_confidence_threshold,
             preferred_midi_input: self.midi_input.as_ref().map(|h| h.port_name.clone()),
+            theme: Some(self.state.current_theme_name.clone()),
         };
         if let Err(err) = settings.save() {
             self.state.status_text = format!("UI settings save error: {err}");

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -418,6 +418,54 @@ impl App {
                 self.persist_ui_settings();
                 self.state.status_text = "MIDI input disconnected".to_string();
             }
+            Message::SelectTheme(name) => {
+                if let Some(palette) = self.resolve_theme(&name) {
+                    th::set_theme(palette);
+                    self.state.current_theme_name = name.clone();
+                    self.persist_ui_settings();
+                    self.state.status_text = format!("Theme: {name}");
+                } else {
+                    self.state.status_text = format!("Theme {name:?} not found");
+                }
+            }
+            Message::RescanThemes => {
+                let (themes, warnings) = crate::themes::scan_user_themes();
+                let count = themes.len();
+                self.state.user_themes = themes;
+                self.state.status_text = if warnings.is_empty() {
+                    format!("{count} user theme(s) found")
+                } else {
+                    format!("{count} user theme(s), {} skipped", warnings.len())
+                };
+                for warning in warnings {
+                    eprintln!("vibez: theme scan: {warning}");
+                }
+            }
+            Message::ThemeSaveNameChanged(name) => {
+                self.state.theme_save_name = name;
+            }
+            Message::SaveCurrentTheme => {
+                let name = self.state.theme_save_name.trim().to_string();
+                if name.is_empty() {
+                    self.state.status_text = "Name the theme before saving".to_string();
+                    return Task::none();
+                }
+                let mut palette = th::current();
+                palette.name = name.clone();
+                match crate::themes::save_user_theme(&palette) {
+                    Ok(path) => {
+                        let (themes, _) = crate::themes::scan_user_themes();
+                        self.state.user_themes = themes;
+                        self.state.current_theme_name = name;
+                        self.state.theme_save_name.clear();
+                        self.persist_ui_settings();
+                        self.state.status_text = format!("Theme saved to {}", path.display());
+                    }
+                    Err(err) => {
+                        self.state.status_text = format!("Theme save error: {err}");
+                    }
+                }
+            }
             Message::RewarpAllClips => {
                 return self.handle_rewarp_all_clips();
             }
@@ -544,7 +592,7 @@ impl App {
                     async {
                         let handle = rfd::AsyncFileDialog::new()
                             .set_title("Open Vibez Project")
-                            .add_filter("Vibez Project", &["vibez", "json"])
+                            .add_filter("Vibez Project", &["vzp", "vibez", "json"])
                             .pick_file()
                             .await;
                         handle.map(|file| file.path().to_path_buf())
@@ -566,8 +614,8 @@ impl App {
                     async {
                         let handle = rfd::AsyncFileDialog::new()
                             .set_title("Save Vibez Project")
-                            .set_file_name("Untitled.vibez")
-                            .add_filter("Vibez Project", &["vibez"])
+                            .set_file_name("Untitled.vzp")
+                            .add_filter("Vibez Project", &["vzp", "vibez"])
                             .save_file()
                             .await;
                         handle.map(|file| file.path().to_path_buf())
@@ -590,7 +638,7 @@ impl App {
             Message::ProjectSavePathSelected(path) => {
                 if let Some(mut path) = path {
                     if path.extension().is_none() {
-                        path.set_extension("vibez");
+                        path.set_extension("vzp");
                     }
                     let project = self.project_from_state();
                     return Task::perform(save_project_async(path, project), Message::ProjectSaved);

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -27,27 +27,27 @@ impl App {
             );
             let dropbox_active = !local_active;
             let tab_btn = |label: &'static str, active: bool, mode| {
-                button(
-                    text(label)
-                        .size(11)
-                        .color(if active { th::ACCENT } else { th::TEXT_DIM }),
-                )
+                button(text(label).size(11).color(if active {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                }))
                 .on_press(Message::Browser(BrowserMsg::SetSampleBrowserMode(mode)))
                 .padding([4, 12])
                 .style(move |_theme: &Theme, status| {
                     let bg = if active {
-                        Some(th::ACCENT_DIM.into())
+                        Some(th::accent_dim().into())
                     } else {
                         match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::BG_HOVER.into())
+                                Some(th::bg_hover().into())
                             }
                             _ => None,
                         }
                     };
                     button::Style {
                         background: bg,
-                        text_color: if active { th::ACCENT } else { th::TEXT_DIM },
+                        text_color: if active { th::accent() } else { th::text_dim() },
                         border: iced::Border::default(),
                         ..Default::default()
                     }
@@ -82,9 +82,9 @@ impl App {
         .width(Length::Fixed(320.0))
         .height(Length::Fill)
         .style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 0.0.into(),
             },
@@ -94,19 +94,21 @@ impl App {
     }
 
     pub(super) fn view_local_sample_browser(&self) -> Element<'_, Message> {
-        let title = text("Sample Browser").size(14).color(th::ACCENT);
-        let mut add_root_btn = button(text("Add Root").size(11).color(th::TEXT))
+        let title = text("Sample Browser").size(14).color(th::accent());
+        let mut add_root_btn = button(text("Add Root").size(11).color(th::text()))
             .padding([4, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_ELEVATED.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_elevated().into()),
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -115,18 +117,20 @@ impl App {
             });
         add_root_btn = add_root_btn.on_press(Message::AddSampleLibraryRoot);
 
-        let mut rescan_btn = button(text("Rescan").size(11).color(th::TEXT))
+        let mut rescan_btn = button(text("Rescan").size(11).color(th::text()))
             .padding([4, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_ELEVATED.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_elevated().into()),
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -146,7 +150,7 @@ impl App {
                 header,
                 text("Add a root folder to index your sample library.")
                     .size(12)
-                    .color(th::TEXT_DIM)
+                    .color(th::text_dim())
             ]
             .spacing(10)
             .padding(10);
@@ -154,9 +158,9 @@ impl App {
                 .width(Length::Fixed(320.0))
                 .height(Length::Fill)
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_SURFACE.into()),
+                    background: Some(th::bg_surface().into()),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 0.0.into(),
                     },
@@ -174,25 +178,31 @@ impl App {
         let mut roots_col = column![].spacing(4);
         let all_active = self.state.browser.root_filter.is_none();
         let mut all_btn = button(text("All Roots").size(11).color(if all_active {
-            th::ACCENT
+            th::accent()
         } else {
-            th::TEXT_DIM
+            th::text_dim()
         }))
         .padding([4, 8])
         .style(move |_theme: &Theme, status| {
             let bg = if all_active {
-                Some(th::ACCENT_DIM.into())
+                Some(th::accent_dim().into())
             } else {
                 match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_ELEVATED.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_elevated().into()),
                 }
             };
             button::Style {
                 background: bg,
-                text_color: if all_active { th::ACCENT } else { th::TEXT_DIM },
+                text_color: if all_active {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                },
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -210,28 +220,28 @@ impl App {
                 .as_ref()
                 .is_some_and(|selected| selected == root);
             let mut filter_btn = button(text(root_label(root)).size(11).color(if active {
-                th::ACCENT
+                th::accent()
             } else {
-                th::TEXT
+                th::text()
             }))
             .padding([4, 8])
             .width(Length::Fill)
             .style(move |_theme: &Theme, status| {
                 let bg = if active {
-                    Some(th::ACCENT_DIM.into())
+                    Some(th::accent_dim().into())
                 } else {
                     match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     }
                 };
                 button::Style {
                     background: bg,
-                    text_color: if active { th::ACCENT } else { th::TEXT },
+                    text_color: if active { th::accent() } else { th::text() },
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -242,7 +252,7 @@ impl App {
                 BrowserMsg::SelectSampleBrowserRoot(Some(root.clone())),
             ));
 
-            let remove_btn = button(icons::icon(icons::X).size(10).color(th::DANGER))
+            let remove_btn = button(icons::icon(icons::X).size(10).color(th::danger()))
                 .on_press(Message::Browser(BrowserMsg::RemoveSampleLibraryRoot(
                     root.clone(),
                 )))
@@ -250,13 +260,13 @@ impl App {
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::DANGER,
+                        text_color: th::danger(),
                         border: iced::Border::default(),
                         ..Default::default()
                     }
@@ -304,13 +314,13 @@ impl App {
             let entry_body = container(
                 column![
                     text(entry.name.as_str()).size(12).color(if selected {
-                        th::ACCENT
+                        th::accent()
                     } else {
-                        th::TEXT
+                        th::text()
                     }),
                     text(entry.relative_path.display().to_string())
                         .size(10)
-                        .color(th::TEXT_DIM)
+                        .color(th::text_dim())
                 ]
                 .spacing(2)
                 .width(Length::Fill),
@@ -320,14 +330,14 @@ impl App {
             .style(move |_theme: &Theme| container::Style {
                 background: Some(
                     if selected {
-                        th::ACCENT_DIM
+                        th::accent_dim()
                     } else {
-                        th::BG_ELEVATED
+                        th::bg_elevated()
                     }
                     .into(),
                 ),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -340,21 +350,21 @@ impl App {
                 }))
                 .on_release(Message::ClickLocalBrowserEntry(entry.source.clone()))
                 .into();
-            let preview_btn = button(icons::icon(icons::VOLUME_2).size(12).color(th::TEXT_DIM))
+            let preview_btn = button(icons::icon(icons::VOLUME_2).size(12).color(th::text_dim()))
                 .on_press(Message::PreviewLocalEntry(entry.source.clone()))
                 .padding([6, 8])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::ACCENT,
+                        text_color: th::accent(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -373,7 +383,7 @@ impl App {
                 container(
                     text("No samples match the current filters")
                         .size(11)
-                        .color(th::TEXT_DIM),
+                        .color(th::text_dim()),
                 )
                 .padding([8, 4]),
             );
@@ -390,7 +400,7 @@ impl App {
             }
         ))
         .size(10)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
 
         let selected_text = selected_entry
             .map(|entry| entry.relative_path.display().to_string())
@@ -412,18 +422,20 @@ impl App {
             _ => "No sampler or drum rack selected".to_string(),
         };
 
-        let mut add_clip_btn = button(text("Add Clip").size(11).color(th::TEXT))
+        let mut add_clip_btn = button(text("Add Clip").size(11).color(th::text()))
             .padding([6, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_ELEVATED.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_elevated().into()),
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -434,18 +446,20 @@ impl App {
             add_clip_btn = add_clip_btn.on_press(Message::ImportSelectedBrowserSampleToArrangement);
         }
 
-        let mut load_device_btn = button(text("Load Device").size(11).color(th::TEXT))
+        let mut load_device_btn = button(text("Load Device").size(11).color(th::text()))
             .padding([6, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_ELEVATED.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_elevated().into()),
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -457,8 +471,8 @@ impl App {
         }
 
         let footer = column![
-            text(selected_text).size(11).color(th::TEXT),
-            text(selected_hint).size(10).color(th::TEXT_DIM),
+            text(selected_text).size(11).color(th::text()),
+            text(selected_hint).size(10).color(th::text_dim()),
             row![add_clip_btn, load_device_btn]
                 .spacing(6)
                 .align_y(iced::Alignment::Center)
@@ -482,7 +496,7 @@ impl App {
     }
 
     pub(super) fn view_dropbox_browser(&self) -> Element<'_, Message> {
-        let title = text("Dropbox").size(14).color(th::ACCENT);
+        let title = text("Dropbox").size(14).color(th::accent());
 
         if !self.state.browser.dropbox.connected {
             let hint = if self.state.browser.dropbox.auth_in_progress {
@@ -490,7 +504,7 @@ impl App {
             } else {
                 "Connect in Settings > Dropbox to browse your library."
             };
-            return column![title, text(hint).size(12).color(th::TEXT_DIM)]
+            return column![title, text(hint).size(12).color(th::text_dim())]
                 .spacing(10)
                 .padding(10)
                 .height(Length::Fill)
@@ -504,7 +518,7 @@ impl App {
             .account_email
             .clone()
             .unwrap_or_default();
-        let header = column![title, text(account).size(11).color(th::TEXT_DIM),].spacing(2);
+        let header = column![title, text(account).size(11).color(th::text_dim()),].spacing(2);
 
         let mut rows: Vec<Element<'_, Message>> = Vec::new();
         self.render_dropbox_tree(String::new(), 0, &mut rows);
@@ -514,7 +528,7 @@ impl App {
             } else {
                 "Empty (or still fetching)."
             };
-            rows.push(text(msg).size(11).color(th::TEXT_DIM).into());
+            rows.push(text(msg).size(11).color(th::text_dim()).into());
         }
         let mut entries_col = column![].spacing(2);
         for row in rows {
@@ -531,20 +545,20 @@ impl App {
         // no dedicated button here.
 
         let add_clip_btn: Element<'_, Message> = {
-            let mut btn = button(text("Add Clip").size(11).color(th::TEXT))
+            let mut btn = button(text("Add Clip").size(11).color(th::text()))
                 .padding([6, 10])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT,
+                        text_color: th::text(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -558,20 +572,20 @@ impl App {
         };
 
         let load_device_btn: Element<'_, Message> = {
-            let mut btn = button(text("Load Device").size(11).color(th::TEXT))
+            let mut btn = button(text("Load Device").size(11).color(th::text()))
                 .padding([6, 10])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT,
+                        text_color: th::text(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -589,13 +603,13 @@ impl App {
 
         let error_line: Element<'_, Message> =
             if let Some(err) = self.state.browser.dropbox.last_error.clone() {
-                text(err).size(10).color(th::DANGER).into()
+                text(err).size(10).color(th::danger()).into()
             } else {
                 horizontal_space().width(Length::Shrink).into()
             };
 
         let footer = column![
-            text(selected_label).size(11).color(th::TEXT),
+            text(selected_label).size(11).color(th::text()),
             row![add_clip_btn, load_device_btn].spacing(6),
             error_line,
         ]
@@ -663,16 +677,16 @@ impl App {
                 // Audio rows use a container + mouse_area so press events
                 // reach us (iced Button captures ButtonPressed, which would
                 // hide the drag from mouse_area).
-                let text_color = if selected { th::ACCENT } else { th::TEXT };
+                let text_color = if selected { th::accent() } else { th::text() };
                 let row_body = container(text(label).size(11).color(text_color))
                     .padding([3, 6])
                     .width(Length::Fill)
                     .style(move |_theme: &Theme| container::Style {
                         background: Some(
                             if selected {
-                                th::ACCENT_DIM
+                                th::accent_dim()
                             } else {
-                                th::BG_ELEVATED
+                                th::bg_elevated()
                             }
                             .into(),
                         ),
@@ -691,19 +705,19 @@ impl App {
                     }))
                     .on_release(msg)
                     .into();
-                let speaker = button(icons::icon(icons::VOLUME_2).size(11).color(th::ACCENT))
+                let speaker = button(icons::icon(icons::VOLUME_2).size(11).color(th::accent()))
                     .on_press(Message::DropboxPreview(entry.clone()))
                     .padding([3, 6])
                     .style(|_theme: &Theme, status| {
                         let bg = match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::BG_HOVER.into())
+                                Some(th::bg_hover().into())
                             }
                             _ => None,
                         };
                         button::Style {
                             background: bg,
-                            text_color: th::ACCENT,
+                            text_color: th::accent(),
                             border: iced::Border::default(),
                             ..Default::default()
                         }
@@ -718,29 +732,29 @@ impl App {
                 // Folders + non-audio entries keep the button path since they
                 // don't participate in drag.
                 let btn = button(text(label).size(11).color(if selected {
-                    th::ACCENT
+                    th::accent()
                 } else if entry.is_folder {
-                    th::TEXT
+                    th::text()
                 } else {
-                    th::TEXT_DIM
+                    th::text_dim()
                 }))
                 .on_press(msg)
                 .padding([3, 6])
                 .width(Length::Fill)
                 .style(move |_theme: &Theme, status| {
                     let bg = if selected {
-                        Some(th::ACCENT_DIM.into())
+                        Some(th::accent_dim().into())
                     } else {
                         match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::BG_HOVER.into())
+                                Some(th::bg_hover().into())
                             }
-                            _ => Some(th::BG_ELEVATED.into()),
+                            _ => Some(th::bg_elevated().into()),
                         }
                     };
                     button::Style {
                         background: bg,
-                        text_color: if selected { th::ACCENT } else { th::TEXT },
+                        text_color: if selected { th::accent() } else { th::text() },
                         border: iced::Border::default(),
                         ..Default::default()
                     }

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -38,11 +38,11 @@ impl App {
             let clip_tab = {
                 let active = self.state.view.detail_panel_tab == DetailPanelTab::Clip;
                 let (bg, text_color, border_color) = if active {
-                    (th::BG_ELEVATED, th::ACCENT, th::ACCENT_DIM)
+                    (th::bg_elevated(), th::accent(), th::accent_dim())
                 } else {
                     (
                         iced::Color::TRANSPARENT,
-                        th::TEXT_DIM,
+                        th::text_dim(),
                         iced::Color::TRANSPARENT,
                     )
                 };
@@ -65,11 +65,11 @@ impl App {
             let devices_tab = {
                 let active = self.state.view.detail_panel_tab == DetailPanelTab::Devices;
                 let (bg, text_color, border_color) = if active {
-                    (th::BG_ELEVATED, th::ACCENT, th::ACCENT_DIM)
+                    (th::bg_elevated(), th::accent(), th::accent_dim())
                 } else {
                     (
                         iced::Color::TRANSPARENT,
-                        th::TEXT_DIM,
+                        th::text_dim(),
                         iced::Color::TRANSPARENT,
                     )
                 };
@@ -139,7 +139,7 @@ impl App {
         } else {
             let label = text("Select a track to view devices")
                 .size(14)
-                .color(th::TEXT_DIM);
+                .color(th::text_dim());
             center(label)
                 .width(Length::Fill)
                 .height(Length::Fill)
@@ -160,9 +160,9 @@ impl App {
             .width(Length::Fill)
             .height(panel_height)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_DARK.into()),
+                background: Some(th::bg_dark().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 0.0.into(),
                 },
@@ -174,7 +174,7 @@ impl App {
     pub(super) fn view_clip_placeholder(&self) -> Element<'_, Message> {
         let label = text("Select a clip to view details")
             .size(14)
-            .color(th::TEXT_DIM);
+            .color(th::text_dim());
         center(label)
             .width(Length::Fill)
             .height(Length::Fill)
@@ -251,16 +251,20 @@ impl App {
         let mut content_col = column![].spacing(2).padding(4);
 
         if let Some((ref clip_name_str, clip_pos, clip_dur, clip_loop, tid, cid)) = clip_data {
-            let clip_name = text(clip_name_str.clone()).size(11).color(th::TEXT);
+            let clip_name = text(clip_name_str.clone()).size(11).color(th::text());
             let pos_label = text(format!("Pos: {clip_pos:.1}"))
                 .size(10)
-                .color(th::TEXT_DIM);
+                .color(th::text_dim());
             let dur_label = text(format!("Dur: {clip_dur:.1}"))
                 .size(10)
-                .color(th::TEXT_DIM);
+                .color(th::text_dim());
 
             // Loop toggle
-            let loop_icon_color = if clip_loop { th::ACCENT } else { th::TEXT_DIM };
+            let loop_icon_color = if clip_loop {
+                th::accent()
+            } else {
+                th::text_dim()
+            };
             let loop_btn = button(icons::icon(icons::REPEAT).size(10).color(loop_icon_color))
                 .on_press(Message::PianoRoll(PianoRollMsg::ToggleNoteClipLoop(
                     tid, cid,
@@ -268,16 +272,16 @@ impl App {
                 .padding([2, 4])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: if clip_loop {
-                        Some(th::ACCENT_DIM.into())
+                        Some(th::accent_dim().into())
                     } else {
-                        Some(th::BG_ELEVATED.into())
+                        Some(th::bg_elevated().into())
                     },
                     text_color: loop_icon_color,
                     border: iced::Border {
                         color: if clip_loop {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 3.0.into(),
@@ -287,10 +291,10 @@ impl App {
 
             // Clip operation buttons
             let op_btn_style = |_theme: &Theme, _status| button::Style {
-                background: Some(th::BG_ELEVATED.into()),
-                text_color: th::TEXT_DIM,
+                background: Some(th::bg_elevated().into()),
+                text_color: th::text_dim(),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 3.0.into(),
                 },
@@ -299,8 +303,8 @@ impl App {
 
             let dup_btn = button(
                 row![
-                    icons::icon(icons::COPY).size(10).color(th::TEXT_DIM),
-                    text("Dup").size(10).color(th::TEXT_DIM)
+                    icons::icon(icons::COPY).size(10).color(th::text_dim()),
+                    text("Dup").size(10).color(th::text_dim())
                 ]
                 .spacing(2)
                 .align_y(iced::Alignment::Center),
@@ -309,20 +313,20 @@ impl App {
             .padding([2, 6])
             .style(op_btn_style);
 
-            let double_btn = button(text("2x").size(10).color(th::TEXT_DIM))
+            let double_btn = button(text("2x").size(10).color(th::text_dim()))
                 .on_press(Message::PianoRoll(PianoRollMsg::DoubleNoteClip(tid, cid)))
                 .padding([2, 6])
                 .style(op_btn_style);
 
-            let halve_btn = button(text("\u{00BD}x").size(10).color(th::TEXT_DIM))
+            let halve_btn = button(text("\u{00BD}x").size(10).color(th::text_dim()))
                 .on_press(Message::PianoRoll(PianoRollMsg::HalveNoteClip(tid, cid)))
                 .padding([2, 6])
                 .style(op_btn_style);
 
             let crop_btn = button(
                 row![
-                    icons::icon(icons::SCISSORS).size(10).color(th::TEXT_DIM),
-                    text("Crop").size(10).color(th::TEXT_DIM)
+                    icons::icon(icons::SCISSORS).size(10).color(th::text_dim()),
+                    text("Crop").size(10).color(th::text_dim())
                 ]
                 .spacing(2)
                 .align_y(iced::Alignment::Center),
@@ -342,7 +346,7 @@ impl App {
         }
 
         // ── Header row: label, edit mode toggle, snap grid ──
-        let label = text("Piano Roll").size(11).color(th::TEXT_DIM);
+        let label = text("Piano Roll").size(11).color(th::text_dim());
 
         // Edit mode toggle: Select / Draw
         let select_active = self.state.piano_roll.edit_mode == PianoRollEditMode::Select;
@@ -350,9 +354,9 @@ impl App {
 
         let select_btn = {
             let (bg, tc) = if select_active {
-                (th::ACCENT_DIM, th::ACCENT)
+                (th::accent_dim(), th::accent())
             } else {
-                (th::BG_ELEVATED, th::TEXT_DIM)
+                (th::bg_elevated(), th::text_dim())
             };
             button(icons::icon(icons::MOUSE_POINTER).size(10).color(tc))
                 .on_press(Message::PianoRoll(PianoRollMsg::ToggleEditMode))
@@ -362,9 +366,9 @@ impl App {
                     text_color: tc,
                     border: iced::Border {
                         color: if select_active {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 3.0.into(),
@@ -375,9 +379,9 @@ impl App {
 
         let draw_btn = {
             let (bg, tc) = if draw_active {
-                (th::ACCENT_DIM, th::ACCENT)
+                (th::accent_dim(), th::accent())
             } else {
-                (th::BG_ELEVATED, th::TEXT_DIM)
+                (th::bg_elevated(), th::text_dim())
             };
             button(icons::icon(icons::PENCIL).size(10).color(tc))
                 .on_press(Message::PianoRoll(PianoRollMsg::ToggleEditMode))
@@ -387,9 +391,9 @@ impl App {
                     text_color: tc,
                     border: iced::Border {
                         color: if draw_active {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 3.0.into(),
@@ -406,9 +410,9 @@ impl App {
         for &grid in SnapGrid::all() {
             let is_active = self.state.view.snap_grid == grid;
             let (bg, text_color) = if is_active {
-                (th::ACCENT_DIM, th::ACCENT)
+                (th::accent_dim(), th::accent())
             } else {
-                (th::BG_ELEVATED, th::TEXT_DIM)
+                (th::bg_elevated(), th::text_dim())
             };
             let btn = button(text(grid.label()).size(10).color(text_color))
                 .on_press(Message::View(ViewMsg::SetSnapGrid(grid)))
@@ -418,9 +422,9 @@ impl App {
                     text_color,
                     border: iced::Border {
                         color: if is_active {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 3.0.into(),
@@ -429,7 +433,7 @@ impl App {
                 });
             snap_row = snap_row.push(btn);
         }
-        let snap_label = text("Snap:").size(10).color(th::TEXT_DIM);
+        let snap_label = text("Snap:").size(10).color(th::text_dim());
         let header_row = row![label, mode_row, horizontal_space(), snap_label, snap_row]
             .spacing(4)
             .align_y(iced::Alignment::Center);
@@ -440,9 +444,9 @@ impl App {
             .width(Length::FillPortion(1))
             .height(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_DARK.into()),
+                background: Some(th::bg_dark().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 0.0.into(),
                 },
@@ -485,14 +489,14 @@ impl App {
             .height(Length::Fill)
             .into();
 
-        let label = text("Waveform").size(11).color(th::TEXT_DIM);
+        let label = text("Waveform").size(11).color(th::text_dim());
         let clip_info = text(format!(
             "{}: {:.1}s",
             clip.name,
             clip.duration as f64 / self.state.transport.sample_rate as f64
         ))
         .size(10)
-        .color(th::TEXT_MUTED);
+        .color(th::text_muted());
 
         let header_row = row![label, horizontal_space(), clip_info]
             .spacing(4)
@@ -509,9 +513,9 @@ impl App {
             .width(Length::FillPortion(1))
             .height(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_DARK.into()),
+                background: Some(th::bg_dark().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 0.0.into(),
                 },
@@ -526,7 +530,7 @@ impl App {
         clip: &UiClip,
     ) -> Element<'_, Message> {
         let clip_id = clip.id;
-        let label = text("Warp").size(11).color(th::TEXT_DIM);
+        let label = text("Warp").size(11).color(th::text_dim());
 
         let default_text = clip
             .original_bpm
@@ -557,14 +561,14 @@ impl App {
 
         let button_style = |_theme: &Theme, status: button::Status| {
             let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                _ => Some(th::BG_ELEVATED.into()),
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
+                _ => Some(th::bg_elevated().into()),
             };
             button::Style {
                 background: bg,
-                text_color: th::TEXT,
+                text_color: th::text(),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -572,7 +576,7 @@ impl App {
             }
         };
 
-        let detect_btn = button(text("Detect").size(11).color(th::TEXT))
+        let detect_btn = button(text("Detect").size(11).color(th::text()))
             .on_press(Message::DetectClipBpm { track_id, clip_id })
             .padding([4, 10])
             .style(button_style);
@@ -580,7 +584,7 @@ impl App {
         let warp_btn = button(
             text(format!("Warp → {:.0} BPM", self.state.transport.bpm))
                 .size(11)
-                .color(th::TEXT),
+                .color(th::text()),
         )
         .on_press(Message::WarpClipToProject { track_id, clip_id })
         .padding([4, 10])
@@ -591,7 +595,7 @@ impl App {
             .align_y(iced::Alignment::Center);
 
         if clip.warped {
-            let clear_btn = button(text("Clear warp").size(11).color(th::TEXT_DIM))
+            let clear_btn = button(text("Clear warp").size(11).color(th::text_dim()))
                 .on_press(Message::Arrangement(ArrangementMsg::ClearClipWarp {
                     track_id,
                     clip_id,
@@ -606,7 +610,7 @@ impl App {
                     row_widgets = row_widgets.push(
                         text(format!("(was {:.0})", warped_to))
                             .size(10)
-                            .color(th::METER_YELLOW),
+                            .color(th::meter_yellow()),
                     );
                 }
             }
@@ -622,7 +626,7 @@ impl App {
                         self.state.transport.bpm
                     ))
                     .size(10)
-                    .color(th::METER_YELLOW),
+                    .color(th::meter_yellow()),
                 );
             }
         }
@@ -635,9 +639,9 @@ impl App {
         track_id: TrackId,
         clip_id: ClipId,
     ) -> Element<'_, Message> {
-        let label = text("Quantize").size(11).color(th::TEXT_DIM);
+        let label = text("Quantize").size(11).color(th::text_dim());
         let grid_btn = |grid: crate::state::SnapGrid| -> Element<'_, Message> {
-            button(text(grid.label()).size(11).color(th::TEXT))
+            button(text(grid.label()).size(11).color(th::text()))
                 .on_press(Message::QuantizeAudioClipAt {
                     track_id,
                     clip_id,
@@ -647,15 +651,15 @@ impl App {
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT,
+                        text_color: th::text(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -28,9 +28,9 @@ impl App {
         // Header: track name + right-click hint
         let track_label = text(format!("{} — Devices", track.name))
             .size(13)
-            .color(th::TEXT);
+            .color(th::text());
 
-        let hint_label = text("Right-click to add").size(10).color(th::TEXT_MUTED);
+        let hint_label = text("Right-click to add").size(10).color(th::text_muted());
 
         let header = row![track_label, horizontal_space(), hint_label]
             .spacing(8)
@@ -139,16 +139,16 @@ impl App {
         // Band columns, left to right along the frequency axis:
         // (label, gain idx, freq idx, third idx, bell?, color)
         let bands: [(&str, usize, usize, usize, bool, Color); 4] = [
-            ("LF", 0, 1, 2, true, th::EQ_LF),
-            ("LMF", 3, 4, 5, false, th::EQ_LMF),
-            ("HMF", 6, 7, 8, false, th::EQ_HMF),
-            ("HF", 9, 10, 11, true, th::EQ_HF),
+            ("LF", 0, 1, 2, true, th::eq_lf()),
+            ("LMF", 3, 4, 5, false, th::eq_lmf()),
+            ("HMF", 6, 7, 8, false, th::eq_hmf()),
+            ("HF", 9, 10, 11, true, th::eq_hf()),
         ];
 
         let knob_color = if effect.bypass {
-            th::TEXT_MUTED
+            th::text_muted()
         } else {
-            th::TEXT_DIM
+            th::text_dim()
         };
         let mut band_row = row![].spacing(4);
         for (label, gain_i, freq_i, third_i, is_bell, color) in bands {
@@ -176,9 +176,11 @@ impl App {
             let mut col = column![
                 text(label).size(9).color(band_color),
                 knob(gain_i, 28.0),
-                text(format!("{gain_v:+.1}")).size(8).color(th::TEXT_DIM),
+                text(format!("{gain_v:+.1}")).size(8).color(th::text_dim()),
                 knob(freq_i, 24.0),
-                text(format_value(freq_v, "Hz")).size(8).color(th::TEXT_DIM),
+                text(format_value(freq_v, "Hz"))
+                    .size(8)
+                    .color(th::text_dim()),
             ]
             .spacing(2)
             .width(Length::Fixed(BAND_COL_W))
@@ -187,9 +189,9 @@ impl App {
             if is_bell {
                 let bell_on = effect.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
                 let bell = button(text("BELL").size(6).color(if bell_on {
-                    th::BG_DARK
+                    th::bg_dark()
                 } else {
-                    th::TEXT_DIM
+                    th::text_dim()
                 }))
                 .on_press(Message::set_effect_param(
                     track_id,
@@ -202,11 +204,15 @@ impl App {
                     background: Some(if bell_on {
                         band_color.into()
                     } else {
-                        th::BG_ELEVATED.into()
+                        th::bg_elevated().into()
                     }),
-                    text_color: if bell_on { th::BG_DARK } else { th::TEXT_DIM },
+                    text_color: if bell_on {
+                        th::bg_dark()
+                    } else {
+                        th::text_dim()
+                    },
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 2.0.into(),
                     },
@@ -217,9 +223,9 @@ impl App {
                 let q_v = effect.params.get(third_i).copied().unwrap_or(0.7);
                 col = col.push(
                     row![
-                        text("Q").size(8).color(th::TEXT_DIM),
+                        text("Q").size(8).color(th::text_dim()),
                         knob(third_i, 20.0),
-                        text(format!("{q_v:.2}")).size(8).color(th::TEXT_DIM),
+                        text(format!("{q_v:.2}")).size(8).color(th::text_dim()),
                     ]
                     .spacing(2)
                     .align_y(iced::Alignment::Center),
@@ -252,7 +258,7 @@ impl App {
             .padding([4, 6])
             .width(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 ..Default::default()
             })
     }
@@ -264,11 +270,11 @@ impl App {
         remove: Option<Message>,
     ) -> iced::widget::Row<'_, Message> {
         let dot = text("\u{25CF}").size(8).color(track_color);
-        let name = text(name.to_string()).size(11).color(th::TEXT);
+        let name = text(name.to_string()).size(11).color(th::text());
         let mut r = row![dot, name].spacing(5).align_y(iced::Alignment::Center);
         if let Some(msg) = remove {
             let remove_btn: Element<'_, Message> =
-                Self::device_icon_btn(icons::X, th::TEXT_DIM, th::DANGER, msg).into();
+                Self::device_icon_btn(icons::X, th::text_dim(), th::danger(), msg).into();
             r = r.push(horizontal_space().width(Length::Fixed(12.0)));
             r = r.push(remove_btn);
         }
@@ -281,7 +287,7 @@ impl App {
         label: &'static str,
         content: Element<'a, Message>,
     ) -> Element<'a, Message> {
-        column![text(label).size(8).color(th::TEXT_MUTED), content]
+        column![text(label).size(8).color(th::text_muted()), content]
             .spacing(6)
             .align_x(iced::Alignment::Start)
             .into()
@@ -293,7 +299,7 @@ impl App {
             .width(Length::Fixed(1.0))
             .height(Length::Fixed(th::DEVICE_BODY_H - 12.0))
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::DIVIDER.into()),
+                background: Some(th::divider().into()),
                 ..Default::default()
             })
             .into()
@@ -312,9 +318,9 @@ impl App {
     pub(super) fn device_card(content: iced::widget::Column<'_, Message>) -> Element<'_, Message> {
         container(content)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_ELEVATED.into()),
+                background: Some(th::bg_elevated().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -335,8 +341,8 @@ impl App {
             .padding([3, 5])
             .style(move |_theme: &Theme, status| {
                 let (bg, tc) = match status {
-                    button::Status::Hovered => (Some(th::BG_HOVER.into()), hover_color),
-                    button::Status::Pressed => (Some(th::BG_DARK.into()), hover_color),
+                    button::Status::Hovered => (Some(th::bg_hover().into()), hover_color),
+                    button::Status::Pressed => (Some(th::bg_dark().into()), hover_color),
                     _ => (None, color),
                 };
                 button::Style {
@@ -362,26 +368,26 @@ impl App {
         let plugin_name = track.plugin_instrument_name.as_deref().unwrap_or("Plugin");
 
         let name_section =
-            container(text(plugin_name).size(11).color(th::TEXT)).width(Length::Fill);
+            container(text(plugin_name).size(11).color(th::text())).width(Length::Fill);
 
         // Edit button for plugins with a native GUI
         let edit_btn: Option<iced::widget::Button<'_, Message>> = if track.has_plugin_instrument_gui
         {
             let gui_key = PluginGuiKey::Instrument { track_id };
             Some(
-                button(text("Edit").size(9).color(th::TEXT_DIM))
+                button(text("Edit").size(9).color(th::text_dim()))
                     .on_press(Message::OpenPluginGui(gui_key))
                     .padding([2, 5])
                     .style(|_theme: &Theme, status| {
                         let (bg, tc) = match status {
-                            button::Status::Hovered => (Some(th::BG_HOVER.into()), th::ACCENT),
-                            _ => (None, th::TEXT_DIM),
+                            button::Status::Hovered => (Some(th::bg_hover().into()), th::accent()),
+                            _ => (None, th::text_dim()),
                         };
                         button::Style {
                             background: bg,
                             text_color: tc,
                             border: iced::Border {
-                                color: th::BORDER,
+                                color: th::border(),
                                 width: 1.0,
                                 radius: 3.0.into(),
                             },
@@ -395,8 +401,8 @@ impl App {
 
         let remove: Element<'a, Message> = Self::device_icon_btn(
             icons::X,
-            th::TEXT_DIM,
-            th::DANGER,
+            th::text_dim(),
+            th::danger(),
             Message::remove_track_instrument(track_id),
         )
         .into();
@@ -461,15 +467,23 @@ impl App {
                     .size(9)
                     .width(Length::Fixed(30.0))
                     .align_x(iced::Alignment::Center)
-                    .color(if active { th::BG_DARK } else { th::TEXT_DIM }),
+                    .color(if active {
+                        th::bg_dark()
+                    } else {
+                        th::text_dim()
+                    }),
             )
             .on_press(Message::set_instrument_param(track_id, 0, i as f32))
             .padding([3, 4])
             .style(move |_theme: &Theme, _status| button::Style {
-                background: Some(if active { th::ACCENT } else { th::BG_DARK }.into()),
-                text_color: if active { th::BG_DARK } else { th::TEXT_DIM },
+                background: Some(if active { th::accent() } else { th::bg_dark() }.into()),
+                text_color: if active {
+                    th::bg_dark()
+                } else {
+                    th::text_dim()
+                },
                 border: iced::Border {
-                    color: if active { th::ACCENT } else { th::BORDER },
+                    color: if active { th::accent() } else { th::border() },
                     width: 1.0,
                     radius: 3.0.into(),
                 },
@@ -583,26 +597,26 @@ impl App {
                 } else {
                     name.clone()
                 };
-                text(display).size(10).color(th::TEXT)
+                text(display).size(10).color(th::text())
             }
-            None => text("No Sample").size(10).color(th::TEXT_MUTED),
+            None => text("No Sample").size(10).color(th::text_muted()),
         };
-        let load_btn = button(text("Load").size(9).color(th::TEXT))
+        let load_btn = button(text("Load").size(9).color(th::text()))
             .on_press(Message::LoadSamplerSample(track_id))
             .padding([2, 8])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered => th::BG_HOVER,
-                    _ => th::BG_DARK,
+                    button::Status::Hovered => th::bg_hover(),
+                    _ => th::bg_dark(),
                 };
                 button::Style {
                     background: Some(bg.into()),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 3.0.into(),
                     },
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     ..Default::default()
                 }
             });
@@ -716,10 +730,10 @@ impl App {
                     column![
                         text(format!("{:02}  {pad_note}", pad_index + 1))
                             .size(9)
-                            .color(if active { th::ACCENT } else { th::TEXT_DIM }),
+                            .color(if active { th::accent() } else { th::text_dim() }),
                         text(label)
                             .size(8)
-                            .color(if active { th::ACCENT } else { th::TEXT })
+                            .color(if active { th::accent() } else { th::text() })
                     ]
                     .spacing(2)
                     .align_x(iced::Alignment::Center),
@@ -728,10 +742,21 @@ impl App {
                 .width(Length::Fixed(52.0))
                 .height(Length::Fixed(30.0))
                 .style(move |_theme: &Theme| container::Style {
-                    background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
-                    text_color: Some(if active { th::ACCENT } else { th::TEXT }),
+                    background: Some(
+                        if active {
+                            th::accent_dim()
+                        } else {
+                            th::bg_dark()
+                        }
+                        .into(),
+                    ),
+                    text_color: Some(if active { th::accent() } else { th::text() }),
                     border: iced::Border {
-                        color: if active { th::ACCENT_DIM } else { th::BORDER },
+                        color: if active {
+                            th::accent_dim()
+                        } else {
+                            th::border()
+                        },
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -761,42 +786,44 @@ impl App {
             .unwrap_or_else(|| "Use the browser or Load".to_string());
         let selected_pad_state = &track.drum_rack_pads[selected_pad];
 
-        let load_btn = button(text("Load").size(9).color(th::TEXT))
+        let load_btn = button(text("Load").size(9).color(th::text()))
             .on_press(Message::LoadDrumRackPadSample(track_id, selected_pad))
             .padding([2, 8])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered => th::BG_HOVER,
-                    _ => th::BG_DARK,
+                    button::Status::Hovered => th::bg_hover(),
+                    _ => th::bg_dark(),
                 };
                 button::Style {
                     background: Some(bg.into()),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 3.0.into(),
                     },
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     ..Default::default()
                 }
             });
 
-        let clear_btn = button(text("Clear").size(9).color(th::TEXT_DIM))
+        let clear_btn = button(text("Clear").size(9).color(th::text_dim()))
             .on_press(Message::clear_drum_rack_pad(track_id, selected_pad))
             .padding([2, 8])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_DARK.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_dark().into()),
                 };
                 button::Style {
                     background: bg,
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 3.0.into(),
                     },
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     ..Default::default()
                 }
             });
@@ -804,10 +831,10 @@ impl App {
         let footer = column![
             text(truncate_end(&selected_name, 22))
                 .size(10)
-                .color(th::TEXT),
+                .color(th::text()),
             text(truncate_end(&source_hint, 26))
                 .size(9)
-                .color(th::TEXT_DIM),
+                .color(th::text_dim()),
             row![load_btn, clear_btn]
                 .spacing(6)
                 .align_y(iced::Alignment::Center)
@@ -892,9 +919,9 @@ impl App {
 
         let one_shot_active = selected_pad_state.one_shot;
         let one_shot_btn = button(text("One-shot").size(9).color(if one_shot_active {
-            th::ACCENT
+            th::accent()
         } else {
-            th::TEXT_DIM
+            th::text_dim()
         }))
         .on_press(Message::Devices(
             crate::domains::devices::DevicesMsg::SetDrumPadOneShot {
@@ -907,22 +934,22 @@ impl App {
         .style(move |_theme: &Theme, _status| button::Style {
             background: Some(
                 if one_shot_active {
-                    th::ACCENT_DIM
+                    th::accent_dim()
                 } else {
-                    th::BG_DARK
+                    th::bg_dark()
                 }
                 .into(),
             ),
             text_color: if one_shot_active {
-                th::ACCENT
+                th::accent()
             } else {
-                th::TEXT_DIM
+                th::text_dim()
             },
             border: iced::Border {
                 color: if one_shot_active {
-                    th::ACCENT_DIM
+                    th::accent_dim()
                 } else {
-                    th::BORDER
+                    th::border()
                 },
                 width: 1.0,
                 radius: 3.0.into(),
@@ -930,7 +957,7 @@ impl App {
             ..Default::default()
         });
 
-        let mut choke_row = row![text("Choke").size(9).color(th::TEXT_DIM)]
+        let mut choke_row = row![text("Choke").size(9).color(th::text_dim())]
             .spacing(2)
             .align_y(iced::Alignment::Center);
         for (group, label) in [
@@ -941,30 +968,40 @@ impl App {
             (Some(4), "4"),
         ] {
             let active = selected_pad_state.choke_group == group;
-            let btn =
-                button(
-                    text(label)
-                        .size(9)
-                        .color(if active { th::ACCENT } else { th::TEXT_DIM }),
-                )
-                .on_press(Message::Devices(
-                    crate::domains::devices::DevicesMsg::SetDrumPadChokeGroup {
-                        track_id,
-                        pad_index: selected_pad,
-                        choke_group: group,
+            let btn = button(text(label).size(9).color(if active {
+                th::accent()
+            } else {
+                th::text_dim()
+            }))
+            .on_press(Message::Devices(
+                crate::domains::devices::DevicesMsg::SetDrumPadChokeGroup {
+                    track_id,
+                    pad_index: selected_pad,
+                    choke_group: group,
+                },
+            ))
+            .padding([2, 6])
+            .style(move |_theme: &Theme, _status| button::Style {
+                background: Some(
+                    if active {
+                        th::accent_dim()
+                    } else {
+                        th::bg_dark()
+                    }
+                    .into(),
+                ),
+                text_color: if active { th::accent() } else { th::text_dim() },
+                border: iced::Border {
+                    color: if active {
+                        th::accent_dim()
+                    } else {
+                        th::border()
                     },
-                ))
-                .padding([2, 6])
-                .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
-                    text_color: if active { th::ACCENT } else { th::TEXT_DIM },
-                    border: iced::Border {
-                        color: if active { th::ACCENT_DIM } else { th::BORDER },
-                        width: 1.0,
-                        radius: 3.0.into(),
-                    },
-                    ..Default::default()
-                });
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                ..Default::default()
+            });
             choke_row = choke_row.push(btn);
         }
 
@@ -1020,8 +1057,8 @@ impl App {
 
     /// Placeholder card for MIDI tracks with no instrument attached.
     pub(super) fn view_add_instrument_placeholder(&self) -> Element<'_, Message> {
-        let title = Self::device_title_bar(text("No Instrument").size(11).color(th::TEXT_DIM));
-        let body = container(text("Right-click to add").size(9).color(th::TEXT_MUTED))
+        let title = Self::device_title_bar(text("No Instrument").size(11).color(th::text_dim()));
+        let body = container(text("Right-click to add").size(9).color(th::text_muted()))
             .padding([8, 6])
             .width(Length::Fill);
 

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -39,9 +39,9 @@ impl App {
         if is_midi {
             let inst_active = menu.category == Some(DeviceMenuCategory::Instruments);
             let (bg, tc) = if inst_active {
-                (th::ACCENT_DIM, th::ACCENT)
+                (th::accent_dim(), th::accent())
             } else {
-                (th::BG_ELEVATED, th::TEXT_DIM)
+                (th::bg_elevated(), th::text_dim())
             };
             let inst_tab = button(text("Instruments").size(11).color(tc))
                 .on_press(Message::set_device_menu_category(
@@ -53,9 +53,9 @@ impl App {
                     text_color: tc,
                     border: iced::Border {
                         color: if inst_active {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 4.0.into(),
@@ -66,9 +66,9 @@ impl App {
         }
         let fx_active = menu.category == Some(DeviceMenuCategory::Effects);
         let (bg, tc) = if fx_active {
-            (th::ACCENT_DIM, th::ACCENT)
+            (th::accent_dim(), th::accent())
         } else {
-            (th::BG_ELEVATED, th::TEXT_DIM)
+            (th::bg_elevated(), th::text_dim())
         };
         let fx_tab = button(text("Effects").size(11).color(tc))
             .on_press(Message::set_device_menu_category(
@@ -80,9 +80,9 @@ impl App {
                 text_color: tc,
                 border: iced::Border {
                     color: if fx_active {
-                        th::ACCENT_DIM
+                        th::accent_dim()
                     } else {
-                        th::BORDER
+                        th::border()
                     },
                     width: 1.0,
                     radius: 4.0.into(),
@@ -94,9 +94,9 @@ impl App {
         // Plugins tab
         let plugins_active = menu.category == Some(DeviceMenuCategory::Plugins);
         let (bg, tc) = if plugins_active {
-            (th::ACCENT_DIM, th::ACCENT)
+            (th::accent_dim(), th::accent())
         } else {
-            (th::BG_ELEVATED, th::TEXT_DIM)
+            (th::bg_elevated(), th::text_dim())
         };
         let plugins_tab = button(text("Plugins").size(11).color(tc))
             .on_press(Message::set_device_menu_category(
@@ -108,9 +108,9 @@ impl App {
                 text_color: tc,
                 border: iced::Border {
                     color: if plugins_active {
-                        th::ACCENT_DIM
+                        th::accent_dim()
                     } else {
-                        th::BORDER
+                        th::border()
                     },
                     width: 1.0,
                     radius: 4.0.into(),
@@ -141,20 +141,20 @@ impl App {
                     if !search_lower.is_empty() && !name.to_lowercase().contains(&search_lower) {
                         continue;
                     }
-                    let btn = button(text(name).size(12).color(th::TEXT))
+                    let btn = button(text(name).size(12).color(th::text()))
                         .on_press(Message::set_track_instrument(track_id, kind))
                         .padding([6, 10])
                         .width(Length::Fill)
                         .style(|_theme: &Theme, status| {
                             let bg = match status {
                                 button::Status::Hovered | button::Status::Pressed => {
-                                    Some(th::BG_HOVER.into())
+                                    Some(th::bg_hover().into())
                                 }
                                 _ => None,
                             };
                             button::Style {
                                 background: bg,
-                                text_color: th::TEXT,
+                                text_color: th::text(),
                                 border: iced::Border::default(),
                                 ..Default::default()
                             }
@@ -169,7 +169,7 @@ impl App {
                     items_col = items_col.push(
                         text("No plugins scanned yet.\nUse File → Settings to scan.")
                             .size(11)
-                            .color(th::TEXT_DIM),
+                            .color(th::text_dim()),
                     );
                     est_rows = 2;
                 } else {
@@ -203,10 +203,10 @@ impl App {
                             // cell width: truncated names made the
                             // LSP suite indistinguishable.
                             let cell = column![
-                                text(plugin.name.clone()).size(11).color(th::TEXT),
+                                text(plugin.name.clone()).size(11).color(th::text()),
                                 text(format!("{format_badge} {cat_label}"))
                                     .size(9)
-                                    .color(th::TEXT_DIM),
+                                    .color(th::text_dim()),
                             ]
                             .spacing(1);
                             let btn = button(cell)
@@ -216,13 +216,13 @@ impl App {
                                 .style(|_theme: &Theme, status| {
                                     let bg = match status {
                                         button::Status::Hovered | button::Status::Pressed => {
-                                            Some(th::BG_HOVER.into())
+                                            Some(th::bg_hover().into())
                                         }
                                         _ => None,
                                     };
                                     button::Style {
                                         background: bg,
-                                        text_color: th::TEXT,
+                                        text_color: th::text(),
                                         border: iced::Border::default(),
                                         ..Default::default()
                                     }
@@ -239,20 +239,20 @@ impl App {
                     if !search_lower.is_empty() && !name.to_lowercase().contains(&search_lower) {
                         continue;
                     }
-                    let btn = button(text(name).size(12).color(th::TEXT))
+                    let btn = button(text(name).size(12).color(th::text()))
                         .on_press(Message::add_effect(track_id, et))
                         .padding([6, 10])
                         .width(Length::Fill)
                         .style(|_theme: &Theme, status| {
                             let bg = match status {
                                 button::Status::Hovered | button::Status::Pressed => {
-                                    Some(th::BG_HOVER.into())
+                                    Some(th::bg_hover().into())
                                 }
                                 _ => None,
                             };
                             button::Style {
                                 background: bg,
-                                text_color: th::TEXT,
+                                text_color: th::text(),
                                 border: iced::Border::default(),
                                 ..Default::default()
                             }
@@ -288,9 +288,9 @@ impl App {
             .width(Length::Fixed(menu_w));
 
         let menu_card = container(menu_content).style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 6.0.into(),
             },
@@ -320,8 +320,8 @@ impl App {
         let make_menu_btn = |label: &'static str, icon: char, msg: Message| {
             button(
                 row![
-                    icons::icon(icon).size(12).color(th::TEXT),
-                    text(label).size(12).color(th::TEXT)
+                    icons::icon(icon).size(12).color(th::text()),
+                    text(label).size(12).color(th::text())
                 ]
                 .spacing(6)
                 .align_y(iced::Alignment::Center),
@@ -331,12 +331,14 @@ impl App {
             .width(Length::Fill)
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border::default(),
                     ..Default::default()
                 }
@@ -362,8 +364,8 @@ impl App {
             row![
                 icons::icon(icons::SLIDERS_VERTICAL)
                     .size(12)
-                    .color(th::TEXT),
-                text("Settings...").size(12).color(th::TEXT)
+                    .color(th::text()),
+                text("Settings...").size(12).color(th::text())
             ]
             .spacing(6)
             .align_y(iced::Alignment::Center),
@@ -373,12 +375,12 @@ impl App {
         .width(Length::Fill)
         .style(|_theme: &Theme, status| {
             let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
                 _ => None,
             };
             button::Style {
                 background: bg,
-                text_color: th::TEXT,
+                text_color: th::text(),
                 border: iced::Border::default(),
                 ..Default::default()
             }
@@ -395,9 +397,9 @@ impl App {
             .width(Length::Fixed(220.0));
 
         let menu_card = container(menu_content).style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 6.0.into(),
             },
@@ -422,7 +424,7 @@ impl App {
             .size(14)
             .width(Length::Fixed(250.0));
 
-        let label = text("Rename Clip").size(14).color(th::TEXT);
+        let label = text("Rename Clip").size(14).color(th::text());
 
         let dialog = container(
             column![label, input]
@@ -431,9 +433,9 @@ impl App {
                 .width(Length::Fixed(280.0)),
         )
         .style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 6.0.into(),
             },
@@ -456,8 +458,8 @@ impl App {
             |icon_char: char, label_text: String, msg: Message| -> Element<'_, Message> {
                 button(
                     row![
-                        icons::icon(icon_char).size(13).color(th::TEXT),
-                        text(label_text).size(13).color(th::TEXT)
+                        icons::icon(icon_char).size(13).color(th::text()),
+                        text(label_text).size(13).color(th::text())
                     ]
                     .spacing(8)
                     .align_y(iced::Alignment::Center),
@@ -467,12 +469,12 @@ impl App {
                 .width(Length::Fill)
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => th::BG_HOVER,
-                        _ => th::BG_SURFACE,
+                        button::Status::Hovered | button::Status::Pressed => th::bg_hover(),
+                        _ => th::bg_surface(),
                     };
                     button::Style {
                         background: Some(bg.into()),
-                        text_color: th::TEXT,
+                        text_color: th::text(),
                         border: iced::Border::default(),
                         ..Default::default()
                     }
@@ -620,9 +622,9 @@ impl App {
 
         let menu_container = container(menu_items)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -93,6 +93,11 @@ impl App {
                 SettingsTab::Warping,
                 active == SettingsTab::Warping
             ),
+            make_tab_btn(
+                "Appearance",
+                SettingsTab::Appearance,
+                active == SettingsTab::Appearance
+            ),
         ]
         .spacing(0);
 
@@ -102,6 +107,7 @@ impl App {
             SettingsTab::Plugins => self.view_settings_plugins_tab(),
             SettingsTab::Dropbox => self.view_settings_dropbox_tab(),
             SettingsTab::Warping => self.view_settings_warping_tab(),
+            SettingsTab::Appearance => self.view_settings_appearance_tab(),
         };
 
         let content = column![
@@ -720,5 +726,198 @@ impl App {
         ]
         .spacing(10)
         .into()
+    }
+
+    pub(super) fn view_settings_appearance_tab(&self) -> Element<'_, Message> {
+        use iced::widget::scrollable;
+
+        let title = text("Appearance").size(14).color(th::text());
+        let hint = text(
+            "Themes recolor the whole interface, track palette included. \
+             Drop .vzt files in the themes folder and rescan to add your own.",
+        )
+        .size(11)
+        .color(th::text_dim());
+
+        // One selectable row per theme: swatch strip + name.
+        let theme_row = |palette: &th::ThemePalette| -> Element<'_, Message> {
+            let name = palette.name.clone();
+            let selected = self.state.current_theme_name == name;
+            let mut swatches = row![].spacing(2);
+            for color in [
+                palette.bg_dark,
+                palette.bg_elevated,
+                palette.accent,
+                palette.track_colors[0],
+                palette.track_colors[3],
+                palette.track_colors[5],
+            ] {
+                swatches = swatches.push(
+                    container(
+                        column![]
+                            .width(Length::Fixed(14.0))
+                            .height(Length::Fixed(14.0)),
+                    )
+                    .style(move |_theme: &Theme| container::Style {
+                        background: Some(color.into()),
+                        border: iced::Border {
+                            color: th::border(),
+                            width: 1.0,
+                            radius: 2.0.into(),
+                        },
+                        ..Default::default()
+                    }),
+                );
+            }
+            let label =
+                text(name.clone())
+                    .size(12)
+                    .color(if selected { th::accent() } else { th::text() });
+            let marker: Element<'_, Message> = if selected {
+                icons::icon(icons::CIRCLE_DOT)
+                    .size(11)
+                    .color(th::accent())
+                    .into()
+            } else {
+                icons::icon(icons::CIRCLE)
+                    .size(11)
+                    .color(th::text_muted())
+                    .into()
+            };
+            button(
+                row![marker, swatches, label]
+                    .spacing(10)
+                    .align_y(iced::Alignment::Center),
+            )
+            .on_press(Message::SelectTheme(name))
+            .padding([5, 8])
+            .width(Length::Fill)
+            .style(move |_theme: &Theme, status| {
+                let bg = if selected {
+                    Some(th::bg_elevated().into())
+                } else {
+                    match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::bg_hover().into())
+                        }
+                        _ => None,
+                    }
+                };
+                button::Style {
+                    background: bg,
+                    text_color: th::text(),
+                    border: iced::Border {
+                        color: if selected {
+                            th::accent_dim()
+                        } else {
+                            iced::Color::TRANSPARENT
+                        },
+                        width: 1.0,
+                        radius: 4.0.into(),
+                    },
+                    ..Default::default()
+                }
+            })
+            .into()
+        };
+
+        let mut builtin_col = column![].spacing(2);
+        for palette in crate::themes::builtins() {
+            builtin_col = builtin_col.push(theme_row(&palette));
+        }
+
+        // User theme section: scanned .vzt files + rescan, like the
+        // plugin library.
+        let user_header = row![
+            text("Your Themes").size(13).color(th::text()),
+            horizontal_space(),
+            text(crate::themes::themes_dir().display().to_string())
+                .size(10)
+                .color(th::text_muted()),
+            button(text("Rescan").size(11).color(th::accent()))
+                .on_press(Message::RescanThemes)
+                .padding([3, 10])
+                .style(|_theme: &Theme, status| {
+                    let bg = match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::bg_hover().into())
+                        }
+                        _ => None,
+                    };
+                    button::Style {
+                        background: bg,
+                        text_color: th::accent(),
+                        border: iced::Border {
+                            color: th::accent_dim(),
+                            width: 1.0,
+                            radius: 4.0.into(),
+                        },
+                        ..Default::default()
+                    }
+                }),
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center);
+
+        let mut user_col = column![].spacing(2);
+        if self.state.user_themes.is_empty() {
+            user_col = user_col.push(
+                text("No .vzt themes found — save one below or drop files in the folder.")
+                    .size(11)
+                    .color(th::text_muted()),
+            );
+        } else {
+            for user in &self.state.user_themes {
+                user_col = user_col.push(theme_row(&user.palette));
+            }
+        }
+
+        // Save the active palette under a new name.
+        let save_row = row![
+            text_input("Theme name...", &self.state.theme_save_name)
+                .on_input(Message::ThemeSaveNameChanged)
+                .on_submit(Message::SaveCurrentTheme)
+                .size(12)
+                .padding([5, 8]),
+            button(text("Save Current").size(11).color(th::text()))
+                .on_press(Message::SaveCurrentTheme)
+                .padding([6, 12])
+                .style(|_theme: &Theme, status| {
+                    let bg = match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::bg_hover().into())
+                        }
+                        _ => None,
+                    };
+                    button::Style {
+                        background: bg,
+                        text_color: th::text(),
+                        border: iced::Border {
+                            color: th::accent_dim(),
+                            width: 1.0,
+                            radius: 4.0.into(),
+                        },
+                        ..Default::default()
+                    }
+                }),
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center);
+
+        let divider = || {
+            container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
+                |_theme: &Theme| container::Style {
+                    background: Some(th::border().into()),
+                    ..Default::default()
+                },
+            )
+        };
+
+        let list = scrollable(column![builtin_col, divider(), user_header, user_col,].spacing(8))
+            .height(Length::Fixed(300.0));
+
+        column![title, hint, list, divider(), save_row]
+            .spacing(10)
+            .into()
     }
 }

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -16,18 +16,20 @@ use super::*;
 
 impl App {
     pub(super) fn view_settings_modal(&self) -> Element<'_, Message> {
-        let title = text("Settings").size(18).color(th::ACCENT);
-        let close_btn = button(icons::icon(icons::X).size(14).color(th::TEXT_DIM))
+        let title = text("Settings").size(18).color(th::accent());
+        let close_btn = button(icons::icon(icons::X).size(14).color(th::text_dim()))
             .on_press(Message::CloseSettings)
             .padding([4, 8])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border::default(),
                     ..Default::default()
                 }
@@ -37,7 +39,11 @@ impl App {
 
         // -- Tab bar --
         let make_tab_btn = |label: &'static str, tab: SettingsTab, is_active: bool| {
-            let color = if is_active { th::ACCENT } else { th::TEXT_DIM };
+            let color = if is_active {
+                th::accent()
+            } else {
+                th::text_dim()
+            };
             button(text(label).size(13).color(color))
                 .on_press(Message::SelectSettingsTab(tab))
                 .padding([6, 16])
@@ -47,7 +53,7 @@ impl App {
                     } else {
                         match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::BG_HOVER.into())
+                                Some(th::bg_hover().into())
                             }
                             _ => None,
                         }
@@ -57,7 +63,7 @@ impl App {
                         text_color: color,
                         border: iced::Border {
                             color: if is_active {
-                                th::ACCENT
+                                th::accent()
                             } else {
                                 Color::TRANSPARENT
                             },
@@ -102,14 +108,14 @@ impl App {
             header,
             container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
                 |_theme: &Theme| container::Style {
-                    background: Some(th::BORDER.into()),
+                    background: Some(th::border().into()),
                     ..Default::default()
                 }
             ),
             tab_bar,
             container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
                 |_theme: &Theme| container::Style {
-                    background: Some(th::BORDER.into()),
+                    background: Some(th::border().into()),
                     ..Default::default()
                 }
             ),
@@ -120,9 +126,9 @@ impl App {
         .width(Length::Fixed(480.0));
 
         let dialog = container(content).style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 8.0.into(),
             },
@@ -144,10 +150,10 @@ impl App {
     }
 
     pub(super) fn view_settings_audio_tab(&self) -> Element<'_, Message> {
-        let buf_label = text("Buffer Size").size(14).color(th::TEXT);
+        let buf_label = text("Buffer Size").size(14).color(th::text());
         let buf_hint = text("Lower = less latency, higher = more CPU headroom")
             .size(11)
-            .color(th::TEXT_DIM);
+            .color(th::text_dim());
 
         let sizes: &[u32] = &[64, 128, 256, 512, 1024, 2048, 4096];
         let mut buf_row = row![].spacing(4);
@@ -155,19 +161,19 @@ impl App {
             let is_selected = self.state.settings_buffer_size == size;
             let label = format!("{size}");
             let btn = button(text(label).size(11).color(if is_selected {
-                th::TEXT
+                th::text()
             } else {
-                th::TEXT_DIM
+                th::text_dim()
             }))
             .on_press(Message::SetBufferSize(size))
             .padding([6, 10])
             .style(move |_theme: &Theme, status| {
                 if is_selected {
                     button::Style {
-                        background: Some(th::ACCENT.into()),
-                        text_color: th::TEXT,
+                        background: Some(th::accent().into()),
+                        text_color: th::text(),
                         border: iced::Border {
-                            color: th::ACCENT,
+                            color: th::accent(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -176,15 +182,15 @@ impl App {
                 } else {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT_DIM,
+                        text_color: th::text_dim(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -195,41 +201,43 @@ impl App {
             buf_row = buf_row.push(btn);
         }
 
-        let sr_label = text("Sample Rate").size(14).color(th::TEXT);
+        let sr_label = text("Sample Rate").size(14).color(th::text());
         let sr_value = text(format!("{} Hz", self.state.transport.sample_rate))
             .size(13)
-            .color(th::TEXT_DIM);
+            .color(th::text_dim());
 
         // ---- MIDI input picker ----
-        let midi_label = text("MIDI Input").size(14).color(th::TEXT);
+        let midi_label = text("MIDI Input").size(14).color(th::text());
         let midi_hint = text(
             "External MIDI routes to the currently selected instrument track. \
              Plug your keyboard or Push in, hit Rescan, then pick the port.",
         )
         .size(11)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
 
         let current_port_line: Element<'_, Message> = match self.midi_input.as_ref() {
             Some(h) => text(format!("Connected: {}", h.port_name))
                 .size(12)
-                .color(th::ACCENT)
+                .color(th::accent())
                 .into(),
-            None => text("Not connected").size(12).color(th::TEXT_DIM).into(),
+            None => text("Not connected").size(12).color(th::text_dim()).into(),
         };
 
-        let rescan_btn = button(text("Rescan ports").size(11).color(th::TEXT))
+        let rescan_btn = button(text("Rescan ports").size(11).color(th::text()))
             .on_press(Message::RescanMidiInputs)
             .padding([4, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -237,19 +245,21 @@ impl App {
                 }
             });
 
-        let disconnect_btn = button(text("Disconnect").size(11).color(th::TEXT_DIM))
+        let disconnect_btn = button(text("Disconnect").size(11).color(th::text_dim()))
             .on_press(Message::CloseMidiInput)
             .padding([4, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -276,30 +286,30 @@ impl App {
                     name.clone()
                 })
                 .size(11)
-                .color(if is_current { th::ACCENT } else { th::TEXT }),
+                .color(if is_current { th::accent() } else { th::text() }),
             )
             .on_press(Message::OpenMidiInput(label))
             .padding([4, 10])
             .width(Length::Fill)
             .style(move |_theme: &Theme, status| {
                 let bg = if is_current {
-                    Some(th::BG_HOVER.into())
+                    Some(th::bg_hover().into())
                 } else {
                     match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     }
                 };
                 button::Style {
                     background: bg,
-                    text_color: if is_current { th::ACCENT } else { th::TEXT },
+                    text_color: if is_current { th::accent() } else { th::text() },
                     border: iced::Border {
                         color: if is_current {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 4.0.into(),
@@ -318,7 +328,7 @@ impl App {
             sr_value,
             container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
                 |_theme: &Theme| container::Style {
-                    background: Some(th::BORDER.into()),
+                    background: Some(th::border().into()),
                     ..Default::default()
                 }
             ),
@@ -334,18 +344,18 @@ impl App {
 
     pub(super) fn view_settings_plugins_tab(&self) -> Element<'_, Message> {
         // Plugin section header
-        let plugin_title = text("Plugin Library").size(14).color(th::TEXT);
+        let plugin_title = text("Plugin Library").size(14).color(th::text());
 
         // Default paths checkbox
         let default_paths_label = if self.state.plugin_settings.scan_default_paths {
-            icons::icon(icons::CIRCLE_DOT).size(12).color(th::ACCENT)
+            icons::icon(icons::CIRCLE_DOT).size(12).color(th::accent())
         } else {
-            icons::icon(icons::CIRCLE).size(12).color(th::TEXT_DIM)
+            icons::icon(icons::CIRCLE).size(12).color(th::text_dim())
         };
         let default_paths_btn = button(
             row![
                 default_paths_label,
-                text("Scan default system paths").size(12).color(th::TEXT)
+                text("Scan default system paths").size(12).color(th::text())
             ]
             .spacing(6)
             .align_y(iced::Alignment::Center),
@@ -354,7 +364,7 @@ impl App {
         .padding([4, 8])
         .style(|_theme: &Theme, _status| button::Style {
             background: None,
-            text_color: th::TEXT,
+            text_color: th::text(),
             border: iced::Border::default(),
             ..Default::default()
         });
@@ -370,20 +380,20 @@ impl App {
         {
             let path_text = text(path.display().to_string())
                 .size(11)
-                .color(th::TEXT_DIM);
-            let remove_btn = button(icons::icon(icons::X).size(10).color(th::DANGER))
+                .color(th::text_dim());
+            let remove_btn = button(icons::icon(icons::X).size(10).color(th::danger()))
                 .on_press(Message::RemovePluginScanPath(i))
                 .padding([2, 6])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::DANGER,
+                        text_color: th::danger(),
                         border: iced::Border::default(),
                         ..Default::default()
                     }
@@ -397,8 +407,8 @@ impl App {
 
         let add_path_btn = button(
             row![
-                icons::icon(icons::PLUS).size(12).color(th::ACCENT),
-                text("Add Path").size(12).color(th::ACCENT)
+                icons::icon(icons::PLUS).size(12).color(th::accent()),
+                text("Add Path").size(12).color(th::accent())
             ]
             .spacing(4)
             .align_y(iced::Alignment::Center),
@@ -407,14 +417,14 @@ impl App {
         .padding([6, 12])
         .style(|_theme: &Theme, status| {
             let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
                 _ => None,
             };
             button::Style {
                 background: bg,
-                text_color: th::ACCENT,
+                text_color: th::accent(),
                 border: iced::Border {
-                    color: th::ACCENT_DIM,
+                    color: th::accent_dim(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -428,21 +438,21 @@ impl App {
         } else {
             "Scan Plugins"
         };
-        let scan_btn = button(text(scan_label).size(12).color(th::TEXT))
+        let scan_btn = button(text(scan_label).size(12).color(th::text()))
             .on_press(Message::ScanPlugins)
             .padding([8, 16])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
                     button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::ACCENT_DIM.into())
+                        Some(th::accent_dim().into())
                     }
-                    _ => Some(th::BG_ELEVATED.into()),
+                    _ => Some(th::bg_elevated().into()),
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -455,11 +465,11 @@ impl App {
         let status = if !self.state.plugin_scan_status.is_empty() {
             text(&self.state.plugin_scan_status)
                 .size(11)
-                .color(th::TEXT_DIM)
+                .color(th::text_dim())
         } else {
             text(format!("{cache_count} plugins cached"))
                 .size(11)
-                .color(th::TEXT_DIM)
+                .color(th::text_dim())
         };
 
         column![
@@ -476,32 +486,34 @@ impl App {
     }
 
     pub(super) fn view_settings_dropbox_tab(&self) -> Element<'_, Message> {
-        let title = text("Dropbox").size(14).color(th::TEXT);
+        let title = text("Dropbox").size(14).color(th::text());
         let hint = text(
             "Register an app at https://www.dropbox.com/developers/apps \
             (Scoped access, Full Dropbox). Paste the App key below.",
         )
         .size(11)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
 
         let app_key_input = text_input("App key", &self.state.browser.dropbox.app_key_input)
             .on_input(|s| Message::Browser(BrowserMsg::SetDropboxAppKey(s)))
             .on_submit(Message::SaveDropboxAppKey)
             .size(13)
             .width(Length::Fill);
-        let save_key_btn = button(text("Save").size(12).color(th::TEXT))
+        let save_key_btn = button(text("Save").size(12).color(th::text()))
             .on_press(Message::SaveDropboxAppKey)
             .padding([6, 12])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::ACCENT_DIM,
+                        color: th::accent_dim(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -523,15 +535,15 @@ impl App {
                 .unwrap_or_else(|| "connected".into());
             text(format!("Connected: {email}"))
                 .size(12)
-                .color(th::ACCENT)
+                .color(th::accent())
                 .into()
         } else if self.state.browser.dropbox.auth_in_progress {
             text("Waiting for browser authorisation...")
                 .size(12)
-                .color(th::TEXT_DIM)
+                .color(th::text_dim())
                 .into()
         } else {
-            text("Not connected").size(12).color(th::TEXT_DIM).into()
+            text("Not connected").size(12).color(th::text_dim()).into()
         };
 
         let can_connect =
@@ -544,20 +556,22 @@ impl App {
             "Connect"
         };
         let connect_btn = {
-            let mut btn = button(text(connect_label).size(12).color(th::ACCENT));
+            let mut btn = button(text(connect_label).size(12).color(th::accent()));
             if can_connect {
                 btn = btn.on_press(Message::ConnectDropbox);
             }
             btn.padding([6, 12]).style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::ACCENT,
+                    text_color: th::accent(),
                     border: iced::Border {
-                        color: th::ACCENT_DIM,
+                        color: th::accent_dim(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -567,19 +581,19 @@ impl App {
         };
 
         let disconnect_btn: Element<'_, Message> = if self.state.browser.dropbox.connected {
-            button(text("Disconnect").size(12).color(th::TEXT_DIM))
+            button(text("Disconnect").size(12).color(th::text_dim()))
                 .on_press(Message::DisconnectDropbox)
                 .padding([6, 12])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT_DIM,
+                        text_color: th::text_dim(),
                         border: iced::Border::default(),
                         ..Default::default()
                     }
@@ -591,7 +605,7 @@ impl App {
 
         let error_line: Element<'_, Message> =
             if let Some(err) = self.state.browser.dropbox.last_error.clone() {
-                text(err).size(11).color(th::DANGER).into()
+                text(err).size(11).color(th::danger()).into()
             } else {
                 horizontal_space().width(Length::Shrink).into()
             };
@@ -611,24 +625,26 @@ impl App {
     }
 
     pub(super) fn view_settings_warping_tab(&self) -> Element<'_, Message> {
-        let title = text("Sample Warping").size(14).color(th::TEXT);
+        let title = text("Sample Warping").size(14).color(th::text());
         let hint = text(
             "Auto-warp detects BPM of each dropped sample and time-stretches it to \
              the project tempo, preserving pitch. Turn this off to keep samples at their \
              original speed.",
         )
         .size(11)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
 
         let toggle_icon = if self.state.auto_warp_on_import {
-            icons::icon(icons::CIRCLE_DOT).size(12).color(th::ACCENT)
+            icons::icon(icons::CIRCLE_DOT).size(12).color(th::accent())
         } else {
-            icons::icon(icons::CIRCLE).size(12).color(th::TEXT_DIM)
+            icons::icon(icons::CIRCLE).size(12).color(th::text_dim())
         };
         let toggle_btn = button(
             row![
                 toggle_icon,
-                text("Auto-warp samples on import").size(12).color(th::TEXT)
+                text("Auto-warp samples on import")
+                    .size(12)
+                    .color(th::text())
             ]
             .spacing(6)
             .align_y(iced::Alignment::Center),
@@ -637,7 +653,7 @@ impl App {
         .padding([4, 8])
         .style(|_theme: &Theme, _status| button::Style {
             background: None,
-            text_color: th::TEXT,
+            text_color: th::text(),
             border: iced::Border::default(),
             ..Default::default()
         });
@@ -645,33 +661,33 @@ impl App {
         let conf = self.state.warp_confidence_threshold;
         let conf_label = text("Detection confidence threshold")
             .size(12)
-            .color(th::TEXT);
-        let conf_value = text(format!("{:.2}", conf)).size(12).color(th::TEXT_DIM);
+            .color(th::text());
+        let conf_value = text(format!("{:.2}", conf)).size(12).color(th::text_dim());
         let conf_hint = text(
             "Higher = only warp when the detector is very sure. \
              Lower = warp even ambiguous clips.",
         )
         .size(11)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
         let conf_slider = slider(0.0..=1.0, conf, Message::SetWarpConfidenceThreshold).step(0.05);
 
         let rewarp_btn = button(
             text("Re-warp all clips to project tempo")
                 .size(12)
-                .color(th::TEXT),
+                .color(th::text()),
         )
         .on_press(Message::RewarpAllClips)
         .padding([6, 12])
         .style(|_theme: &Theme, status| {
             let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
                 _ => None,
             };
             button::Style {
                 background: bg,
-                text_color: th::TEXT,
+                text_color: th::text(),
                 border: iced::Border {
-                    color: th::ACCENT_DIM,
+                    color: th::accent_dim(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -685,7 +701,7 @@ impl App {
             toggle_btn,
             container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
                 |_theme: &Theme| container::Style {
-                    background: Some(th::BORDER.into()),
+                    background: Some(th::border().into()),
                     ..Default::default()
                 }
             ),
@@ -696,7 +712,7 @@ impl App {
                 .align_y(iced::Alignment::Center),
             container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
                 |_theme: &Theme| container::Style {
-                    background: Some(th::BORDER.into()),
+                    background: Some(th::border().into()),
                     ..Default::default()
                 }
             ),

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -73,17 +73,17 @@ impl App {
     }
 
     pub(super) fn view_header(&self) -> Element<'_, Message> {
-        let title = text("vibez").size(22).color(th::ACCENT);
+        let title = text("vibez").size(22).color(th::accent());
 
         // Workspace tabs
         let arrange_tab = {
             let active = self.state.view.workspace == Workspace::Arrange;
             let (bg, text_color, border_color) = if active {
-                (th::BG_ELEVATED, th::ACCENT, th::ACCENT_DIM)
+                (th::bg_elevated(), th::accent(), th::accent_dim())
             } else {
                 (
                     iced::Color::TRANSPARENT,
-                    th::TEXT_DIM,
+                    th::text_dim(),
                     iced::Color::TRANSPARENT,
                 )
             };
@@ -112,11 +112,11 @@ impl App {
         let mix_tab = {
             let active = self.state.view.workspace == Workspace::Mix;
             let (bg, text_color, border_color) = if active {
-                (th::BG_ELEVATED, th::ACCENT, th::ACCENT_DIM)
+                (th::bg_elevated(), th::accent(), th::accent_dim())
             } else {
                 (
                     iced::Color::TRANSPARENT,
-                    th::TEXT_DIM,
+                    th::text_dim(),
                     iced::Color::TRANSPARENT,
                 )
             };
@@ -146,17 +146,19 @@ impl App {
 
         let tabs = row![arrange_tab, mix_tab].spacing(4);
 
-        let file_btn = button(text("File").size(13).color(th::TEXT_DIM))
+        let file_btn = button(text("File").size(13).color(th::text_dim()))
             .on_press(Message::Project(ProjectMsg::ToggleFileMenu))
             .padding([6, 14])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border::default(),
                     ..Default::default()
                 }
@@ -168,14 +170,14 @@ impl App {
                 icons::icon(icons::AUDIO_WAVEFORM)
                     .size(13)
                     .color(if browser_active {
-                        th::ACCENT
+                        th::accent()
                     } else {
-                        th::TEXT_DIM
+                        th::text_dim()
                     }),
                 text("Browser").size(13).color(if browser_active {
-                    th::ACCENT
+                    th::accent()
                 } else {
-                    th::TEXT_DIM
+                    th::text_dim()
                 })
             ]
             .spacing(4)
@@ -185,23 +187,25 @@ impl App {
         .padding([6, 14])
         .style(move |_theme: &Theme, status| {
             let bg = if browser_active {
-                Some(th::BG_ELEVATED.into())
+                Some(th::bg_elevated().into())
             } else {
                 match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 }
             };
             button::Style {
                 background: bg,
                 text_color: if browser_active {
-                    th::ACCENT
+                    th::accent()
                 } else {
-                    th::TEXT_DIM
+                    th::text_dim()
                 },
                 border: iced::Border {
                     color: if browser_active {
-                        th::ACCENT_DIM
+                        th::accent_dim()
                     } else {
                         Color::TRANSPARENT
                     },
@@ -219,9 +223,9 @@ impl App {
         container(header)
             .width(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 0.0,
                     radius: 0.0.into(),
                 },
@@ -236,7 +240,7 @@ impl App {
         if self.state.arrangement.tracks.is_empty() {
             let prompt = text("Right-click or Ctrl+T to add a track")
                 .size(16)
-                .color(th::TEXT_DIM);
+                .color(th::text_dim());
 
             let centered = center(prompt).width(Length::Fill).height(Length::Fill);
 
@@ -245,7 +249,7 @@ impl App {
                     .width(Length::Fill)
                     .height(Length::FillPortion(5))
                     .style(|_theme: &Theme| container::Style {
-                        background: Some(th::BG_DARK.into()),
+                        background: Some(th::bg_dark().into()),
                         ..Default::default()
                     }),
             )
@@ -290,7 +294,7 @@ impl App {
             ))
             .height(Length::Fixed(28.0))
             .style(|_theme: &Theme| iced::widget::container::Style {
-                background: Some(crate::theme::BG_SURFACE.into()),
+                background: Some(crate::theme::bg_surface().into()),
                 ..Default::default()
             });
 
@@ -338,7 +342,7 @@ impl App {
             ))
             .height(Length::Fixed(40.0))
             .style(|_theme: &Theme| iced::widget::container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 ..Default::default()
             });
         let minimap_canvas: Element<'_, Message> = canvas(minimap)
@@ -452,7 +456,7 @@ impl App {
                 .width(Length::Fill)
                 .height(Length::FillPortion(5))
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_DARK.into()),
+                    background: Some(th::bg_dark().into()),
                     ..Default::default()
                 }),
         )
@@ -470,7 +474,7 @@ impl App {
         if self.state.arrangement.tracks.is_empty() {
             let prompt = text("Add a track to get started")
                 .size(16)
-                .color(th::TEXT_DIM);
+                .color(th::text_dim());
 
             let centered = center(prompt).width(Length::Fill).height(Length::Fill);
 
@@ -478,7 +482,7 @@ impl App {
                 .width(Length::Fill)
                 .height(Length::FillPortion(5))
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_DARK.into()),
+                    background: Some(th::bg_dark().into()),
                     ..Default::default()
                 })
                 .into();
@@ -517,7 +521,7 @@ impl App {
                 .width(Length::Fill)
                 .height(Length::FillPortion(5))
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_DARK.into()),
+                    background: Some(th::bg_dark().into()),
                     ..Default::default()
                 }),
         )
@@ -533,14 +537,14 @@ impl App {
 
     pub(super) fn view_transport(&self) -> Element<'_, Message> {
         // Skip back button
-        let skip_back_btn = button(icons::icon(icons::SKIP_BACK).size(16).color(th::TEXT))
+        let skip_back_btn = button(icons::icon(icons::SKIP_BACK).size(16).color(th::text()))
             .on_press(Message::Transport(TransportMsg::Stop))
             .padding([8, 12])
             .style(|_theme: &Theme, _status| button::Style {
-                background: Some(th::BG_ELEVATED.into()),
-                text_color: th::TEXT,
+                background: Some(th::bg_elevated().into()),
+                text_color: th::text(),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -549,28 +553,28 @@ impl App {
 
         // Play/Pause button
         let play_pause_btn = if self.state.transport.playing {
-            button(icons::icon(icons::PAUSE).size(16).color(th::ACCENT))
+            button(icons::icon(icons::PAUSE).size(16).color(th::accent()))
                 .on_press(Message::Transport(TransportMsg::Stop))
                 .padding([8, 14])
                 .style(|_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::ACCENT,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::accent(),
                     border: iced::Border {
-                        color: th::ACCENT_DIM,
+                        color: th::accent_dim(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
                     ..Default::default()
                 })
         } else {
-            button(icons::icon(icons::PLAY).size(16).color(th::SUCCESS))
+            button(icons::icon(icons::PLAY).size(16).color(th::success()))
                 .on_press(Message::Transport(TransportMsg::Play))
                 .padding([8, 14])
                 .style(|_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::SUCCESS,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::success(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -580,28 +584,28 @@ impl App {
 
         // Loop toggle button
         let loop_btn = if self.state.transport.loop_enabled {
-            button(icons::icon(icons::REPEAT).size(16).color(th::ACCENT))
+            button(icons::icon(icons::REPEAT).size(16).color(th::accent()))
                 .on_press(Message::Transport(TransportMsg::ToggleArrangementLoop))
                 .padding([8, 12])
                 .style(|_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::ACCENT,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::accent(),
                     border: iced::Border {
-                        color: th::ACCENT_DIM,
+                        color: th::accent_dim(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
                     ..Default::default()
                 })
         } else {
-            button(icons::icon(icons::REPEAT).size(16).color(th::TEXT_DIM))
+            button(icons::icon(icons::REPEAT).size(16).color(th::text_dim()))
                 .on_press(Message::Transport(TransportMsg::ToggleArrangementLoop))
                 .padding([8, 12])
                 .style(|_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::TEXT_DIM,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -618,7 +622,7 @@ impl App {
             AppState::format_time(self.state.duration_seconds()),
         ))
         .size(14)
-        .color(th::TEXT);
+        .color(th::text());
 
         // BPM
         let bpm_input = text_input("BPM", &self.state.transport.bpm_text)
@@ -628,19 +632,19 @@ impl App {
             .size(14);
 
         let bpm_nudge = |icon: char, delta: f64| {
-            button(icons::icon(icon).size(8).color(th::TEXT_DIM))
+            button(icons::icon(icon).size(8).color(th::text_dim()))
                 .on_press(Message::Transport(TransportMsg::NudgeBpm(delta)))
                 .padding([0, 4])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT_DIM,
+                        text_color: th::text_dim(),
                         border: iced::Border {
                             radius: 2.0.into(),
                             ..Default::default()
@@ -655,7 +659,7 @@ impl App {
         ]
         .spacing(1);
 
-        let bpm_label = text("BPM").size(12).color(th::TEXT_DIM);
+        let bpm_label = text("BPM").size(12).color(th::text_dim());
 
         // Master VU meter
         let master_meter = VuMeterWidget {
@@ -667,7 +671,7 @@ impl App {
             .height(Length::Fixed(28.0))
             .into();
 
-        let volume_icon = icons::icon(icons::VOLUME_2).size(14).color(th::TEXT_DIM);
+        let volume_icon = icons::icon(icons::VOLUME_2).size(14).color(th::text_dim());
 
         let transport = row![
             transport_buttons,
@@ -688,9 +692,9 @@ impl App {
         container(transport)
             .width(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 0.0.into(),
                 },
@@ -700,13 +704,13 @@ impl App {
     }
 
     pub(super) fn view_status(&self) -> Element<'_, Message> {
-        let status = text(&self.state.status_text).size(11).color(th::TEXT_DIM);
+        let status = text(&self.state.status_text).size(11).color(th::text_dim());
 
         container(status)
             .width(Length::Fill)
             .padding([3, 12])
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_DARK.into()),
+                background: Some(th::bg_dark().into()),
                 ..Default::default()
             })
             .into()
@@ -725,7 +729,7 @@ impl App {
 
         for lane in &track.automation {
             let label = target_label(&lane.target, track);
-            let remove = button(icons::icon(icons::TRASH_2).size(9).color(th::TEXT_DIM))
+            let remove = button(icons::icon(icons::TRASH_2).size(9).color(th::text_dim()))
                 .on_press(Message::Automation(AutomationMsg::RemoveLane {
                     track_id: track.id,
                     lane_id: lane.id,
@@ -733,13 +737,13 @@ impl App {
                 .padding([1, 4])
                 .style(|_theme: &Theme, _status| button::Style {
                     background: None,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border::default(),
                     ..Default::default()
                 });
             let lane_header = container(
                 row![
-                    text(label).size(11).color(th::TEXT_DIM),
+                    text(label).size(11).color(th::text_dim()),
                     horizontal_space(),
                     remove
                 ]
@@ -753,7 +757,7 @@ impl App {
             .height(Length::Fixed(LANE_HEIGHT))
             .align_y(iced::alignment::Vertical::Center)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 ..Default::default()
             });
 
@@ -862,23 +866,23 @@ impl App {
                 .size(11)
                 .padding([4, 8])
                 .style(|_theme: &Theme, _status| iced::widget::text_input::Style {
-                    background: th::BG_DARK.into(),
+                    background: th::bg_dark().into(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 3.0.into(),
                     },
-                    icon: th::TEXT_DIM,
-                    placeholder: th::TEXT_DIM,
-                    value: th::TEXT,
-                    selection: th::ACCENT,
+                    icon: th::text_dim(),
+                    placeholder: th::text_dim(),
+                    value: th::text(),
+                    selection: th::accent(),
                 });
-            let close = button(icons::icon(icons::X).size(10).color(th::TEXT_DIM))
+            let close = button(icons::icon(icons::X).size(10).color(th::text_dim()))
                 .on_press(Message::Automation(AutomationMsg::CloseLanePicker))
                 .padding([3, 6])
                 .style(|_theme: &Theme, _status| button::Style {
                     background: None,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border::default(),
                     ..Default::default()
                 });
@@ -888,7 +892,7 @@ impl App {
                 let target = choice.target;
                 let track_id = track.id;
                 list = list.push(
-                    button(text(choice.label).size(11).color(th::TEXT))
+                    button(text(choice.label).size(11).color(th::text()))
                         .on_press(Message::Automation(AutomationMsg::AddLane {
                             track_id,
                             target,
@@ -898,13 +902,13 @@ impl App {
                         .style(|_theme: &Theme, status| {
                             let bg = match status {
                                 button::Status::Hovered | button::Status::Pressed => {
-                                    Some(th::BG_HOVER.into())
+                                    Some(th::bg_hover().into())
                                 }
                                 _ => None,
                             };
                             button::Style {
                                 background: bg,
-                                text_color: th::TEXT,
+                                text_color: th::text(),
                                 border: iced::Border::default(),
                                 ..Default::default()
                             }
@@ -916,7 +920,7 @@ impl App {
                     container(
                         text(format!("{hidden} more \u{2014} refine the search"))
                             .size(10)
-                            .color(th::TEXT_DIM),
+                            .color(th::text_dim()),
                     )
                     .padding([3, 10]),
                 );
@@ -926,7 +930,7 @@ impl App {
                     container(
                         text("Everything is already automated")
                             .size(10)
-                            .color(th::TEXT_DIM),
+                            .color(th::text_dim()),
                     )
                     .padding([3, 10]),
                 );
@@ -944,9 +948,9 @@ impl App {
             .padding(8)
             .width(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 3.0.into(),
                 },
@@ -956,22 +960,22 @@ impl App {
         } else {
             let track_id = track.id;
             container(
-                button(text("+ Add automation").size(11).color(th::TEXT_DIM))
+                button(text("+ Add automation").size(11).color(th::text_dim()))
                     .on_press(Message::Automation(AutomationMsg::OpenLanePicker(track_id)))
                     .width(Length::Fill)
                     .padding([3, 10])
                     .style(|_theme: &Theme, status| {
                         let bg = match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::BG_HOVER.into())
+                                Some(th::bg_hover().into())
                             }
-                            _ => Some(th::BG_ELEVATED.into()),
+                            _ => Some(th::bg_elevated().into()),
                         };
                         button::Style {
                             background: bg,
-                            text_color: th::TEXT_DIM,
+                            text_color: th::text_dim(),
                             border: iced::Border {
-                                color: th::BORDER,
+                                color: th::border(),
                                 width: 1.0,
                                 radius: 3.0.into(),
                             },
@@ -995,7 +999,7 @@ impl App {
             container(panel)
                 .width(Length::Fixed(panel_width))
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_SURFACE.into()),
+                    background: Some(th::bg_surface().into()),
                     ..Default::default()
                 }),
             iced::widget::horizontal_space()

--- a/crates/vibez-ui/src/lib.rs
+++ b/crates/vibez-ui/src/lib.rs
@@ -7,6 +7,7 @@ mod services;
 mod spectrum;
 mod state;
 mod theme;
+mod themes;
 mod ui_settings;
 mod warp;
 pub mod widgets;

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -237,6 +237,14 @@ pub enum Message {
     OpenMidiInput(String),
     /// Settings: close the currently-open MIDI input port.
     CloseMidiInput,
+    /// Appearance: activate a theme by name (built-in or user).
+    SelectTheme(String),
+    /// Appearance: rescan the themes directory for `.vzt` files.
+    RescanThemes,
+    /// Appearance: live edit of the save-as-theme name field.
+    ThemeSaveNameChanged(String),
+    /// Appearance: save the current palette as a user `.vzt`.
+    SaveCurrentTheme,
     AddSampleLibraryRoot,
     SampleLibraryRootSelected(Option<PathBuf>),
     RescanSampleLibrary,

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -106,6 +106,7 @@ pub enum SettingsTab {
     Plugins,
     Dropbox,
     Warping,
+    Appearance,
 }
 
 /// A point-in-time snapshot of the editable project state, used to
@@ -402,6 +403,11 @@ pub struct AppState {
     // Browser domain slice (sample library, Dropbox, drag-drop).
     pub browser: BrowserState,
 
+    // Appearance / themes
+    pub current_theme_name: String,
+    pub user_themes: Vec<crate::themes::UserTheme>,
+    pub theme_save_name: String,
+
     // Plugin hosting
     pub plugin_settings: PluginSettings,
     pub plugin_scan_in_progress: bool,
@@ -435,6 +441,9 @@ impl Default for AppState {
             warp_confidence_threshold: 0.6,
             automation_ui: crate::domains::automation::AutomationState::default(),
             browser: BrowserState::default(),
+            current_theme_name: "Charcoal".to_string(),
+            user_themes: Vec::new(),
+            theme_save_name: String::new(),
             plugin_settings: PluginSettings::load(),
             plugin_scan_in_progress: false,
             plugin_scan_status: String::new(),

--- a/crates/vibez-ui/src/theme.rs
+++ b/crates/vibez-ui/src/theme.rs
@@ -1,288 +1,385 @@
+//! Runtime theme system.
+//!
+//! Every color the UI paints comes from the current [`ThemePalette`],
+//! swapped at runtime by the Appearance settings. Accessors mirror
+//! the old constant names in snake_case (`th::accent()` was
+//! `th::ACCENT`), so call sites read the same and canvases pick up a
+//! theme switch on the next frame. A palette serializes to JSON with
+//! hex colors — that is exactly the `.vzt` theme file format.
+
+use std::sync::{LazyLock, RwLock};
+
 use iced::theme::Palette;
 use iced::{Color, Theme};
+use serde::{Deserialize, Serialize};
 
-// ── Main palette (dark charcoal) ──
+/// A complete vibez color scheme. Serialized as the `.vzt` file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThemePalette {
+    pub name: String,
 
-/// Near-black main background: #1a1a1a
-pub const BG_DARK: Color = Color {
-    r: 0.102,
-    g: 0.102,
-    b: 0.102,
-    a: 1.0,
-};
+    // ── Backgrounds ──
+    #[serde(with = "hex")]
+    pub bg_dark: Color,
+    #[serde(with = "hex")]
+    pub bg_surface: Color,
+    #[serde(with = "hex")]
+    pub bg_elevated: Color,
+    #[serde(with = "hex")]
+    pub bg_hover: Color,
 
-/// Panels, headers, strips: #242424
-pub const BG_SURFACE: Color = Color {
-    r: 0.141,
-    g: 0.141,
-    b: 0.141,
-    a: 1.0,
-};
+    // ── Text ──
+    #[serde(with = "hex")]
+    pub text: Color,
+    #[serde(with = "hex")]
+    pub text_dim: Color,
+    #[serde(with = "hex")]
+    pub text_muted: Color,
 
-/// Cards, effect slots, raised elements: #2d2d2d
-pub const BG_ELEVATED: Color = Color {
-    r: 0.176,
-    g: 0.176,
-    b: 0.176,
-    a: 1.0,
-};
+    // ── Accent ──
+    #[serde(with = "hex")]
+    pub accent: Color,
+    #[serde(with = "hex")]
+    pub accent_dim: Color,
 
-/// Hover state for interactive elements: #363636
-#[allow(dead_code)]
-pub const BG_HOVER: Color = Color {
-    r: 0.212,
-    g: 0.212,
-    b: 0.212,
-    a: 1.0,
-};
+    // ── Borders ──
+    #[serde(with = "hex")]
+    pub border: Color,
+    #[serde(with = "hex")]
+    pub border_light: Color,
+    #[serde(with = "hex")]
+    pub divider: Color,
 
-// ── Text ──
+    // ── Semantic ──
+    #[serde(with = "hex")]
+    pub success: Color,
+    #[serde(with = "hex")]
+    pub danger: Color,
+    #[serde(with = "hex")]
+    pub playhead: Color,
 
-/// Primary text: #e0e0e0
-pub const TEXT: Color = Color {
-    r: 0.878,
-    g: 0.878,
-    b: 0.878,
-    a: 1.0,
-};
+    // ── Meters ──
+    #[serde(with = "hex")]
+    pub meter_green: Color,
+    #[serde(with = "hex")]
+    pub meter_yellow: Color,
+    #[serde(with = "hex")]
+    pub meter_red: Color,
 
-/// Secondary text, labels: #808080
-pub const TEXT_DIM: Color = Color {
-    r: 0.502,
-    g: 0.502,
-    b: 0.502,
-    a: 1.0,
-};
+    /// Recessed display wells (mini waveforms, sample views).
+    #[serde(with = "hex")]
+    pub display_bg: Color,
 
-/// Disabled, placeholder: #505050
-pub const TEXT_MUTED: Color = Color {
-    r: 0.314,
-    g: 0.314,
-    b: 0.314,
-    a: 1.0,
-};
+    // ── Knobs / faders ──
+    #[serde(with = "hex")]
+    pub knob_arc: Color,
+    #[serde(with = "hex")]
+    pub knob_body: Color,
+    #[serde(with = "hex")]
+    pub knob_body_engaged: Color,
+    #[serde(with = "hex")]
+    pub knob_track: Color,
+    #[serde(with = "hex")]
+    pub fader_handle: Color,
 
-// ── Accent ──
+    // ── Track palette (auto-assigned per track, index wraps) ──
+    #[serde(with = "hex_array")]
+    pub track_colors: [Color; 8],
 
-/// Orange accent — transport active, selected: #ff8c00
-pub const ACCENT: Color = Color {
-    r: 1.0,
-    g: 0.549,
-    b: 0.0,
-    a: 1.0,
-};
+    // ── Channel EQ bands ──
+    #[serde(with = "hex")]
+    pub eq_lf: Color,
+    #[serde(with = "hex")]
+    pub eq_lmf: Color,
+    #[serde(with = "hex")]
+    pub eq_hmf: Color,
+    #[serde(with = "hex")]
+    pub eq_hf: Color,
 
-/// Accent at lower intensity: #995400
-pub const ACCENT_DIM: Color = Color {
-    r: 0.600,
-    g: 0.329,
-    b: 0.0,
-    a: 1.0,
-};
+    // ── Clips / waveforms ──
+    #[serde(with = "hex")]
+    pub clip_body: Color,
+    #[serde(with = "hex")]
+    pub clip_border: Color,
+    #[serde(with = "hex")]
+    pub waveform: Color,
+    #[serde(with = "hex")]
+    pub ruler_line: Color,
 
-// ── Borders / dividers ──
+    // ── Editor grid lines (bar / beat / subdivision) ──
+    #[serde(with = "hex")]
+    pub grid_bar: Color,
+    #[serde(with = "hex")]
+    pub grid_beat: Color,
+    #[serde(with = "hex")]
+    pub grid_sub: Color,
 
-/// Subtle panel borders: #3a3a3a
-pub const BORDER: Color = Color {
-    r: 0.227,
-    g: 0.227,
-    b: 0.227,
-    a: 1.0,
-};
+    // ── Piano roll ──
+    #[serde(with = "hex")]
+    pub piano_white_row: Color,
+    #[serde(with = "hex")]
+    pub piano_black_row: Color,
+    #[serde(with = "hex")]
+    pub piano_octave_line: Color,
+    #[serde(with = "hex")]
+    pub piano_grid: Color,
+    #[serde(with = "hex")]
+    pub piano_white_key: Color,
+    #[serde(with = "hex")]
+    pub piano_black_key: Color,
+    #[serde(with = "hex")]
+    pub piano_key_label: Color,
+}
 
-/// Stronger borders for cards: #4a4a4a
-#[allow(dead_code)]
-pub const BORDER_LIGHT: Color = Color {
-    r: 0.290,
-    g: 0.290,
-    b: 0.290,
-    a: 1.0,
-};
+/// Hex color (de)serialization: `#rrggbb` or `#rrggbbaa`.
+mod hex {
+    use iced::Color;
+    use serde::{Deserialize, Deserializer, Serializer};
 
-/// Section dividers: #2a2a2a
-pub const DIVIDER: Color = Color {
-    r: 0.165,
-    g: 0.165,
-    b: 0.165,
-    a: 1.0,
-};
+    pub fn to_hex(c: &Color) -> String {
+        let [r, g, b, a] = c.into_rgba8();
+        if a == 255 {
+            format!("#{r:02x}{g:02x}{b:02x}")
+        } else {
+            format!("#{r:02x}{g:02x}{b:02x}{a:02x}")
+        }
+    }
 
-// ── Semantic colors ──
+    pub fn parse(s: &str) -> Option<Color> {
+        let s = s.strip_prefix('#')?;
+        let byte = |i: usize| u8::from_str_radix(s.get(i..i + 2)?, 16).ok();
+        match s.len() {
+            6 => Some(Color::from_rgb8(byte(0)?, byte(2)?, byte(4)?)),
+            8 => Some(Color::from_rgba8(
+                byte(0)?,
+                byte(2)?,
+                byte(4)?,
+                byte(6)? as f32 / 255.0,
+            )),
+            _ => None,
+        }
+    }
 
-/// Success/green for play: #4ade80
-pub const SUCCESS: Color = Color {
-    r: 0.290,
-    g: 0.871,
-    b: 0.502,
-    a: 1.0,
-};
+    pub fn serialize<S: Serializer>(c: &Color, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&to_hex(c))
+    }
 
-/// Danger/red: #f87171
-pub const DANGER: Color = Color {
-    r: 0.973,
-    g: 0.443,
-    b: 0.443,
-    a: 1.0,
-};
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Color, D::Error> {
+        let s = String::deserialize(d)?;
+        parse(&s).ok_or_else(|| serde::de::Error::custom(format!("invalid hex color {s:?}")))
+    }
+}
 
-/// Playhead: white at 80% opacity
-pub const PLAYHEAD: Color = Color {
-    r: 1.0,
-    g: 1.0,
-    b: 1.0,
-    a: 0.8,
-};
+mod hex_array {
+    use iced::Color;
+    use serde::{Deserialize, Deserializer, Serializer};
 
-// ── Meter colors ──
+    pub fn serialize<S: Serializer>(colors: &[Color; 8], s: S) -> Result<S::Ok, S::Error> {
+        s.collect_seq(colors.iter().map(super::hex::to_hex))
+    }
 
-/// VU meter green: #4ade80
-pub const METER_GREEN: Color = Color {
-    r: 0.290,
-    g: 0.871,
-    b: 0.502,
-    a: 1.0,
-};
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[Color; 8], D::Error> {
+        let raw = Vec::<String>::deserialize(d)?;
+        if raw.len() != 8 {
+            return Err(serde::de::Error::custom(format!(
+                "track_colors needs exactly 8 entries, got {}",
+                raw.len()
+            )));
+        }
+        let mut out = [Color::BLACK; 8];
+        for (slot, s) in out.iter_mut().zip(&raw) {
+            *slot = super::hex::parse(s)
+                .ok_or_else(|| serde::de::Error::custom(format!("invalid hex color {s:?}")))?;
+        }
+        Ok(out)
+    }
+}
 
-/// VU meter yellow: #ffd700
-pub const METER_YELLOW: Color = Color {
-    r: 1.0,
-    g: 0.843,
-    b: 0.0,
-    a: 1.0,
-};
+const fn rgb(r: f32, g: f32, b: f32) -> Color {
+    Color { r, g, b, a: 1.0 }
+}
 
-/// VU meter red: #f87171
-pub const METER_RED: Color = Color {
-    r: 0.973,
-    g: 0.443,
-    b: 0.443,
-    a: 1.0,
-};
+const fn rgba(r: f32, g: f32, b: f32, a: f32) -> Color {
+    Color { r, g, b, a }
+}
 
-// ── Button state colors ──
+impl ThemePalette {
+    /// The founding vibez look: dark charcoal, orange accent.
+    pub fn charcoal() -> Self {
+        Self {
+            name: "Charcoal".to_string(),
+            bg_dark: rgb(0.102, 0.102, 0.102),
+            bg_surface: rgb(0.141, 0.141, 0.141),
+            bg_elevated: rgb(0.176, 0.176, 0.176),
+            bg_hover: rgb(0.212, 0.212, 0.212),
+            text: rgb(0.878, 0.878, 0.878),
+            text_dim: rgb(0.502, 0.502, 0.502),
+            text_muted: rgb(0.314, 0.314, 0.314),
+            accent: rgb(1.0, 0.549, 0.0),
+            accent_dim: rgb(0.600, 0.329, 0.0),
+            border: rgb(0.227, 0.227, 0.227),
+            border_light: rgb(0.290, 0.290, 0.290),
+            divider: rgb(0.165, 0.165, 0.165),
+            success: rgb(0.290, 0.871, 0.502),
+            danger: rgb(0.973, 0.443, 0.443),
+            playhead: rgba(1.0, 1.0, 1.0, 0.8),
+            meter_green: rgb(0.290, 0.871, 0.502),
+            meter_yellow: rgb(1.0, 0.843, 0.0),
+            meter_red: rgb(0.973, 0.443, 0.443),
+            display_bg: rgb(0.07, 0.07, 0.07),
+            knob_arc: rgb(0.533, 0.533, 0.533),
+            knob_body: rgb(0.12, 0.12, 0.12),
+            knob_body_engaged: rgb(0.16, 0.16, 0.16),
+            knob_track: rgb(0.22, 0.22, 0.22),
+            fader_handle: rgb(0.533, 0.533, 0.533),
+            track_colors: [
+                rgb(0.878, 0.376, 0.376), // red
+                rgb(0.878, 0.565, 0.251), // orange
+                rgb(0.816, 0.753, 0.251), // yellow
+                rgb(0.314, 0.690, 0.376), // green
+                rgb(0.251, 0.627, 0.690), // cyan
+                rgb(0.376, 0.502, 0.816), // blue
+                rgb(0.565, 0.376, 0.753), // purple
+                rgb(0.753, 0.376, 0.627), // pink
+            ],
+            eq_lf: rgb(0.65, 0.46, 0.28),
+            eq_lmf: rgb(0.36, 0.48, 0.72),
+            eq_hmf: rgb(0.33, 0.62, 0.38),
+            eq_hf: rgb(0.76, 0.33, 0.30),
+            clip_body: rgba(0.300, 0.480, 0.900, 0.6),
+            clip_border: rgba(0.380, 0.565, 1.0, 0.9),
+            waveform: rgba(0.380, 0.565, 1.0, 0.6),
+            ruler_line: rgba(0.227, 0.227, 0.227, 0.5),
+            grid_bar: rgb(0.376, 0.376, 0.376),
+            grid_beat: rgb(0.251, 0.251, 0.251),
+            grid_sub: rgb(0.216, 0.216, 0.216),
+            piano_white_row: rgb(0.145, 0.145, 0.145),
+            piano_black_row: rgb(0.110, 0.110, 0.110),
+            piano_octave_line: rgb(0.227, 0.227, 0.227),
+            piano_grid: rgb(0.165, 0.165, 0.165),
+            piano_white_key: rgb(0.784, 0.784, 0.784),
+            piano_black_key: rgb(0.102, 0.102, 0.102),
+            piano_key_label: rgb(0.35, 0.35, 0.35),
+        }
+    }
+}
 
-/// Mute active: #f87171 (red)
-pub const MUTE_ACTIVE: Color = DANGER;
+impl Default for ThemePalette {
+    fn default() -> Self {
+        Self::charcoal()
+    }
+}
 
-/// Solo active: #ffd700 (yellow)
-pub const SOLO_ACTIVE: Color = METER_YELLOW;
+static CURRENT: LazyLock<RwLock<ThemePalette>> =
+    LazyLock::new(|| RwLock::new(ThemePalette::charcoal()));
 
-// ── Knob / fader colors ──
+/// Swap the active theme; the next frame repaints everything.
+#[allow(dead_code)] // wired up by the Appearance settings
+pub fn set_theme(palette: ThemePalette) {
+    *CURRENT.write().unwrap() = palette;
+}
 
-/// Knob background: BG_ELEVATED
-pub const KNOB_BG: Color = BG_ELEVATED;
+/// Snapshot of the whole current palette (theme save, swatches).
+#[allow(dead_code)] // wired up by the Appearance settings
+pub fn current() -> ThemePalette {
+    CURRENT.read().unwrap().clone()
+}
 
-/// Default knob arc color (overridden by track color): #888888
-#[allow(dead_code)]
-pub const KNOB_ARC: Color = Color {
-    r: 0.533,
-    g: 0.533,
-    b: 0.533,
-    a: 1.0,
-};
+macro_rules! accessors {
+    ($($fn_name:ident => $field:ident),* $(,)?) => {
+        $(
+            #[allow(dead_code)]
+            pub fn $fn_name() -> Color {
+                CURRENT.read().unwrap().$field
+            }
+        )*
+    };
+}
 
-/// Fader track color: BG_ELEVATED
-pub const FADER_TRACK: Color = BG_ELEVATED;
+accessors! {
+    bg_dark => bg_dark,
+    bg_surface => bg_surface,
+    bg_elevated => bg_elevated,
+    bg_hover => bg_hover,
+    text => text,
+    text_dim => text_dim,
+    text_muted => text_muted,
+    accent => accent,
+    accent_dim => accent_dim,
+    border => border,
+    border_light => border_light,
+    divider => divider,
+    success => success,
+    danger => danger,
+    playhead => playhead,
+    meter_green => meter_green,
+    meter_yellow => meter_yellow,
+    meter_red => meter_red,
+    display_bg => display_bg,
+    knob_arc => knob_arc,
+    knob_body => knob_body,
+    knob_body_engaged => knob_body_engaged,
+    knob_track => knob_track,
+    fader_handle => fader_handle,
+    eq_lf => eq_lf,
+    eq_lmf => eq_lmf,
+    eq_hmf => eq_hmf,
+    eq_hf => eq_hf,
+    clip_body => clip_body,
+    clip_border => clip_border,
+    waveform => waveform,
+    ruler_line => ruler_line,
+    grid_bar => grid_bar,
+    grid_beat => grid_beat,
+    grid_sub => grid_sub,
+    piano_white_row => piano_white_row,
+    piano_black_row => piano_black_row,
+    piano_octave_line => piano_octave_line,
+    piano_grid => piano_grid,
+    piano_white_key => piano_white_key,
+    piano_black_key => piano_black_key,
+    piano_key_label => piano_key_label,
+}
 
-/// Fader handle color: #888888
-pub const FADER_HANDLE: Color = Color {
-    r: 0.533,
-    g: 0.533,
-    b: 0.533,
-    a: 1.0,
-};
+// ── Derived roles (aliases of palette fields) ──
 
-// ── Track colors (auto-assigned per track) ──
+pub fn mute_active() -> Color {
+    danger()
+}
 
-pub const TRACK_COLORS: [Color; 8] = [
-    // Red: #e06060
-    Color {
-        r: 0.878,
-        g: 0.376,
-        b: 0.376,
-        a: 1.0,
-    },
-    // Orange: #e09040
-    Color {
-        r: 0.878,
-        g: 0.565,
-        b: 0.251,
-        a: 1.0,
-    },
-    // Yellow: #d0c040
-    Color {
-        r: 0.816,
-        g: 0.753,
-        b: 0.251,
-        a: 1.0,
-    },
-    // Green: #50b060
-    Color {
-        r: 0.314,
-        g: 0.690,
-        b: 0.376,
-        a: 1.0,
-    },
-    // Cyan: #40a0b0
-    Color {
-        r: 0.251,
-        g: 0.627,
-        b: 0.690,
-        a: 1.0,
-    },
-    // Blue: #6080d0
-    Color {
-        r: 0.376,
-        g: 0.502,
-        b: 0.816,
-        a: 1.0,
-    },
-    // Purple: #9060c0
-    Color {
-        r: 0.565,
-        g: 0.376,
-        b: 0.753,
-        a: 1.0,
-    },
-    // Pink: #c060a0
-    Color {
-        r: 0.753,
-        g: 0.376,
-        b: 0.627,
-        a: 1.0,
-    },
-];
+pub fn solo_active() -> Color {
+    meter_yellow()
+}
+
+pub fn knob_bg() -> Color {
+    bg_elevated()
+}
+
+pub fn fader_track() -> Color {
+    bg_elevated()
+}
+
+pub fn track_bg() -> Color {
+    bg_dark()
+}
+
+pub fn track_bg_selected() -> Color {
+    bg_elevated()
+}
+
+pub fn ruler_bg() -> Color {
+    bg_surface()
+}
+
+pub fn ruler_text() -> Color {
+    text_dim()
+}
 
 /// Get a track color by index (wraps around).
 pub fn track_color(index: u8) -> Color {
-    TRACK_COLORS[index as usize % TRACK_COLORS.len()]
+    let palette = CURRENT.read().unwrap();
+    palette.track_colors[index as usize % palette.track_colors.len()]
 }
-
-// ── Channel EQ band colors (console convention, muted) ──
-pub const EQ_HF: Color = Color {
-    r: 0.76,
-    g: 0.33,
-    b: 0.30,
-    a: 1.0,
-};
-pub const EQ_HMF: Color = Color {
-    r: 0.33,
-    g: 0.62,
-    b: 0.38,
-    a: 1.0,
-};
-pub const EQ_LMF: Color = Color {
-    r: 0.36,
-    g: 0.48,
-    b: 0.72,
-    a: 1.0,
-};
-pub const EQ_LF: Color = Color {
-    r: 0.65,
-    g: 0.46,
-    b: 0.28,
-    a: 1.0,
-};
 
 /// Darken a color by a factor (for borders, etc.)
 pub fn darken(color: Color, factor: f32) -> Color {
@@ -295,68 +392,23 @@ pub fn darken(color: Color, factor: f32) -> Color {
 }
 
 /// Apply alpha to a color.
+#[allow(dead_code)]
 pub fn with_alpha(color: Color, alpha: f32) -> Color {
     Color { a: alpha, ..color }
 }
 
-// ── Aliases for backward compatibility in widgets ──
-
-/// Track lane background
-pub const TRACK_BG: Color = BG_DARK;
-
-/// Selected track background
-pub const TRACK_BG_SELECTED: Color = BG_ELEVATED;
-
-/// Clip body color (default, overridden by track color)
-#[allow(dead_code)]
-pub const CLIP_BODY: Color = Color {
-    r: 0.300,
-    g: 0.480,
-    b: 0.900,
-    a: 0.6,
-};
-
-/// Clip border color (default, overridden by track color)
-#[allow(dead_code)]
-pub const CLIP_BORDER: Color = Color {
-    r: 0.380,
-    g: 0.565,
-    b: 1.0,
-    a: 0.9,
-};
-
-/// Waveform display color (default, overridden by track color)
-pub const WAVEFORM: Color = Color {
-    r: 0.380,
-    g: 0.565,
-    b: 1.0,
-    a: 0.6,
-};
-
-/// Ruler background
-pub const RULER_BG: Color = BG_SURFACE;
-
-/// Ruler text
-pub const RULER_TEXT: Color = TEXT_DIM;
-
-/// Ruler line
-#[allow(dead_code)]
-pub const RULER_LINE: Color = Color {
-    r: 0.227,
-    g: 0.227,
-    b: 0.227,
-    a: 0.5,
-};
-
+/// iced theme derived from the current palette (built-in widget
+/// chrome: scrollbars, text inputs, pick lists).
 pub fn vibez_theme() -> Theme {
+    let p = CURRENT.read().unwrap();
     Theme::custom(
-        "Vibez".to_string(),
+        p.name.clone(),
         Palette {
-            background: BG_DARK,
-            text: TEXT,
-            primary: ACCENT,
-            success: SUCCESS,
-            danger: DANGER,
+            background: p.bg_dark,
+            text: p.text,
+            primary: p.accent,
+            success: p.success,
+            danger: p.danger,
         },
     )
 }
@@ -364,3 +416,42 @@ pub fn vibez_theme() -> Theme {
 /// Uniform device-card body height across the device chain: the
 /// panel scrolls horizontally, so cards share one rack height.
 pub const DEVICE_BODY_H: f32 = 184.0;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_roundtrip() {
+        for c in [
+            rgb(0.102, 0.102, 0.102),
+            rgb(1.0, 0.549, 0.0),
+            rgba(1.0, 1.0, 1.0, 0.8),
+        ] {
+            let s = hex::to_hex(&c);
+            let back = hex::parse(&s).unwrap();
+            let [r1, g1, b1, a1] = c.into_rgba8();
+            let [r2, g2, b2, a2] = back.into_rgba8();
+            assert_eq!((r1, g1, b1, a1), (r2, g2, b2, a2), "{s}");
+        }
+        assert!(hex::parse("#12345").is_none());
+        assert!(hex::parse("nope").is_none());
+    }
+
+    #[test]
+    fn palette_serializes_as_vzt_json_and_loads_back() {
+        let p = ThemePalette::charcoal();
+        let json = serde_json::to_string_pretty(&p).unwrap();
+        assert!(json.contains("\"accent\": \"#ff8c00\""));
+        let back: ThemePalette = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.name, "Charcoal");
+        assert_eq!(hex::to_hex(&back.accent), "#ff8c00");
+        assert_eq!(back.track_colors.len(), 8);
+    }
+
+    #[test]
+    fn missing_field_is_a_load_error_not_a_panic() {
+        let result = serde_json::from_str::<ThemePalette>("{\"name\": \"Broken\"}");
+        assert!(result.is_err());
+    }
+}

--- a/crates/vibez-ui/src/themes.rs
+++ b/crates/vibez-ui/src/themes.rs
@@ -1,0 +1,631 @@
+//! The built-in theme collection and the `.vzt` user-theme service.
+//!
+//! Built-ins are authored from a handful of seeds through the
+//! dark/light builders below, so every theme fills the complete
+//! [`ThemePalette`]. User themes are plain `.vzt` JSON files scanned
+//! from the config themes directory, plugin-cache style.
+
+use std::path::PathBuf;
+
+use iced::Color;
+
+use crate::theme::ThemePalette;
+
+const fn rgb8(r: u8, g: u8, b: u8) -> Color {
+    Color {
+        r: r as f32 / 255.0,
+        g: g as f32 / 255.0,
+        b: b as f32 / 255.0,
+        a: 1.0,
+    }
+}
+
+/// Move `c` toward white by `f` (0..1).
+fn lighten(c: Color, f: f32) -> Color {
+    Color {
+        r: c.r + (1.0 - c.r) * f,
+        g: c.g + (1.0 - c.g) * f,
+        b: c.b + (1.0 - c.b) * f,
+        a: c.a,
+    }
+}
+
+/// Move `c` toward black by `f` (0..1).
+fn darken(c: Color, f: f32) -> Color {
+    Color {
+        r: c.r * (1.0 - f),
+        g: c.g * (1.0 - f),
+        b: c.b * (1.0 - f),
+        a: c.a,
+    }
+}
+
+fn alpha(c: Color, a: f32) -> Color {
+    Color { a, ..c }
+}
+
+/// Console-convention EQ band colors (LF brown, LMF blue, HMF green,
+/// HF red), shared by most themes.
+const EQ_CONSOLE: [Color; 4] = [
+    Color {
+        r: 0.65,
+        g: 0.46,
+        b: 0.28,
+        a: 1.0,
+    },
+    Color {
+        r: 0.36,
+        g: 0.48,
+        b: 0.72,
+        a: 1.0,
+    },
+    Color {
+        r: 0.33,
+        g: 0.62,
+        b: 0.38,
+        a: 1.0,
+    },
+    Color {
+        r: 0.76,
+        g: 0.33,
+        b: 0.30,
+        a: 1.0,
+    },
+];
+
+/// The default track rainbow (charcoal's).
+const TRACKS_CLASSIC: [Color; 8] = [
+    rgb8(224, 96, 96),
+    rgb8(224, 144, 64),
+    rgb8(208, 192, 64),
+    rgb8(80, 176, 96),
+    rgb8(64, 160, 176),
+    rgb8(96, 128, 208),
+    rgb8(144, 96, 192),
+    rgb8(192, 96, 160),
+];
+
+const TRACKS_NEON: [Color; 8] = [
+    rgb8(255, 64, 96),
+    rgb8(255, 144, 0),
+    rgb8(230, 255, 0),
+    rgb8(57, 255, 20),
+    rgb8(0, 255, 213),
+    rgb8(0, 160, 255),
+    rgb8(191, 64, 255),
+    rgb8(255, 64, 208),
+];
+
+const TRACKS_PASTEL: [Color; 8] = [
+    rgb8(243, 139, 168),
+    rgb8(250, 179, 135),
+    rgb8(249, 226, 175),
+    rgb8(166, 227, 161),
+    rgb8(148, 226, 213),
+    rgb8(137, 180, 250),
+    rgb8(203, 166, 247),
+    rgb8(245, 194, 231),
+];
+
+const TRACKS_WARM: [Color; 8] = [
+    rgb8(204, 102, 84),
+    rgb8(214, 143, 84),
+    rgb8(199, 178, 90),
+    rgb8(143, 158, 96),
+    rgb8(114, 150, 137),
+    rgb8(122, 138, 176),
+    rgb8(158, 118, 160),
+    rgb8(186, 118, 132),
+];
+
+const TRACKS_MONO: [Color; 8] = [
+    rgb8(220, 220, 220),
+    rgb8(190, 190, 190),
+    rgb8(160, 160, 160),
+    rgb8(200, 200, 200),
+    rgb8(150, 150, 150),
+    rgb8(210, 210, 210),
+    rgb8(170, 170, 170),
+    rgb8(140, 140, 140),
+];
+
+struct Seed {
+    name: &'static str,
+    bg: Color,
+    accent: Color,
+    text: Color,
+    tracks: [Color; 8],
+    eq: [Color; 4],
+}
+
+/// Fill a complete palette from a dark seed: surfaces step up from
+/// the background, text tiers step down, grids sit between.
+fn dark(seed: Seed) -> ThemePalette {
+    let bg = seed.bg;
+    ThemePalette {
+        name: seed.name.to_string(),
+        bg_dark: bg,
+        bg_surface: lighten(bg, 0.045),
+        bg_elevated: lighten(bg, 0.085),
+        bg_hover: lighten(bg, 0.125),
+        text: seed.text,
+        text_dim: darken(seed.text, 0.43),
+        text_muted: darken(seed.text, 0.64),
+        accent: seed.accent,
+        accent_dim: darken(seed.accent, 0.4),
+        border: lighten(bg, 0.14),
+        border_light: lighten(bg, 0.21),
+        divider: lighten(bg, 0.07),
+        success: rgb8(74, 222, 128),
+        danger: rgb8(248, 113, 113),
+        playhead: alpha(Color::WHITE, 0.8),
+        meter_green: rgb8(74, 222, 128),
+        meter_yellow: rgb8(255, 215, 0),
+        meter_red: rgb8(248, 113, 113),
+        display_bg: darken(bg, 0.32),
+        knob_arc: lighten(bg, 0.48),
+        knob_body: lighten(bg, 0.02),
+        knob_body_engaged: lighten(bg, 0.065),
+        knob_track: lighten(bg, 0.13),
+        fader_handle: lighten(bg, 0.48),
+        track_colors: seed.tracks,
+        eq_lf: seed.eq[0],
+        eq_lmf: seed.eq[1],
+        eq_hmf: seed.eq[2],
+        eq_hf: seed.eq[3],
+        clip_body: alpha(seed.accent, 0.35),
+        clip_border: alpha(lighten(seed.accent, 0.2), 0.9),
+        waveform: alpha(lighten(seed.accent, 0.2), 0.6),
+        ruler_line: alpha(lighten(bg, 0.14), 0.5),
+        grid_bar: lighten(bg, 0.30),
+        grid_beat: lighten(bg, 0.17),
+        grid_sub: lighten(bg, 0.13),
+        piano_white_row: lighten(bg, 0.05),
+        piano_black_row: lighten(bg, 0.01),
+        piano_octave_line: lighten(bg, 0.14),
+        piano_grid: lighten(bg, 0.07),
+        piano_white_key: rgb8(200, 200, 200),
+        piano_black_key: darken(bg, 0.15),
+        piano_key_label: lighten(bg, 0.32),
+    }
+}
+
+/// Fill a complete palette from a light seed: surfaces step down
+/// from the background, text is ink, grids darker than paper.
+fn light(seed: Seed) -> ThemePalette {
+    let bg = seed.bg;
+    ThemePalette {
+        name: seed.name.to_string(),
+        bg_dark: bg,
+        bg_surface: darken(bg, 0.035),
+        bg_elevated: darken(bg, 0.065),
+        bg_hover: darken(bg, 0.10),
+        text: seed.text,
+        text_dim: lighten(seed.text, 0.38),
+        text_muted: lighten(seed.text, 0.58),
+        accent: seed.accent,
+        accent_dim: lighten(seed.accent, 0.3),
+        border: darken(bg, 0.14),
+        border_light: darken(bg, 0.22),
+        divider: darken(bg, 0.07),
+        success: rgb8(34, 154, 82),
+        danger: rgb8(205, 60, 60),
+        playhead: alpha(Color::BLACK, 0.7),
+        meter_green: rgb8(46, 178, 99),
+        meter_yellow: rgb8(212, 165, 8),
+        meter_red: rgb8(205, 60, 60),
+        display_bg: darken(bg, 0.05),
+        knob_arc: darken(bg, 0.45),
+        knob_body: darken(bg, 0.05),
+        knob_body_engaged: darken(bg, 0.10),
+        knob_track: darken(bg, 0.18),
+        fader_handle: darken(bg, 0.45),
+        track_colors: seed.tracks,
+        eq_lf: darken(seed.eq[0], 0.12),
+        eq_lmf: darken(seed.eq[1], 0.12),
+        eq_hmf: darken(seed.eq[2], 0.12),
+        eq_hf: darken(seed.eq[3], 0.12),
+        clip_body: alpha(seed.accent, 0.35),
+        clip_border: alpha(darken(seed.accent, 0.2), 0.9),
+        waveform: alpha(darken(seed.accent, 0.25), 0.65),
+        ruler_line: alpha(darken(bg, 0.14), 0.5),
+        grid_bar: darken(bg, 0.32),
+        grid_beat: darken(bg, 0.18),
+        grid_sub: darken(bg, 0.12),
+        piano_white_row: darken(bg, 0.02),
+        piano_black_row: darken(bg, 0.075),
+        piano_octave_line: darken(bg, 0.20),
+        piano_grid: darken(bg, 0.10),
+        piano_white_key: rgb8(250, 250, 250),
+        piano_black_key: rgb8(40, 40, 40),
+        piano_key_label: darken(bg, 0.45),
+    }
+}
+
+/// All built-in themes, default first.
+pub fn builtins() -> Vec<ThemePalette> {
+    let mut themes = vec![ThemePalette::charcoal()];
+    themes.extend([
+        dark(Seed {
+            name: "Obsidian",
+            bg: rgb8(10, 10, 12),
+            accent: rgb8(125, 200, 255),
+            text: rgb8(222, 226, 230),
+            tracks: TRACKS_CLASSIC,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Berlin",
+            bg: rgb8(6, 6, 6),
+            accent: rgb8(192, 57, 43),
+            text: rgb8(200, 200, 200),
+            tracks: TRACKS_MONO,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Acid",
+            bg: rgb8(8, 10, 6),
+            accent: rgb8(170, 255, 0),
+            text: rgb8(214, 230, 202),
+            tracks: TRACKS_NEON,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Vaporwave",
+            bg: rgb8(24, 14, 42),
+            accent: rgb8(255, 113, 206),
+            text: rgb8(230, 220, 245),
+            tracks: TRACKS_NEON,
+            eq: [
+                rgb8(255, 113, 206),
+                rgb8(1, 205, 254),
+                rgb8(5, 255, 161),
+                rgb8(185, 103, 255),
+            ],
+        }),
+        dark(Seed {
+            name: "Nord",
+            bg: rgb8(46, 52, 64),
+            accent: rgb8(136, 192, 208),
+            text: rgb8(216, 222, 233),
+            tracks: [
+                rgb8(191, 97, 106),
+                rgb8(208, 135, 112),
+                rgb8(235, 203, 139),
+                rgb8(163, 190, 140),
+                rgb8(143, 188, 187),
+                rgb8(129, 161, 193),
+                rgb8(180, 142, 173),
+                rgb8(94, 129, 172),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Dracula",
+            bg: rgb8(40, 42, 54),
+            accent: rgb8(189, 147, 249),
+            text: rgb8(248, 248, 242),
+            tracks: [
+                rgb8(255, 85, 85),
+                rgb8(255, 184, 108),
+                rgb8(241, 250, 140),
+                rgb8(80, 250, 123),
+                rgb8(139, 233, 253),
+                rgb8(98, 114, 164),
+                rgb8(189, 147, 249),
+                rgb8(255, 121, 198),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Gruvbox",
+            bg: rgb8(40, 40, 40),
+            accent: rgb8(254, 128, 25),
+            text: rgb8(235, 219, 178),
+            tracks: [
+                rgb8(204, 36, 29),
+                rgb8(214, 93, 14),
+                rgb8(215, 153, 33),
+                rgb8(152, 151, 26),
+                rgb8(104, 157, 106),
+                rgb8(69, 133, 136),
+                rgb8(177, 98, 134),
+                rgb8(254, 128, 25),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Solarized Dark",
+            bg: rgb8(0, 43, 54),
+            accent: rgb8(38, 139, 210),
+            text: rgb8(147, 161, 161),
+            tracks: [
+                rgb8(220, 50, 47),
+                rgb8(203, 75, 22),
+                rgb8(181, 137, 0),
+                rgb8(133, 153, 0),
+                rgb8(42, 161, 152),
+                rgb8(38, 139, 210),
+                rgb8(108, 113, 196),
+                rgb8(211, 54, 130),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Monokai",
+            bg: rgb8(39, 40, 34),
+            accent: rgb8(166, 226, 46),
+            text: rgb8(248, 248, 242),
+            tracks: [
+                rgb8(249, 38, 114),
+                rgb8(253, 151, 31),
+                rgb8(230, 219, 116),
+                rgb8(166, 226, 46),
+                rgb8(102, 217, 239),
+                rgb8(118, 149, 216),
+                rgb8(174, 129, 255),
+                rgb8(249, 38, 114),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Tokyo Night",
+            bg: rgb8(26, 27, 38),
+            accent: rgb8(122, 162, 247),
+            text: rgb8(192, 202, 245),
+            tracks: [
+                rgb8(247, 118, 142),
+                rgb8(255, 158, 100),
+                rgb8(224, 175, 104),
+                rgb8(158, 206, 106),
+                rgb8(115, 218, 202),
+                rgb8(122, 162, 247),
+                rgb8(187, 154, 247),
+                rgb8(255, 117, 127),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Catppuccin",
+            bg: rgb8(30, 30, 46),
+            accent: rgb8(203, 166, 247),
+            text: rgb8(205, 214, 244),
+            tracks: TRACKS_PASTEL,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "One Dark",
+            bg: rgb8(40, 44, 52),
+            accent: rgb8(97, 175, 239),
+            text: rgb8(171, 178, 191),
+            tracks: [
+                rgb8(224, 108, 117),
+                rgb8(209, 154, 102),
+                rgb8(229, 192, 123),
+                rgb8(152, 195, 121),
+                rgb8(86, 182, 194),
+                rgb8(97, 175, 239),
+                rgb8(198, 120, 221),
+                rgb8(190, 80, 70),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Deep Sea",
+            bg: rgb8(11, 26, 36),
+            accent: rgb8(46, 196, 182),
+            text: rgb8(202, 220, 228),
+            tracks: [
+                rgb8(231, 111, 81),
+                rgb8(244, 162, 97),
+                rgb8(233, 196, 106),
+                rgb8(138, 177, 125),
+                rgb8(42, 157, 143),
+                rgb8(69, 123, 157),
+                rgb8(131, 111, 168),
+                rgb8(190, 111, 130),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Espresso",
+            bg: rgb8(36, 26, 20),
+            accent: rgb8(212, 163, 115),
+            text: rgb8(230, 218, 205),
+            tracks: TRACKS_WARM,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Slate",
+            bg: rgb8(28, 33, 40),
+            accent: rgb8(83, 155, 245),
+            text: rgb8(205, 217, 229),
+            tracks: TRACKS_CLASSIC,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Rose Pine",
+            bg: rgb8(25, 23, 36),
+            accent: rgb8(235, 188, 186),
+            text: rgb8(224, 222, 244),
+            tracks: [
+                rgb8(235, 111, 146),
+                rgb8(246, 193, 119),
+                rgb8(234, 154, 151),
+                rgb8(49, 116, 143),
+                rgb8(156, 207, 216),
+                rgb8(196, 167, 231),
+                rgb8(144, 122, 169),
+                rgb8(235, 188, 186),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "High Contrast",
+            bg: rgb8(0, 0, 0),
+            accent: rgb8(255, 215, 0),
+            text: rgb8(255, 255, 255),
+            tracks: TRACKS_NEON,
+            eq: EQ_CONSOLE,
+        }),
+        light(Seed {
+            name: "Solarized Light",
+            bg: rgb8(253, 246, 227),
+            accent: rgb8(38, 139, 210),
+            text: rgb8(88, 110, 117),
+            tracks: [
+                rgb8(220, 50, 47),
+                rgb8(203, 75, 22),
+                rgb8(181, 137, 0),
+                rgb8(133, 153, 0),
+                rgb8(42, 161, 152),
+                rgb8(38, 139, 210),
+                rgb8(108, 113, 196),
+                rgb8(211, 54, 130),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        light(Seed {
+            name: "Porcelain",
+            bg: rgb8(242, 242, 240),
+            accent: rgb8(235, 120, 15),
+            text: rgb8(40, 42, 46),
+            tracks: TRACKS_CLASSIC,
+            eq: EQ_CONSOLE,
+        }),
+    ]);
+    themes
+}
+
+/// Look a built-in up by name.
+pub fn builtin_by_name(name: &str) -> Option<ThemePalette> {
+    builtins().into_iter().find(|t| t.name == name)
+}
+
+// ── User theme (.vzt) service ──────────────────────────────────────
+
+/// A user theme scanned from the themes directory.
+#[derive(Debug, Clone)]
+pub struct UserTheme {
+    /// Source file; kept for future delete/reveal actions.
+    #[allow(dead_code)]
+    pub path: PathBuf,
+    pub palette: ThemePalette,
+}
+
+/// `~/.config/vibez/themes`, created on first use.
+pub fn themes_dir() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("vibez")
+        .join("themes")
+}
+
+/// Scan the themes directory for `.vzt` files, plugin-cache style.
+/// Unreadable or malformed files are skipped with a warning list so
+/// one broken theme never hides the rest.
+pub fn scan_user_themes() -> (Vec<UserTheme>, Vec<String>) {
+    let mut themes = Vec::new();
+    let mut warnings = Vec::new();
+    let dir = themes_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(_) => return (themes, warnings), // no dir yet: no themes
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("vzt") {
+            continue;
+        }
+        match std::fs::read_to_string(&path)
+            .map_err(|e| e.to_string())
+            .and_then(|s| serde_json::from_str::<ThemePalette>(&s).map_err(|e| e.to_string()))
+        {
+            Ok(palette) => themes.push(UserTheme {
+                path: path.clone(),
+                palette,
+            }),
+            Err(e) => warnings.push(format!("{}: {e}", path.display())),
+        }
+    }
+    themes.sort_by(|a, b| {
+        a.palette
+            .name
+            .to_lowercase()
+            .cmp(&b.palette.name.to_lowercase())
+    });
+    (themes, warnings)
+}
+
+/// Save a palette into the themes directory as `<slug>.vzt`.
+pub fn save_user_theme(palette: &ThemePalette) -> Result<PathBuf, String> {
+    let dir = themes_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let slug: String = palette
+        .name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    let slug = if slug.is_empty() {
+        "custom".to_string()
+    } else {
+        slug
+    };
+    let path = dir.join(format!("{slug}.vzt"));
+    let json = serde_json::to_string_pretty(palette).map_err(|e| e.to_string())?;
+    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn twenty_builtins_with_unique_names() {
+        let themes = builtins();
+        assert_eq!(themes.len(), 20, "the collection ships 20 themes");
+        let mut names: Vec<&str> = themes.iter().map(|t| t.name.as_str()).collect();
+        names.sort();
+        names.dedup();
+        assert_eq!(names.len(), themes.len(), "names must be unique");
+        assert_eq!(themes[0].name, "Charcoal", "default first");
+    }
+
+    #[test]
+    fn builtin_text_contrasts_with_background() {
+        // Cheap luminance gate: every theme's primary text must sit
+        // far from its background, dark or light.
+        fn luma(c: Color) -> f32 {
+            0.2126 * c.r + 0.7152 * c.g + 0.0722 * c.b
+        }
+        for t in builtins() {
+            let d = (luma(t.text) - luma(t.bg_dark)).abs();
+            assert!(d > 0.45, "theme {} text/bg contrast too low: {d}", t.name);
+        }
+    }
+
+    #[test]
+    fn vzt_roundtrip_through_the_service() {
+        let dir = tempfile::tempdir().unwrap();
+        // Redirect the service to a temp dir via direct file ops:
+        // save_user_theme always writes to the real config dir, so
+        // exercise the same serialize/parse path manually here.
+        let mut palette = ThemePalette::charcoal();
+        palette.name = "Test Custom".to_string();
+        let json = serde_json::to_string_pretty(&palette).unwrap();
+        let path = dir.path().join("test-custom.vzt");
+        std::fs::write(&path, &json).unwrap();
+        let back: ThemePalette =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(back.name, "Test Custom");
+    }
+}

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -23,6 +23,10 @@ pub struct UiSettings {
     /// startup. `None` means auto-pick the first visible port.
     #[serde(default)]
     pub preferred_midi_input: Option<String>,
+    /// Selected theme name (built-in or user `.vzt`); `None` means
+    /// the default Charcoal.
+    #[serde(default)]
+    pub theme: Option<String>,
 }
 
 impl Default for UiSettings {
@@ -33,6 +37,7 @@ impl Default for UiSettings {
             auto_warp_on_import: false,
             warp_confidence_threshold: default_warp_confidence_threshold(),
             preferred_midi_input: None,
+            theme: None,
         }
     }
 }

--- a/crates/vibez-ui/src/widgets/audio_clip_detail.rs
+++ b/crates/vibez-ui/src/widgets/audio_clip_detail.rs
@@ -39,7 +39,7 @@ impl canvas::Program<Message> for AudioClipDetailWidget {
         let h = bounds.height;
 
         // Background
-        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::BG_DARK);
+        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::bg_dark());
 
         // Center line
         let center_y = h / 2.0;
@@ -52,7 +52,7 @@ impl canvas::Program<Message> for AudioClipDetailWidget {
             canvas::Stroke::default()
                 .with_color(Color {
                     a: 0.3,
-                    ..theme::TEXT_DIM
+                    ..theme::text_dim()
                 })
                 .with_width(1.0),
         );
@@ -183,7 +183,7 @@ impl canvas::Program<Message> for AudioClipDetailWidget {
             frame.stroke(
                 &playhead_line,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(2.0),
             );
         }

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -173,7 +173,10 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                         offset: 0,
                     },
                     ..canvas::Stroke::default()
-                        .with_color(Color::from_rgba(0.85, 0.83, 0.78, 0.35))
+                        .with_color(Color {
+                            a: 0.35,
+                            ..th::text()
+                        })
                         .with_width(1.0)
                 },
             );
@@ -184,7 +187,10 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         let label = |content: &str, position: Point, bottom: bool| canvas::Text {
             content: content.to_string(),
             position,
-            color: Color::from_rgba(0.75, 0.73, 0.68, 0.55),
+            color: Color {
+                a: 0.55,
+                ..th::text()
+            },
             size: iced::Pixels(9.0),
             vertical_alignment: if bottom {
                 iced::alignment::Vertical::Bottom
@@ -262,9 +268,9 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                     || (state.drag.is_none() && self.selected == Some(i));
                 let handle = canvas::Path::circle(center, HANDLE_RADIUS);
                 if selected {
-                    frame.fill(&handle, th::ACCENT);
+                    frame.fill(&handle, th::accent());
                 } else {
-                    frame.fill(&handle, Color::from_rgba(0.09, 0.09, 0.1, 1.0));
+                    frame.fill(&handle, th::bg_dark());
                     frame.stroke(
                         &handle,
                         canvas::Stroke::default()
@@ -284,7 +290,10 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                 frame.fill_rectangle(
                     Point::new(x0, 0.0),
                     iced::Size::new(x1 - x0, h),
-                    Color::from_rgba(0.9, 0.35, 0.25, 0.18),
+                    Color {
+                        a: 0.18,
+                        ..th::danger()
+                    },
                 );
             }
         }

--- a/crates/vibez-ui/src/widgets/effect_knob.rs
+++ b/crates/vibez-ui/src/widgets/effect_knob.rs
@@ -172,8 +172,8 @@ pub fn param_column<'a>(
         .into();
     column![
         knob_canvas,
-        text(label).size(9).color(theme::TEXT_DIM),
-        text(value_text).size(9).color(theme::TEXT),
+        text(label).size(9).color(theme::text_dim()),
+        text(value_text).size(9).color(theme::text()),
     ]
     .spacing(2)
     .width(Length::Fixed(PARAM_COLUMN_WIDTH))
@@ -239,14 +239,7 @@ impl canvas::Program<Message> for EffectKnobWidget {
         let bg_arc = build_arc(center, arc_radius, ARC_START, ARC_END);
         frame.stroke(
             &bg_arc,
-            round
-                .with_color(Color {
-                    r: 0.22,
-                    g: 0.22,
-                    b: 0.22,
-                    a: 1.0,
-                })
-                .with_width(2.5),
+            round.with_color(theme::knob_track()).with_width(2.5),
         );
 
         if norm > 0.005 {
@@ -269,19 +262,9 @@ impl canvas::Program<Message> for EffectKnobWidget {
         frame.fill(
             &body,
             if engaged {
-                Color {
-                    r: 0.16,
-                    g: 0.16,
-                    b: 0.16,
-                    a: 1.0,
-                }
+                theme::knob_body_engaged()
             } else {
-                Color {
-                    r: 0.12,
-                    g: 0.12,
-                    b: 0.12,
-                    a: 1.0,
-                }
+                theme::knob_body()
             },
         );
 
@@ -303,9 +286,9 @@ impl canvas::Program<Message> for EffectKnobWidget {
             &pointer,
             round
                 .with_color(if engaged {
-                    theme::TEXT
+                    theme::text()
                 } else {
-                    theme::TEXT_DIM
+                    theme::text_dim()
                 })
                 .with_width(2.0),
         );

--- a/crates/vibez-ui/src/widgets/effect_slot.rs
+++ b/crates/vibez-ui/src/widgets/effect_slot.rs
@@ -26,7 +26,7 @@ pub fn view_effect_slot<'a>(
     let is_plugin = effect.plugin_name.is_some();
 
     let dot_color = if is_bypassed {
-        th::TEXT_MUTED
+        th::text_muted()
     } else {
         track_color
     };
@@ -37,7 +37,7 @@ pub fn view_effect_slot<'a>(
         .padding([2, 3])
         .style(move |_theme: &Theme, status| {
             let bg = match status {
-                button::Status::Hovered => Some(th::BG_HOVER.into()),
+                button::Status::Hovered => Some(th::bg_hover().into()),
                 _ => None,
             };
             button::Style {
@@ -55,7 +55,11 @@ pub fn view_effect_slot<'a>(
         .plugin_name
         .as_deref()
         .unwrap_or_else(|| effect.effect_type.name());
-    let name_color = if is_bypassed { th::TEXT_DIM } else { th::TEXT };
+    let name_color = if is_bypassed {
+        th::text_dim()
+    } else {
+        th::text()
+    };
 
     let name_elem = text(display_name).size(11).color(name_color);
 
@@ -73,19 +77,19 @@ pub fn view_effect_slot<'a>(
             effect_id: effect.id,
         };
         Some(
-            button(text("Edit").size(9).color(th::TEXT_DIM))
+            button(text("Edit").size(9).color(th::text_dim()))
                 .on_press(Message::OpenPluginGui(gui_key))
                 .padding([2, 5])
                 .style(|_theme: &Theme, status| {
                     let (bg, tc) = match status {
-                        button::Status::Hovered => (Some(th::BG_HOVER.into()), th::ACCENT),
-                        _ => (None, th::TEXT_DIM),
+                        button::Status::Hovered => (Some(th::bg_hover().into()), th::accent()),
+                        _ => (None, th::text_dim()),
                     };
                     button::Style {
                         background: bg,
                         text_color: tc,
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 3.0.into(),
                         },
@@ -97,9 +101,9 @@ pub fn view_effect_slot<'a>(
 
     let bypass_label = if is_bypassed { "Off" } else { "On" };
     let bypass_color = if is_bypassed {
-        th::TEXT_MUTED
+        th::text_muted()
     } else {
-        th::SUCCESS
+        th::success()
     };
     let make_bypass = move || {
         button(text(bypass_label).size(9).color(bypass_color))
@@ -107,7 +111,7 @@ pub fn view_effect_slot<'a>(
             .padding([2, 5])
             .style(move |_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered => Some(th::bg_hover().into()),
                     _ => None,
                 };
                 button::Style {
@@ -115,9 +119,9 @@ pub fn view_effect_slot<'a>(
                     text_color: bypass_color,
                     border: iced::Border {
                         color: if is_bypassed {
-                            th::BORDER
+                            th::border()
                         } else {
-                            th::darken(th::SUCCESS, 0.5)
+                            th::darken(th::success(), 0.5)
                         },
                         width: 1.0,
                         radius: 3.0.into(),
@@ -130,8 +134,8 @@ pub fn view_effect_slot<'a>(
     let make_move_up = || -> Element<'a, Message> {
         action_btn(
             icons::CHEVRON_UP,
-            th::TEXT_DIM,
-            th::TEXT,
+            th::text_dim(),
+            th::text(),
             Message::move_effect_up(track_id, effect.id),
         )
         .into()
@@ -139,16 +143,16 @@ pub fn view_effect_slot<'a>(
     let make_move_down = || -> Element<'a, Message> {
         action_btn(
             icons::CHEVRON_DOWN,
-            th::TEXT_DIM,
-            th::TEXT,
+            th::text_dim(),
+            th::text(),
             Message::move_effect_down(track_id, effect.id),
         )
         .into()
     };
     let remove: Element<'a, Message> = action_btn(
         icons::X,
-        th::TEXT_DIM,
-        th::DANGER,
+        th::text_dim(),
+        th::danger(),
         Message::remove_effect(track_id, effect.id),
     )
     .into();
@@ -175,7 +179,7 @@ pub fn view_effect_slot<'a>(
         .padding([4, 6])
         .width(Length::Fill)
         .style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             ..Default::default()
         });
 
@@ -188,7 +192,7 @@ pub fn view_effect_slot<'a>(
             .into()
     } else if has_params && !has_gui {
         let knob_color = if is_bypassed {
-            th::TEXT_MUTED
+            th::text_muted()
         } else {
             track_color
         };
@@ -226,12 +230,12 @@ pub fn view_effect_slot<'a>(
             .as_ref()
             .map(|d| d.format.to_uppercase())
             .unwrap_or_else(|| "PLUGIN".to_string());
-        let badge = container(text(format_label).size(8).color(th::ACCENT))
+        let badge = container(text(format_label).size(8).color(th::accent()))
             .padding([2, 8])
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_DARK.into()),
+                background: Some(th::bg_dark().into()),
                 border: iced::Border {
-                    color: th::ACCENT_DIM,
+                    color: th::accent_dim(),
                     width: 1.0,
                     radius: 3.0.into(),
                 },
@@ -279,9 +283,9 @@ pub fn view_effect_slot<'a>(
 
     container(card)
         .style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_ELEVATED.into()),
+            background: Some(th::bg_elevated().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 4.0.into(),
             },
@@ -302,8 +306,8 @@ fn action_btn(
         .padding([3, 4])
         .style(move |_theme: &Theme, status| {
             let (bg, tc) = match status {
-                button::Status::Hovered => (Some(th::BG_HOVER.into()), hover_color),
-                button::Status::Pressed => (Some(th::BG_DARK.into()), hover_color),
+                button::Status::Hovered => (Some(th::bg_hover().into()), hover_color),
+                button::Status::Pressed => (Some(th::bg_dark().into()), hover_color),
                 _ => (None, color),
             };
             button::Style {

--- a/crates/vibez-ui/src/widgets/eq_display.rs
+++ b/crates/vibez-ui/src/widgets/eq_display.rs
@@ -30,7 +30,6 @@ struct Band {
     gain_i: usize,
     freq_i: usize,
     q_i: Option<usize>,
-    color: Color,
 }
 
 const BANDS: [Band; 4] = [
@@ -38,27 +37,33 @@ const BANDS: [Band; 4] = [
         gain_i: 0,
         freq_i: 1,
         q_i: None,
-        color: th::EQ_LF,
     },
     Band {
         gain_i: 3,
         freq_i: 4,
         q_i: Some(5),
-        color: th::EQ_LMF,
     },
     Band {
         gain_i: 6,
         freq_i: 7,
         q_i: Some(8),
-        color: th::EQ_HMF,
     },
     Band {
         gain_i: 9,
         freq_i: 10,
         q_i: Some(11),
-        color: th::EQ_HF,
     },
 ];
+
+/// Band color from the current theme, by BANDS index (LF..HF).
+fn band_color(idx: usize) -> Color {
+    match idx {
+        0 => th::eq_lf(),
+        1 => th::eq_lmf(),
+        2 => th::eq_hmf(),
+        _ => th::eq_hf(),
+    }
+}
 
 pub struct EqDisplayWidget {
     pub track_id: TrackId,
@@ -156,13 +161,13 @@ impl canvas::Program<Message> for EqDisplayWidget {
         // ── Panel ──
         frame.fill(
             &canvas::Path::rounded_rectangle(Point::ORIGIN, bounds.size(), 3.0.into()),
-            th::BG_DARK,
+            th::bg_dark(),
         );
 
         // ── Grid: decade frequency lines + dB lines ──
         let grid = Color {
             a: 0.35,
-            ..th::BORDER
+            ..th::border()
         };
         let labeled: [(f32, &str); 3] = [(100.0, "100"), (1_000.0, "1k"), (10_000.0, "10k")];
         for f in [
@@ -178,7 +183,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
             frame.fill_text(canvas::Text {
                 content: label.to_string(),
                 position: Point::new(freq_to_norm(f) * w + 3.0, h - 2.0),
-                color: th::TEXT_MUTED,
+                color: th::text_muted(),
                 size: 8.0.into(),
                 vertical_alignment: iced::alignment::Vertical::Bottom,
                 ..canvas::Text::default()
@@ -198,7 +203,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
             canvas::Stroke::default()
                 .with_color(Color {
                     a: 0.8,
-                    ..th::BORDER
+                    ..th::border()
                 })
                 .with_width(1.0),
         );
@@ -219,7 +224,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
                 &path,
                 Color {
                     a: 0.13,
-                    ..th::TEXT_DIM
+                    ..th::text_dim()
                 },
             );
             frame.stroke(
@@ -227,7 +232,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
                 canvas::Stroke::default()
                     .with_color(Color {
                         a: 0.30,
-                        ..th::TEXT_DIM
+                        ..th::text_dim()
                     })
                     .with_width(1.0),
             );
@@ -257,7 +262,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
                 &fill,
                 Color {
                     a: 0.10,
-                    ..th::ACCENT
+                    ..th::accent()
                 },
             );
         }
@@ -269,9 +274,9 @@ impl canvas::Program<Message> for EqDisplayWidget {
             }
         });
         let (curve_color, curve_w) = if self.bypass {
-            (th::TEXT_MUTED, 1.5)
+            (th::text_muted(), 1.5)
         } else {
-            (th::TEXT, 2.0)
+            (th::text(), 2.0)
         };
         frame.stroke(
             &curve,
@@ -288,17 +293,17 @@ impl canvas::Program<Message> for EqDisplayWidget {
             let p = self.handle_pos(band, bounds);
             let engaged = state.drag == Some(i) || (state.drag.is_none() && state.hover == Some(i));
             let color = if self.bypass {
-                th::TEXT_MUTED
+                th::text_muted()
             } else {
-                band.color
+                band_color(i)
             };
             frame.fill(&canvas::Path::circle(p, HANDLE_R), color);
-            frame.fill(&canvas::Path::circle(p, HANDLE_R - 2.5), th::BG_DARK);
+            frame.fill(&canvas::Path::circle(p, HANDLE_R - 2.5), th::bg_dark());
             if engaged {
                 frame.stroke(
                     &canvas::Path::circle(p, HANDLE_R + 2.0),
                     canvas::Stroke::default()
-                        .with_color(th::TEXT)
+                        .with_color(th::text())
                         .with_width(1.0),
                 );
                 // Readout: freq / gain / Q next to the handle.
@@ -318,7 +323,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
                         p.x.clamp(60.0, w - 80.0),
                         if above { p.y - 12.0 } else { p.y + 12.0 },
                     ),
-                    color: th::TEXT,
+                    color: th::text(),
                     size: 9.0.into(),
                     horizontal_alignment: iced::alignment::Horizontal::Center,
                     vertical_alignment: if above {
@@ -335,7 +340,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
         frame.stroke(
             &canvas::Path::rounded_rectangle(Point::ORIGIN, bounds.size(), 3.0.into()),
             canvas::Stroke::default()
-                .with_color(th::BORDER)
+                .with_color(th::border())
                 .with_width(1.0),
         );
 

--- a/crates/vibez-ui/src/widgets/fader.rs
+++ b/crates/vibez-ui/src/widgets/fader.rs
@@ -56,7 +56,7 @@ impl canvas::Program<Message> for HorizontalFaderWidget {
         frame.fill_rectangle(
             iced::Point::new(track_left, track_y),
             iced::Size::new(track_w, track_h),
-            theme::FADER_TRACK,
+            theme::fader_track(),
         );
 
         // Unity gain mark (at 0.5 of the track = gain 1.0)
@@ -68,7 +68,7 @@ impl canvas::Program<Message> for HorizontalFaderWidget {
         frame.stroke(
             &unity_line,
             canvas::Stroke::default()
-                .with_color(theme::TEXT_DIM)
+                .with_color(theme::text_dim())
                 .with_width(1.0),
         );
 
@@ -93,7 +93,7 @@ impl canvas::Program<Message> for HorizontalFaderWidget {
         frame.fill_rectangle(
             iced::Point::new(handle_x - handle_w / 2.0, handle_y),
             iced::Size::new(handle_w, handle_h),
-            theme::FADER_HANDLE,
+            theme::fader_handle(),
         );
 
         vec![frame.into_geometry()]
@@ -205,7 +205,7 @@ impl canvas::Program<Message> for FaderWidget {
         frame.fill_rectangle(
             iced::Point::new(track_x, track_top),
             iced::Size::new(track_w, track_h),
-            theme::FADER_TRACK,
+            theme::fader_track(),
         );
 
         // Unity gain mark (at 0.5 of the track = gain 1.0)
@@ -217,7 +217,7 @@ impl canvas::Program<Message> for FaderWidget {
         frame.stroke(
             &unity_line,
             canvas::Stroke::default()
-                .with_color(theme::TEXT_DIM)
+                .with_color(theme::text_dim())
                 .with_width(1.0),
         );
 
@@ -242,7 +242,7 @@ impl canvas::Program<Message> for FaderWidget {
         frame.fill_rectangle(
             iced::Point::new(handle_x, handle_y - handle_h / 2.0),
             iced::Size::new(handle_w, handle_h),
-            theme::FADER_HANDLE,
+            theme::fader_handle(),
         );
 
         vec![frame.into_geometry()]

--- a/crates/vibez-ui/src/widgets/knob.rs
+++ b/crates/vibez-ui/src/widgets/knob.rs
@@ -82,7 +82,7 @@ impl canvas::Program<Message> for KnobWidget {
 
         // Background circle
         let bg_circle = canvas::Path::circle(center, radius);
-        frame.fill(&bg_circle, theme::KNOB_BG);
+        frame.fill(&bg_circle, theme::knob_bg());
 
         let arc_radius = radius - 2.0;
 
@@ -91,7 +91,7 @@ impl canvas::Program<Message> for KnobWidget {
         frame.stroke(
             &bg_arc,
             canvas::Stroke::default()
-                .with_color(theme::FADER_TRACK)
+                .with_color(theme::fader_track())
                 .with_width(3.0),
         );
 
@@ -123,7 +123,7 @@ impl canvas::Program<Message> for KnobWidget {
         frame.stroke(
             &pointer,
             canvas::Stroke::default()
-                .with_color(theme::TEXT)
+                .with_color(theme::text())
                 .with_width(2.0),
         );
 
@@ -143,7 +143,7 @@ impl canvas::Program<Message> for KnobWidget {
         frame.stroke(
             &tick,
             canvas::Stroke::default()
-                .with_color(theme::TEXT_DIM)
+                .with_color(theme::text_dim())
                 .with_width(1.0),
         );
 

--- a/crates/vibez-ui/src/widgets/mini_waveform.rs
+++ b/crates/vibez-ui/src/widgets/mini_waveform.rs
@@ -79,15 +79,7 @@ impl canvas::Program<Message> for MiniWaveform {
                 iced::Size::new(w, h),
                 3.0.into(),
             );
-            frame.fill(
-                &bg,
-                Color {
-                    r: 0.07,
-                    g: 0.07,
-                    b: 0.07,
-                    a: 1.0,
-                },
-            );
+            frame.fill(&bg, theme::display_bg());
 
             let Some(audio) = &self.audio else {
                 // Empty state: flat center line.
@@ -98,7 +90,7 @@ impl canvas::Program<Message> for MiniWaveform {
                 frame.stroke(
                     &line,
                     canvas::Stroke::default()
-                        .with_color(theme::BORDER)
+                        .with_color(theme::border())
                         .with_width(1.0),
                 );
                 return;
@@ -163,7 +155,7 @@ impl canvas::Program<Message> for MiniWaveform {
                     frame.stroke(
                         &line,
                         canvas::Stroke::default()
-                            .with_color(theme::TEXT_DIM)
+                            .with_color(theme::text_dim())
                             .with_width(1.0),
                     );
                 }
@@ -197,15 +189,7 @@ impl canvas::Program<Message> for OscScope {
 
         let bg =
             canvas::Path::rounded_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), 3.0.into());
-        frame.fill(
-            &bg,
-            Color {
-                r: 0.07,
-                g: 0.07,
-                b: 0.07,
-                a: 1.0,
-            },
-        );
+        frame.fill(&bg, theme::display_bg());
 
         let mid = h / 2.0;
         let amp = h / 2.0 - 4.0;
@@ -285,15 +269,7 @@ impl canvas::Program<Message> for AdsrScope {
 
         let bg =
             canvas::Path::rounded_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), 3.0.into());
-        frame.fill(
-            &bg,
-            Color {
-                r: 0.07,
-                g: 0.07,
-                b: 0.07,
-                a: 1.0,
-            },
-        );
+        frame.fill(&bg, theme::display_bg());
 
         let pad = 3.0;
         let top = pad;

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -19,7 +19,7 @@ use vibez_core::midi::TrackKind;
 pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message> {
     let is_master = track.id.is_master();
     let track_color = if is_master {
-        th::ACCENT
+        th::accent()
     } else {
         th::track_color(track.color_index)
     };
@@ -40,7 +40,7 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
 
     let name = text(&track.name)
         .size(12)
-        .color(th::TEXT)
+        .color(th::text())
         .width(Length::Fill);
 
     let name_row = row![type_icon, name]
@@ -54,7 +54,7 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
         .height(Length::Fixed(36.0))
         .into();
 
-    let pan_label = text(format_pan(track.pan)).size(10).color(th::TEXT_DIM);
+    let pan_label = text(format_pan(track.pan)).size(10).color(th::text_dim());
 
     // Fader (wider)
     let fader = FaderWidget::new(track.id, track.gain, track_color);
@@ -65,7 +65,7 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
 
     let gain_label = text(format_gain_db(track.gain))
         .size(11)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
 
     // VU meter (wider)
     let meter = VuMeterWidget {
@@ -81,12 +81,12 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
     let mute_btn = {
         let label = text("M").size(11);
         if track.mute {
-            button(label.color(th::BG_DARK))
+            button(label.color(th::bg_dark()))
                 .on_press(Message::set_track_mute(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::MUTE_ACTIVE.into()),
-                    text_color: th::BG_DARK,
+                    background: Some(th::mute_active().into()),
+                    text_color: th::bg_dark(),
                     border: iced::Border {
                         radius: 2.0.into(),
                         ..Default::default()
@@ -94,14 +94,14 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
                     ..Default::default()
                 })
         } else {
-            button(label.color(th::TEXT_DIM))
+            button(label.color(th::text_dim()))
                 .on_press(Message::set_track_mute(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::TEXT_DIM,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 2.0.into(),
                     },
@@ -114,12 +114,12 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
     let solo_btn = {
         let label = text("S").size(11);
         if track.solo {
-            button(label.color(th::BG_DARK))
+            button(label.color(th::bg_dark()))
                 .on_press(Message::set_track_solo(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::SOLO_ACTIVE.into()),
-                    text_color: th::BG_DARK,
+                    background: Some(th::solo_active().into()),
+                    text_color: th::bg_dark(),
                     border: iced::Border {
                         radius: 2.0.into(),
                         ..Default::default()
@@ -127,14 +127,14 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
                     ..Default::default()
                 })
         } else {
-            button(label.color(th::TEXT_DIM))
+            button(label.color(th::text_dim()))
                 .on_press(Message::set_track_solo(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::TEXT_DIM,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 2.0.into(),
                     },
@@ -155,12 +155,12 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
     let strip = if is_master {
         // No pan, mute, or solo on the sum: a MASTER tag keeps the
         // strip's vertical rhythm instead.
-        let badge = container(text("MASTER").size(8).color(th::ACCENT))
+        let badge = container(text("MASTER").size(8).color(th::accent()))
             .padding([3, 8])
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_ELEVATED.into()),
+                background: Some(th::bg_elevated().into()),
                 border: iced::Border {
-                    color: th::ACCENT_DIM,
+                    color: th::accent_dim(),
                     width: 1.0,
                     radius: 2.0.into(),
                 },
@@ -187,9 +187,9 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
     let body = container(strip)
         .height(Length::Fill)
         .style(move |_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: if selected { th::ACCENT } else { th::BORDER },
+                color: if selected { th::accent() } else { th::border() },
                 width: 1.0,
                 radius: 2.0.into(),
             },
@@ -218,21 +218,21 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
 
     let Some(eq) = eq else {
         return container(
-            button(text("+ EQ").size(10).color(th::TEXT_DIM))
+            button(text("+ EQ").size(10).color(th::text_dim()))
                 .on_press(Message::add_effect(track.id, EffectType::Eq))
                 .padding([2, 10])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT_DIM,
+                        text_color: th::text_dim(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 2.0.into(),
                         },
@@ -244,11 +244,11 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         .into();
     };
 
-    // Console band colors, muted for the theme.
-    const HF: iced::Color = th::EQ_HF;
-    const HMF: iced::Color = th::EQ_HMF;
-    const LMF: iced::Color = th::EQ_LMF;
-    const LF: iced::Color = th::EQ_LF;
+    // Console band colors, from the current theme.
+    let hf = th::eq_hf();
+    let hmf = th::eq_hmf();
+    let lmf = th::eq_lmf();
+    let lf = th::eq_lf();
 
     let mut bands = column![].spacing(2).align_x(iced::Alignment::Center);
 
@@ -257,21 +257,25 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         let active = !eq.bypass;
         let label = text("IN").size(8);
         button(if active {
-            label.color(th::BG_DARK)
+            label.color(th::bg_dark())
         } else {
-            label.color(th::TEXT_DIM)
+            label.color(th::text_dim())
         })
         .on_press(Message::toggle_effect_bypass(track.id, eq.id))
         .padding([1, 5])
         .style(move |_theme: &Theme, _status| button::Style {
             background: Some(if active {
-                th::ACCENT.into()
+                th::accent().into()
             } else {
-                th::BG_ELEVATED.into()
+                th::bg_elevated().into()
             }),
-            text_color: if active { th::BG_DARK } else { th::TEXT_DIM },
+            text_color: if active {
+                th::bg_dark()
+            } else {
+                th::text_dim()
+            },
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 2.0.into(),
             },
@@ -279,17 +283,17 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         })
     };
     bands = bands.push(
-        row![text("EQ").size(9).color(th::TEXT_DIM), in_btn]
+        row![text("EQ").size(9).color(th::text_dim()), in_btn]
             .spacing(6)
             .align_y(iced::Alignment::Center),
     );
 
     // (gain idx, freq idx, q/bell idx, bell?, color, label)
     let rows: [(usize, usize, usize, bool, iced::Color, &str); 4] = [
-        (9, 10, 11, true, HF, "HF"),
-        (6, 7, 8, false, HMF, "HMF"),
-        (3, 4, 5, false, LMF, "LMF"),
-        (0, 1, 2, true, LF, "LF"),
+        (9, 10, 11, true, hf, "HF"),
+        (6, 7, 8, false, hmf, "HMF"),
+        (3, 4, 5, false, lmf, "LMF"),
+        (0, 1, 2, true, lf, "LF"),
     ];
     for (i, (gain_i, freq_i, third_i, is_bell_toggle, color, label)) in rows.into_iter().enumerate()
     {
@@ -302,7 +306,7 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
                         background: Some(
                             iced::Color {
                                 a: 0.5,
-                                ..th::BORDER
+                                ..th::border()
                             }
                             .into(),
                         ),
@@ -359,7 +363,7 @@ fn view_eq_band<'a>(
     // tucks under the gain. The eye zig-zags down the strip.
     let dim = iced::Color {
         a: 0.75,
-        ..th::TEXT_DIM
+        ..th::text_dim()
     };
     let gain_col = column![
         row![
@@ -375,11 +379,11 @@ fn view_eq_band<'a>(
 
     let third_el: Element<'a, Message> = if bell_toggle {
         let bell_on = eq.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
-        button(
-            text("BELL")
-                .size(6)
-                .color(if bell_on { th::BG_DARK } else { th::TEXT_DIM }),
-        )
+        button(text("BELL").size(6).color(if bell_on {
+            th::bg_dark()
+        } else {
+            th::text_dim()
+        }))
         .on_press(Message::set_effect_param(
             track_id,
             eq.id,
@@ -391,11 +395,15 @@ fn view_eq_band<'a>(
             background: Some(if bell_on {
                 color.into()
             } else {
-                th::BG_ELEVATED.into()
+                th::bg_elevated().into()
             }),
-            text_color: if bell_on { th::BG_DARK } else { th::TEXT_DIM },
+            text_color: if bell_on {
+                th::bg_dark()
+            } else {
+                th::text_dim()
+            },
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 2.0.into(),
             },

--- a/crates/vibez-ui/src/widgets/piano_roll/draw.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/draw.rs
@@ -36,7 +36,7 @@ impl PianoRollWidget {
         let grid_ppb = grid_width / total as f32;
 
         // Full background
-        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::BG_DARK);
+        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::bg_dark());
 
         // Determine visible row range for culling
         let first_visible = (self.scroll_y / KEY_HEIGHT).floor() as usize;
@@ -54,7 +54,11 @@ impl PianoRollWidget {
             }
 
             let is_black = is_black_key(pitch);
-            let row_bg = if is_black { BLACK_ROW_BG } else { WHITE_ROW_BG };
+            let row_bg = if is_black {
+                theme::piano_black_row()
+            } else {
+                theme::piano_white_row()
+            };
 
             frame.fill_rectangle(
                 iced::Point::new(KEY_WIDTH, y),
@@ -65,9 +69,9 @@ impl PianoRollWidget {
             // Horizontal grid line
             let is_c = pitch.is_multiple_of(12);
             let (line_color, line_width) = if is_c {
-                (OCTAVE_LINE, 1.0)
+                (theme::piano_octave_line(), 1.0)
             } else {
-                (GRID_LINE, 0.5)
+                (theme::piano_grid(), 0.5)
             };
             let hline = canvas::Path::line(
                 iced::Point::new(KEY_WIDTH, y + KEY_HEIGHT),
@@ -97,10 +101,10 @@ impl PianoRollWidget {
                 } else if hovered_pitch == Some(pitch) {
                     Color {
                         a: 0.75,
-                        ..WHITE_KEY_COLOR
+                        ..theme::piano_white_key()
                     }
                 } else {
-                    WHITE_KEY_COLOR
+                    theme::piano_white_key()
                 };
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
@@ -116,7 +120,7 @@ impl PianoRollWidget {
                 frame.stroke(
                     &border,
                     canvas::Stroke::default()
-                        .with_color(theme::DIVIDER)
+                        .with_color(theme::divider())
                         .with_width(0.5),
                 );
             }
@@ -137,26 +141,16 @@ impl PianoRollWidget {
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
                     iced::Size::new(KEY_WIDTH, KEY_HEIGHT),
-                    Color {
-                        r: 0.14,
-                        g: 0.14,
-                        b: 0.14,
-                        a: 1.0,
-                    },
+                    theme::piano_white_row(),
                 );
 
                 // Black key itself
                 let fill = if pressed_pitch == Some(pitch) {
                     self.track_color
                 } else if hovered_pitch == Some(pitch) {
-                    Color {
-                        r: 0.35,
-                        g: 0.35,
-                        b: 0.35,
-                        a: 1.0,
-                    }
+                    theme::border_light()
                 } else {
-                    BLACK_KEY_COLOR
+                    theme::piano_black_key()
                 };
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
@@ -172,7 +166,7 @@ impl PianoRollWidget {
                 frame.stroke(
                     &border,
                     canvas::Stroke::default()
-                        .with_color(theme::DIVIDER)
+                        .with_color(theme::divider())
                         .with_width(0.5),
                 );
             }
@@ -192,7 +186,7 @@ impl PianoRollWidget {
                 frame.fill_text(canvas::Text {
                     content: label,
                     position: iced::Point::new(black_key_width + 3.0, y + 2.0),
-                    color: KEY_LABEL_COLOR,
+                    color: theme::piano_key_label(),
                     size: iced::Pixels(10.0),
                     ..Default::default()
                 });
@@ -207,7 +201,7 @@ impl PianoRollWidget {
         frame.stroke(
             &sep,
             canvas::Stroke::default()
-                .with_color(theme::BORDER)
+                .with_color(theme::border())
                 .with_width(1.0),
         );
 
@@ -227,35 +221,11 @@ impl PianoRollWidget {
             let is_beat = beat_int % 1000 == 0;
 
             let (line_color, line_width) = if is_bar {
-                (
-                    Color {
-                        r: 0.376,
-                        g: 0.376,
-                        b: 0.376,
-                        a: 1.0,
-                    },
-                    1.5,
-                ) // #606060
+                (theme::grid_bar(), 1.5)
             } else if is_beat {
-                (
-                    Color {
-                        r: 0.251,
-                        g: 0.251,
-                        b: 0.251,
-                        a: 1.0,
-                    },
-                    1.0,
-                ) // #404040
+                (theme::grid_beat(), 1.0)
             } else {
-                (
-                    Color {
-                        r: 0.216,
-                        g: 0.216,
-                        b: 0.216,
-                        a: 1.0,
-                    },
-                    1.0,
-                ) // #373737
+                (theme::grid_sub(), 1.0)
             };
 
             let vline =
@@ -270,7 +240,7 @@ impl PianoRollWidget {
 
         // ── Draw notes ──
         if let Some(ref clip_data) = self.clip {
-            let selected_color = theme::SOLO_ACTIVE;
+            let selected_color = theme::solo_active();
             let looping =
                 clip_data.loop_enabled && clip_data.loop_end_beats > clip_data.loop_start_beats;
             let loop_len = if looping {
@@ -483,7 +453,7 @@ impl PianoRollWidget {
             frame.stroke(
                 &playhead_line,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(1.5),
             );
         }
@@ -493,7 +463,7 @@ impl PianoRollWidget {
         frame.fill_rectangle(
             iced::Point::ORIGIN,
             iced::Size::new(w, RULER_HEIGHT),
-            theme::BG_SURFACE,
+            theme::bg_surface(),
         );
 
         // Bottom border
@@ -504,7 +474,7 @@ impl PianoRollWidget {
         frame.stroke(
             &ruler_border,
             canvas::Stroke::default()
-                .with_color(theme::BORDER)
+                .with_color(theme::border())
                 .with_width(1.0),
         );
 
@@ -529,13 +499,13 @@ impl PianoRollWidget {
                 frame.stroke(
                     &tick,
                     canvas::Stroke::default()
-                        .with_color(theme::TEXT_MUTED)
+                        .with_color(theme::text_muted())
                         .with_width(1.0),
                 );
                 frame.fill_text(canvas::Text {
                     content: format!("{bar_num}"),
                     position: iced::Point::new(x + 3.0, 3.0),
-                    color: theme::TEXT_DIM,
+                    color: theme::text_dim(),
                     size: iced::Pixels(10.0),
                     ..Default::default()
                 });
@@ -550,13 +520,13 @@ impl PianoRollWidget {
                 frame.stroke(
                     &tick,
                     canvas::Stroke::default()
-                        .with_color(theme::TEXT_MUTED)
+                        .with_color(theme::text_muted())
                         .with_width(0.5),
                 );
                 frame.fill_text(canvas::Text {
                     content: format!("{}.{}", bar_index + 1, beat_in_bar),
                     position: iced::Point::new(x + 2.0, 5.0),
-                    color: theme::TEXT_MUTED,
+                    color: theme::text_muted(),
                     size: iced::Pixels(8.0),
                     ..Default::default()
                 });
@@ -572,7 +542,7 @@ impl PianoRollWidget {
             frame.stroke(
                 &marker,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(1.5),
             );
         }

--- a/crates/vibez-ui/src/widgets/piano_roll/mod.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/mod.rs
@@ -218,64 +218,6 @@ pub struct PianoRollState {
     audition_pitch: Option<u8>,
 }
 
-// ── Grid row colors ──
-
-/// White key row background: #252525
-const WHITE_ROW_BG: Color = Color {
-    r: 0.145,
-    g: 0.145,
-    b: 0.145,
-    a: 1.0,
-};
-
-/// Black key row background: #1c1c1c
-const BLACK_ROW_BG: Color = Color {
-    r: 0.110,
-    g: 0.110,
-    b: 0.110,
-    a: 1.0,
-};
-
-/// Octave boundary line color: #3a3a3a
-const OCTAVE_LINE: Color = Color {
-    r: 0.227,
-    g: 0.227,
-    b: 0.227,
-    a: 1.0,
-};
-
-/// Normal horizontal grid line: #2a2a2a
-const GRID_LINE: Color = Color {
-    r: 0.165,
-    g: 0.165,
-    b: 0.165,
-    a: 1.0,
-};
-
-/// White key fill for piano: #c8c8c8
-const WHITE_KEY_COLOR: Color = Color {
-    r: 0.784,
-    g: 0.784,
-    b: 0.784,
-    a: 1.0,
-};
-
-/// Black key fill for piano: #1a1a1a
-const BLACK_KEY_COLOR: Color = Color {
-    r: 0.102,
-    g: 0.102,
-    b: 0.102,
-    a: 1.0,
-};
-
-/// Piano key label color for C notes
-const KEY_LABEL_COLOR: Color = Color {
-    r: 0.35,
-    g: 0.35,
-    b: 0.35,
-    a: 1.0,
-};
-
 impl canvas::Program<Message> for PianoRollWidget {
     type State = PianoRollState;
 

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -26,11 +26,11 @@ impl TrackClipCanvas {
 
         // Background
         let bg_color = if drop_hover {
-            theme::ACCENT_DIM
+            theme::accent_dim()
         } else if self.selected {
-            theme::TRACK_BG_SELECTED
+            theme::track_bg_selected()
         } else {
-            theme::TRACK_BG
+            theme::track_bg()
         };
         frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), bg_color);
 
@@ -54,7 +54,7 @@ impl TrackClipCanvas {
                     frame.stroke(
                         &vline,
                         canvas::Stroke::default()
-                            .with_color(theme::BORDER)
+                            .with_color(theme::border())
                             .with_width(1.0),
                     );
                 } else if ppb >= 40.0 {
@@ -64,7 +64,7 @@ impl TrackClipCanvas {
                     frame.stroke(
                         &vline,
                         canvas::Stroke::default()
-                            .with_color(theme::DIVIDER)
+                            .with_color(theme::divider())
                             .with_width(0.5),
                     );
                 }
@@ -82,12 +82,7 @@ impl TrackClipCanvas {
                             frame.stroke(
                                 &sub_line,
                                 canvas::Stroke::default()
-                                    .with_color(Color {
-                                        r: 0.13,
-                                        g: 0.13,
-                                        b: 0.13,
-                                        a: 1.0,
-                                    })
+                                    .with_color(theme::divider())
                                     .with_width(0.3),
                             );
                         }
@@ -180,7 +175,7 @@ impl TrackClipCanvas {
                         frame.fill_text(canvas::Text {
                             content: "L".to_string(),
                             position: iced::Point::new(clip_x + clip_w - 14.0, clip_y + 3.0),
-                            color: theme::ACCENT,
+                            color: theme::accent(),
                             size: iced::Pixels(9.0),
                             ..Default::default()
                         });
@@ -190,7 +185,7 @@ impl TrackClipCanvas {
                 // Selection highlight
                 let is_selected = self.selected_clips.contains(&clip.clip_id);
                 let border_color = if is_selected {
-                    theme::ACCENT
+                    theme::accent()
                 } else {
                     clip_border_color
                 };
@@ -226,7 +221,7 @@ impl TrackClipCanvas {
                     frame.fill_text(canvas::Text {
                         content: clip.name.clone(),
                         position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
-                        color: theme::TEXT,
+                        color: theme::text(),
                         size: iced::Pixels(11.0),
                         ..Default::default()
                     });
@@ -237,7 +232,7 @@ impl TrackClipCanvas {
                 // opacity so the waveform and clip colour remain
                 // legible, but strong enough to catch the eye.
                 if clip.warp_stale && clip_w > 4.0 {
-                    let stripe_color = theme::with_alpha(theme::METER_YELLOW, 0.22);
+                    let stripe_color = theme::with_alpha(theme::meter_yellow(), 0.22);
                     let stripe_spacing = 8.0f32;
                     let stripe_stroke = 1.5f32;
                     let mut offset = -clip_h;
@@ -389,7 +384,7 @@ impl TrackClipCanvas {
                         frame.fill_text(canvas::Text {
                             content: "L".to_string(),
                             position: iced::Point::new(clip_x + clip_w - 14.0, clip_y + 3.0),
-                            color: theme::ACCENT,
+                            color: theme::accent(),
                             size: iced::Pixels(9.0),
                             ..Default::default()
                         });
@@ -399,7 +394,7 @@ impl TrackClipCanvas {
                 // Selection highlight
                 let is_selected = self.selected_clips.contains(&note_clip.clip_id);
                 let border_color = if is_selected {
-                    theme::ACCENT
+                    theme::accent()
                 } else {
                     theme::darken(self.track_color, 0.7)
                 };
@@ -435,7 +430,7 @@ impl TrackClipCanvas {
                     frame.fill_text(canvas::Text {
                         content: note_clip.name.clone(),
                         position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
-                        color: theme::TEXT,
+                        color: theme::text(),
                         size: iced::Pixels(11.0),
                         ..Default::default()
                     });
@@ -453,7 +448,7 @@ impl TrackClipCanvas {
                 frame.fill_rectangle(
                     iced::Point::new(fill_x, 0.0),
                     iced::Size::new(fill_w, h),
-                    theme::with_alpha(theme::ACCENT, 0.06),
+                    theme::with_alpha(theme::accent(), 0.06),
                 );
             }
         }
@@ -476,7 +471,7 @@ impl TrackClipCanvas {
                 frame.fill_rectangle(
                     iced::Point::new(fill_x, 0.0),
                     iced::Size::new(fill_w, h),
-                    theme::with_alpha(theme::ACCENT, 0.04),
+                    theme::with_alpha(theme::accent(), 0.04),
                 );
             }
         }
@@ -491,7 +486,7 @@ impl TrackClipCanvas {
             frame.stroke(
                 &playhead_line,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(2.0),
             );
         }
@@ -501,7 +496,7 @@ impl TrackClipCanvas {
         frame.stroke(
             &sep,
             canvas::Stroke::default()
-                .with_color(theme::DIVIDER)
+                .with_color(theme::divider())
                 .with_width(1.0),
         );
 
@@ -516,7 +511,7 @@ impl TrackClipCanvas {
             frame.stroke(
                 &outline,
                 canvas::Stroke::default()
-                    .with_color(theme::ACCENT)
+                    .with_color(theme::accent())
                     .with_width(2.0),
             );
             if let Some(local) = cursor.position_in(bounds) {
@@ -530,7 +525,7 @@ impl TrackClipCanvas {
                     frame.stroke(
                         &drop_line,
                         canvas::Stroke::default()
-                            .with_color(theme::ACCENT)
+                            .with_color(theme::accent())
                             .with_width(2.0),
                     );
                 }
@@ -539,7 +534,7 @@ impl TrackClipCanvas {
             frame.fill_text(canvas::Text {
                 content: format!("Drop on: {}", self.track_name),
                 position: iced::Point::new(8.0, 8.0),
-                color: theme::ACCENT,
+                color: theme::accent(),
                 size: 14.0.into(),
                 ..Default::default()
             });

--- a/crates/vibez-ui/src/widgets/timeline/minimap.rs
+++ b/crates/vibez-ui/src/widgets/timeline/minimap.rs
@@ -68,7 +68,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
         frame.fill_rectangle(
             iced::Point::ORIGIN,
             iced::Size::new(w, h),
-            theme::BG_ELEVATED,
+            theme::bg_elevated(),
         );
 
         if self.total_beats <= 0.0 || self.tracks.is_empty() {
@@ -107,7 +107,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
                 frame.fill_rectangle(
                     iced::Point::new(fill_x, 0.0),
                     iced::Size::new(fill_w, h),
-                    theme::with_alpha(theme::ACCENT, 0.15),
+                    theme::with_alpha(theme::accent(), 0.15),
                 );
             }
         }
@@ -124,10 +124,8 @@ impl canvas::Program<Message> for ArrangementMinimap {
                 iced::Point::new(vx, 0.0),
                 iced::Size::new(vw, h),
                 Color {
-                    r: 1.0,
-                    g: 1.0,
-                    b: 1.0,
                     a: 0.05,
+                    ..theme::text()
                 },
             );
             // Orange border
@@ -141,7 +139,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
             frame.stroke(
                 &rect_path,
                 canvas::Stroke::default()
-                    .with_color(theme::ACCENT)
+                    .with_color(theme::accent())
                     .with_width(1.5),
             );
         }
@@ -154,7 +152,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
             frame.stroke(
                 &playhead,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(1.0),
             );
         }
@@ -165,7 +163,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
         frame.stroke(
             &border,
             canvas::Stroke::default()
-                .with_color(theme::BORDER)
+                .with_color(theme::border())
                 .with_width(1.0),
         );
 

--- a/crates/vibez-ui/src/widgets/timeline/ruler.rs
+++ b/crates/vibez-ui/src/widgets/timeline/ruler.rs
@@ -70,7 +70,11 @@ impl canvas::Program<Message> for RulerWidget {
         let h = bounds.height;
 
         // Background
-        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::RULER_BG);
+        frame.fill_rectangle(
+            iced::Point::ORIGIN,
+            iced::Size::new(w, h),
+            theme::ruler_bg(),
+        );
 
         if self.bpm > 0.0 {
             let beats_per_bar = 4.0_f64;
@@ -122,7 +126,7 @@ impl canvas::Program<Message> for RulerWidget {
                         frame.stroke(
                             &tick,
                             canvas::Stroke::default()
-                                .with_color(theme::BORDER)
+                                .with_color(theme::border())
                                 .with_width(1.5),
                         );
                     }
@@ -135,7 +139,7 @@ impl canvas::Program<Message> for RulerWidget {
                             frame.fill_text(canvas::Text {
                                 content: label,
                                 position: iced::Point::new(x + 4.0, 3.0),
-                                color: theme::RULER_TEXT,
+                                color: theme::ruler_text(),
                                 size: iced::Pixels(12.0),
                                 ..Default::default()
                             });
@@ -145,7 +149,7 @@ impl canvas::Program<Message> for RulerWidget {
                             frame.fill_text(canvas::Text {
                                 content: label,
                                 position: iced::Point::new(x + 4.0, 3.0),
-                                color: theme::RULER_TEXT,
+                                color: theme::ruler_text(),
                                 size: iced::Pixels(12.0),
                                 ..Default::default()
                             });
@@ -158,7 +162,7 @@ impl canvas::Program<Message> for RulerWidget {
                     frame.stroke(
                         &tick,
                         canvas::Stroke::default()
-                            .with_color(theme::DIVIDER)
+                            .with_color(theme::divider())
                             .with_width(0.5),
                     );
 
@@ -168,7 +172,7 @@ impl canvas::Program<Message> for RulerWidget {
                         frame.fill_text(canvas::Text {
                             content: label,
                             position: iced::Point::new(x + 2.0, 6.0),
-                            color: theme::TEXT_MUTED,
+                            color: theme::text_muted(),
                             size: iced::Pixels(9.0),
                             ..Default::default()
                         });
@@ -188,7 +192,7 @@ impl canvas::Program<Message> for RulerWidget {
                             frame.stroke(
                                 &sub_tick,
                                 canvas::Stroke::default()
-                                    .with_color(theme::DIVIDER)
+                                    .with_color(theme::divider())
                                     .with_width(0.3),
                             );
                         }
@@ -202,7 +206,7 @@ impl canvas::Program<Message> for RulerWidget {
             frame.stroke(
                 &bottom_border,
                 canvas::Stroke::default()
-                    .with_color(theme::BORDER)
+                    .with_color(theme::border())
                     .with_width(1.0),
             );
         }
@@ -218,7 +222,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.fill_rectangle(
                     iced::Point::new(fill_x, 0.0),
                     iced::Size::new(fill_w, h),
-                    theme::with_alpha(theme::ACCENT, 0.15),
+                    theme::with_alpha(theme::accent(), 0.15),
                 );
 
                 // REPEAT icon centered in the loop region
@@ -226,7 +230,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.fill_text(canvas::Text {
                     content: crate::icons::REPEAT.to_string(),
                     position: iced::Point::new(center_x - 6.0, (h - 12.0) / 2.0),
-                    color: theme::with_alpha(theme::ACCENT, 0.7),
+                    color: theme::with_alpha(theme::accent(), 0.7),
                     size: iced::Pixels(12.0),
                     font: crate::icons::ICON_FONT,
                     ..Default::default()
@@ -242,7 +246,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.stroke(
                     &bracket,
                     canvas::Stroke::default()
-                        .with_color(theme::ACCENT)
+                        .with_color(theme::accent())
                         .with_width(2.0),
                 );
             }
@@ -254,7 +258,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.stroke(
                     &bracket,
                     canvas::Stroke::default()
-                        .with_color(theme::ACCENT)
+                        .with_color(theme::accent())
                         .with_width(2.0),
                 );
             }
@@ -271,7 +275,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.fill_rectangle(
                     iced::Point::new(fill_x, 0.0),
                     iced::Size::new(fill_w, h),
-                    theme::with_alpha(theme::ACCENT, 0.10),
+                    theme::with_alpha(theme::accent(), 0.10),
                 );
             }
 
@@ -282,7 +286,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.stroke(
                     &bracket,
                     canvas::Stroke::default()
-                        .with_color(theme::ACCENT)
+                        .with_color(theme::accent())
                         .with_width(1.0),
                 );
             }
@@ -292,7 +296,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.stroke(
                     &bracket,
                     canvas::Stroke::default()
-                        .with_color(theme::ACCENT)
+                        .with_color(theme::accent())
                         .with_width(1.0),
                 );
             }
@@ -308,7 +312,7 @@ impl canvas::Program<Message> for RulerWidget {
             frame.stroke(
                 &playhead_line,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(2.0),
             );
         }

--- a/crates/vibez-ui/src/widgets/track_header.rs
+++ b/crates/vibez-ui/src/widgets/track_header.rs
@@ -49,7 +49,11 @@ pub fn view_track_header<'a>(
             .width(Length::Fill)
             .into()
     } else {
-        let name_color = if track.mute { th::TEXT_DIM } else { th::TEXT };
+        let name_color = if track.mute {
+            th::text_dim()
+        } else {
+            th::text()
+        };
         let msg = if selected {
             Message::View(ViewMsg::StartEditingTrackName(track.id))
         } else {
@@ -60,7 +64,7 @@ pub fn view_track_header<'a>(
             .padding(0)
             .style(|_theme: &Theme, _status| button::Style {
                 background: None,
-                text_color: th::TEXT,
+                text_color: th::text(),
                 border: iced::Border::default(),
                 ..Default::default()
             })
@@ -68,11 +72,11 @@ pub fn view_track_header<'a>(
     };
 
     let add_btn = match track.kind {
-        TrackKind::Audio => button(icons::icon(icons::PLUS).size(11).color(th::TEXT_DIM))
+        TrackKind::Audio => button(icons::icon(icons::PLUS).size(11).color(th::text_dim()))
             .on_press(Message::AddClipToTrack(track.id))
             .padding([2, 6]),
         TrackKind::Instrument(_) | TrackKind::Midi => {
-            button(icons::icon(icons::PLUS).size(11).color(th::TEXT_DIM))
+            button(icons::icon(icons::PLUS).size(11).color(th::text_dim()))
                 .on_press(Message::PianoRoll(PianoRollMsg::AddNoteClipToTrack(
                     track.id,
                 )))
@@ -80,17 +84,17 @@ pub fn view_track_header<'a>(
         }
     };
 
-    let delete_btn = button(icons::icon(icons::TRASH_2).size(10).color(th::TEXT_DIM))
+    let delete_btn = button(icons::icon(icons::TRASH_2).size(10).color(th::text_dim()))
         .on_press(Message::remove_track(track.id))
         .padding([2, 4])
         .style(|_theme: &Theme, status| {
             let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
                 _ => None,
             };
             button::Style {
                 background: bg,
-                text_color: th::TEXT_DIM,
+                text_color: th::text_dim(),
                 border: iced::Border::default(),
                 ..Default::default()
             }
@@ -98,9 +102,9 @@ pub fn view_track_header<'a>(
 
     let auto_btn = {
         let color = if automation_open {
-            th::ACCENT
+            th::accent()
         } else {
-            th::TEXT_DIM
+            th::text_dim()
         };
         button(icons::icon(icons::SLIDERS_VERTICAL).size(10).color(color))
             .on_press(Message::Automation(AutomationMsg::ToggleTrackLanes(
@@ -109,12 +113,14 @@ pub fn view_track_header<'a>(
             .padding([2, 4])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border::default(),
                     ..Default::default()
                 }
@@ -136,12 +142,12 @@ pub fn view_track_header<'a>(
     let mute_btn = {
         let label = text("M").size(11);
         if track.mute {
-            button(label.color(th::BG_DARK))
+            button(label.color(th::bg_dark()))
                 .on_press(Message::set_track_mute(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::MUTE_ACTIVE.into()),
-                    text_color: th::BG_DARK,
+                    background: Some(th::mute_active().into()),
+                    text_color: th::bg_dark(),
                     border: iced::Border {
                         radius: 2.0.into(),
                         ..Default::default()
@@ -149,14 +155,14 @@ pub fn view_track_header<'a>(
                     ..Default::default()
                 })
         } else {
-            button(label.color(th::TEXT_DIM))
+            button(label.color(th::text_dim()))
                 .on_press(Message::set_track_mute(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::TEXT_DIM,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 2.0.into(),
                     },
@@ -168,12 +174,12 @@ pub fn view_track_header<'a>(
     let solo_btn = {
         let label = text("S").size(11);
         if track.solo {
-            button(label.color(th::BG_DARK))
+            button(label.color(th::bg_dark()))
                 .on_press(Message::set_track_solo(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::SOLO_ACTIVE.into()),
-                    text_color: th::BG_DARK,
+                    background: Some(th::solo_active().into()),
+                    text_color: th::bg_dark(),
                     border: iced::Border {
                         radius: 2.0.into(),
                         ..Default::default()
@@ -181,14 +187,14 @@ pub fn view_track_header<'a>(
                     ..Default::default()
                 })
         } else {
-            button(label.color(th::TEXT_DIM))
+            button(label.color(th::text_dim()))
                 .on_press(Message::set_track_solo(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::TEXT_DIM,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 2.0.into(),
                     },
@@ -232,14 +238,18 @@ pub fn view_track_header<'a>(
     let card = container(header_with_bar).style(move |_theme: &Theme| container::Style {
         background: Some(
             if selected {
-                th::TRACK_BG_SELECTED
+                th::track_bg_selected()
             } else {
-                th::BG_SURFACE
+                th::bg_surface()
             }
             .into(),
         ),
         border: iced::Border {
-            color: if selected { th::ACCENT_DIM } else { th::BORDER },
+            color: if selected {
+                th::accent_dim()
+            } else {
+                th::border()
+            },
             width: if selected { 1.0 } else { 0.0 },
             radius: 0.0.into(),
         },

--- a/crates/vibez-ui/src/widgets/vu_meter.rs
+++ b/crates/vibez-ui/src/widgets/vu_meter.rs
@@ -44,7 +44,7 @@ impl canvas::Program<crate::message::Message> for VuMeterWidget {
         frame.fill_rectangle(
             iced::Point::ORIGIN,
             iced::Size::new(w, h),
-            theme::BG_ELEVATED,
+            theme::bg_elevated(),
         );
 
         let bar_width = (w / 2.0 - 3.0).max(4.0);
@@ -62,7 +62,7 @@ impl canvas::Program<crate::message::Message> for VuMeterWidget {
                 frame.fill_rectangle(
                     iced::Point::new(x, h - padding - green_h),
                     iced::Size::new(bar_width, green_h),
-                    theme::METER_GREEN,
+                    theme::meter_green(),
                 );
 
                 // Yellow portion (0.6..0.85)
@@ -73,7 +73,7 @@ impl canvas::Program<crate::message::Message> for VuMeterWidget {
                     frame.fill_rectangle(
                         iced::Point::new(x, yellow_y),
                         iced::Size::new(bar_width, yellow_h),
-                        theme::METER_YELLOW,
+                        theme::meter_yellow(),
                     );
                 }
 
@@ -84,7 +84,7 @@ impl canvas::Program<crate::message::Message> for VuMeterWidget {
                     frame.fill_rectangle(
                         iced::Point::new(x, red_y),
                         iced::Size::new(bar_width, red_h),
-                        theme::METER_RED,
+                        theme::meter_red(),
                     );
                 }
             }
@@ -138,7 +138,7 @@ impl canvas::Program<crate::message::Message> for HorizontalVuMeterWidget {
         frame.fill_rectangle(
             iced::Point::ORIGIN,
             iced::Size::new(w, h),
-            theme::BG_ELEVATED,
+            theme::bg_elevated(),
         );
 
         let padding = 1.0;
@@ -152,9 +152,9 @@ impl canvas::Program<crate::message::Message> for HorizontalVuMeterWidget {
                 let bar_w = (level * max_width).clamp(0.0, max_width);
                 // Use track color with brightness modulated by level
                 let color = if level > 0.85 {
-                    theme::METER_RED
+                    theme::meter_red()
                 } else if level > 0.6 {
-                    theme::METER_YELLOW
+                    theme::meter_yellow()
                 } else {
                     track_color
                 };

--- a/crates/vibez-ui/src/widgets/waveform.rs
+++ b/crates/vibez-ui/src/widgets/waveform.rs
@@ -59,7 +59,7 @@ impl canvas::Program<crate::message::Message> for WaveformWidget {
             frame.fill_rectangle(
                 iced::Point::ORIGIN,
                 iced::Size::new(w, h),
-                theme::BG_SURFACE,
+                theme::bg_surface(),
             );
 
             // Center line
@@ -73,7 +73,7 @@ impl canvas::Program<crate::message::Message> for WaveformWidget {
                 canvas::Stroke::default()
                     .with_color(Color {
                         a: 0.3,
-                        ..theme::TEXT_DIM
+                        ..theme::text_dim()
                     })
                     .with_width(1.0),
             );
@@ -113,7 +113,7 @@ impl canvas::Program<crate::message::Message> for WaveformWidget {
                     frame.fill_rectangle(
                         iced::Point::new(x as f32, y_top),
                         iced::Size::new(1.0, height),
-                        theme::WAVEFORM,
+                        theme::waveform(),
                     );
                 }
             }
@@ -131,7 +131,7 @@ impl canvas::Program<crate::message::Message> for WaveformWidget {
                 frame.stroke(
                     &playhead_line,
                     canvas::Stroke::default()
-                        .with_color(theme::PLAYHEAD)
+                        .with_color(theme::playhead())
                         .with_width(1.5),
                 );
             }


### PR DESCRIPTION
## What

**Runtime theme system** (commit 1, zero visual change): every color the UI paints now comes from a runtime `ThemePalette` read through `th::accent()`-style accessors. Hardcoded widget colors (knob grays, piano roll rows/keys, grid lines, display wells, automation overlays) were herded into named palette roles so themes reach every canvas.

**The collection + Appearance tab** (commit 2):
- 20 built-in themes: Charcoal (default), Obsidian, Berlin, Acid, Vaporwave, Nord, Dracula, Gruvbox, Solarized Dark, Monokai, Tokyo Night, Catppuccin, One Dark, Deep Sea, Espresso, Slate, Rose Pine, High Contrast, Solarized Light, Porcelain
- Settings → Appearance: swatch rows, instant switching (canvases included), track palette follows the theme
- User themes: `.vzt` files (plain JSON, hex colors) scanned from `~/.config/vibez/themes` plugin-library style, with Rescan and Save Current
- Selection persists in ui.json and restores on launch
- Projects save as `.vzp` now; `.vibez` files still open fine and keep their extension when saved in place

## Verified live (Xvfb sandbox)
- Vaporwave + Porcelain (light) screenshots across arrange/mix/settings
- Save Current → .vzt written, appears under Your Themes, survives restart
- Theme restored from ui.json on relaunch

## Gate
21 test suites ok, 0 failed (incl. new: hex roundtrip, .vzt roundtrip, 20-theme collection with per-theme text/bg contrast check), clippy -D warnings clean.