### PR TITLE
Release: automation, console mixer, master channel, themes (v0.0.3-alpha)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to vibez
+
+## Branching
+
+```
+main <- dev <- feature/your-thing
+```
+
+- **main** is release-quality. Only `dev` merges into it, and releases are
+  tagged from it (`v*` tags trigger the release pipeline).
+- **dev** is the integration branch and the default branch for pull requests.
+- **feature/…** (or `fix/…`, `docs/…`) branches off `dev` and comes back via PR.
+
+## Requirements for a PR
+
+- CI green on all three platforms: `cargo test --workspace` and
+  `cargo clippy --workspace -- -D warnings`
+- `cargo fmt` clean
+- New logic comes with unit tests; UI logic belongs in a domain module
+  (see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)) so it is testable
+  without the GUI
+- No source file over 1,000 lines; split along the existing seams instead
+- Nothing that allocates, locks, or does I/O in the audio callback
+
+## Releasing
+
+Merge `dev` into `main`, then tag:
+
+```sh
+git tag v0.x.y && git push origin v0.x.y
+```
+
+The release workflow builds the .deb, AppImage, tar.gz, both macOS .dmg
+bundles, and the Windows installer, and attaches them to the GitHub Release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,6 +5078,7 @@ dependencies = [
  "rtrb",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "vibez-audio-io",
  "vibez-core",

--- a/crates/vibez-core/src/automation.rs
+++ b/crates/vibez-core/src/automation.rs
@@ -16,6 +16,25 @@ use crate::id::{EffectId, LaneId};
 pub struct AutomationPoint {
     pub beat: f64,
     pub value: f32,
+    /// Shape of the segment LEAVING this point: 0 is linear,
+    /// positive bends toward the destination late (ease-in),
+    /// negative early (ease-out). Range -1..1.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub curve: f32,
+}
+
+fn is_zero(v: &f32) -> bool {
+    *v == 0.0
+}
+
+/// Apply a segment's curve shaping to linear progress `t` (0..1).
+pub fn shape(t: f32, curve: f32) -> f32 {
+    if curve == 0.0 {
+        return t;
+    }
+    // Exponent sweep: curve -1 -> t^(1/8) (early), +1 -> t^8 (late).
+    let exp = 2.0_f32.powf(curve * 3.0);
+    t.powf(exp)
 }
 
 /// What a lane drives.
@@ -77,7 +96,7 @@ impl AutomationLane {
         if span <= f64::EPSILON {
             return Some(b.value);
         }
-        let t = ((beat - a.beat) / span) as f32;
+        let t = shape(((beat - a.beat) / span) as f32, a.curve);
         Some(a.value + (b.value - a.value) * t)
     }
 
@@ -109,6 +128,7 @@ mod tests {
             l.insert_point(AutomationPoint {
                 beat: *beat,
                 value: *value,
+                curve: 0.0,
             });
         }
         l
@@ -141,6 +161,7 @@ mod tests {
         l.insert_point(AutomationPoint {
             beat: 4.0,
             value: 0.9,
+            curve: 0.0,
         });
         assert_eq!(l.points.len(), 3);
         assert_eq!(l.value_at(4.0), Some(0.9));
@@ -152,5 +173,44 @@ mod tests {
         let json = serde_json::to_string(&l).unwrap();
         let back: AutomationLane = serde_json::from_str(&json).unwrap();
         assert_eq!(l, back);
+    }
+}
+
+#[cfg(test)]
+mod curve_tests {
+    use super::*;
+
+    #[test]
+    fn curve_bends_interpolation() {
+        let mut l = AutomationLane::new(AutomationTarget::TrackGain);
+        l.insert_point(AutomationPoint {
+            beat: 0.0,
+            value: 0.0,
+            curve: 1.0, // strong ease-in: stays low, rises late
+        });
+        l.insert_point(AutomationPoint {
+            beat: 8.0,
+            value: 1.0,
+            curve: 0.0,
+        });
+        let mid = l.value_at(4.0).unwrap();
+        assert!(mid < 0.05, "eased-in midpoint should hug the start: {mid}");
+        // Linear again once the curve resets.
+        l.points[0].curve = 0.0;
+        assert_eq!(l.value_at(4.0), Some(0.5));
+    }
+
+    #[test]
+    fn zero_curve_serializes_compactly_and_loads_back() {
+        let mut l = AutomationLane::new(AutomationTarget::TrackPan);
+        l.insert_point(AutomationPoint {
+            beat: 0.0,
+            value: 0.5,
+            curve: 0.0,
+        });
+        let json = serde_json::to_string(&l).unwrap();
+        assert!(!json.contains("curve"));
+        let back: AutomationLane = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.points[0].curve, 0.0);
     }
 }

--- a/crates/vibez-core/src/automation.rs
+++ b/crates/vibez-core/src/automation.rs
@@ -1,0 +1,156 @@
+//! Automation lanes: parameter values drawn over time.
+//!
+//! A lane targets one parameter and holds points sorted by beat.
+//! Evaluation is linear interpolation between points, holding the
+//! first value before the first point and the last value after the
+//! last point. Block-rate evaluation (once per render segment) is
+//! the v1 contract; no sample-accurate ramps yet.
+
+use serde::{Deserialize, Serialize};
+
+use crate::id::{EffectId, LaneId};
+
+/// One breakpoint on a lane. `value` is in the target parameter's
+/// native unit (gain multiplier, pan 0..1, effect param range).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct AutomationPoint {
+    pub beat: f64,
+    pub value: f32,
+}
+
+/// What a lane drives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AutomationTarget {
+    TrackGain,
+    TrackPan,
+    EffectParam {
+        effect_id: EffectId,
+        param_index: usize,
+    },
+    InstrumentParam {
+        param_index: usize,
+    },
+    /// Third-party plugin parameter. `effect_id` is `None` for the
+    /// track's plugin instrument.
+    PluginParam {
+        effect_id: Option<EffectId>,
+        param_id: u32,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationLane {
+    pub id: LaneId,
+    pub target: AutomationTarget,
+    /// Sorted by beat. Editing code must keep this invariant;
+    /// [`AutomationLane::insert_point`] does.
+    pub points: Vec<AutomationPoint>,
+}
+
+impl AutomationLane {
+    pub fn new(target: AutomationTarget) -> Self {
+        Self {
+            id: LaneId::new(),
+            target,
+            points: Vec::new(),
+        }
+    }
+
+    /// Evaluate the lane at `beat`. `None` when the lane is empty.
+    pub fn value_at(&self, beat: f64) -> Option<f32> {
+        let points = &self.points;
+        if points.is_empty() {
+            return None;
+        }
+        if beat <= points[0].beat {
+            return Some(points[0].value);
+        }
+        let last = points[points.len() - 1];
+        if beat >= last.beat {
+            return Some(last.value);
+        }
+        // partition_point: first index whose beat is > beat.
+        let idx = points.partition_point(|p| p.beat <= beat);
+        let a = points[idx - 1];
+        let b = points[idx];
+        let span = b.beat - a.beat;
+        if span <= f64::EPSILON {
+            return Some(b.value);
+        }
+        let t = ((beat - a.beat) / span) as f32;
+        Some(a.value + (b.value - a.value) * t)
+    }
+
+    /// Insert keeping beat order. Replaces an existing point on the
+    /// same beat (within a hair) instead of stacking duplicates.
+    pub fn insert_point(&mut self, point: AutomationPoint) {
+        const EPS: f64 = 1e-9;
+        match self
+            .points
+            .iter()
+            .position(|p| (p.beat - point.beat).abs() < EPS)
+        {
+            Some(i) => self.points[i] = point,
+            None => {
+                let idx = self.points.partition_point(|p| p.beat < point.beat);
+                self.points.insert(idx, point);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lane(points: &[(f64, f32)]) -> AutomationLane {
+        let mut l = AutomationLane::new(AutomationTarget::TrackGain);
+        for (beat, value) in points {
+            l.insert_point(AutomationPoint {
+                beat: *beat,
+                value: *value,
+            });
+        }
+        l
+    }
+
+    #[test]
+    fn empty_lane_has_no_value() {
+        assert_eq!(lane(&[]).value_at(4.0), None);
+    }
+
+    #[test]
+    fn holds_first_and_last_values_outside_range() {
+        let l = lane(&[(4.0, 0.2), (8.0, 0.8)]);
+        assert_eq!(l.value_at(0.0), Some(0.2));
+        assert_eq!(l.value_at(100.0), Some(0.8));
+    }
+
+    #[test]
+    fn interpolates_linearly_between_points() {
+        let l = lane(&[(0.0, 0.0), (8.0, 1.0)]);
+        assert_eq!(l.value_at(4.0), Some(0.5));
+        assert_eq!(l.value_at(2.0), Some(0.25));
+    }
+
+    #[test]
+    fn insert_keeps_order_and_replaces_same_beat() {
+        let mut l = lane(&[(8.0, 0.8), (0.0, 0.1), (4.0, 0.4)]);
+        let beats: Vec<f64> = l.points.iter().map(|p| p.beat).collect();
+        assert_eq!(beats, vec![0.0, 4.0, 8.0]);
+        l.insert_point(AutomationPoint {
+            beat: 4.0,
+            value: 0.9,
+        });
+        assert_eq!(l.points.len(), 3);
+        assert_eq!(l.value_at(4.0), Some(0.9));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let l = lane(&[(0.0, 0.0), (16.0, 1.0)]);
+        let json = serde_json::to_string(&l).unwrap();
+        let back: AutomationLane = serde_json::from_str(&json).unwrap();
+        assert_eq!(l, back);
+    }
+}

--- a/crates/vibez-core/src/id.rs
+++ b/crates/vibez-core/src/id.rs
@@ -47,6 +47,17 @@ macro_rules! typed_id {
 }
 
 typed_id!(TrackId);
+
+impl TrackId {
+    /// Reserved id for the master bus. The global counter starts at 1
+    /// and only moves up, so 0 can never collide with a minted id.
+    pub const MASTER: TrackId = TrackId(0);
+
+    pub fn is_master(self) -> bool {
+        self.0 == 0
+    }
+}
+
 typed_id!(ClipId);
 typed_id!(EffectId);
 typed_id!(LaneId);

--- a/crates/vibez-core/src/id.rs
+++ b/crates/vibez-core/src/id.rs
@@ -49,6 +49,7 @@ macro_rules! typed_id {
 typed_id!(TrackId);
 typed_id!(ClipId);
 typed_id!(EffectId);
+typed_id!(LaneId);
 
 #[cfg(test)]
 mod tests {

--- a/crates/vibez-core/src/lib.rs
+++ b/crates/vibez-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio_buffer;
+pub mod automation;
 pub mod constants;
 pub mod effect;
 pub mod id;

--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -88,6 +88,9 @@ pub struct TrackInfo {
     /// Third-party plugin instrument on this track, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugin_instrument: Option<crate::effect::PluginDeviceInfo>,
+    /// Automation lanes on this track.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub automation: Vec<crate::automation::AutomationLane>,
 }
 
 impl TrackInfo {
@@ -105,6 +108,7 @@ impl TrackInfo {
             instrument: None,
             native_instrument: None,
             plugin_instrument: None,
+            automation: Vec::new(),
         }
     }
 }

--- a/crates/vibez-dsp/src/eq.rs
+++ b/crates/vibez-dsp/src/eq.rs
@@ -3,39 +3,99 @@ use vibez_core::effect::{EffectType, ParamDescriptor};
 use crate::effect::AudioEffect;
 
 static EQ_PARAMS: &[ParamDescriptor] = &[
+    // ── LF band ──
     ParamDescriptor {
-        name: "Low",
-        min: -18.0,
-        max: 18.0,
+        name: "LF Gain",
+        min: -15.0,
+        max: 15.0,
         default: 0.0,
         unit: "dB",
     },
     ParamDescriptor {
-        name: "Mid Freq",
-        min: 200.0,
-        max: 4000.0,
-        default: 1000.0,
+        name: "LF Freq",
+        min: 30.0,
+        max: 450.0,
+        default: 80.0,
         unit: "Hz",
     },
     ParamDescriptor {
-        name: "Mid",
-        min: -18.0,
-        max: 18.0,
+        name: "LF Bell",
+        min: 0.0,
+        max: 1.0,
+        default: 0.0,
+        unit: "",
+    },
+    // ── LMF band ──
+    ParamDescriptor {
+        name: "LMF Gain",
+        min: -15.0,
+        max: 15.0,
         default: 0.0,
         unit: "dB",
     },
     ParamDescriptor {
-        name: "High",
-        min: -18.0,
-        max: 18.0,
+        name: "LMF Freq",
+        min: 200.0,
+        max: 2500.0,
+        default: 700.0,
+        unit: "Hz",
+    },
+    ParamDescriptor {
+        name: "LMF Q",
+        min: 0.3,
+        max: 4.0,
+        default: 0.7,
+        unit: "",
+    },
+    // ── HMF band ──
+    ParamDescriptor {
+        name: "HMF Gain",
+        min: -15.0,
+        max: 15.0,
         default: 0.0,
         unit: "dB",
     },
+    ParamDescriptor {
+        name: "HMF Freq",
+        min: 600.0,
+        max: 7000.0,
+        default: 2500.0,
+        unit: "Hz",
+    },
+    ParamDescriptor {
+        name: "HMF Q",
+        min: 0.3,
+        max: 4.0,
+        default: 0.7,
+        unit: "",
+    },
+    // ── HF band ──
+    ParamDescriptor {
+        name: "HF Gain",
+        min: -15.0,
+        max: 15.0,
+        default: 0.0,
+        unit: "dB",
+    },
+    ParamDescriptor {
+        name: "HF Freq",
+        min: 1500.0,
+        max: 16000.0,
+        default: 8000.0,
+        unit: "Hz",
+    },
+    ParamDescriptor {
+        name: "HF Bell",
+        min: 0.0,
+        max: 1.0,
+        default: 0.0,
+        unit: "",
+    },
 ];
 
-const LOW_SHELF_HZ: f32 = 150.0;
-const HIGH_SHELF_HZ: f32 = 4_000.0;
-const MID_Q: f32 = 0.707;
+/// Fixed bell width for the LF/HF bands when switched out of shelf
+/// mode, matching the console's fairly broad bell.
+const SHELF_BELL_Q: f32 = 0.85;
 
 #[derive(Default)]
 struct Biquad {
@@ -144,41 +204,53 @@ impl Biquad {
     }
 }
 
-/// 3-band EQ: low shelf @ 150Hz, peaking mid (sweepable), high shelf @ 4kHz.
+/// SSL E-series style four-band parametric EQ.
+///
+/// LF and HF are shelves with a bell option; LMF and HMF are fully
+/// parametric bells with sweepable Q. Parameter indices follow
+/// [`EQ_PARAMS`].
 pub struct EqEffect {
-    low_db: f32,
-    mid_hz: f32,
-    mid_db: f32,
-    high_db: f32,
+    params: [f32; 12],
     sample_rate: f32,
-    low: Biquad,
-    mid: Biquad,
-    high: Biquad,
+    lf: Biquad,
+    lmf: Biquad,
+    hmf: Biquad,
+    hf: Biquad,
 }
 
 impl EqEffect {
     pub fn new(sample_rate: f32) -> Self {
+        let mut params = [0.0_f32; 12];
+        for (i, d) in EQ_PARAMS.iter().enumerate() {
+            params[i] = d.default;
+        }
         let mut fx = Self {
-            low_db: 0.0,
-            mid_hz: 1000.0,
-            mid_db: 0.0,
-            high_db: 0.0,
+            params,
             sample_rate,
-            low: Biquad::identity(),
-            mid: Biquad::identity(),
-            high: Biquad::identity(),
+            lf: Biquad::identity(),
+            lmf: Biquad::identity(),
+            hmf: Biquad::identity(),
+            hf: Biquad::identity(),
         };
         fx.recompute();
         fx
     }
 
     fn recompute(&mut self) {
-        self.low
-            .set_low_shelf(LOW_SHELF_HZ, self.low_db, self.sample_rate);
-        self.mid
-            .set_peaking(self.mid_hz, MID_Q, self.mid_db, self.sample_rate);
-        self.high
-            .set_high_shelf(HIGH_SHELF_HZ, self.high_db, self.sample_rate);
+        let p = &self.params;
+        let sr = self.sample_rate;
+        if p[2] >= 0.5 {
+            self.lf.set_peaking(p[1], SHELF_BELL_Q, p[0], sr);
+        } else {
+            self.lf.set_low_shelf(p[1], p[0], sr);
+        }
+        self.lmf.set_peaking(p[4], p[5], p[3], sr);
+        self.hmf.set_peaking(p[7], p[8], p[6], sr);
+        if p[11] >= 0.5 {
+            self.hf.set_peaking(p[10], SHELF_BELL_Q, p[9], sr);
+        } else {
+            self.hf.set_high_shelf(p[10], p[9], sr);
+        }
     }
 }
 
@@ -192,39 +264,16 @@ impl AudioEffect for EqEffect {
     }
 
     fn set_param(&mut self, index: usize, value: f32) -> bool {
-        match index {
-            0 => {
-                self.low_db = value.clamp(-18.0, 18.0);
-                self.recompute();
-                true
-            }
-            1 => {
-                self.mid_hz = value.clamp(200.0, 4000.0);
-                self.recompute();
-                true
-            }
-            2 => {
-                self.mid_db = value.clamp(-18.0, 18.0);
-                self.recompute();
-                true
-            }
-            3 => {
-                self.high_db = value.clamp(-18.0, 18.0);
-                self.recompute();
-                true
-            }
-            _ => false,
-        }
+        let Some(d) = EQ_PARAMS.get(index) else {
+            return false;
+        };
+        self.params[index] = value.clamp(d.min, d.max);
+        self.recompute();
+        true
     }
 
     fn get_param(&self, index: usize) -> f32 {
-        match index {
-            0 => self.low_db,
-            1 => self.mid_hz,
-            2 => self.mid_db,
-            3 => self.high_db,
-            _ => 0.0,
-        }
+        self.params.get(index).copied().unwrap_or(0.0)
     }
 
     fn process(&mut self, buffer: &mut [f32], channels: usize) {
@@ -234,24 +283,36 @@ impl AudioEffect for EqEffect {
             for c in 0..ch {
                 let idx = frame * ch + c;
                 let mut s = buffer[idx];
-                s = self.low.process(s, c);
-                s = self.mid.process(s, c);
-                s = self.high.process(s, c);
+                s = self.lf.process(s, c);
+                s = self.lmf.process(s, c);
+                s = self.hmf.process(s, c);
+                s = self.hf.process(s, c);
                 buffer[idx] = s;
             }
         }
     }
 
     fn reset(&mut self) {
-        self.low.reset();
-        self.mid.reset();
-        self.high.reset();
+        self.lf.reset();
+        self.lmf.reset();
+        self.hmf.reset();
+        self.hf.reset();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rms(buf: &[f32]) -> f32 {
+        (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt()
+    }
+
+    fn tone(freq: f32, sr: f32, n: usize) -> Vec<f32> {
+        (0..n)
+            .map(|i| ((i as f32 / sr) * freq * std::f32::consts::TAU).sin() * 0.2)
+            .collect()
+    }
 
     #[test]
     fn flat_eq_approximately_passthrough() {
@@ -269,16 +330,59 @@ mod tests {
     }
 
     #[test]
-    fn low_boost_amplifies_low_frequencies() {
+    fn lf_shelf_boost_amplifies_lows_only() {
         let mut fx = EqEffect::new(44_100.0);
-        fx.set_param(0, 12.0);
-        // 60 Hz tone
-        let mut buf: Vec<f32> = (0..4_410)
-            .map(|i| ((i as f32 / 44_100.0) * 60.0 * std::f32::consts::TAU).sin() * 0.2)
-            .collect();
-        let in_rms: f32 = (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt();
+        fx.set_param(0, 12.0); // LF gain
+        fx.set_param(1, 120.0); // LF freq
+        let mut low = tone(60.0, 44_100.0, 4_410);
+        let in_rms = rms(&low);
+        fx.process(&mut low, 1);
+        assert!(rms(&low) > in_rms * 1.5, "low should boost");
+
+        fx.reset();
+        let mut high = tone(5_000.0, 44_100.0, 4_410);
+        let in_rms = rms(&high);
+        fx.process(&mut high, 1);
+        assert!(
+            (rms(&high) / in_rms - 1.0).abs() < 0.15,
+            "highs should be untouched by an LF shelf"
+        );
+    }
+
+    #[test]
+    fn hmf_bell_cuts_at_its_center() {
+        let mut fx = EqEffect::new(44_100.0);
+        fx.set_param(6, -12.0); // HMF gain
+        fx.set_param(7, 2_000.0); // HMF freq
+        fx.set_param(8, 1.0); // Q
+        let mut buf = tone(2_000.0, 44_100.0, 8_820);
+        let in_rms = rms(&buf);
         fx.process(&mut buf, 1);
-        let out_rms: f32 = (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt();
-        assert!(out_rms > in_rms * 1.5, "in {in_rms} out {out_rms}");
+        assert!(rms(&buf) < in_rms * 0.5, "bell cut should attenuate center");
+    }
+
+    #[test]
+    fn hf_bell_mode_leaves_extreme_highs_alone() {
+        // Shelf boosts everything above the corner; a bell at the same
+        // spot returns to unity well above its center.
+        let sr = 96_000.0;
+        let mut shelf = EqEffect::new(sr);
+        shelf.set_param(9, 12.0); // HF gain
+        shelf.set_param(10, 4_000.0);
+        let mut bell = EqEffect::new(sr);
+        bell.set_param(9, 12.0);
+        bell.set_param(10, 4_000.0);
+        bell.set_param(11, 1.0); // bell mode
+
+        let mut a = tone(30_000.0, sr, 9_600);
+        let mut b = a.clone();
+        shelf.process(&mut a, 1);
+        bell.process(&mut b, 1);
+        assert!(
+            rms(&a) > rms(&b) * 1.3,
+            "shelf should lift extreme highs more than bell: shelf {} bell {}",
+            rms(&a),
+            rms(&b)
+        );
     }
 }

--- a/crates/vibez-dsp/src/eq.rs
+++ b/crates/vibez-dsp/src/eq.rs
@@ -184,6 +184,19 @@ impl Biquad {
         self.a2 = a2 / a0;
     }
 
+    /// Magnitude of the transfer function at normalized angular
+    /// frequency `w` (radians/sample). Used for drawing the response
+    /// curve; never called on the audio thread.
+    fn magnitude_at(&self, w: f64) -> f64 {
+        let (cos_w, sin_w) = (w.cos(), w.sin());
+        let (cos_2w, sin_2w) = ((2.0 * w).cos(), (2.0 * w).sin());
+        let num_re = self.b0 + self.b1 * cos_w + self.b2 * cos_2w;
+        let num_im = -(self.b1 * sin_w + self.b2 * sin_2w);
+        let den_re = 1.0 + self.a1 * cos_w + self.a2 * cos_2w;
+        let den_im = -(self.a1 * sin_w + self.a2 * sin_2w);
+        ((num_re * num_re + num_im * num_im) / (den_re * den_re + den_im * den_im)).sqrt()
+    }
+
     fn process(&mut self, sample: f32, channel: usize) -> f32 {
         let x0 = sample as f64;
         let z = &mut self.z[channel];
@@ -234,6 +247,30 @@ impl EqEffect {
         };
         fx.recompute();
         fx
+    }
+
+    /// Build an EQ from a parameter vector without touching audio
+    /// state; the UI uses this to evaluate the response curve.
+    pub fn from_params(sample_rate: f32, params: &[f32]) -> Self {
+        let mut fx = Self::new(sample_rate);
+        for (i, v) in params.iter().copied().enumerate().take(12) {
+            if let Some(d) = EQ_PARAMS.get(i) {
+                fx.params[i] = v.clamp(d.min, d.max);
+            }
+        }
+        fx.recompute();
+        fx
+    }
+
+    /// Combined magnitude response of all four bands at `freq_hz`,
+    /// in dB. Drawing-time helper; not for the audio thread.
+    pub fn response_db(&self, freq_hz: f32) -> f32 {
+        let w = 2.0 * std::f64::consts::PI * freq_hz as f64 / self.sample_rate as f64;
+        let mag = self.lf.magnitude_at(w)
+            * self.lmf.magnitude_at(w)
+            * self.hmf.magnitude_at(w)
+            * self.hf.magnitude_at(w);
+        (20.0 * mag.max(1e-9).log10()) as f32
     }
 
     fn recompute(&mut self) {
@@ -312,6 +349,46 @@ mod tests {
         (0..n)
             .map(|i| ((i as f32 / sr) * freq * std::f32::consts::TAU).sin() * 0.2)
             .collect()
+    }
+
+    #[test]
+    fn response_curve_matches_the_settings() {
+        // Flat EQ: ~0 dB everywhere.
+        let flat = EqEffect::new(48_000.0);
+        for f in [30.0, 200.0, 1_000.0, 8_000.0, 18_000.0] {
+            assert!(
+                flat.response_db(f).abs() < 0.05,
+                "flat response at {f} Hz should be ~0 dB"
+            );
+        }
+
+        // LF shelf boost: +12 dB below the corner, ~0 dB well above.
+        let mut params: Vec<f32> = EQ_PARAMS.iter().map(|d| d.default).collect();
+        params[0] = 12.0; // LF gain
+        params[1] = 120.0; // LF freq
+        let boosted = EqEffect::from_params(48_000.0, &params);
+        assert!(
+            boosted.response_db(40.0) > 10.0,
+            "lows should read near +12 dB, got {}",
+            boosted.response_db(40.0)
+        );
+        assert!(
+            boosted.response_db(8_000.0).abs() < 0.5,
+            "highs should stay flat under an LF shelf, got {}",
+            boosted.response_db(8_000.0)
+        );
+
+        // HMF bell cut reads back at its center.
+        params[0] = 0.0;
+        params[6] = -9.0; // HMF gain
+        params[7] = 2_000.0; // HMF freq
+        params[8] = 1.5; // Q
+        let cut = EqEffect::from_params(48_000.0, &params);
+        assert!(
+            cut.response_db(2_000.0) < -8.0,
+            "bell center should read near -9 dB, got {}",
+            cut.response_db(2_000.0)
+        );
     }
 
     #[test]

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -71,6 +71,16 @@ pub enum EngineCommand {
     },
     /// Set the gain for a track.
     SetTrackGain(TrackId, f32),
+    /// Upsert one automation lane (whole-lane replace; points are
+    /// built on the UI thread).
+    SetAutomationLane {
+        track_id: TrackId,
+        lane: vibez_core::automation::AutomationLane,
+    },
+    RemoveAutomationLane {
+        track_id: TrackId,
+        lane_id: vibez_core::id::LaneId,
+    },
     /// Set the pan for a track (0.0 = left, 0.5 = center, 1.0 = right).
     SetTrackPan(TrackId, f32),
     /// Set the mute state for a track.

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -90,6 +90,10 @@ pub enum EngineCommand {
 
     // -- Infrastructure --
     SetSampleRate(u32),
+    /// Select which track streams post-effects samples to the UI
+    /// spectrum analyser ring (`None` disables the tap).
+    /// `TrackId::MASTER` taps the summed master bus.
+    SetSpectrumTap(Option<TrackId>),
 
     // -- Effects --
     AddEffect {

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -159,6 +159,10 @@ impl AudioEngine {
     }
 
     /// Read the tracks (for inspection / testing).
+    pub fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
     pub fn tracks(&self) -> &[EngineTrack] {
         &self.tracks
     }
@@ -246,6 +250,20 @@ impl AudioEngine {
                 continue;
             }
 
+            // Block-rate automation: evaluate every lane at the
+            // segment-start beat. Effect/instrument params apply in
+            // place; gain/pan come back as overrides for the sum
+            // stage below.
+            let beat = {
+                let bpm = self.transport.bpm();
+                if bpm > 0.0 {
+                    pos as f64 * bpm / (self.sample_rate as f64 * 60.0)
+                } else {
+                    0.0
+                }
+            };
+            let (auto_gain, auto_pan) = track.apply_automation(beat);
+
             let loop_region = self.transport.active_loop_region();
             let rendered = if track.instrument.is_some() {
                 let tempo_map = TempoMap::new(self.transport.bpm(), self.sample_rate);
@@ -267,8 +285,8 @@ impl AudioEngine {
                 continue;
             }
 
-            let gain = track.gain;
-            let (pan_l, pan_r) = equal_power_pan(track.pan);
+            let gain = auto_gain.unwrap_or(track.gain);
+            let (pan_l, pan_r) = equal_power_pan(auto_pan.unwrap_or(track.pan));
             let track_id = track.id;
             let buf_size = frames * channels;
 
@@ -505,6 +523,19 @@ impl AudioEngine {
                 EngineCommand::SetTrackGain(id, gain) => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == id) {
                         track.gain = gain;
+                    }
+                }
+                EngineCommand::SetAutomationLane { track_id, lane } => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                        match track.automation.iter_mut().find(|l| l.id == lane.id) {
+                            Some(existing) => *existing = lane,
+                            None => track.automation.push(lane),
+                        }
+                    }
+                }
+                EngineCommand::RemoveAutomationLane { track_id, lane_id } => {
+                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                        track.automation.retain(|l| l.id != lane_id);
                     }
                 }
                 EngineCommand::SetTrackPan(id, pan) => {

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use rtrb::{Consumer, Producer, RingBuffer};
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::constants::RING_BUFFER_CAPACITY;
+use vibez_core::id::TrackId;
 
 use vibez_core::time::TempoMap;
 use vibez_dsp::factory::create_effect;
@@ -16,6 +17,10 @@ use crate::mixer::{
     EngineTrack,
 };
 use crate::transport::Transport;
+
+/// Capacity of the UI spectrum-analyser sample ring: roughly a third
+/// of a second of mono audio at 48 kHz, ample for a 60 fps drain.
+const SPECTRUM_RING_CAPACITY: usize = 16_384;
 
 /// The real-time audio engine.
 ///
@@ -39,6 +44,17 @@ pub struct AudioEngine {
     audio: Option<Arc<DecodedAudio>>,
     /// Multi-track state.
     tracks: Vec<EngineTrack>,
+    /// The master bus: a track-shaped channel (gain + effect chain,
+    /// no clips or instrument) applied to the summed mix. Addressed
+    /// by commands via [`TrackId::MASTER`].
+    master: EngineTrack,
+    /// Which track streams samples to the UI spectrum analyser.
+    spectrum_track: Option<TrackId>,
+    /// Producer side of the spectrum ring (mono samples).
+    spectrum_tx: Producer<f32>,
+    /// Consumer side, parked here until the UI takes it before the
+    /// engine moves to the audio thread.
+    spectrum_rx: Option<Consumer<f32>>,
     /// One-shot sample preview, bypasses transport and soloed/muted state.
     preview: Option<PreviewVoice>,
     sample_rate: u32,
@@ -67,11 +83,16 @@ impl AudioEngine {
     pub fn new() -> (Self, Producer<EngineCommand>, Consumer<EngineEvent>) {
         let (cmd_tx, cmd_rx) = RingBuffer::<EngineCommand>::new(RING_BUFFER_CAPACITY);
         let (event_tx, event_rx) = RingBuffer::<EngineEvent>::new(RING_BUFFER_CAPACITY);
+        let (spectrum_tx, spectrum_rx) = RingBuffer::<f32>::new(SPECTRUM_RING_CAPACITY);
 
         let engine = Self {
             transport: Transport::new(),
             audio: None,
             tracks: Vec::new(),
+            master: EngineTrack::new(TrackId::MASTER),
+            spectrum_track: None,
+            spectrum_tx,
+            spectrum_rx: Some(spectrum_rx),
             preview: None,
             sample_rate: 44100,
             cmd_rx,
@@ -80,6 +101,13 @@ impl AudioEngine {
         };
 
         (engine, cmd_tx, event_rx)
+    }
+
+    /// Take the consumer side of the spectrum-analyser ring. Must be
+    /// called on the UI thread before the engine moves to the audio
+    /// thread; returns `None` if already taken.
+    pub fn take_spectrum_consumer(&mut self) -> Option<Consumer<f32>> {
+        self.spectrum_rx.take()
     }
 
     /// Process one audio callback worth of data.
@@ -109,6 +137,23 @@ impl AudioEngine {
         } else {
             // ---- 4. Legacy single-audio path ----------------------------
             self.process_legacy(output, frames, channels);
+        }
+
+        // ---- 4.4 Master bus: effect chain + gain over the summed mix.
+        // Runs whether or not the transport is playing so queued
+        // plugin params are delivered and tails ring out, matching
+        // the per-track idle behavior.
+        for slot in &mut self.master.effects {
+            if !slot.bypass {
+                slot.effect.process(output, channels);
+            }
+        }
+        if (self.master.gain - 1.0).abs() > f32::EPSILON {
+            let gain = self.master.gain;
+            output.iter_mut().for_each(|s| *s *= gain);
+        }
+        if self.spectrum_track == Some(self.master.id) {
+            push_spectrum(&mut self.spectrum_tx, output, channels);
         }
 
         // ---- 4.5 Preview channel (bypasses transport) -------------------
@@ -170,6 +215,17 @@ impl AudioEngine {
     // ------------------------------------------------------------------
     // Private helpers
     // ------------------------------------------------------------------
+
+    /// Resolve a command's target channel: the master bus for
+    /// [`TrackId::MASTER`], otherwise the matching track. Only used
+    /// by commands that make sense on both (gain, effect chain).
+    fn channel_mut(&mut self, id: TrackId) -> Option<&mut EngineTrack> {
+        if id.is_master() {
+            Some(&mut self.master)
+        } else {
+            self.tracks.iter_mut().find(|t| t.id == id)
+        }
+    }
 
     /// Multi-track rendering: render each track, apply gain/pan, sum into output.
     ///
@@ -274,6 +330,13 @@ impl AudioEngine {
 
             if rendered {
                 track.process_effects(frames, channels);
+                if self.spectrum_track == Some(track.id) {
+                    push_spectrum(
+                        &mut self.spectrum_tx,
+                        &track.mix_buffer[..frames * channels],
+                        channels,
+                    );
+                }
             }
 
             if !rendered {
@@ -521,7 +584,7 @@ impl AudioEngine {
                     self.recalculate_audio_length();
                 }
                 EngineCommand::SetTrackGain(id, gain) => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == id) {
+                    if let Some(track) = self.channel_mut(id) {
                         track.gain = gain;
                     }
                 }
@@ -558,6 +621,9 @@ impl AudioEngine {
                 EngineCommand::SetSampleRate(sr) => {
                     self.sample_rate = sr;
                 }
+                EngineCommand::SetSpectrumTap(target) => {
+                    self.spectrum_track = target;
+                }
 
                 // -- Effects --
                 EngineCommand::AddEffect {
@@ -566,8 +632,8 @@ impl AudioEngine {
                     effect_type,
                     position,
                 } => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        let effect = create_effect(effect_type, self.sample_rate as f32);
+                    let effect = create_effect(effect_type, self.sample_rate as f32);
+                    if let Some(track) = self.channel_mut(track_id) {
                         let slot = EffectSlot {
                             id: effect_id,
                             effect,
@@ -582,11 +648,15 @@ impl AudioEngine {
                     }
                 }
                 EngineCommand::RemoveEffect(track_id, effect_id) => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(pos) = track.effects.iter().position(|e| e.id == effect_id) {
-                            let slot = track.effects.remove(pos);
-                            self.dispose_effect(slot.effect);
-                        }
+                    let removed = self.channel_mut(track_id).and_then(|track| {
+                        track
+                            .effects
+                            .iter()
+                            .position(|e| e.id == effect_id)
+                            .map(|pos| track.effects.remove(pos))
+                    });
+                    if let Some(slot) = removed {
+                        self.dispose_effect(slot.effect);
                     }
                 }
                 EngineCommand::SetEffectParam {
@@ -595,7 +665,7 @@ impl AudioEngine {
                     param_index,
                     value,
                 } => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                    if let Some(track) = self.channel_mut(track_id) {
                         if let Some(slot) = track.effects.iter_mut().find(|e| e.id == effect_id) {
                             slot.effect.set_param(param_index, value);
                         }
@@ -606,7 +676,7 @@ impl AudioEngine {
                     effect_id,
                     bypass,
                 } => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                    if let Some(track) = self.channel_mut(track_id) {
                         if let Some(slot) = track.effects.iter_mut().find(|e| e.id == effect_id) {
                             slot.bypass = bypass;
                         }
@@ -617,7 +687,7 @@ impl AudioEngine {
                     effect_id,
                     new_index,
                 } => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                    if let Some(track) = self.channel_mut(track_id) {
                         if let Some(old_idx) = track.effects.iter().position(|e| e.id == effect_id)
                         {
                             let slot = track.effects.remove(old_idx);
@@ -878,7 +948,7 @@ impl AudioEngine {
                     effect,
                     position,
                 } => {
-                    if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                    if let Some(track) = self.channel_mut(track_id) {
                         let slot = EffectSlot {
                             id: effect_id,
                             effect,
@@ -948,6 +1018,13 @@ impl AudioEngine {
                 track.clear_buffer(frames, channels);
             }
             track.process_effects(frames, channels);
+            if self.spectrum_track == Some(track.id) {
+                push_spectrum(
+                    &mut self.spectrum_tx,
+                    &track.mix_buffer[..frames * channels],
+                    channels,
+                );
+            }
             let gain = track.gain;
             let (pan_l, pan_r) = equal_power_pan(track.pan);
             let buf_size = frames * channels;
@@ -1007,6 +1084,22 @@ impl AudioEngine {
         } else if self.audio.is_none() {
             // Only clear audio length if no legacy audio is loaded
             self.transport.set_audio_length(None);
+        }
+    }
+}
+
+/// Stream a block to the UI spectrum analyser as mono samples.
+/// Lock-free and allocation-free; drops samples when the ring is
+/// full (the UI drains at 60 fps, so sustained overflow just means
+/// the analyser skips audio it would have averaged away anyway).
+fn push_spectrum(tx: &mut Producer<f32>, buffer: &[f32], channels: usize) {
+    if channels >= 2 {
+        for frame in buffer.chunks_exact(channels) {
+            let _ = tx.push((frame[0] + frame[1]) * 0.5);
+        }
+    } else {
+        for &s in buffer {
+            let _ = tx.push(s);
         }
     }
 }

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -928,11 +928,24 @@ impl AudioEngine {
     fn render_idle_instruments(&mut self, output: &mut [f32], frames: usize, channels: usize) {
         let has_solo = any_solo(&self.tracks);
         for track in &mut self.tracks {
-            if track.instrument.is_none() || track.mute || (has_solo && !track.solo) {
+            if track.mute || (has_solo && !track.solo) {
                 continue;
             }
-            if !track.render_instrument_idle(frames, channels) {
+            // Instruments render so auditioned notes sound; every
+            // effect chain keeps processing while stopped so delay
+            // and reverb tails ring out and queued plugin parameter
+            // changes (knob edits, automation) actually reach the
+            // plugin instead of waiting for play.
+            let has_signal = if track.instrument.is_some() {
+                track.render_instrument_idle(frames, channels)
+            } else {
+                false
+            };
+            if !has_signal && track.effects.is_empty() {
                 continue;
+            }
+            if !has_signal && track.instrument.is_none() {
+                track.clear_buffer(frames, channels);
             }
             track.process_effects(frames, channels);
             let gain = track.gain;

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -1035,10 +1035,12 @@ fn gain_lane_ramps_track_volume_down() {
     lane.insert_point(AutomationPoint {
         beat: 0.0,
         value: 1.0,
+        curve: 0.0,
     });
     lane.insert_point(AutomationPoint {
         beat: 2.0,
         value: 0.0,
+        curve: 0.0,
     });
     cmd_tx
         .push(EngineCommand::SetAutomationLane {
@@ -1092,14 +1094,17 @@ fn pan_lane_moves_signal_between_channels() {
     lane.insert_point(AutomationPoint {
         beat: 0.0,
         value: 0.0,
+        curve: 0.0,
     });
     lane.insert_point(AutomationPoint {
         beat: 1.0,
         value: 0.0,
+        curve: 0.0,
     });
     lane.insert_point(AutomationPoint {
         beat: 1.01,
         value: 1.0,
+        curve: 0.0,
     });
     cmd_tx
         .push(EngineCommand::SetAutomationLane {
@@ -1140,6 +1145,7 @@ fn removing_a_lane_restores_the_knob_value() {
     lane.insert_point(AutomationPoint {
         beat: 0.0,
         value: 0.0,
+        curve: 0.0,
     });
     let lane_id = lane.id;
     cmd_tx

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -989,3 +989,181 @@ fn note_clip_loop_renders() {
         "Expected synth audio in looped region (beat 2-3)"
     );
 }
+
+// ---- Automation ----
+
+fn rms(buf: &[f32]) -> f32 {
+    (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt()
+}
+
+fn constant_clip_track(
+    cmd_tx: &mut rtrb::Producer<EngineCommand>,
+    frames: usize,
+) -> (TrackId, ClipId) {
+    let tid = TrackId::new();
+    let cid = ClipId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(tid, "Track".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddClip {
+            track_id: tid,
+            clip_id: cid,
+            audio: make_constant_audio(frames, 0.5),
+            position: 0,
+            source_offset: 0,
+            duration: frames as u64,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+    (tid, cid)
+}
+
+#[test]
+fn gain_lane_ramps_track_volume_down() {
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let sr = engine.sample_rate();
+    let frames_total = sr as usize; // one second of audio
+    let (tid, _cid) = constant_clip_track(&mut cmd_tx, frames_total);
+
+    // 120 BPM: one second = 2 beats. Ramp 1.0 -> 0.0 across it.
+    let mut lane = AutomationLane::new(AutomationTarget::TrackGain);
+    lane.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 1.0,
+    });
+    lane.insert_point(AutomationPoint {
+        beat: 2.0,
+        value: 0.0,
+    });
+    cmd_tx
+        .push(EngineCommand::SetAutomationLane {
+            track_id: tid,
+            lane,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let block = 512usize;
+    let mut buf = vec![0.0f32; block * 2];
+    let mut first_rms = None;
+    let mut mid_rms = None;
+    let blocks = frames_total / block;
+    for i in 0..blocks {
+        buf.fill(0.0);
+        engine.process(&mut buf, 2);
+        if i == 0 {
+            first_rms = Some(rms(&buf));
+        }
+        if i == blocks / 2 {
+            mid_rms = Some(rms(&buf));
+        }
+    }
+    let last_rms = rms(&buf);
+    let (first, mid) = (first_rms.unwrap(), mid_rms.unwrap());
+
+    // 0.5 amplitude through center equal-power pan = ~0.354 RMS.
+    assert!(first > 0.3, "start should be near full volume: {first}");
+    assert!(
+        mid < first * 0.7 && mid > first * 0.3,
+        "midpoint should be roughly half: first {first}, mid {mid}"
+    );
+    assert!(
+        last_rms < first * 0.1,
+        "end should be near silent: first {first}, last {last_rms}"
+    );
+}
+
+#[test]
+fn pan_lane_moves_signal_between_channels() {
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let sr = engine.sample_rate();
+    let frames_total = sr as usize;
+    let (tid, _cid) = constant_clip_track(&mut cmd_tx, frames_total);
+
+    // Hard left for the first beat, hard right after.
+    let mut lane = AutomationLane::new(AutomationTarget::TrackPan);
+    lane.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 0.0,
+    });
+    lane.insert_point(AutomationPoint {
+        beat: 1.0,
+        value: 0.0,
+    });
+    lane.insert_point(AutomationPoint {
+        beat: 1.01,
+        value: 1.0,
+    });
+    cmd_tx
+        .push(EngineCommand::SetAutomationLane {
+            track_id: tid,
+            lane,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let block = 512usize;
+    let mut buf = vec![0.0f32; block * 2];
+    engine.process(&mut buf, 2); // first block: hard left
+    let l: f32 = buf.iter().step_by(2).map(|s| s.abs()).sum();
+    let r: f32 = buf.iter().skip(1).step_by(2).map(|s| s.abs()).sum();
+    assert!(l > 1.0 && r < 0.01, "expected hard left: l {l}, r {r}");
+
+    // Jump past beat 1 and render again.
+    let one_beat_samples = (sr as f64 * 60.0 / 120.0) as u64;
+    cmd_tx
+        .push(EngineCommand::Seek(one_beat_samples + 4096))
+        .unwrap();
+    buf.fill(0.0);
+    engine.process(&mut buf, 2);
+    let l: f32 = buf.iter().step_by(2).map(|s| s.abs()).sum();
+    let r: f32 = buf.iter().skip(1).step_by(2).map(|s| s.abs()).sum();
+    assert!(r > 1.0 && l < 0.01, "expected hard right: l {l}, r {r}");
+}
+
+#[test]
+fn removing_a_lane_restores_the_knob_value() {
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let sr = engine.sample_rate();
+    let (tid, _cid) = constant_clip_track(&mut cmd_tx, sr as usize);
+
+    let mut lane = AutomationLane::new(AutomationTarget::TrackGain);
+    lane.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 0.0,
+    });
+    let lane_id = lane.id;
+    cmd_tx
+        .push(EngineCommand::SetAutomationLane {
+            track_id: tid,
+            lane,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut buf = vec![0.0f32; 1024];
+    engine.process(&mut buf, 2);
+    assert!(rms(&buf) < 1e-6, "lane at zero should silence the track");
+
+    cmd_tx
+        .push(EngineCommand::RemoveAutomationLane {
+            track_id: tid,
+            lane_id,
+        })
+        .unwrap();
+    buf.fill(0.0);
+    engine.process(&mut buf, 2);
+    assert!(
+        rms(&buf) > 0.2,
+        "removing the lane should restore the track gain"
+    );
+}

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -1167,3 +1167,46 @@ fn removing_a_lane_restores_the_knob_value() {
         "removing the lane should restore the track gain"
     );
 }
+
+#[test]
+fn effect_tails_ring_out_after_stop() {
+    // A delay tail must keep sounding after the transport stops:
+    // effect chains process while stopped. (This is also what
+    // delivers queued plugin param changes without pressing play.)
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let sr = engine.sample_rate() as usize;
+    let (tid, _cid) = constant_clip_track(&mut cmd_tx, sr);
+
+    let effect_id = vibez_core::id::EffectId::new();
+    cmd_tx
+        .push(EngineCommand::AddEffect {
+            track_id: tid,
+            effect_id,
+            effect_type: vibez_core::effect::EffectType::Delay,
+            position: None,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    // Delay time defaults to 500 ms: play well past it so echoes
+    // exist, then listen for them after stop.
+    let mut buf = vec![0.0f32; 1024];
+    for _ in 0..60 {
+        buf.fill(0.0);
+        engine.process(&mut buf, 2);
+    }
+    cmd_tx.push(EngineCommand::Stop).unwrap();
+    buf.fill(0.0);
+    engine.process(&mut buf, 2); // drains Stop, first stopped block
+
+    let mut tail = 0.0f32;
+    for _ in 0..40 {
+        buf.fill(0.0);
+        engine.process(&mut buf, 2);
+        tail += buf.iter().map(|s| s.abs()).sum::<f32>();
+    }
+    assert!(
+        tail > 0.01,
+        "delay tail should ring out after stop, got {tail}"
+    );
+}

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use vibez_core::audio_buffer::DecodedAudio;
-use vibez_core::id::{ClipId, TrackId};
+use vibez_core::id::{ClipId, EffectId, TrackId};
 
 /// Helper to create a simple stereo decoded audio with a known pattern.
 fn make_test_audio(frames: usize) -> Arc<DecodedAudio> {
@@ -1214,5 +1214,177 @@ fn effect_tails_ring_out_after_stop() {
     assert!(
         tail > 0.01,
         "delay tail should ring out after stop, got {tail}"
+    );
+}
+
+#[test]
+fn master_gain_scales_the_summed_mix() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let tid = TrackId::new();
+    let cid = ClipId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddClip {
+            track_id: tid,
+            clip_id: cid,
+            audio: make_constant_audio(100, 0.5),
+            position: 0,
+            source_offset: 0,
+            duration: 100,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetTrackGain(TrackId::MASTER, 0.5))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut buf = vec![0.0f32; 16];
+    engine.process(&mut buf, 2);
+
+    let expected = 0.5 * std::f32::consts::FRAC_1_SQRT_2 * 0.5;
+    assert!(
+        (buf[0] - expected).abs() < 1e-4,
+        "master gain 0.5 should halve the mix: expected {expected} got {}",
+        buf[0]
+    );
+}
+
+#[test]
+fn master_effect_chain_processes_the_summed_mix() {
+    use vibez_core::effect::EffectType;
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let tid = TrackId::new();
+    let cid = ClipId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(tid, "Track 1".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddClip {
+            track_id: tid,
+            clip_id: cid,
+            audio: make_constant_audio(4_096, 0.5),
+            position: 0,
+            source_offset: 0,
+            duration: 4_096,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+    // A master EQ with the LF shelf slammed down should attenuate a
+    // constant (DC-heavy) signal relative to the flat default.
+    let eq_id = EffectId::new();
+    cmd_tx
+        .push(EngineCommand::AddEffect {
+            track_id: TrackId::MASTER,
+            effect_id: eq_id,
+            effect_type: EffectType::Eq,
+            position: None,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetEffectParam {
+            track_id: TrackId::MASTER,
+            effect_id: eq_id,
+            param_index: 0, // LF gain
+            value: -15.0,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetEffectParam {
+            track_id: TrackId::MASTER,
+            effect_id: eq_id,
+            param_index: 1, // LF freq up to make the cut obvious
+            value: 450.0,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut buf = vec![0.0f32; 2_048];
+    let mut last_rms = 0.0f32;
+    for _ in 0..3 {
+        buf.fill(0.0);
+        engine.process(&mut buf, 2);
+        last_rms = (buf.iter().map(|s| s * s).sum::<f32>() / buf.len() as f32).sqrt();
+    }
+    let flat = 0.5 * std::f32::consts::FRAC_1_SQRT_2;
+    assert!(
+        last_rms < flat * 0.5,
+        "master LF cut should attenuate the constant mix well below {flat}, got {last_rms}"
+    );
+
+    // Bypassing the master EQ restores the flat mix.
+    cmd_tx
+        .push(EngineCommand::SetEffectBypass {
+            track_id: TrackId::MASTER,
+            effect_id: eq_id,
+            bypass: true,
+        })
+        .unwrap();
+    buf.fill(0.0);
+    engine.process(&mut buf, 2);
+    assert!(
+        (buf[0] - flat).abs() < 1e-3,
+        "bypassed master chain should pass the mix through, got {}",
+        buf[0]
+    );
+}
+
+#[test]
+fn spectrum_tap_streams_track_samples() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let mut spectrum_rx = engine.take_spectrum_consumer().unwrap();
+    let tid = TrackId::new();
+    let cid = ClipId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(tid, "T".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddClip {
+            track_id: tid,
+            clip_id: cid,
+            audio: make_constant_audio(10_000, 0.5),
+            position: 0,
+            source_offset: 0,
+            duration: 10_000,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetSpectrumTap(Some(tid)))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut buf = vec![0.0f32; 1024];
+    engine.process(&mut buf, 2);
+
+    let mut peak = 0.0f32;
+    let mut count = 0;
+    while let Ok(s) = spectrum_rx.pop() {
+        peak = peak.max(s.abs());
+        count += 1;
+    }
+    assert_eq!(count, 512, "one mono sample per frame");
+    assert!(peak > 0.4, "tap should carry the clip audio, got {peak}");
+
+    // Retarget to master: still streams (the summed mix).
+    cmd_tx
+        .push(EngineCommand::SetSpectrumTap(Some(TrackId::MASTER)))
+        .unwrap();
+    engine.process(&mut buf, 2);
+    let mut master_peak = 0.0f32;
+    while let Ok(s) = spectrum_rx.pop() {
+        master_peak = master_peak.max(s.abs());
+    }
+    assert!(
+        master_peak > 0.3,
+        "master tap should carry the mix, got {master_peak}"
     );
 }

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -140,12 +140,22 @@ impl EngineTrack {
                     param_index,
                 } => {
                     if let Some(slot) = self.effects.iter_mut().find(|e| e.id == effect_id) {
-                        slot.effect.set_param(param_index, value);
+                        // Lanes are normalized 0..1; parameters live in
+                        // their native descriptor range.
+                        let native = match slot.effect.param_descriptors().get(param_index) {
+                            Some(d) => d.min + value * (d.max - d.min),
+                            None => value,
+                        };
+                        slot.effect.set_param(param_index, native);
                     }
                 }
                 AutomationTarget::InstrumentParam { param_index } => {
                     if let Some(instrument) = self.instrument.as_mut() {
-                        instrument.set_param(param_index, value);
+                        let native = match instrument.param_descriptors().get(param_index) {
+                            Some(d) => d.min + value * (d.max - d.min),
+                            None => value,
+                        };
+                        instrument.set_param(param_index, native);
                     }
                 }
                 AutomationTarget::PluginParam { .. } => {}

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -164,6 +164,17 @@ impl EngineTrack {
         (gain, pan)
     }
 
+    /// Zero the mix buffer: an idle block for a track with no source
+    /// signal, so the effect chain can still run (tails, queued
+    /// plugin param changes).
+    pub fn clear_buffer(&mut self, frames: usize, channels: usize) {
+        let buf_size = frames * channels;
+        self.ensure_buffer(buf_size);
+        for s in self.mix_buffer[..buf_size].iter_mut() {
+            *s = 0.0;
+        }
+    }
+
     /// Render the instrument with no clip events (transport stopped):
     /// lets auditioned/held notes sound and plugin event queues drain.
     /// Returns true when the buffer has signal.

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -83,6 +83,8 @@ pub struct EngineTrack {
     pub mix_buffer: Vec<f32>,
     pub effects: Vec<EffectSlot>,
     pub note_clips: Vec<EngineNoteClip>,
+    /// Automation lanes, evaluated once per render segment.
+    pub automation: Vec<vibez_core::automation::AutomationLane>,
     pub instrument: Option<Box<dyn Instrument>>,
     /// Scratch storage for batch rendering: (frame_offset, pitch, velocity)
     timed_note_ons: Vec<(u32, u8, u8)>,
@@ -109,11 +111,47 @@ impl EngineTrack {
             mix_buffer: Vec::new(),
             effects: Vec::new(),
             note_clips: Vec::new(),
+            automation: Vec::new(),
             instrument: None,
             timed_note_ons: Vec::new(),
             timed_note_offs: Vec::new(),
             active_notes: 0,
         }
+    }
+
+    /// Evaluate every automation lane at `beat` (block-rate): effect
+    /// and instrument parameters are applied in place; gain and pan
+    /// come back as overrides for the mix stage. Plugin parameter
+    /// lanes are handled by the plugin event path, not here.
+    pub fn apply_automation(&mut self, beat: f64) -> (Option<f32>, Option<f32>) {
+        use vibez_core::automation::AutomationTarget;
+        let mut gain = None;
+        let mut pan = None;
+        for lane_idx in 0..self.automation.len() {
+            let lane = &self.automation[lane_idx];
+            let Some(value) = lane.value_at(beat) else {
+                continue;
+            };
+            match lane.target {
+                AutomationTarget::TrackGain => gain = Some(value),
+                AutomationTarget::TrackPan => pan = Some(value),
+                AutomationTarget::EffectParam {
+                    effect_id,
+                    param_index,
+                } => {
+                    if let Some(slot) = self.effects.iter_mut().find(|e| e.id == effect_id) {
+                        slot.effect.set_param(param_index, value);
+                    }
+                }
+                AutomationTarget::InstrumentParam { param_index } => {
+                    if let Some(instrument) = self.instrument.as_mut() {
+                        instrument.set_param(param_index, value);
+                    }
+                }
+                AutomationTarget::PluginParam { .. } => {}
+            }
+        }
+        (gain, pan)
     }
 
     /// Render the instrument with no clip events (transport stopped):

--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -47,6 +47,9 @@ pub enum BounceMode {
 /// decoded audio for every asset referenced by the snapshot.
 pub struct BounceRequest {
     pub tracks: Vec<TrackInfo>,
+    /// Master bus (gain + effect chain), applied to the summed mix
+    /// in [`BounceMode::Master`] renders.
+    pub master: Option<TrackInfo>,
     pub audio_clips: Vec<ClipInfo>,
     pub note_clips: Vec<NoteClipInfo>,
     pub clip_audio: HashMap<ClipId, Arc<DecodedAudio>>,
@@ -196,6 +199,35 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
     let total_frames = end.saturating_sub(start) as usize;
     let has_solo = matches!(req.mode, BounceMode::Master) && any_solo(&tracks);
 
+    // Master bus chain + gain, applied to the summed mix so the
+    // export matches live playback. Only master-mode renders route
+    // through it (single-track/clip bounces are pre-master stems).
+    let mut master_fx: Vec<EffectSlot> = Vec::new();
+    let mut master_gain = 1.0f32;
+    if matches!(req.mode, BounceMode::Master) {
+        if let Some(info) = &req.master {
+            master_gain = info.gain;
+            for fx_info in &info.effects {
+                if fx_info.plugin.is_some() {
+                    warnings.push(format!(
+                        "Master plugin effect '{}' not rendered offline",
+                        fx_info
+                            .plugin
+                            .as_ref()
+                            .map(|d| d.name.as_str())
+                            .unwrap_or("?")
+                    ));
+                    continue;
+                }
+                master_fx.push(EffectSlot {
+                    id: fx_info.id,
+                    effect: create_effect_with_params(fx_info.effect_type, sr_f32, &fx_info.params),
+                    bypass: fx_info.bypass,
+                });
+            }
+        }
+    }
+
     let mut out_l = Vec::with_capacity(total_frames);
     let mut out_r = Vec::with_capacity(total_frames);
 
@@ -238,6 +270,15 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
                 scratch[idx] += track.mix_buffer[idx] * gain * pan_l;
                 scratch[idx + 1] += track.mix_buffer[idx + 1] * gain * pan_r;
             }
+        }
+
+        for slot in &mut master_fx {
+            if !slot.bypass {
+                slot.effect.process(scratch, CHANNELS);
+            }
+        }
+        if (master_gain - 1.0).abs() > f32::EPSILON {
+            scratch.iter_mut().for_each(|s| *s *= master_gain);
         }
 
         for frame in 0..block {
@@ -338,6 +379,7 @@ mod tests {
         clip_audio.insert(cid, audio);
 
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: vec![clip],
             note_clips: Vec::new(),
@@ -386,6 +428,7 @@ mod tests {
         clip_audio.insert(cid, audio);
 
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: vec![clip],
             note_clips: Vec::new(),
@@ -427,6 +470,7 @@ mod tests {
         let mut clip_audio = HashMap::new();
         clip_audio.insert(cid, audio);
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: vec![clip],
             note_clips: Vec::new(),
@@ -488,6 +532,7 @@ mod tests {
         clip_audio.insert(cid_b, audio_b);
 
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: vec![clip_a, clip_b],
             note_clips: Vec::new(),
@@ -544,6 +589,7 @@ mod tests {
             }],
         };
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: Vec::new(),
             note_clips: vec![note_clip],
@@ -578,6 +624,7 @@ mod tests {
             automation: Vec::new(),
         };
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: Vec::new(),
             note_clips: Vec::new(),
@@ -628,6 +675,7 @@ mod tests {
         clip_audio.insert(cid, audio);
 
         let req = BounceRequest {
+            master: None,
             tracks: vec![track],
             audio_clips: vec![clip],
             note_clips: Vec::new(),

--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -306,6 +306,7 @@ mod tests {
             instrument: None,
             native_instrument: None,
             plugin_instrument: None,
+            automation: Vec::new(),
         }
     }
 
@@ -524,6 +525,7 @@ mod tests {
             instrument: Some(InstrumentKind::SubtractiveSynth),
             native_instrument: Some(InstrumentStateInfo::SubtractiveSynth { params: Vec::new() }),
             plugin_instrument: None,
+            automation: Vec::new(),
         };
         let note_clip = NoteClipInfo {
             id: cid,
@@ -573,6 +575,7 @@ mod tests {
             instrument: None,
             native_instrument: None,
             plugin_instrument: None,
+            automation: Vec::new(),
         };
         let req = BounceRequest {
             tracks: vec![track],

--- a/crates/vibez-instruments/src/lib.rs
+++ b/crates/vibez-instruments/src/lib.rs
@@ -15,6 +15,17 @@ use sampler::Sampler;
 use synth::SubtractiveSynth;
 
 /// Trait implemented by all instruments (synths, samplers, etc.).
+/// Parameter descriptors for an instrument kind, without building
+/// an instance (UI pickers, automation lane labels).
+pub fn descriptors_for(kind: InstrumentKind) -> &'static [ParamDescriptor] {
+    match kind {
+        InstrumentKind::SubtractiveSynth => synth::SYNTH_PARAMS,
+        InstrumentKind::Sampler => sampler::SAMPLER_PARAMS,
+        // The drum rack has per-pad state, no top-level params.
+        InstrumentKind::DrumRack => &[],
+    }
+}
+
 pub trait Instrument: Send {
     fn instrument_kind(&self) -> InstrumentKind;
     fn param_descriptors(&self) -> &'static [ParamDescriptor];

--- a/crates/vibez-plugin-host/src/clap_host/instance.rs
+++ b/crates/vibez-plugin-host/src/clap_host/instance.rs
@@ -22,6 +22,12 @@ pub struct ClapPluginInstance {
     _lib: libloading::Library,
     param_descriptors: Vec<ParamDescriptor>,
     param_values: Vec<f32>,
+    /// CLAP param ids and cookies, index-aligned with the
+    /// descriptors (cookies stored as usize to stay Send).
+    param_ids: Vec<u32>,
+    param_cookies: Vec<usize>,
+    /// (id, cookie, native value) queued for the next process block.
+    pending_params: Vec<(u32, usize, f64)>,
     buffer_adapter: AudioBufferAdapter,
     note_events: Vec<NoteEvent>,
     sample_rate: f64,
@@ -182,7 +188,7 @@ impl ClapPluginInstance {
             return Err("Plugin init() failed".into());
         }
 
-        let (param_descriptors, param_values) = query_params(plugin_ptr);
+        let (param_descriptors, param_values, param_ids, param_cookies) = query_params(plugin_ptr);
         let buffer_adapter = AudioBufferAdapter::new(2, max_buffer_size as usize);
 
         let mut instance = Self {
@@ -192,6 +198,9 @@ impl ClapPluginInstance {
             _lib: partial.lib,
             param_descriptors,
             param_values,
+            param_ids,
+            param_cookies,
+            pending_params: Vec::new(),
             buffer_adapter,
             note_events: Vec::new(),
             sample_rate,
@@ -219,7 +228,10 @@ impl ClapPluginInstance {
     }
 }
 
-fn query_params(plugin_ptr: *const clap_plugin) -> (Vec<ParamDescriptor>, Vec<f32>) {
+#[allow(clippy::type_complexity)]
+fn query_params(
+    plugin_ptr: *const clap_plugin,
+) -> (Vec<ParamDescriptor>, Vec<f32>, Vec<u32>, Vec<usize>) {
     let plugin_ref = unsafe { &*plugin_ptr };
 
     let ext_ptr =
@@ -227,7 +239,7 @@ fn query_params(plugin_ptr: *const clap_plugin) -> (Vec<ParamDescriptor>, Vec<f3
             as *const clap_plugin_params;
 
     if ext_ptr.is_null() {
-        return (Vec::new(), Vec::new());
+        return (Vec::new(), Vec::new(), Vec::new(), Vec::new());
     }
 
     let params_ext = unsafe { &*ext_ptr };
@@ -235,6 +247,8 @@ fn query_params(plugin_ptr: *const clap_plugin) -> (Vec<ParamDescriptor>, Vec<f3
 
     let mut descriptors = Vec::with_capacity(count);
     let mut values = Vec::with_capacity(count);
+    let mut ids = Vec::with_capacity(count);
+    let mut cookies = Vec::with_capacity(count);
 
     for i in 0..count {
         let mut info = clap_sys::ext::params::clap_param_info {
@@ -275,9 +289,11 @@ fn query_params(plugin_ptr: *const clap_plugin) -> (Vec<ParamDescriptor>, Vec<f3
             unit: "",
         });
         values.push(value as f32);
+        ids.push(info.id);
+        cookies.push(info.cookie as usize);
     }
 
-    (descriptors, values)
+    (descriptors, values, ids, cookies)
 }
 
 impl PluginInstance for ClapPluginInstance {
@@ -304,6 +320,12 @@ impl PluginInstance for ClapPluginInstance {
     fn set_param(&mut self, index: usize, value: f32) -> bool {
         if index < self.param_values.len() {
             self.param_values[index] = value;
+            // Deliver as a CLAP param event on the next process block.
+            self.pending_params.push((
+                self.param_ids[index],
+                self.param_cookies[index],
+                value as f64,
+            ));
             true
         } else {
             false
@@ -352,9 +374,45 @@ impl PluginInstance for ClapPluginInstance {
             input_events_storage.push(ClapNoteEventWrapper(event));
         }
 
+        // Param events (automation): delivered at block start.
+        let param_events_storage: Vec<clap_sys::events::clap_event_param_value> = self
+            .pending_params
+            .drain(..)
+            .map(
+                |(id, cookie, value)| clap_sys::events::clap_event_param_value {
+                    header: clap_event_header {
+                        size: std::mem::size_of::<clap_sys::events::clap_event_param_value>()
+                            as u32,
+                        time: 0,
+                        space_id: CLAP_CORE_EVENT_SPACE_ID,
+                        type_: clap_sys::events::CLAP_EVENT_PARAM_VALUE,
+                        flags: 0,
+                    },
+                    param_id: id,
+                    cookie: cookie as *mut std::ffi::c_void,
+                    note_id: -1,
+                    port_index: -1,
+                    channel: -1,
+                    key: -1,
+                    value,
+                },
+            )
+            .collect();
+
+        // Merge into one header list: params first (time 0), then the
+        // time-sorted notes.
+        let mut event_headers: Vec<*const clap_event_header> =
+            Vec::with_capacity(param_events_storage.len() + input_events_storage.len());
+        for pe in &param_events_storage {
+            event_headers.push(&pe.header as *const clap_event_header);
+        }
+        for ne in &input_events_storage {
+            event_headers.push(&ne.0.header as *const clap_event_header);
+        }
+
         // Create input/output event lists
         let input_events = ClapInputEvents {
-            events: &input_events_storage,
+            events: &event_headers,
         };
         let input_events_clap = clap_input_events {
             ctx: &input_events as *const ClapInputEvents as *const std::ffi::c_void
@@ -498,7 +556,9 @@ impl Drop for ClapPluginInstance {
 struct ClapNoteEventWrapper(clap_event_note);
 
 struct ClapInputEvents<'a> {
-    events: &'a [ClapNoteEventWrapper],
+    /// Type-erased event headers (notes and param values), sorted by
+    /// time. The pointed-to storage outlives the process() call.
+    events: &'a [*const clap_event_header],
 }
 
 unsafe extern "C" fn input_events_size(list: *const clap_input_events) -> u32 {
@@ -512,7 +572,7 @@ unsafe extern "C" fn input_events_get(
 ) -> *const clap_event_header {
     let events = &*((*list).ctx as *const ClapInputEvents);
     if (index as usize) < events.events.len() {
-        &events.events[index as usize].0.header as *const clap_event_header
+        events.events[index as usize]
     } else {
         std::ptr::null()
     }

--- a/crates/vibez-plugin-host/src/vst3_host/instance.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/instance.rs
@@ -26,6 +26,10 @@ pub struct Vst3PluginInstance {
     controller_is_separate: bool,
     param_descriptors: Vec<ParamDescriptor>,
     param_values: Vec<f32>,
+    /// VST3 ParamIDs, index-aligned with the descriptors.
+    param_ids: Vec<u32>,
+    /// (id, normalized value) queued for the next process block.
+    pending_params: Vec<(u32, f64)>,
     buffer_adapter: AudioBufferAdapter,
     /// Separate output buffers: VST3 process() is out-of-place by
     /// default and JUCE plugins do not reliably write in-place.
@@ -187,6 +191,144 @@ static PARAM_CHANGES_STUB: ParamChangesStub = ParamChangesStub {
 
 fn param_changes_stub() -> *mut std::ffi::c_void {
     &PARAM_CHANGES_STUB as *const ParamChangesStub as *mut std::ffi::c_void
+}
+
+// ── Live IParameterChanges (input) ──
+// Stack-allocated per process() call; spec-compliant plugins do not
+// retain the pointer past the call.
+
+#[repr(C)]
+struct LiveParamQueue {
+    vtbl: *const ParamQueueVtbl,
+    id: u32,
+    value: f64,
+}
+
+unsafe extern "system" fn lpq_parameter_id(this: *mut std::ffi::c_void) -> u32 {
+    unsafe { (*(this as *const LiveParamQueue)).id }
+}
+unsafe extern "system" fn lpq_point_count(_this: *mut std::ffi::c_void) -> i32 {
+    1
+}
+unsafe extern "system" fn lpq_get_point(
+    this: *mut std::ffi::c_void,
+    index: i32,
+    offset: *mut i32,
+    value: *mut f64,
+) -> i32 {
+    if index != 0 {
+        return 1; // kResultFalse
+    }
+    unsafe {
+        if !offset.is_null() {
+            *offset = 0;
+        }
+        if !value.is_null() {
+            *value = (*(this as *const LiveParamQueue)).value;
+        }
+    }
+    0
+}
+
+static LIVE_PARAM_QUEUE_VTBL: ParamQueueVtbl = ParamQueueVtbl {
+    query_interface: pc_query_interface,
+    add_ref: pc_add_ref,
+    release: pc_release,
+    get_parameter_id: lpq_parameter_id,
+    get_point_count: lpq_point_count,
+    get_point: lpq_get_point,
+    add_point: pq_add_point,
+};
+
+#[repr(C)]
+struct LiveParamChanges {
+    vtbl: *const ParamChangesVtbl,
+    queues: *const LiveParamQueue,
+    len: usize,
+}
+
+unsafe extern "system" fn lpc_count(this: *mut std::ffi::c_void) -> i32 {
+    unsafe { (*(this as *const LiveParamChanges)).len as i32 }
+}
+unsafe extern "system" fn lpc_get_data(
+    this: *mut std::ffi::c_void,
+    index: i32,
+) -> *mut std::ffi::c_void {
+    let changes = unsafe { &*(this as *const LiveParamChanges) };
+    if index < 0 || index as usize >= changes.len {
+        return std::ptr::null_mut();
+    }
+    unsafe { changes.queues.add(index as usize) as *mut std::ffi::c_void }
+}
+
+static LIVE_PARAM_CHANGES_VTBL: ParamChangesVtbl = ParamChangesVtbl {
+    query_interface: pc_query_interface,
+    add_ref: pc_add_ref,
+    release: pc_release,
+    get_parameter_count: lpc_count,
+    get_parameter_data: lpc_get_data,
+    add_parameter_data: pc_add_data,
+};
+
+/// Enumerate parameters via IEditController.
+/// Vtable slots: FUnknown 0-2, IPluginBase 3-4, then
+/// setComponentState(5) setState(6) getState(7) getParameterCount(8)
+/// getParameterInfo(9) ... getParamNormalized(14).
+fn query_vst3_params(
+    controller: *mut std::ffi::c_void,
+) -> (Vec<ParamDescriptor>, Vec<f32>, Vec<u32>) {
+    type GetCountFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> i32;
+    type GetInfoFn = unsafe extern "system" fn(
+        *mut std::ffi::c_void,
+        i32,
+        *mut vst3::Steinberg::Vst::ParameterInfo,
+    ) -> i32;
+    type GetNormalizedFn = unsafe extern "system" fn(*mut std::ffi::c_void, u32) -> f64;
+
+    let mut descriptors = Vec::new();
+    let mut values = Vec::new();
+    let mut ids = Vec::new();
+
+    unsafe {
+        let vtbl = *(controller as *const *const *const std::ffi::c_void);
+        let get_count: GetCountFn = std::mem::transmute(*vtbl.add(8));
+        let get_info: GetInfoFn = std::mem::transmute(*vtbl.add(9));
+        let get_normalized: GetNormalizedFn = std::mem::transmute(*vtbl.add(14));
+
+        let count = get_count(controller).max(0);
+        for i in 0..count {
+            let mut info: vst3::Steinberg::Vst::ParameterInfo = std::mem::zeroed();
+            if get_info(controller, i, &mut info) != 0 {
+                continue;
+            }
+            // Skip read-only / hidden params.
+            const CAN_AUTOMATE: i32 = 1 << 0;
+            const IS_READ_ONLY: i32 = 1 << 1;
+            if info.flags & IS_READ_ONLY != 0 {
+                continue;
+            }
+            if info.flags & CAN_AUTOMATE == 0 {
+                continue;
+            }
+            let title: String = char16_to_string(&info.title);
+            let name_static: &'static str = Box::leak(title.into_boxed_str());
+            descriptors.push(ParamDescriptor {
+                name: name_static,
+                min: 0.0,
+                max: 1.0,
+                default: info.defaultNormalizedValue as f32,
+                unit: "",
+            });
+            values.push(get_normalized(controller, info.id) as f32);
+            ids.push(info.id);
+        }
+    }
+    (descriptors, values, ids)
+}
+
+fn char16_to_string(chars: &[u16]) -> String {
+    let units: Vec<u16> = chars.iter().take_while(|&&c| c != 0).copied().collect();
+    String::from_utf16_lossy(&units)
 }
 
 /// Output of [`Vst3PluginInstance::load_partial`]: a dlopen'd module
@@ -548,6 +690,8 @@ impl Vst3PluginInstance {
             controller_is_separate,
             param_descriptors: Vec::new(),
             param_values: Vec::new(),
+            param_ids: Vec::new(),
+            pending_params: Vec::new(),
             buffer_adapter,
             out_adapter,
             audio_in_buses,
@@ -557,6 +701,15 @@ impl Vst3PluginInstance {
             sample_rate,
             active: false,
         };
+
+        // Enumerate parameters from the edit controller (VST3 params
+        // are always normalized 0..1).
+        if !instance.controller.is_null() {
+            let (descriptors, values, ids) = query_vst3_params(instance.controller);
+            instance.param_descriptors = descriptors;
+            instance.param_values = values;
+            instance.param_ids = ids;
+        }
 
         instance.prepare(sample_rate, max_buffer_size);
         instance.activate();
@@ -627,6 +780,8 @@ impl PluginInstance for Vst3PluginInstance {
     fn set_param(&mut self, index: usize, value: f32) -> bool {
         if index < self.param_values.len() {
             self.param_values[index] = value;
+            self.pending_params
+                .push((self.param_ids[index], value.clamp(0.0, 1.0) as f64));
             true
         } else {
             false
@@ -706,6 +861,23 @@ impl PluginInstance for Vst3PluginInstance {
             })
             .collect();
 
+        // Automation param changes for this block; storage must
+        // outlive the process() call below.
+        let live_queues: Vec<LiveParamQueue> = self
+            .pending_params
+            .drain(..)
+            .map(|(id, value)| LiveParamQueue {
+                vtbl: &LIVE_PARAM_QUEUE_VTBL,
+                id,
+                value,
+            })
+            .collect();
+        let live_changes = LiveParamChanges {
+            vtbl: &LIVE_PARAM_CHANGES_VTBL,
+            queues: live_queues.as_ptr(),
+            len: live_queues.len(),
+        };
+
         let mut process_data = ProcessDataRaw {
             process_mode: 0,
             symbolic_sample_size: 0,
@@ -714,7 +886,11 @@ impl PluginInstance for Vst3PluginInstance {
             num_outputs,
             inputs: input_buses.as_mut_ptr(),
             outputs: output_buses.as_mut_ptr(),
-            input_parameter_changes: param_changes_stub(),
+            input_parameter_changes: if live_queues.is_empty() {
+                param_changes_stub()
+            } else {
+                &live_changes as *const LiveParamChanges as *mut std::ffi::c_void
+            },
             output_parameter_changes: param_changes_stub(),
             input_events: std::ptr::null_mut(),
             output_events: std::ptr::null_mut(),

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -344,3 +344,50 @@ mod tests {
         ));
     }
 }
+
+#[cfg(test)]
+mod automation_persistence_tests {
+    use super::*;
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+    use vibez_core::track::TrackInfo;
+
+    #[test]
+    fn lanes_survive_a_save_load_roundtrip() {
+        let mut track = TrackInfo::new("T1");
+        let mut lane = AutomationLane::new(AutomationTarget::TrackGain);
+        lane.insert_point(AutomationPoint {
+            beat: 0.0,
+            value: 1.0,
+        });
+        lane.insert_point(AutomationPoint {
+            beat: 8.0,
+            value: 0.25,
+        });
+        track.automation.push(lane.clone());
+
+        let project = Project {
+            name: "roundtrip".to_string(),
+            tracks: vec![track],
+            ..Default::default()
+        };
+
+        let dir = std::env::temp_dir().join("vibez-lane-roundtrip-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("p.vibez");
+        project.save_to_file(&path).unwrap();
+        let loaded = Project::load_from_file(&path).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(loaded.tracks[0].automation, vec![lane]);
+    }
+
+    #[test]
+    fn projects_without_lanes_still_load() {
+        // Backcompat: pre-automation files have no `automation` key.
+        let json = r#"{"name":"old","bpm":120.0,"sample_rate":48000,
+            "tracks":[{"id":1,"name":"T","gain":1.0,"pan":0.5,
+            "mute":false,"solo":false}],"clips":[]}"#;
+        let project: Project = serde_json::from_str(json).unwrap();
+        assert!(project.tracks[0].automation.is_empty());
+    }
+}

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -14,6 +14,10 @@ pub struct Project {
     pub clips: Vec<ClipInfo>,
     #[serde(default)]
     pub note_clips: Vec<NoteClipInfo>,
+    /// The master bus channel (gain + effect chain). Absent in
+    /// projects saved before the master was a real channel.
+    #[serde(default)]
+    pub master: Option<TrackInfo>,
 }
 
 impl Default for Project {
@@ -25,6 +29,7 @@ impl Default for Project {
             tracks: Vec::new(),
             clips: Vec::new(),
             note_clips: Vec::new(),
+            master: None,
         }
     }
 }
@@ -156,6 +161,7 @@ mod tests {
         let path = dir.path().join("test.vibez");
 
         let project = Project {
+            master: None,
             name: "Test Project".into(),
             bpm: 140.0,
             sample_rate: 48_000,
@@ -261,6 +267,7 @@ mod tests {
 
         let tid = TrackId::new();
         let project = Project {
+            master: None,
             name: "Note Test".into(),
             bpm: 128.0,
             sample_rate: 44_100,
@@ -323,6 +330,7 @@ mod tests {
         });
 
         let project = Project {
+            master: None,
             name: "FX Test".into(),
             bpm: 120.0,
             sample_rate: 44_100,
@@ -368,6 +376,7 @@ mod automation_persistence_tests {
         track.automation.push(lane.clone());
 
         let project = Project {
+            master: None,
             name: "roundtrip".to_string(),
             tracks: vec![track],
             ..Default::default()

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -358,10 +358,12 @@ mod automation_persistence_tests {
         lane.insert_point(AutomationPoint {
             beat: 0.0,
             value: 1.0,
+            curve: 0.0,
         });
         lane.insert_point(AutomationPoint {
             beat: 8.0,
             value: 0.25,
+            curve: 0.5,
         });
         track.automation.push(lane.clone());
 

--- a/crates/vibez-ui/Cargo.toml
+++ b/crates/vibez-ui/Cargo.toml
@@ -22,3 +22,6 @@ rfd = "0.15"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync"] }
 x11rb = "0.13"
 dirs = "5"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/vibez-ui/examples/make_demo.rs
+++ b/crates/vibez-ui/examples/make_demo.rs
@@ -29,6 +29,7 @@ fn track(name: &str, kind: InstrumentKind, color_index: u8) -> TrackInfo {
         instrument: Some(kind),
         native_instrument: None,
         plugin_instrument: None,
+        automation: Vec::new(),
     }
 }
 

--- a/crates/vibez-ui/examples/make_demo.rs
+++ b/crates/vibez-ui/examples/make_demo.rs
@@ -151,6 +151,7 @@ fn main() {
     note_clips.push(clip(lead.id, "Hook", 32.0, 16.0, notes));
 
     let project = Project {
+        master: None,
         name: "Neon Skyline".to_string(),
         bpm: 124.0,
         sample_rate: 48_000,

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -226,13 +226,17 @@ impl App {
             }
 
             if let Some(track) = self.state.find_track_mut(track_id) {
-                let descriptors: &'static [vibez_core::effect::ParamDescriptor] =
-                    Box::leak(Vec::new().into_boxed_slice());
+                // Real plugin parameters (already leaked 'static by the
+                // wrapper): drives the knob strip and automation picker.
+                let descriptors = effect.param_descriptors();
+                let params: Vec<f32> = (0..descriptors.len())
+                    .map(|i| effect.get_param(i))
+                    .collect();
                 let ui_effect = UiEffect {
                     id: effect_id,
                     effect_type: EffectType::Gain,
                     bypass: false,
-                    params: Vec::new(),
+                    params,
                     descriptors,
                     plugin_name: Some(plugin_name.clone()),
                     has_plugin_gui: has_gui,
@@ -284,6 +288,7 @@ impl App {
                 track.has_instrument = true;
                 track.plugin_instrument_name = Some(plugin_name.clone());
                 track.plugin_instrument_ref = Some(result.device_ref.clone());
+                track.plugin_instrument_descriptors = instrument.param_descriptors();
                 track.has_plugin_instrument_gui = has_gui;
             }
             self.send_command(EngineCommand::SetPluginInstrument {

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -375,6 +375,9 @@ impl App {
                     EngineEvent::Metering { peak_l, peak_r, .. } => {
                         self.state.peak_l = peak_l.max(self.state.peak_l * 0.85);
                         self.state.peak_r = peak_r.max(self.state.peak_r * 0.85);
+                        // The master strip meters the same summed mix.
+                        self.state.arrangement.master.peak_l = self.state.peak_l;
+                        self.state.arrangement.master.peak_r = self.state.peak_r;
                     }
                     EngineEvent::PlaybackStopped => {
                         self.state.transport.playing = false;
@@ -397,10 +400,48 @@ impl App {
         }
     }
 
+    /// Keep the engine's spectrum tap on the selected track and pump
+    /// drained samples through the analyser.
+    fn poll_spectrum(&mut self) {
+        let wanted = self.state.arrangement.selected_track;
+        if wanted != self.spectrum_tap {
+            self.send_command(EngineCommand::SetSpectrumTap(wanted));
+            self.spectrum_tap = wanted;
+            self.state.spectrum.reset();
+        }
+        if let Some(ref mut rx) = self.spectrum_rx {
+            // Drain in slices; the ring holds well under a second.
+            let mut chunk = [0.0f32; 512];
+            loop {
+                let mut n = 0;
+                while n < chunk.len() {
+                    match rx.pop() {
+                        Ok(s) => {
+                            chunk[n] = s;
+                            n += 1;
+                        }
+                        Err(_) => break,
+                    }
+                }
+                if n == 0 {
+                    break;
+                }
+                self.state.spectrum.ingest(&chunk[..n]);
+                if n < chunk.len() {
+                    break;
+                }
+            }
+        }
+        self.state
+            .spectrum
+            .analyse(self.state.transport.sample_rate as f32);
+    }
+
     /// One frame of the 60fps subscription: drain engine events and
     /// pump every background service.
     pub(super) fn handle_tick(&mut self) -> Task<Message> {
         self.poll_engine_events();
+        self.poll_spectrum();
         self.poll_plugin_loads();
         self.poll_plugin_windows();
         self.poll_midi_input();

--- a/crates/vibez-ui/src/app/bounce.rs
+++ b/crates/vibez-ui/src/app/bounce.rs
@@ -96,6 +96,7 @@ impl App {
 
         let request = vibez_engine::render::BounceRequest {
             tracks: project.tracks,
+            master: project.master,
             audio_clips: project.clips,
             note_clips: project.note_clips,
             clip_audio: assets.clips,

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -35,6 +35,12 @@ struct App {
     state: AppState,
     cmd_tx: Option<Producer<EngineCommand>>,
     event_rx: Option<Consumer<EngineEvent>>,
+    /// Post-effects mono samples from the engine's spectrum tap,
+    /// feeding the EQ analyser.
+    spectrum_rx: Option<Consumer<f32>>,
+    /// Track the engine tap currently points at, so tick can retarget
+    /// it when the selection moves.
+    spectrum_tap: Option<vibez_core::id::TrackId>,
     _stream: Option<AudioOutputStream>,
     // Channels for receiving loaded plugins from background threads
     plugin_effect_rx: std::sync::mpsc::Receiver<PluginLoadResult>,
@@ -118,7 +124,8 @@ mod views_shell;
 
 impl App {
     fn new() -> (Self, Task<Message>) {
-        let (engine, cmd_tx, event_rx) = AudioEngine::new();
+        let (mut engine, cmd_tx, event_rx) = AudioEngine::new();
+        let spectrum_rx = engine.take_spectrum_consumer();
         let ui_settings = UiSettings::load();
 
         let (stream, sample_rate) = match AudioOutputStream::open(engine, Some(512)) {
@@ -187,6 +194,8 @@ impl App {
             state,
             cmd_tx: Some(cmd_tx),
             event_rx: Some(event_rx),
+            spectrum_rx,
+            spectrum_tap: None,
             _stream: stream,
             plugin_effect_rx,
             plugin_effect_tx,
@@ -204,6 +213,10 @@ impl App {
 
         // Inform the engine of the actual sample rate
         app.send_command(EngineCommand::SetBpm(app.state.transport.bpm));
+
+        // Console model: the master bus carries its channel EQ from
+        // the first frame.
+        app.ensure_master_eq();
 
         let startup_task = if app.state.browser.roots.is_empty() {
             Task::none()

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -215,7 +215,16 @@ impl App {
             )
         };
 
-        (app, startup_task)
+        // `vibez <project.vibez>` opens a project straight from the
+        // command line (also how file-manager associations launch us).
+        let open_task = std::env::args()
+            .nth(1)
+            .map(std::path::PathBuf::from)
+            .filter(|p| p.is_file())
+            .map(|p| Task::done(Message::ProjectOpenPathSelected(Some(p))))
+            .unwrap_or_else(Task::none);
+
+        (app, Task::batch([startup_task, open_task]))
     }
 
     fn send_command(&mut self, cmd: EngineCommand) {

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -159,7 +159,7 @@ impl App {
             ..Default::default()
         };
 
-        let state = AppState {
+        let mut state = AppState {
             transport: crate::state::TransportState {
                 sample_rate,
                 ..Default::default()
@@ -174,6 +174,27 @@ impl App {
             },
             ..Default::default()
         };
+
+        // Themes: scan the user's .vzt collection, then restore the
+        // saved selection (built-in name or user theme name).
+        let (user_themes, theme_warnings) = crate::themes::scan_user_themes();
+        for warning in theme_warnings {
+            eprintln!("vibez: theme scan: {warning}");
+        }
+        state.user_themes = user_themes;
+        if let Some(name) = &ui_settings.theme {
+            let palette = crate::themes::builtin_by_name(name).or_else(|| {
+                state
+                    .user_themes
+                    .iter()
+                    .find(|t| t.palette.name == *name)
+                    .map(|t| t.palette.clone())
+            });
+            if let Some(palette) = palette {
+                th::set_theme(palette);
+                state.current_theme_name = name.clone();
+            }
+        }
 
         let (plugin_effect_tx, plugin_effect_rx) = std::sync::mpsc::channel();
         let (plugin_instrument_tx, plugin_instrument_rx) = std::sync::mpsc::channel();
@@ -228,8 +249,9 @@ impl App {
             )
         };
 
-        // `vibez <project.vibez>` opens a project straight from the
-        // command line (also how file-manager associations launch us).
+        // `vibez <project.vzp>` opens a project straight from the
+        // command line (also how file-manager associations launch
+        // us). Legacy `.vibez` files load the same way.
         let open_task = std::env::args()
             .nth(1)
             .map(std::path::PathBuf::from)
@@ -238,6 +260,18 @@ impl App {
             .unwrap_or_else(Task::none);
 
         (app, Task::batch([startup_task, open_task]))
+    }
+
+    /// Find a theme by name: built-ins first, then the scanned user
+    /// collection.
+    pub(crate) fn resolve_theme(&self, name: &str) -> Option<crate::theme::ThemePalette> {
+        crate::themes::builtin_by_name(name).or_else(|| {
+            self.state
+                .user_themes
+                .iter()
+                .find(|t| t.palette.name == name)
+                .map(|t| t.palette.clone())
+        })
     }
 
     fn send_command(&mut self, cmd: EngineCommand) {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -35,6 +35,7 @@ impl App {
         }
 
         self.state.arrangement.tracks.clear();
+        self.reset_master_channel();
         // The engine drops all plugin instances with their tracks;
         // their GUI windows and stale raw pointers must go with them
         // (pumping a closed plugin's run-loop timers segfaults).
@@ -62,8 +63,47 @@ impl App {
         self.state.view.edit_name_text.clear();
     }
 
+    /// Tear the master bus back to a bare channel: engine chain
+    /// cleared, gain at unity, fresh UI model. Callers re-attach the
+    /// channel EQ (or load a saved chain) afterwards.
+    pub(super) fn reset_master_channel(&mut self) {
+        let effect_ids: Vec<EffectId> = self
+            .state
+            .arrangement
+            .master
+            .effects
+            .iter()
+            .map(|e| e.id)
+            .collect();
+        for effect_id in effect_ids {
+            self.send_command(EngineCommand::RemoveEffect(TrackId::MASTER, effect_id));
+        }
+        self.state.arrangement.master = crate::state::new_master_track();
+        self.send_command(EngineCommand::SetTrackGain(TrackId::MASTER, 1.0));
+    }
+
+    /// Console model: the master bus always carries its channel EQ.
+    /// Attaches a flat one when missing (fresh session, old project).
+    pub(super) fn ensure_master_eq(&mut self) {
+        let has_eq = self
+            .state
+            .arrangement
+            .master
+            .effects
+            .iter()
+            .any(|e| e.effect_type == EffectType::Eq && e.plugin_ref.is_none());
+        if !has_eq {
+            let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+            crate::domains::arrangement::attach_channel_eq(
+                &mut engine,
+                &mut self.state.arrangement.master,
+            );
+        }
+    }
+
     pub(super) fn reset_to_new_project(&mut self) {
         self.clear_project_runtime();
+        self.ensure_master_eq();
         self.state.transport.bpm = vibez_core::constants::DEFAULT_BPM;
         self.state.transport.bpm_text = format!("{:.0}", self.state.transport.bpm);
         self.send_command(EngineCommand::SetBpm(self.state.transport.bpm));
@@ -234,6 +274,7 @@ impl App {
             tracks,
             clips,
             note_clips,
+            master: Some(self.track_info_from_ui(&self.state.arrangement.master)),
         }
     }
 
@@ -252,6 +293,13 @@ impl App {
             .flat_map(|t| std::iter::once(t.id.raw()).chain(t.effects.iter().map(|e| e.id.raw())))
             .chain(loaded.project.clips.iter().map(|c| c.id.raw()))
             .chain(loaded.project.note_clips.iter().map(|c| c.id.raw()))
+            .chain(
+                loaded
+                    .project
+                    .master
+                    .iter()
+                    .flat_map(|m| m.effects.iter().map(|e| e.id.raw())),
+            )
             .max()
             .unwrap_or(0);
         vibez_core::id::ensure_ids_above(max_loaded_id);
@@ -443,6 +491,64 @@ impl App {
             self.state.arrangement.tracks.push(track);
         }
 
+        // Master bus: gain + effect chain from the file, then the
+        // channel-EQ backfill for projects saved before the master
+        // was a real channel. clear_project_runtime left it bare.
+        if let Some(master_info) = &loaded.project.master {
+            self.state.arrangement.master.gain = master_info.gain;
+            self.send_command(EngineCommand::SetTrackGain(
+                TrackId::MASTER,
+                master_info.gain,
+            ));
+            for (chain_pos, effect_info) in master_info.effects.iter().enumerate() {
+                if let Some(dev) = &effect_info.plugin {
+                    plugin_effect_requests.push((
+                        TrackId::MASTER,
+                        effect_info.id,
+                        chain_pos,
+                        dev.clone(),
+                    ));
+                    continue;
+                }
+                let fx = vibez_dsp::factory::create_effect_with_params(
+                    effect_info.effect_type,
+                    self.state.transport.sample_rate as f32,
+                    &effect_info.params,
+                );
+                let descriptors = fx.param_descriptors();
+                self.state.arrangement.master.effects.push(UiEffect {
+                    id: effect_info.id,
+                    effect_type: effect_info.effect_type,
+                    bypass: effect_info.bypass,
+                    params: effect_info.params.clone(),
+                    descriptors,
+                    plugin_name: None,
+                    has_plugin_gui: false,
+                    plugin_ref: None,
+                });
+                self.send_command(EngineCommand::AddEffect {
+                    track_id: TrackId::MASTER,
+                    effect_id: effect_info.id,
+                    effect_type: effect_info.effect_type,
+                    position: None,
+                });
+                for (idx, value) in effect_info.params.iter().copied().enumerate() {
+                    self.send_command(EngineCommand::SetEffectParam {
+                        track_id: TrackId::MASTER,
+                        effect_id: effect_info.id,
+                        param_index: idx,
+                        value,
+                    });
+                }
+                self.send_command(EngineCommand::SetEffectBypass {
+                    track_id: TrackId::MASTER,
+                    effect_id: effect_info.id,
+                    bypass: effect_info.bypass,
+                });
+            }
+        }
+        self.ensure_master_eq();
+
         for loaded_clip in loaded.clips {
             self.send_command(EngineCommand::AddClip {
                 track_id: loaded_clip.info.track_id,
@@ -589,6 +695,7 @@ impl App {
     pub(super) fn take_snapshot(&self) -> crate::state::ProjectSnapshot {
         crate::state::ProjectSnapshot {
             tracks: self.state.arrangement.tracks.clone(),
+            master: self.state.arrangement.master.clone(),
             bpm: self.state.transport.bpm,
             bpm_text: self.state.transport.bpm_text.clone(),
             loop_enabled: self.state.transport.loop_enabled,
@@ -634,7 +741,21 @@ impl App {
         for track_id in existing_track_ids {
             self.send_command(EngineCommand::RemoveTrack(track_id));
         }
+        // The master bus survives track teardown; clear its chain
+        // explicitly so the snapshot replay starts from bare.
+        let master_effect_ids: Vec<EffectId> = self
+            .state
+            .arrangement
+            .master
+            .effects
+            .iter()
+            .map(|e| e.id)
+            .collect();
+        for effect_id in master_effect_ids {
+            self.send_command(EngineCommand::RemoveEffect(TrackId::MASTER, effect_id));
+        }
 
+        self.state.arrangement.master = snapshot.master;
         self.state.arrangement.tracks = snapshot.tracks;
         self.state.transport.bpm = snapshot.bpm;
         self.state.transport.bpm_text = snapshot.bpm_text;
@@ -664,6 +785,8 @@ impl App {
         for track in &tracks {
             self.replay_track_to_engine(track);
         }
+        let master = self.state.arrangement.master.clone();
+        self.replay_track_to_engine(&master);
 
         // Reload plugin devices through the project-open pipeline;
         // they re-enter the chains at their recorded positions.
@@ -671,6 +794,13 @@ impl App {
     }
 
     pub(super) fn replay_track_to_engine(&mut self, track: &UiTrack) {
+        if track.id.is_master() {
+            // The master bus always exists in the engine: replay only
+            // its gain and effect chain.
+            self.send_command(EngineCommand::SetTrackGain(track.id, track.gain));
+            self.replay_effects_to_engine(track);
+            return;
+        }
         match track.kind {
             TrackKind::Audio => {
                 self.send_command(EngineCommand::AddTrack(track.id, track.name.clone()));
@@ -731,27 +861,7 @@ impl App {
             });
         }
 
-        for effect in &track.effects {
-            self.send_command(EngineCommand::AddEffect {
-                track_id: track.id,
-                effect_id: effect.id,
-                effect_type: effect.effect_type,
-                position: None,
-            });
-            for (idx, value) in effect.params.iter().copied().enumerate() {
-                self.send_command(EngineCommand::SetEffectParam {
-                    track_id: track.id,
-                    effect_id: effect.id,
-                    param_index: idx,
-                    value,
-                });
-            }
-            self.send_command(EngineCommand::SetEffectBypass {
-                track_id: track.id,
-                effect_id: effect.id,
-                bypass: effect.bypass,
-            });
-        }
+        self.replay_effects_to_engine(track);
 
         for clip in &track.clips {
             self.send_command(EngineCommand::AddClip {
@@ -787,6 +897,33 @@ impl App {
         }
     }
 
+    /// Replay a channel's built-in effect chain to the engine
+    /// (add, params, bypass). Plugin devices reload through the
+    /// async pipeline instead.
+    fn replay_effects_to_engine(&mut self, track: &UiTrack) {
+        for effect in &track.effects {
+            self.send_command(EngineCommand::AddEffect {
+                track_id: track.id,
+                effect_id: effect.id,
+                effect_type: effect.effect_type,
+                position: None,
+            });
+            for (idx, value) in effect.params.iter().copied().enumerate() {
+                self.send_command(EngineCommand::SetEffectParam {
+                    track_id: track.id,
+                    effect_id: effect.id,
+                    param_index: idx,
+                    value,
+                });
+            }
+            self.send_command(EngineCommand::SetEffectBypass {
+                track_id: track.id,
+                effect_id: effect.id,
+                bypass: effect.bypass,
+            });
+        }
+    }
+
     pub(super) fn handle_export_path_selected(&mut self, path: Option<PathBuf>) -> Task<Message> {
         let Some(mut path) = path else {
             return Task::none();
@@ -805,6 +942,7 @@ impl App {
         let bpm = self.state.transport.bpm;
         let request = vibez_engine::render::BounceRequest {
             tracks: project.tracks,
+            master: project.master,
             audio_clips: project.clips,
             note_clips: project.note_clips,
             clip_audio: assets.clips,

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
+use vibez_core::effect::EffectType;
 
 use iced::Task;
 
@@ -400,6 +401,37 @@ impl App {
                     track_id: track_info.id,
                     effect_id: effect_info.id,
                     bypass: effect_info.bypass,
+                });
+            }
+
+            // Console model: every channel has its EQ. Backfill for
+            // projects saved before the channel EQ existed.
+            if !track
+                .effects
+                .iter()
+                .any(|e| e.effect_type == EffectType::Eq && e.plugin_ref.is_none())
+            {
+                let effect_id = EffectId::new();
+                let fx = vibez_dsp::factory::create_effect(
+                    EffectType::Eq,
+                    self.state.transport.sample_rate as f32,
+                );
+                let descriptors = fx.param_descriptors();
+                track.effects.push(UiEffect {
+                    id: effect_id,
+                    effect_type: EffectType::Eq,
+                    bypass: false,
+                    params: descriptors.iter().map(|d| d.default).collect(),
+                    descriptors,
+                    plugin_name: None,
+                    has_plugin_gui: false,
+                    plugin_ref: None,
+                });
+                self.send_command(EngineCommand::AddEffect {
+                    track_id: track_info.id,
+                    effect_id,
+                    effect_type: EffectType::Eq,
+                    position: None,
                 });
             }
 

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -280,6 +280,7 @@ impl App {
             track.pan = track_info.pan;
             track.mute = track_info.mute;
             track.solo = track_info.solo;
+            track.automation = track_info.automation.clone();
             track.instrument_kind = track_info.instrument;
             track.has_instrument = track_info.instrument.is_some();
             if let Some(dev) = &track_info.plugin_instrument {
@@ -346,6 +347,13 @@ impl App {
                         }
                     }
                 }
+            }
+
+            for lane in &track_info.automation {
+                self.send_command(EngineCommand::SetAutomationLane {
+                    track_id: track_info.id,
+                    lane: lane.clone(),
+                });
             }
 
             for (chain_pos, effect_info) in track_info.effects.iter().enumerate() {
@@ -682,6 +690,13 @@ impl App {
                 }
                 InstrumentKind::SubtractiveSynth => {}
             }
+        }
+
+        for lane in &track.automation {
+            self.send_command(EngineCommand::SetAutomationLane {
+                track_id: track.id,
+                lane: lane.clone(),
+            });
         }
 
         for effect in &track.effects {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -146,6 +146,7 @@ impl App {
             instrument: track.instrument_kind,
             native_instrument,
             plugin_instrument,
+            automation: track.automation.clone(),
         }
     }
 

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -120,6 +120,7 @@ impl App {
             auto_warp_on_import: self.state.auto_warp_on_import,
             warp_confidence_threshold: self.state.warp_confidence_threshold,
             preferred_midi_input: self.midi_input.as_ref().map(|h| h.port_name.clone()),
+            theme: Some(self.state.current_theme_name.clone()),
         };
         if let Err(err) = settings.save() {
             self.state.status_text = format!("UI settings save error: {err}");

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -98,7 +98,8 @@ impl App {
                 | Message::ClipAutoWarpReady { .. }
         ) || matches!(&message, Message::Devices(m) if m.marks_dirty())
             || matches!(&message, Message::Arrangement(m) if m.marks_dirty())
-            || matches!(&message, Message::PianoRoll(m) if m.marks_dirty());
+            || matches!(&message, Message::PianoRoll(m) if m.marks_dirty())
+            || matches!(&message, Message::Automation(m) if m.marks_dirty());
         if should_mark_dirty {
             self.push_undo_snapshot();
             self.mark_project_dirty();
@@ -177,6 +178,19 @@ impl App {
                 let action = self.state.browser.update(msg);
                 return self.apply_browser_action(action);
             }
+            Message::Automation(msg) => {
+                let action = {
+                    let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+                    self.state.automation_ui.update(
+                        msg,
+                        &mut engine,
+                        &mut self.state.arrangement.tracks,
+                    )
+                };
+                if let Some(status) = action.status {
+                    self.state.status_text = status;
+                }
+            }
             Message::View(msg) => {
                 let ctx = crate::domains::view::ViewCtx {
                     total_beats: self.state.total_beats(),
@@ -224,7 +238,13 @@ impl App {
                 {
                     return Task::none();
                 }
-                // Priority 1: selected notes in the open piano roll.
+                // Priority 1: a selected automation point.
+                if self.state.automation_ui.selected.is_some() {
+                    return self.update(Message::Automation(
+                        crate::domains::automation::AutomationMsg::DeleteSelectedPoint,
+                    ));
+                }
+                // Priority 2: selected notes in the open piano roll.
                 if let Some((track_id, clip_id)) = self.state.arrangement.selected_note_clip {
                     let has_selection = self
                         .state
@@ -237,7 +257,7 @@ impl App {
                         )));
                     }
                 }
-                // Priority 2: selected arrangement clips.
+                // Priority 3: selected arrangement clips.
                 if !self.state.arrangement.selected_clips.is_empty() {
                     return self.update(Message::Arrangement(ArrangementMsg::DeleteSelectedClip));
                 }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -138,6 +138,7 @@ impl App {
                         msg,
                         &mut engine,
                         &mut self.state.arrangement.tracks,
+                        &mut self.state.arrangement.master,
                         sample_rate,
                     )
                 };
@@ -581,10 +582,9 @@ impl App {
                         .dropbox_client
                         .clone()
                         .map(|client| (client, self.dropbox_cache.clone()));
-                    return Task::perform(
-                        load_project_async(path, dropbox),
-                        Message::ProjectLoaded,
-                    );
+                    return Task::perform(load_project_async(path, dropbox), |result| {
+                        Message::ProjectLoaded(Box::new(result))
+                    });
                 }
             }
             Message::ProjectSavePathSelected(path) => {
@@ -596,7 +596,7 @@ impl App {
                     return Task::perform(save_project_async(path, project), Message::ProjectSaved);
                 }
             }
-            Message::ProjectLoaded(result) => match result {
+            Message::ProjectLoaded(result) => match *result {
                 Ok(loaded) => {
                     self.rebuild_from_loaded_project(loaded);
                 }
@@ -680,6 +680,12 @@ impl App {
                     let is_instrument = info.category.is_instrument();
                     let loading_name = info.name.clone();
 
+                    if is_instrument && track_id.is_master() {
+                        // The master bus hosts effects only.
+                        self.state.status_text =
+                            format!("{loading_name} is an instrument; Master takes effects only");
+                        return Task::none();
+                    }
                     if is_instrument {
                         let tx = self.plugin_instrument_tx.clone();
                         std::thread::spawn(move || {

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -418,6 +418,54 @@ impl App {
                 self.persist_ui_settings();
                 self.state.status_text = "MIDI input disconnected".to_string();
             }
+            Message::SelectTheme(name) => {
+                if let Some(palette) = self.resolve_theme(&name) {
+                    th::set_theme(palette);
+                    self.state.current_theme_name = name.clone();
+                    self.persist_ui_settings();
+                    self.state.status_text = format!("Theme: {name}");
+                } else {
+                    self.state.status_text = format!("Theme {name:?} not found");
+                }
+            }
+            Message::RescanThemes => {
+                let (themes, warnings) = crate::themes::scan_user_themes();
+                let count = themes.len();
+                self.state.user_themes = themes;
+                self.state.status_text = if warnings.is_empty() {
+                    format!("{count} user theme(s) found")
+                } else {
+                    format!("{count} user theme(s), {} skipped", warnings.len())
+                };
+                for warning in warnings {
+                    eprintln!("vibez: theme scan: {warning}");
+                }
+            }
+            Message::ThemeSaveNameChanged(name) => {
+                self.state.theme_save_name = name;
+            }
+            Message::SaveCurrentTheme => {
+                let name = self.state.theme_save_name.trim().to_string();
+                if name.is_empty() {
+                    self.state.status_text = "Name the theme before saving".to_string();
+                    return Task::none();
+                }
+                let mut palette = th::current();
+                palette.name = name.clone();
+                match crate::themes::save_user_theme(&palette) {
+                    Ok(path) => {
+                        let (themes, _) = crate::themes::scan_user_themes();
+                        self.state.user_themes = themes;
+                        self.state.current_theme_name = name;
+                        self.state.theme_save_name.clear();
+                        self.persist_ui_settings();
+                        self.state.status_text = format!("Theme saved to {}", path.display());
+                    }
+                    Err(err) => {
+                        self.state.status_text = format!("Theme save error: {err}");
+                    }
+                }
+            }
             Message::RewarpAllClips => {
                 return self.handle_rewarp_all_clips();
             }
@@ -544,7 +592,7 @@ impl App {
                     async {
                         let handle = rfd::AsyncFileDialog::new()
                             .set_title("Open Vibez Project")
-                            .add_filter("Vibez Project", &["vibez", "json"])
+                            .add_filter("Vibez Project", &["vzp", "vibez", "json"])
                             .pick_file()
                             .await;
                         handle.map(|file| file.path().to_path_buf())
@@ -566,8 +614,8 @@ impl App {
                     async {
                         let handle = rfd::AsyncFileDialog::new()
                             .set_title("Save Vibez Project")
-                            .set_file_name("Untitled.vibez")
-                            .add_filter("Vibez Project", &["vibez"])
+                            .set_file_name("Untitled.vzp")
+                            .add_filter("Vibez Project", &["vzp", "vibez"])
                             .save_file()
                             .await;
                         handle.map(|file| file.path().to_path_buf())
@@ -590,7 +638,7 @@ impl App {
             Message::ProjectSavePathSelected(path) => {
                 if let Some(mut path) = path {
                     if path.extension().is_none() {
-                        path.set_extension("vibez");
+                        path.set_extension("vzp");
                     }
                     let project = self.project_from_state();
                     return Task::perform(save_project_async(path, project), Message::ProjectSaved);

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -27,27 +27,27 @@ impl App {
             );
             let dropbox_active = !local_active;
             let tab_btn = |label: &'static str, active: bool, mode| {
-                button(
-                    text(label)
-                        .size(11)
-                        .color(if active { th::ACCENT } else { th::TEXT_DIM }),
-                )
+                button(text(label).size(11).color(if active {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                }))
                 .on_press(Message::Browser(BrowserMsg::SetSampleBrowserMode(mode)))
                 .padding([4, 12])
                 .style(move |_theme: &Theme, status| {
                     let bg = if active {
-                        Some(th::ACCENT_DIM.into())
+                        Some(th::accent_dim().into())
                     } else {
                         match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::BG_HOVER.into())
+                                Some(th::bg_hover().into())
                             }
                             _ => None,
                         }
                     };
                     button::Style {
                         background: bg,
-                        text_color: if active { th::ACCENT } else { th::TEXT_DIM },
+                        text_color: if active { th::accent() } else { th::text_dim() },
                         border: iced::Border::default(),
                         ..Default::default()
                     }
@@ -82,9 +82,9 @@ impl App {
         .width(Length::Fixed(320.0))
         .height(Length::Fill)
         .style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 0.0.into(),
             },
@@ -94,19 +94,21 @@ impl App {
     }
 
     pub(super) fn view_local_sample_browser(&self) -> Element<'_, Message> {
-        let title = text("Sample Browser").size(14).color(th::ACCENT);
-        let mut add_root_btn = button(text("Add Root").size(11).color(th::TEXT))
+        let title = text("Sample Browser").size(14).color(th::accent());
+        let mut add_root_btn = button(text("Add Root").size(11).color(th::text()))
             .padding([4, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_ELEVATED.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_elevated().into()),
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -115,18 +117,20 @@ impl App {
             });
         add_root_btn = add_root_btn.on_press(Message::AddSampleLibraryRoot);
 
-        let mut rescan_btn = button(text("Rescan").size(11).color(th::TEXT))
+        let mut rescan_btn = button(text("Rescan").size(11).color(th::text()))
             .padding([4, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_ELEVATED.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_elevated().into()),
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -146,7 +150,7 @@ impl App {
                 header,
                 text("Add a root folder to index your sample library.")
                     .size(12)
-                    .color(th::TEXT_DIM)
+                    .color(th::text_dim())
             ]
             .spacing(10)
             .padding(10);
@@ -154,9 +158,9 @@ impl App {
                 .width(Length::Fixed(320.0))
                 .height(Length::Fill)
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_SURFACE.into()),
+                    background: Some(th::bg_surface().into()),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 0.0.into(),
                     },
@@ -174,25 +178,31 @@ impl App {
         let mut roots_col = column![].spacing(4);
         let all_active = self.state.browser.root_filter.is_none();
         let mut all_btn = button(text("All Roots").size(11).color(if all_active {
-            th::ACCENT
+            th::accent()
         } else {
-            th::TEXT_DIM
+            th::text_dim()
         }))
         .padding([4, 8])
         .style(move |_theme: &Theme, status| {
             let bg = if all_active {
-                Some(th::ACCENT_DIM.into())
+                Some(th::accent_dim().into())
             } else {
                 match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_ELEVATED.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_elevated().into()),
                 }
             };
             button::Style {
                 background: bg,
-                text_color: if all_active { th::ACCENT } else { th::TEXT_DIM },
+                text_color: if all_active {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                },
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -210,28 +220,28 @@ impl App {
                 .as_ref()
                 .is_some_and(|selected| selected == root);
             let mut filter_btn = button(text(root_label(root)).size(11).color(if active {
-                th::ACCENT
+                th::accent()
             } else {
-                th::TEXT
+                th::text()
             }))
             .padding([4, 8])
             .width(Length::Fill)
             .style(move |_theme: &Theme, status| {
                 let bg = if active {
-                    Some(th::ACCENT_DIM.into())
+                    Some(th::accent_dim().into())
                 } else {
                     match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     }
                 };
                 button::Style {
                     background: bg,
-                    text_color: if active { th::ACCENT } else { th::TEXT },
+                    text_color: if active { th::accent() } else { th::text() },
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -242,7 +252,7 @@ impl App {
                 BrowserMsg::SelectSampleBrowserRoot(Some(root.clone())),
             ));
 
-            let remove_btn = button(icons::icon(icons::X).size(10).color(th::DANGER))
+            let remove_btn = button(icons::icon(icons::X).size(10).color(th::danger()))
                 .on_press(Message::Browser(BrowserMsg::RemoveSampleLibraryRoot(
                     root.clone(),
                 )))
@@ -250,13 +260,13 @@ impl App {
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::DANGER,
+                        text_color: th::danger(),
                         border: iced::Border::default(),
                         ..Default::default()
                     }
@@ -304,13 +314,13 @@ impl App {
             let entry_body = container(
                 column![
                     text(entry.name.as_str()).size(12).color(if selected {
-                        th::ACCENT
+                        th::accent()
                     } else {
-                        th::TEXT
+                        th::text()
                     }),
                     text(entry.relative_path.display().to_string())
                         .size(10)
-                        .color(th::TEXT_DIM)
+                        .color(th::text_dim())
                 ]
                 .spacing(2)
                 .width(Length::Fill),
@@ -320,14 +330,14 @@ impl App {
             .style(move |_theme: &Theme| container::Style {
                 background: Some(
                     if selected {
-                        th::ACCENT_DIM
+                        th::accent_dim()
                     } else {
-                        th::BG_ELEVATED
+                        th::bg_elevated()
                     }
                     .into(),
                 ),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -340,21 +350,21 @@ impl App {
                 }))
                 .on_release(Message::ClickLocalBrowserEntry(entry.source.clone()))
                 .into();
-            let preview_btn = button(icons::icon(icons::VOLUME_2).size(12).color(th::TEXT_DIM))
+            let preview_btn = button(icons::icon(icons::VOLUME_2).size(12).color(th::text_dim()))
                 .on_press(Message::PreviewLocalEntry(entry.source.clone()))
                 .padding([6, 8])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::ACCENT,
+                        text_color: th::accent(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -373,7 +383,7 @@ impl App {
                 container(
                     text("No samples match the current filters")
                         .size(11)
-                        .color(th::TEXT_DIM),
+                        .color(th::text_dim()),
                 )
                 .padding([8, 4]),
             );
@@ -390,7 +400,7 @@ impl App {
             }
         ))
         .size(10)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
 
         let selected_text = selected_entry
             .map(|entry| entry.relative_path.display().to_string())
@@ -412,18 +422,20 @@ impl App {
             _ => "No sampler or drum rack selected".to_string(),
         };
 
-        let mut add_clip_btn = button(text("Add Clip").size(11).color(th::TEXT))
+        let mut add_clip_btn = button(text("Add Clip").size(11).color(th::text()))
             .padding([6, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_ELEVATED.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_elevated().into()),
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -434,18 +446,20 @@ impl App {
             add_clip_btn = add_clip_btn.on_press(Message::ImportSelectedBrowserSampleToArrangement);
         }
 
-        let mut load_device_btn = button(text("Load Device").size(11).color(th::TEXT))
+        let mut load_device_btn = button(text("Load Device").size(11).color(th::text()))
             .padding([6, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_ELEVATED.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_elevated().into()),
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -457,8 +471,8 @@ impl App {
         }
 
         let footer = column![
-            text(selected_text).size(11).color(th::TEXT),
-            text(selected_hint).size(10).color(th::TEXT_DIM),
+            text(selected_text).size(11).color(th::text()),
+            text(selected_hint).size(10).color(th::text_dim()),
             row![add_clip_btn, load_device_btn]
                 .spacing(6)
                 .align_y(iced::Alignment::Center)
@@ -482,7 +496,7 @@ impl App {
     }
 
     pub(super) fn view_dropbox_browser(&self) -> Element<'_, Message> {
-        let title = text("Dropbox").size(14).color(th::ACCENT);
+        let title = text("Dropbox").size(14).color(th::accent());
 
         if !self.state.browser.dropbox.connected {
             let hint = if self.state.browser.dropbox.auth_in_progress {
@@ -490,7 +504,7 @@ impl App {
             } else {
                 "Connect in Settings > Dropbox to browse your library."
             };
-            return column![title, text(hint).size(12).color(th::TEXT_DIM)]
+            return column![title, text(hint).size(12).color(th::text_dim())]
                 .spacing(10)
                 .padding(10)
                 .height(Length::Fill)
@@ -504,7 +518,7 @@ impl App {
             .account_email
             .clone()
             .unwrap_or_default();
-        let header = column![title, text(account).size(11).color(th::TEXT_DIM),].spacing(2);
+        let header = column![title, text(account).size(11).color(th::text_dim()),].spacing(2);
 
         let mut rows: Vec<Element<'_, Message>> = Vec::new();
         self.render_dropbox_tree(String::new(), 0, &mut rows);
@@ -514,7 +528,7 @@ impl App {
             } else {
                 "Empty (or still fetching)."
             };
-            rows.push(text(msg).size(11).color(th::TEXT_DIM).into());
+            rows.push(text(msg).size(11).color(th::text_dim()).into());
         }
         let mut entries_col = column![].spacing(2);
         for row in rows {
@@ -531,20 +545,20 @@ impl App {
         // no dedicated button here.
 
         let add_clip_btn: Element<'_, Message> = {
-            let mut btn = button(text("Add Clip").size(11).color(th::TEXT))
+            let mut btn = button(text("Add Clip").size(11).color(th::text()))
                 .padding([6, 10])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT,
+                        text_color: th::text(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -558,20 +572,20 @@ impl App {
         };
 
         let load_device_btn: Element<'_, Message> = {
-            let mut btn = button(text("Load Device").size(11).color(th::TEXT))
+            let mut btn = button(text("Load Device").size(11).color(th::text()))
                 .padding([6, 10])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT,
+                        text_color: th::text(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -589,13 +603,13 @@ impl App {
 
         let error_line: Element<'_, Message> =
             if let Some(err) = self.state.browser.dropbox.last_error.clone() {
-                text(err).size(10).color(th::DANGER).into()
+                text(err).size(10).color(th::danger()).into()
             } else {
                 horizontal_space().width(Length::Shrink).into()
             };
 
         let footer = column![
-            text(selected_label).size(11).color(th::TEXT),
+            text(selected_label).size(11).color(th::text()),
             row![add_clip_btn, load_device_btn].spacing(6),
             error_line,
         ]
@@ -663,16 +677,16 @@ impl App {
                 // Audio rows use a container + mouse_area so press events
                 // reach us (iced Button captures ButtonPressed, which would
                 // hide the drag from mouse_area).
-                let text_color = if selected { th::ACCENT } else { th::TEXT };
+                let text_color = if selected { th::accent() } else { th::text() };
                 let row_body = container(text(label).size(11).color(text_color))
                     .padding([3, 6])
                     .width(Length::Fill)
                     .style(move |_theme: &Theme| container::Style {
                         background: Some(
                             if selected {
-                                th::ACCENT_DIM
+                                th::accent_dim()
                             } else {
-                                th::BG_ELEVATED
+                                th::bg_elevated()
                             }
                             .into(),
                         ),
@@ -691,19 +705,19 @@ impl App {
                     }))
                     .on_release(msg)
                     .into();
-                let speaker = button(icons::icon(icons::VOLUME_2).size(11).color(th::ACCENT))
+                let speaker = button(icons::icon(icons::VOLUME_2).size(11).color(th::accent()))
                     .on_press(Message::DropboxPreview(entry.clone()))
                     .padding([3, 6])
                     .style(|_theme: &Theme, status| {
                         let bg = match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::BG_HOVER.into())
+                                Some(th::bg_hover().into())
                             }
                             _ => None,
                         };
                         button::Style {
                             background: bg,
-                            text_color: th::ACCENT,
+                            text_color: th::accent(),
                             border: iced::Border::default(),
                             ..Default::default()
                         }
@@ -718,29 +732,29 @@ impl App {
                 // Folders + non-audio entries keep the button path since they
                 // don't participate in drag.
                 let btn = button(text(label).size(11).color(if selected {
-                    th::ACCENT
+                    th::accent()
                 } else if entry.is_folder {
-                    th::TEXT
+                    th::text()
                 } else {
-                    th::TEXT_DIM
+                    th::text_dim()
                 }))
                 .on_press(msg)
                 .padding([3, 6])
                 .width(Length::Fill)
                 .style(move |_theme: &Theme, status| {
                     let bg = if selected {
-                        Some(th::ACCENT_DIM.into())
+                        Some(th::accent_dim().into())
                     } else {
                         match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::BG_HOVER.into())
+                                Some(th::bg_hover().into())
                             }
-                            _ => Some(th::BG_ELEVATED.into()),
+                            _ => Some(th::bg_elevated().into()),
                         }
                     };
                     button::Style {
                         background: bg,
-                        text_color: if selected { th::ACCENT } else { th::TEXT },
+                        text_color: if selected { th::accent() } else { th::text() },
                         border: iced::Border::default(),
                         ..Default::default()
                     }

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -38,11 +38,11 @@ impl App {
             let clip_tab = {
                 let active = self.state.view.detail_panel_tab == DetailPanelTab::Clip;
                 let (bg, text_color, border_color) = if active {
-                    (th::BG_ELEVATED, th::ACCENT, th::ACCENT_DIM)
+                    (th::bg_elevated(), th::accent(), th::accent_dim())
                 } else {
                     (
                         iced::Color::TRANSPARENT,
-                        th::TEXT_DIM,
+                        th::text_dim(),
                         iced::Color::TRANSPARENT,
                     )
                 };
@@ -65,11 +65,11 @@ impl App {
             let devices_tab = {
                 let active = self.state.view.detail_panel_tab == DetailPanelTab::Devices;
                 let (bg, text_color, border_color) = if active {
-                    (th::BG_ELEVATED, th::ACCENT, th::ACCENT_DIM)
+                    (th::bg_elevated(), th::accent(), th::accent_dim())
                 } else {
                     (
                         iced::Color::TRANSPARENT,
-                        th::TEXT_DIM,
+                        th::text_dim(),
                         iced::Color::TRANSPARENT,
                     )
                 };
@@ -139,7 +139,7 @@ impl App {
         } else {
             let label = text("Select a track to view devices")
                 .size(14)
-                .color(th::TEXT_DIM);
+                .color(th::text_dim());
             center(label)
                 .width(Length::Fill)
                 .height(Length::Fill)
@@ -160,9 +160,9 @@ impl App {
             .width(Length::Fill)
             .height(panel_height)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_DARK.into()),
+                background: Some(th::bg_dark().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 0.0.into(),
                 },
@@ -174,7 +174,7 @@ impl App {
     pub(super) fn view_clip_placeholder(&self) -> Element<'_, Message> {
         let label = text("Select a clip to view details")
             .size(14)
-            .color(th::TEXT_DIM);
+            .color(th::text_dim());
         center(label)
             .width(Length::Fill)
             .height(Length::Fill)
@@ -251,16 +251,20 @@ impl App {
         let mut content_col = column![].spacing(2).padding(4);
 
         if let Some((ref clip_name_str, clip_pos, clip_dur, clip_loop, tid, cid)) = clip_data {
-            let clip_name = text(clip_name_str.clone()).size(11).color(th::TEXT);
+            let clip_name = text(clip_name_str.clone()).size(11).color(th::text());
             let pos_label = text(format!("Pos: {clip_pos:.1}"))
                 .size(10)
-                .color(th::TEXT_DIM);
+                .color(th::text_dim());
             let dur_label = text(format!("Dur: {clip_dur:.1}"))
                 .size(10)
-                .color(th::TEXT_DIM);
+                .color(th::text_dim());
 
             // Loop toggle
-            let loop_icon_color = if clip_loop { th::ACCENT } else { th::TEXT_DIM };
+            let loop_icon_color = if clip_loop {
+                th::accent()
+            } else {
+                th::text_dim()
+            };
             let loop_btn = button(icons::icon(icons::REPEAT).size(10).color(loop_icon_color))
                 .on_press(Message::PianoRoll(PianoRollMsg::ToggleNoteClipLoop(
                     tid, cid,
@@ -268,16 +272,16 @@ impl App {
                 .padding([2, 4])
                 .style(move |_theme: &Theme, _status| button::Style {
                     background: if clip_loop {
-                        Some(th::ACCENT_DIM.into())
+                        Some(th::accent_dim().into())
                     } else {
-                        Some(th::BG_ELEVATED.into())
+                        Some(th::bg_elevated().into())
                     },
                     text_color: loop_icon_color,
                     border: iced::Border {
                         color: if clip_loop {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 3.0.into(),
@@ -287,10 +291,10 @@ impl App {
 
             // Clip operation buttons
             let op_btn_style = |_theme: &Theme, _status| button::Style {
-                background: Some(th::BG_ELEVATED.into()),
-                text_color: th::TEXT_DIM,
+                background: Some(th::bg_elevated().into()),
+                text_color: th::text_dim(),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 3.0.into(),
                 },
@@ -299,8 +303,8 @@ impl App {
 
             let dup_btn = button(
                 row![
-                    icons::icon(icons::COPY).size(10).color(th::TEXT_DIM),
-                    text("Dup").size(10).color(th::TEXT_DIM)
+                    icons::icon(icons::COPY).size(10).color(th::text_dim()),
+                    text("Dup").size(10).color(th::text_dim())
                 ]
                 .spacing(2)
                 .align_y(iced::Alignment::Center),
@@ -309,20 +313,20 @@ impl App {
             .padding([2, 6])
             .style(op_btn_style);
 
-            let double_btn = button(text("2x").size(10).color(th::TEXT_DIM))
+            let double_btn = button(text("2x").size(10).color(th::text_dim()))
                 .on_press(Message::PianoRoll(PianoRollMsg::DoubleNoteClip(tid, cid)))
                 .padding([2, 6])
                 .style(op_btn_style);
 
-            let halve_btn = button(text("\u{00BD}x").size(10).color(th::TEXT_DIM))
+            let halve_btn = button(text("\u{00BD}x").size(10).color(th::text_dim()))
                 .on_press(Message::PianoRoll(PianoRollMsg::HalveNoteClip(tid, cid)))
                 .padding([2, 6])
                 .style(op_btn_style);
 
             let crop_btn = button(
                 row![
-                    icons::icon(icons::SCISSORS).size(10).color(th::TEXT_DIM),
-                    text("Crop").size(10).color(th::TEXT_DIM)
+                    icons::icon(icons::SCISSORS).size(10).color(th::text_dim()),
+                    text("Crop").size(10).color(th::text_dim())
                 ]
                 .spacing(2)
                 .align_y(iced::Alignment::Center),
@@ -342,7 +346,7 @@ impl App {
         }
 
         // ── Header row: label, edit mode toggle, snap grid ──
-        let label = text("Piano Roll").size(11).color(th::TEXT_DIM);
+        let label = text("Piano Roll").size(11).color(th::text_dim());
 
         // Edit mode toggle: Select / Draw
         let select_active = self.state.piano_roll.edit_mode == PianoRollEditMode::Select;
@@ -350,9 +354,9 @@ impl App {
 
         let select_btn = {
             let (bg, tc) = if select_active {
-                (th::ACCENT_DIM, th::ACCENT)
+                (th::accent_dim(), th::accent())
             } else {
-                (th::BG_ELEVATED, th::TEXT_DIM)
+                (th::bg_elevated(), th::text_dim())
             };
             button(icons::icon(icons::MOUSE_POINTER).size(10).color(tc))
                 .on_press(Message::PianoRoll(PianoRollMsg::ToggleEditMode))
@@ -362,9 +366,9 @@ impl App {
                     text_color: tc,
                     border: iced::Border {
                         color: if select_active {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 3.0.into(),
@@ -375,9 +379,9 @@ impl App {
 
         let draw_btn = {
             let (bg, tc) = if draw_active {
-                (th::ACCENT_DIM, th::ACCENT)
+                (th::accent_dim(), th::accent())
             } else {
-                (th::BG_ELEVATED, th::TEXT_DIM)
+                (th::bg_elevated(), th::text_dim())
             };
             button(icons::icon(icons::PENCIL).size(10).color(tc))
                 .on_press(Message::PianoRoll(PianoRollMsg::ToggleEditMode))
@@ -387,9 +391,9 @@ impl App {
                     text_color: tc,
                     border: iced::Border {
                         color: if draw_active {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 3.0.into(),
@@ -406,9 +410,9 @@ impl App {
         for &grid in SnapGrid::all() {
             let is_active = self.state.view.snap_grid == grid;
             let (bg, text_color) = if is_active {
-                (th::ACCENT_DIM, th::ACCENT)
+                (th::accent_dim(), th::accent())
             } else {
-                (th::BG_ELEVATED, th::TEXT_DIM)
+                (th::bg_elevated(), th::text_dim())
             };
             let btn = button(text(grid.label()).size(10).color(text_color))
                 .on_press(Message::View(ViewMsg::SetSnapGrid(grid)))
@@ -418,9 +422,9 @@ impl App {
                     text_color,
                     border: iced::Border {
                         color: if is_active {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 3.0.into(),
@@ -429,7 +433,7 @@ impl App {
                 });
             snap_row = snap_row.push(btn);
         }
-        let snap_label = text("Snap:").size(10).color(th::TEXT_DIM);
+        let snap_label = text("Snap:").size(10).color(th::text_dim());
         let header_row = row![label, mode_row, horizontal_space(), snap_label, snap_row]
             .spacing(4)
             .align_y(iced::Alignment::Center);
@@ -440,9 +444,9 @@ impl App {
             .width(Length::FillPortion(1))
             .height(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_DARK.into()),
+                background: Some(th::bg_dark().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 0.0.into(),
                 },
@@ -485,14 +489,14 @@ impl App {
             .height(Length::Fill)
             .into();
 
-        let label = text("Waveform").size(11).color(th::TEXT_DIM);
+        let label = text("Waveform").size(11).color(th::text_dim());
         let clip_info = text(format!(
             "{}: {:.1}s",
             clip.name,
             clip.duration as f64 / self.state.transport.sample_rate as f64
         ))
         .size(10)
-        .color(th::TEXT_MUTED);
+        .color(th::text_muted());
 
         let header_row = row![label, horizontal_space(), clip_info]
             .spacing(4)
@@ -509,9 +513,9 @@ impl App {
             .width(Length::FillPortion(1))
             .height(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_DARK.into()),
+                background: Some(th::bg_dark().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 0.0.into(),
                 },
@@ -526,7 +530,7 @@ impl App {
         clip: &UiClip,
     ) -> Element<'_, Message> {
         let clip_id = clip.id;
-        let label = text("Warp").size(11).color(th::TEXT_DIM);
+        let label = text("Warp").size(11).color(th::text_dim());
 
         let default_text = clip
             .original_bpm
@@ -557,14 +561,14 @@ impl App {
 
         let button_style = |_theme: &Theme, status: button::Status| {
             let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                _ => Some(th::BG_ELEVATED.into()),
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
+                _ => Some(th::bg_elevated().into()),
             };
             button::Style {
                 background: bg,
-                text_color: th::TEXT,
+                text_color: th::text(),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -572,7 +576,7 @@ impl App {
             }
         };
 
-        let detect_btn = button(text("Detect").size(11).color(th::TEXT))
+        let detect_btn = button(text("Detect").size(11).color(th::text()))
             .on_press(Message::DetectClipBpm { track_id, clip_id })
             .padding([4, 10])
             .style(button_style);
@@ -580,7 +584,7 @@ impl App {
         let warp_btn = button(
             text(format!("Warp → {:.0} BPM", self.state.transport.bpm))
                 .size(11)
-                .color(th::TEXT),
+                .color(th::text()),
         )
         .on_press(Message::WarpClipToProject { track_id, clip_id })
         .padding([4, 10])
@@ -591,7 +595,7 @@ impl App {
             .align_y(iced::Alignment::Center);
 
         if clip.warped {
-            let clear_btn = button(text("Clear warp").size(11).color(th::TEXT_DIM))
+            let clear_btn = button(text("Clear warp").size(11).color(th::text_dim()))
                 .on_press(Message::Arrangement(ArrangementMsg::ClearClipWarp {
                     track_id,
                     clip_id,
@@ -606,7 +610,7 @@ impl App {
                     row_widgets = row_widgets.push(
                         text(format!("(was {:.0})", warped_to))
                             .size(10)
-                            .color(th::METER_YELLOW),
+                            .color(th::meter_yellow()),
                     );
                 }
             }
@@ -622,7 +626,7 @@ impl App {
                         self.state.transport.bpm
                     ))
                     .size(10)
-                    .color(th::METER_YELLOW),
+                    .color(th::meter_yellow()),
                 );
             }
         }
@@ -635,9 +639,9 @@ impl App {
         track_id: TrackId,
         clip_id: ClipId,
     ) -> Element<'_, Message> {
-        let label = text("Quantize").size(11).color(th::TEXT_DIM);
+        let label = text("Quantize").size(11).color(th::text_dim());
         let grid_btn = |grid: crate::state::SnapGrid| -> Element<'_, Message> {
-            button(text(grid.label()).size(11).color(th::TEXT))
+            button(text(grid.label()).size(11).color(th::text()))
                 .on_press(Message::QuantizeAudioClipAt {
                     track_id,
                     clip_id,
@@ -647,15 +651,15 @@ impl App {
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT,
+                        text_color: th::text(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -68,7 +68,14 @@ impl App {
 
         // Effect cards
         for effect in &track.effects {
-            let slot = view_effect_slot(track_id, effect, track_color);
+            let custom = if effect.effect_type == vibez_core::effect::EffectType::Eq
+                && effect.plugin_ref.is_none()
+            {
+                Some(self.eq_device_body(track_id, effect))
+            } else {
+                None
+            };
+            let slot = view_effect_slot(track_id, effect, track_color, custom);
             devices_row = devices_row.push(slot);
         }
 
@@ -97,6 +104,142 @@ impl App {
                 },
             ))
             .into()
+    }
+
+    /// Channel EQ card body: response display over the live analyser
+    /// on the left, four color-coded band columns on the right. The
+    /// analyser follows the selected track, which is exactly the
+    /// track whose device chain is on screen.
+    fn eq_device_body<'a>(
+        &'a self,
+        track_id: TrackId,
+        effect: &'a crate::state::UiEffect,
+    ) -> (Element<'a, Message>, f32) {
+        use crate::widgets::effect_knob::{format_value, EffectKnobWidget};
+        use crate::widgets::eq_display::EqDisplayWidget;
+
+        const DISPLAY_W: f32 = 380.0;
+        const BAND_COL_W: f32 = 50.0;
+
+        let display = EqDisplayWidget {
+            track_id,
+            effect_id: effect.id,
+            params: effect.params.clone(),
+            descriptors: effect.descriptors,
+            bypass: effect.bypass,
+            sample_rate: self.state.transport.sample_rate as f32,
+            spectrum: self.state.spectrum.bins.clone(),
+            spectrum_active: self.state.spectrum.active,
+        };
+        let display_canvas: Element<'a, Message> = canvas(display)
+            .width(Length::Fixed(DISPLAY_W))
+            .height(Length::Fill)
+            .into();
+
+        // Band columns, left to right along the frequency axis:
+        // (label, gain idx, freq idx, third idx, bell?, color)
+        let bands: [(&str, usize, usize, usize, bool, Color); 4] = [
+            ("LF", 0, 1, 2, true, th::EQ_LF),
+            ("LMF", 3, 4, 5, false, th::EQ_LMF),
+            ("HMF", 6, 7, 8, false, th::EQ_HMF),
+            ("HF", 9, 10, 11, true, th::EQ_HF),
+        ];
+
+        let knob_color = if effect.bypass {
+            th::TEXT_MUTED
+        } else {
+            th::TEXT_DIM
+        };
+        let mut band_row = row![].spacing(4);
+        for (label, gain_i, freq_i, third_i, is_bell, color) in bands {
+            let band_color = if effect.bypass { knob_color } else { color };
+            let knob = |i: usize, size: f32| -> Element<'a, Message> {
+                let d = &effect.descriptors[i];
+                let w = EffectKnobWidget::new(
+                    track_id,
+                    effect.id,
+                    i,
+                    effect.params.get(i).copied().unwrap_or(d.default),
+                    d.min,
+                    d.max,
+                    d.default,
+                    band_color,
+                );
+                canvas(w)
+                    .width(Length::Fixed(size))
+                    .height(Length::Fixed(size))
+                    .into()
+            };
+            let gain_v = effect.params.get(gain_i).copied().unwrap_or(0.0);
+            let freq_v = effect.params.get(freq_i).copied().unwrap_or(0.0);
+
+            let mut col = column![
+                text(label).size(9).color(band_color),
+                knob(gain_i, 28.0),
+                text(format!("{gain_v:+.1}")).size(8).color(th::TEXT_DIM),
+                knob(freq_i, 24.0),
+                text(format_value(freq_v, "Hz")).size(8).color(th::TEXT_DIM),
+            ]
+            .spacing(2)
+            .width(Length::Fixed(BAND_COL_W))
+            .align_x(iced::Alignment::Center);
+
+            if is_bell {
+                let bell_on = effect.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
+                let bell = button(text("BELL").size(6).color(if bell_on {
+                    th::BG_DARK
+                } else {
+                    th::TEXT_DIM
+                }))
+                .on_press(Message::set_effect_param(
+                    track_id,
+                    effect.id,
+                    third_i,
+                    if bell_on { 0.0 } else { 1.0 },
+                ))
+                .padding([3, 6])
+                .style(move |_theme: &Theme, _status| button::Style {
+                    background: Some(if bell_on {
+                        band_color.into()
+                    } else {
+                        th::BG_ELEVATED.into()
+                    }),
+                    text_color: if bell_on { th::BG_DARK } else { th::TEXT_DIM },
+                    border: iced::Border {
+                        color: th::BORDER,
+                        width: 1.0,
+                        radius: 2.0.into(),
+                    },
+                    ..Default::default()
+                });
+                col = col.push(bell);
+            } else {
+                let q_v = effect.params.get(third_i).copied().unwrap_or(0.7);
+                col = col.push(
+                    row![
+                        text("Q").size(8).color(th::TEXT_DIM),
+                        knob(third_i, 20.0),
+                        text(format!("{q_v:.2}")).size(8).color(th::TEXT_DIM),
+                    ]
+                    .spacing(2)
+                    .align_y(iced::Alignment::Center),
+                );
+            }
+            band_row = band_row.push(col);
+        }
+
+        let body: Element<'a, Message> = row![
+            display_canvas,
+            Self::device_divider(),
+            container(band_row).padding([0, 2]),
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center)
+        .into();
+
+        // padding (20) + display + divider + bands + spacing
+        let card_w = DISPLAY_W + 4.0 * (BAND_COL_W + 4.0) + 48.0;
+        (body, card_w)
     }
 
     // ── Shared device card helpers ──────────────────────────────────

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -28,9 +28,9 @@ impl App {
         // Header: track name + right-click hint
         let track_label = text(format!("{} — Devices", track.name))
             .size(13)
-            .color(th::TEXT);
+            .color(th::text());
 
-        let hint_label = text("Right-click to add").size(10).color(th::TEXT_MUTED);
+        let hint_label = text("Right-click to add").size(10).color(th::text_muted());
 
         let header = row![track_label, horizontal_space(), hint_label]
             .spacing(8)
@@ -139,16 +139,16 @@ impl App {
         // Band columns, left to right along the frequency axis:
         // (label, gain idx, freq idx, third idx, bell?, color)
         let bands: [(&str, usize, usize, usize, bool, Color); 4] = [
-            ("LF", 0, 1, 2, true, th::EQ_LF),
-            ("LMF", 3, 4, 5, false, th::EQ_LMF),
-            ("HMF", 6, 7, 8, false, th::EQ_HMF),
-            ("HF", 9, 10, 11, true, th::EQ_HF),
+            ("LF", 0, 1, 2, true, th::eq_lf()),
+            ("LMF", 3, 4, 5, false, th::eq_lmf()),
+            ("HMF", 6, 7, 8, false, th::eq_hmf()),
+            ("HF", 9, 10, 11, true, th::eq_hf()),
         ];
 
         let knob_color = if effect.bypass {
-            th::TEXT_MUTED
+            th::text_muted()
         } else {
-            th::TEXT_DIM
+            th::text_dim()
         };
         let mut band_row = row![].spacing(4);
         for (label, gain_i, freq_i, third_i, is_bell, color) in bands {
@@ -176,9 +176,11 @@ impl App {
             let mut col = column![
                 text(label).size(9).color(band_color),
                 knob(gain_i, 28.0),
-                text(format!("{gain_v:+.1}")).size(8).color(th::TEXT_DIM),
+                text(format!("{gain_v:+.1}")).size(8).color(th::text_dim()),
                 knob(freq_i, 24.0),
-                text(format_value(freq_v, "Hz")).size(8).color(th::TEXT_DIM),
+                text(format_value(freq_v, "Hz"))
+                    .size(8)
+                    .color(th::text_dim()),
             ]
             .spacing(2)
             .width(Length::Fixed(BAND_COL_W))
@@ -187,9 +189,9 @@ impl App {
             if is_bell {
                 let bell_on = effect.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
                 let bell = button(text("BELL").size(6).color(if bell_on {
-                    th::BG_DARK
+                    th::bg_dark()
                 } else {
-                    th::TEXT_DIM
+                    th::text_dim()
                 }))
                 .on_press(Message::set_effect_param(
                     track_id,
@@ -202,11 +204,15 @@ impl App {
                     background: Some(if bell_on {
                         band_color.into()
                     } else {
-                        th::BG_ELEVATED.into()
+                        th::bg_elevated().into()
                     }),
-                    text_color: if bell_on { th::BG_DARK } else { th::TEXT_DIM },
+                    text_color: if bell_on {
+                        th::bg_dark()
+                    } else {
+                        th::text_dim()
+                    },
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 2.0.into(),
                     },
@@ -217,9 +223,9 @@ impl App {
                 let q_v = effect.params.get(third_i).copied().unwrap_or(0.7);
                 col = col.push(
                     row![
-                        text("Q").size(8).color(th::TEXT_DIM),
+                        text("Q").size(8).color(th::text_dim()),
                         knob(third_i, 20.0),
-                        text(format!("{q_v:.2}")).size(8).color(th::TEXT_DIM),
+                        text(format!("{q_v:.2}")).size(8).color(th::text_dim()),
                     ]
                     .spacing(2)
                     .align_y(iced::Alignment::Center),
@@ -252,7 +258,7 @@ impl App {
             .padding([4, 6])
             .width(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 ..Default::default()
             })
     }
@@ -264,11 +270,11 @@ impl App {
         remove: Option<Message>,
     ) -> iced::widget::Row<'_, Message> {
         let dot = text("\u{25CF}").size(8).color(track_color);
-        let name = text(name.to_string()).size(11).color(th::TEXT);
+        let name = text(name.to_string()).size(11).color(th::text());
         let mut r = row![dot, name].spacing(5).align_y(iced::Alignment::Center);
         if let Some(msg) = remove {
             let remove_btn: Element<'_, Message> =
-                Self::device_icon_btn(icons::X, th::TEXT_DIM, th::DANGER, msg).into();
+                Self::device_icon_btn(icons::X, th::text_dim(), th::danger(), msg).into();
             r = r.push(horizontal_space().width(Length::Fixed(12.0)));
             r = r.push(remove_btn);
         }
@@ -281,7 +287,7 @@ impl App {
         label: &'static str,
         content: Element<'a, Message>,
     ) -> Element<'a, Message> {
-        column![text(label).size(8).color(th::TEXT_MUTED), content]
+        column![text(label).size(8).color(th::text_muted()), content]
             .spacing(6)
             .align_x(iced::Alignment::Start)
             .into()
@@ -293,7 +299,7 @@ impl App {
             .width(Length::Fixed(1.0))
             .height(Length::Fixed(th::DEVICE_BODY_H - 12.0))
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::DIVIDER.into()),
+                background: Some(th::divider().into()),
                 ..Default::default()
             })
             .into()
@@ -312,9 +318,9 @@ impl App {
     pub(super) fn device_card(content: iced::widget::Column<'_, Message>) -> Element<'_, Message> {
         container(content)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_ELEVATED.into()),
+                background: Some(th::bg_elevated().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -335,8 +341,8 @@ impl App {
             .padding([3, 5])
             .style(move |_theme: &Theme, status| {
                 let (bg, tc) = match status {
-                    button::Status::Hovered => (Some(th::BG_HOVER.into()), hover_color),
-                    button::Status::Pressed => (Some(th::BG_DARK.into()), hover_color),
+                    button::Status::Hovered => (Some(th::bg_hover().into()), hover_color),
+                    button::Status::Pressed => (Some(th::bg_dark().into()), hover_color),
                     _ => (None, color),
                 };
                 button::Style {
@@ -362,26 +368,26 @@ impl App {
         let plugin_name = track.plugin_instrument_name.as_deref().unwrap_or("Plugin");
 
         let name_section =
-            container(text(plugin_name).size(11).color(th::TEXT)).width(Length::Fill);
+            container(text(plugin_name).size(11).color(th::text())).width(Length::Fill);
 
         // Edit button for plugins with a native GUI
         let edit_btn: Option<iced::widget::Button<'_, Message>> = if track.has_plugin_instrument_gui
         {
             let gui_key = PluginGuiKey::Instrument { track_id };
             Some(
-                button(text("Edit").size(9).color(th::TEXT_DIM))
+                button(text("Edit").size(9).color(th::text_dim()))
                     .on_press(Message::OpenPluginGui(gui_key))
                     .padding([2, 5])
                     .style(|_theme: &Theme, status| {
                         let (bg, tc) = match status {
-                            button::Status::Hovered => (Some(th::BG_HOVER.into()), th::ACCENT),
-                            _ => (None, th::TEXT_DIM),
+                            button::Status::Hovered => (Some(th::bg_hover().into()), th::accent()),
+                            _ => (None, th::text_dim()),
                         };
                         button::Style {
                             background: bg,
                             text_color: tc,
                             border: iced::Border {
-                                color: th::BORDER,
+                                color: th::border(),
                                 width: 1.0,
                                 radius: 3.0.into(),
                             },
@@ -395,8 +401,8 @@ impl App {
 
         let remove: Element<'a, Message> = Self::device_icon_btn(
             icons::X,
-            th::TEXT_DIM,
-            th::DANGER,
+            th::text_dim(),
+            th::danger(),
             Message::remove_track_instrument(track_id),
         )
         .into();
@@ -461,15 +467,23 @@ impl App {
                     .size(9)
                     .width(Length::Fixed(30.0))
                     .align_x(iced::Alignment::Center)
-                    .color(if active { th::BG_DARK } else { th::TEXT_DIM }),
+                    .color(if active {
+                        th::bg_dark()
+                    } else {
+                        th::text_dim()
+                    }),
             )
             .on_press(Message::set_instrument_param(track_id, 0, i as f32))
             .padding([3, 4])
             .style(move |_theme: &Theme, _status| button::Style {
-                background: Some(if active { th::ACCENT } else { th::BG_DARK }.into()),
-                text_color: if active { th::BG_DARK } else { th::TEXT_DIM },
+                background: Some(if active { th::accent() } else { th::bg_dark() }.into()),
+                text_color: if active {
+                    th::bg_dark()
+                } else {
+                    th::text_dim()
+                },
                 border: iced::Border {
-                    color: if active { th::ACCENT } else { th::BORDER },
+                    color: if active { th::accent() } else { th::border() },
                     width: 1.0,
                     radius: 3.0.into(),
                 },
@@ -583,26 +597,26 @@ impl App {
                 } else {
                     name.clone()
                 };
-                text(display).size(10).color(th::TEXT)
+                text(display).size(10).color(th::text())
             }
-            None => text("No Sample").size(10).color(th::TEXT_MUTED),
+            None => text("No Sample").size(10).color(th::text_muted()),
         };
-        let load_btn = button(text("Load").size(9).color(th::TEXT))
+        let load_btn = button(text("Load").size(9).color(th::text()))
             .on_press(Message::LoadSamplerSample(track_id))
             .padding([2, 8])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered => th::BG_HOVER,
-                    _ => th::BG_DARK,
+                    button::Status::Hovered => th::bg_hover(),
+                    _ => th::bg_dark(),
                 };
                 button::Style {
                     background: Some(bg.into()),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 3.0.into(),
                     },
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     ..Default::default()
                 }
             });
@@ -716,10 +730,10 @@ impl App {
                     column![
                         text(format!("{:02}  {pad_note}", pad_index + 1))
                             .size(9)
-                            .color(if active { th::ACCENT } else { th::TEXT_DIM }),
+                            .color(if active { th::accent() } else { th::text_dim() }),
                         text(label)
                             .size(8)
-                            .color(if active { th::ACCENT } else { th::TEXT })
+                            .color(if active { th::accent() } else { th::text() })
                     ]
                     .spacing(2)
                     .align_x(iced::Alignment::Center),
@@ -728,10 +742,21 @@ impl App {
                 .width(Length::Fixed(52.0))
                 .height(Length::Fixed(30.0))
                 .style(move |_theme: &Theme| container::Style {
-                    background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
-                    text_color: Some(if active { th::ACCENT } else { th::TEXT }),
+                    background: Some(
+                        if active {
+                            th::accent_dim()
+                        } else {
+                            th::bg_dark()
+                        }
+                        .into(),
+                    ),
+                    text_color: Some(if active { th::accent() } else { th::text() }),
                     border: iced::Border {
-                        color: if active { th::ACCENT_DIM } else { th::BORDER },
+                        color: if active {
+                            th::accent_dim()
+                        } else {
+                            th::border()
+                        },
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -761,42 +786,44 @@ impl App {
             .unwrap_or_else(|| "Use the browser or Load".to_string());
         let selected_pad_state = &track.drum_rack_pads[selected_pad];
 
-        let load_btn = button(text("Load").size(9).color(th::TEXT))
+        let load_btn = button(text("Load").size(9).color(th::text()))
             .on_press(Message::LoadDrumRackPadSample(track_id, selected_pad))
             .padding([2, 8])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered => th::BG_HOVER,
-                    _ => th::BG_DARK,
+                    button::Status::Hovered => th::bg_hover(),
+                    _ => th::bg_dark(),
                 };
                 button::Style {
                     background: Some(bg.into()),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 3.0.into(),
                     },
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     ..Default::default()
                 }
             });
 
-        let clear_btn = button(text("Clear").size(9).color(th::TEXT_DIM))
+        let clear_btn = button(text("Clear").size(9).color(th::text_dim()))
             .on_press(Message::clear_drum_rack_pad(track_id, selected_pad))
             .padding([2, 8])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
-                    _ => Some(th::BG_DARK.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => Some(th::bg_dark().into()),
                 };
                 button::Style {
                     background: bg,
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 3.0.into(),
                     },
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     ..Default::default()
                 }
             });
@@ -804,10 +831,10 @@ impl App {
         let footer = column![
             text(truncate_end(&selected_name, 22))
                 .size(10)
-                .color(th::TEXT),
+                .color(th::text()),
             text(truncate_end(&source_hint, 26))
                 .size(9)
-                .color(th::TEXT_DIM),
+                .color(th::text_dim()),
             row![load_btn, clear_btn]
                 .spacing(6)
                 .align_y(iced::Alignment::Center)
@@ -892,9 +919,9 @@ impl App {
 
         let one_shot_active = selected_pad_state.one_shot;
         let one_shot_btn = button(text("One-shot").size(9).color(if one_shot_active {
-            th::ACCENT
+            th::accent()
         } else {
-            th::TEXT_DIM
+            th::text_dim()
         }))
         .on_press(Message::Devices(
             crate::domains::devices::DevicesMsg::SetDrumPadOneShot {
@@ -907,22 +934,22 @@ impl App {
         .style(move |_theme: &Theme, _status| button::Style {
             background: Some(
                 if one_shot_active {
-                    th::ACCENT_DIM
+                    th::accent_dim()
                 } else {
-                    th::BG_DARK
+                    th::bg_dark()
                 }
                 .into(),
             ),
             text_color: if one_shot_active {
-                th::ACCENT
+                th::accent()
             } else {
-                th::TEXT_DIM
+                th::text_dim()
             },
             border: iced::Border {
                 color: if one_shot_active {
-                    th::ACCENT_DIM
+                    th::accent_dim()
                 } else {
-                    th::BORDER
+                    th::border()
                 },
                 width: 1.0,
                 radius: 3.0.into(),
@@ -930,7 +957,7 @@ impl App {
             ..Default::default()
         });
 
-        let mut choke_row = row![text("Choke").size(9).color(th::TEXT_DIM)]
+        let mut choke_row = row![text("Choke").size(9).color(th::text_dim())]
             .spacing(2)
             .align_y(iced::Alignment::Center);
         for (group, label) in [
@@ -941,30 +968,40 @@ impl App {
             (Some(4), "4"),
         ] {
             let active = selected_pad_state.choke_group == group;
-            let btn =
-                button(
-                    text(label)
-                        .size(9)
-                        .color(if active { th::ACCENT } else { th::TEXT_DIM }),
-                )
-                .on_press(Message::Devices(
-                    crate::domains::devices::DevicesMsg::SetDrumPadChokeGroup {
-                        track_id,
-                        pad_index: selected_pad,
-                        choke_group: group,
+            let btn = button(text(label).size(9).color(if active {
+                th::accent()
+            } else {
+                th::text_dim()
+            }))
+            .on_press(Message::Devices(
+                crate::domains::devices::DevicesMsg::SetDrumPadChokeGroup {
+                    track_id,
+                    pad_index: selected_pad,
+                    choke_group: group,
+                },
+            ))
+            .padding([2, 6])
+            .style(move |_theme: &Theme, _status| button::Style {
+                background: Some(
+                    if active {
+                        th::accent_dim()
+                    } else {
+                        th::bg_dark()
+                    }
+                    .into(),
+                ),
+                text_color: if active { th::accent() } else { th::text_dim() },
+                border: iced::Border {
+                    color: if active {
+                        th::accent_dim()
+                    } else {
+                        th::border()
                     },
-                ))
-                .padding([2, 6])
-                .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(if active { th::ACCENT_DIM } else { th::BG_DARK }.into()),
-                    text_color: if active { th::ACCENT } else { th::TEXT_DIM },
-                    border: iced::Border {
-                        color: if active { th::ACCENT_DIM } else { th::BORDER },
-                        width: 1.0,
-                        radius: 3.0.into(),
-                    },
-                    ..Default::default()
-                });
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                ..Default::default()
+            });
             choke_row = choke_row.push(btn);
         }
 
@@ -1020,8 +1057,8 @@ impl App {
 
     /// Placeholder card for MIDI tracks with no instrument attached.
     pub(super) fn view_add_instrument_placeholder(&self) -> Element<'_, Message> {
-        let title = Self::device_title_bar(text("No Instrument").size(11).color(th::TEXT_DIM));
-        let body = container(text("Right-click to add").size(9).color(th::TEXT_MUTED))
+        let title = Self::device_title_bar(text("No Instrument").size(11).color(th::text_dim()));
+        let body = container(text("Right-click to add").size(9).color(th::text_muted()))
             .padding([8, 6])
             .width(Length::Fill);
 

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -39,9 +39,9 @@ impl App {
         if is_midi {
             let inst_active = menu.category == Some(DeviceMenuCategory::Instruments);
             let (bg, tc) = if inst_active {
-                (th::ACCENT_DIM, th::ACCENT)
+                (th::accent_dim(), th::accent())
             } else {
-                (th::BG_ELEVATED, th::TEXT_DIM)
+                (th::bg_elevated(), th::text_dim())
             };
             let inst_tab = button(text("Instruments").size(11).color(tc))
                 .on_press(Message::set_device_menu_category(
@@ -53,9 +53,9 @@ impl App {
                     text_color: tc,
                     border: iced::Border {
                         color: if inst_active {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 4.0.into(),
@@ -66,9 +66,9 @@ impl App {
         }
         let fx_active = menu.category == Some(DeviceMenuCategory::Effects);
         let (bg, tc) = if fx_active {
-            (th::ACCENT_DIM, th::ACCENT)
+            (th::accent_dim(), th::accent())
         } else {
-            (th::BG_ELEVATED, th::TEXT_DIM)
+            (th::bg_elevated(), th::text_dim())
         };
         let fx_tab = button(text("Effects").size(11).color(tc))
             .on_press(Message::set_device_menu_category(
@@ -80,9 +80,9 @@ impl App {
                 text_color: tc,
                 border: iced::Border {
                     color: if fx_active {
-                        th::ACCENT_DIM
+                        th::accent_dim()
                     } else {
-                        th::BORDER
+                        th::border()
                     },
                     width: 1.0,
                     radius: 4.0.into(),
@@ -94,9 +94,9 @@ impl App {
         // Plugins tab
         let plugins_active = menu.category == Some(DeviceMenuCategory::Plugins);
         let (bg, tc) = if plugins_active {
-            (th::ACCENT_DIM, th::ACCENT)
+            (th::accent_dim(), th::accent())
         } else {
-            (th::BG_ELEVATED, th::TEXT_DIM)
+            (th::bg_elevated(), th::text_dim())
         };
         let plugins_tab = button(text("Plugins").size(11).color(tc))
             .on_press(Message::set_device_menu_category(
@@ -108,9 +108,9 @@ impl App {
                 text_color: tc,
                 border: iced::Border {
                     color: if plugins_active {
-                        th::ACCENT_DIM
+                        th::accent_dim()
                     } else {
-                        th::BORDER
+                        th::border()
                     },
                     width: 1.0,
                     radius: 4.0.into(),
@@ -141,20 +141,20 @@ impl App {
                     if !search_lower.is_empty() && !name.to_lowercase().contains(&search_lower) {
                         continue;
                     }
-                    let btn = button(text(name).size(12).color(th::TEXT))
+                    let btn = button(text(name).size(12).color(th::text()))
                         .on_press(Message::set_track_instrument(track_id, kind))
                         .padding([6, 10])
                         .width(Length::Fill)
                         .style(|_theme: &Theme, status| {
                             let bg = match status {
                                 button::Status::Hovered | button::Status::Pressed => {
-                                    Some(th::BG_HOVER.into())
+                                    Some(th::bg_hover().into())
                                 }
                                 _ => None,
                             };
                             button::Style {
                                 background: bg,
-                                text_color: th::TEXT,
+                                text_color: th::text(),
                                 border: iced::Border::default(),
                                 ..Default::default()
                             }
@@ -169,7 +169,7 @@ impl App {
                     items_col = items_col.push(
                         text("No plugins scanned yet.\nUse File → Settings to scan.")
                             .size(11)
-                            .color(th::TEXT_DIM),
+                            .color(th::text_dim()),
                     );
                     est_rows = 2;
                 } else {
@@ -203,10 +203,10 @@ impl App {
                             // cell width: truncated names made the
                             // LSP suite indistinguishable.
                             let cell = column![
-                                text(plugin.name.clone()).size(11).color(th::TEXT),
+                                text(plugin.name.clone()).size(11).color(th::text()),
                                 text(format!("{format_badge} {cat_label}"))
                                     .size(9)
-                                    .color(th::TEXT_DIM),
+                                    .color(th::text_dim()),
                             ]
                             .spacing(1);
                             let btn = button(cell)
@@ -216,13 +216,13 @@ impl App {
                                 .style(|_theme: &Theme, status| {
                                     let bg = match status {
                                         button::Status::Hovered | button::Status::Pressed => {
-                                            Some(th::BG_HOVER.into())
+                                            Some(th::bg_hover().into())
                                         }
                                         _ => None,
                                     };
                                     button::Style {
                                         background: bg,
-                                        text_color: th::TEXT,
+                                        text_color: th::text(),
                                         border: iced::Border::default(),
                                         ..Default::default()
                                     }
@@ -239,20 +239,20 @@ impl App {
                     if !search_lower.is_empty() && !name.to_lowercase().contains(&search_lower) {
                         continue;
                     }
-                    let btn = button(text(name).size(12).color(th::TEXT))
+                    let btn = button(text(name).size(12).color(th::text()))
                         .on_press(Message::add_effect(track_id, et))
                         .padding([6, 10])
                         .width(Length::Fill)
                         .style(|_theme: &Theme, status| {
                             let bg = match status {
                                 button::Status::Hovered | button::Status::Pressed => {
-                                    Some(th::BG_HOVER.into())
+                                    Some(th::bg_hover().into())
                                 }
                                 _ => None,
                             };
                             button::Style {
                                 background: bg,
-                                text_color: th::TEXT,
+                                text_color: th::text(),
                                 border: iced::Border::default(),
                                 ..Default::default()
                             }
@@ -288,9 +288,9 @@ impl App {
             .width(Length::Fixed(menu_w));
 
         let menu_card = container(menu_content).style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 6.0.into(),
             },
@@ -320,8 +320,8 @@ impl App {
         let make_menu_btn = |label: &'static str, icon: char, msg: Message| {
             button(
                 row![
-                    icons::icon(icon).size(12).color(th::TEXT),
-                    text(label).size(12).color(th::TEXT)
+                    icons::icon(icon).size(12).color(th::text()),
+                    text(label).size(12).color(th::text())
                 ]
                 .spacing(6)
                 .align_y(iced::Alignment::Center),
@@ -331,12 +331,14 @@ impl App {
             .width(Length::Fill)
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border::default(),
                     ..Default::default()
                 }
@@ -362,8 +364,8 @@ impl App {
             row![
                 icons::icon(icons::SLIDERS_VERTICAL)
                     .size(12)
-                    .color(th::TEXT),
-                text("Settings...").size(12).color(th::TEXT)
+                    .color(th::text()),
+                text("Settings...").size(12).color(th::text())
             ]
             .spacing(6)
             .align_y(iced::Alignment::Center),
@@ -373,12 +375,12 @@ impl App {
         .width(Length::Fill)
         .style(|_theme: &Theme, status| {
             let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
                 _ => None,
             };
             button::Style {
                 background: bg,
-                text_color: th::TEXT,
+                text_color: th::text(),
                 border: iced::Border::default(),
                 ..Default::default()
             }
@@ -395,9 +397,9 @@ impl App {
             .width(Length::Fixed(220.0));
 
         let menu_card = container(menu_content).style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 6.0.into(),
             },
@@ -422,7 +424,7 @@ impl App {
             .size(14)
             .width(Length::Fixed(250.0));
 
-        let label = text("Rename Clip").size(14).color(th::TEXT);
+        let label = text("Rename Clip").size(14).color(th::text());
 
         let dialog = container(
             column![label, input]
@@ -431,9 +433,9 @@ impl App {
                 .width(Length::Fixed(280.0)),
         )
         .style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 6.0.into(),
             },
@@ -456,8 +458,8 @@ impl App {
             |icon_char: char, label_text: String, msg: Message| -> Element<'_, Message> {
                 button(
                     row![
-                        icons::icon(icon_char).size(13).color(th::TEXT),
-                        text(label_text).size(13).color(th::TEXT)
+                        icons::icon(icon_char).size(13).color(th::text()),
+                        text(label_text).size(13).color(th::text())
                     ]
                     .spacing(8)
                     .align_y(iced::Alignment::Center),
@@ -467,12 +469,12 @@ impl App {
                 .width(Length::Fill)
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => th::BG_HOVER,
-                        _ => th::BG_SURFACE,
+                        button::Status::Hovered | button::Status::Pressed => th::bg_hover(),
+                        _ => th::bg_surface(),
                     };
                     button::Style {
                         background: Some(bg.into()),
-                        text_color: th::TEXT,
+                        text_color: th::text(),
                         border: iced::Border::default(),
                         ..Default::default()
                     }
@@ -620,9 +622,9 @@ impl App {
 
         let menu_container = container(menu_items)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -93,6 +93,11 @@ impl App {
                 SettingsTab::Warping,
                 active == SettingsTab::Warping
             ),
+            make_tab_btn(
+                "Appearance",
+                SettingsTab::Appearance,
+                active == SettingsTab::Appearance
+            ),
         ]
         .spacing(0);
 
@@ -102,6 +107,7 @@ impl App {
             SettingsTab::Plugins => self.view_settings_plugins_tab(),
             SettingsTab::Dropbox => self.view_settings_dropbox_tab(),
             SettingsTab::Warping => self.view_settings_warping_tab(),
+            SettingsTab::Appearance => self.view_settings_appearance_tab(),
         };
 
         let content = column![
@@ -720,5 +726,198 @@ impl App {
         ]
         .spacing(10)
         .into()
+    }
+
+    pub(super) fn view_settings_appearance_tab(&self) -> Element<'_, Message> {
+        use iced::widget::scrollable;
+
+        let title = text("Appearance").size(14).color(th::text());
+        let hint = text(
+            "Themes recolor the whole interface, track palette included. \
+             Drop .vzt files in the themes folder and rescan to add your own.",
+        )
+        .size(11)
+        .color(th::text_dim());
+
+        // One selectable row per theme: swatch strip + name.
+        let theme_row = |palette: &th::ThemePalette| -> Element<'_, Message> {
+            let name = palette.name.clone();
+            let selected = self.state.current_theme_name == name;
+            let mut swatches = row![].spacing(2);
+            for color in [
+                palette.bg_dark,
+                palette.bg_elevated,
+                palette.accent,
+                palette.track_colors[0],
+                palette.track_colors[3],
+                palette.track_colors[5],
+            ] {
+                swatches = swatches.push(
+                    container(
+                        column![]
+                            .width(Length::Fixed(14.0))
+                            .height(Length::Fixed(14.0)),
+                    )
+                    .style(move |_theme: &Theme| container::Style {
+                        background: Some(color.into()),
+                        border: iced::Border {
+                            color: th::border(),
+                            width: 1.0,
+                            radius: 2.0.into(),
+                        },
+                        ..Default::default()
+                    }),
+                );
+            }
+            let label =
+                text(name.clone())
+                    .size(12)
+                    .color(if selected { th::accent() } else { th::text() });
+            let marker: Element<'_, Message> = if selected {
+                icons::icon(icons::CIRCLE_DOT)
+                    .size(11)
+                    .color(th::accent())
+                    .into()
+            } else {
+                icons::icon(icons::CIRCLE)
+                    .size(11)
+                    .color(th::text_muted())
+                    .into()
+            };
+            button(
+                row![marker, swatches, label]
+                    .spacing(10)
+                    .align_y(iced::Alignment::Center),
+            )
+            .on_press(Message::SelectTheme(name))
+            .padding([5, 8])
+            .width(Length::Fill)
+            .style(move |_theme: &Theme, status| {
+                let bg = if selected {
+                    Some(th::bg_elevated().into())
+                } else {
+                    match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::bg_hover().into())
+                        }
+                        _ => None,
+                    }
+                };
+                button::Style {
+                    background: bg,
+                    text_color: th::text(),
+                    border: iced::Border {
+                        color: if selected {
+                            th::accent_dim()
+                        } else {
+                            iced::Color::TRANSPARENT
+                        },
+                        width: 1.0,
+                        radius: 4.0.into(),
+                    },
+                    ..Default::default()
+                }
+            })
+            .into()
+        };
+
+        let mut builtin_col = column![].spacing(2);
+        for palette in crate::themes::builtins() {
+            builtin_col = builtin_col.push(theme_row(&palette));
+        }
+
+        // User theme section: scanned .vzt files + rescan, like the
+        // plugin library.
+        let user_header = row![
+            text("Your Themes").size(13).color(th::text()),
+            horizontal_space(),
+            text(crate::themes::themes_dir().display().to_string())
+                .size(10)
+                .color(th::text_muted()),
+            button(text("Rescan").size(11).color(th::accent()))
+                .on_press(Message::RescanThemes)
+                .padding([3, 10])
+                .style(|_theme: &Theme, status| {
+                    let bg = match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::bg_hover().into())
+                        }
+                        _ => None,
+                    };
+                    button::Style {
+                        background: bg,
+                        text_color: th::accent(),
+                        border: iced::Border {
+                            color: th::accent_dim(),
+                            width: 1.0,
+                            radius: 4.0.into(),
+                        },
+                        ..Default::default()
+                    }
+                }),
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center);
+
+        let mut user_col = column![].spacing(2);
+        if self.state.user_themes.is_empty() {
+            user_col = user_col.push(
+                text("No .vzt themes found — save one below or drop files in the folder.")
+                    .size(11)
+                    .color(th::text_muted()),
+            );
+        } else {
+            for user in &self.state.user_themes {
+                user_col = user_col.push(theme_row(&user.palette));
+            }
+        }
+
+        // Save the active palette under a new name.
+        let save_row = row![
+            text_input("Theme name...", &self.state.theme_save_name)
+                .on_input(Message::ThemeSaveNameChanged)
+                .on_submit(Message::SaveCurrentTheme)
+                .size(12)
+                .padding([5, 8]),
+            button(text("Save Current").size(11).color(th::text()))
+                .on_press(Message::SaveCurrentTheme)
+                .padding([6, 12])
+                .style(|_theme: &Theme, status| {
+                    let bg = match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::bg_hover().into())
+                        }
+                        _ => None,
+                    };
+                    button::Style {
+                        background: bg,
+                        text_color: th::text(),
+                        border: iced::Border {
+                            color: th::accent_dim(),
+                            width: 1.0,
+                            radius: 4.0.into(),
+                        },
+                        ..Default::default()
+                    }
+                }),
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center);
+
+        let divider = || {
+            container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
+                |_theme: &Theme| container::Style {
+                    background: Some(th::border().into()),
+                    ..Default::default()
+                },
+            )
+        };
+
+        let list = scrollable(column![builtin_col, divider(), user_header, user_col,].spacing(8))
+            .height(Length::Fixed(300.0));
+
+        column![title, hint, list, divider(), save_row]
+            .spacing(10)
+            .into()
     }
 }

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -16,18 +16,20 @@ use super::*;
 
 impl App {
     pub(super) fn view_settings_modal(&self) -> Element<'_, Message> {
-        let title = text("Settings").size(18).color(th::ACCENT);
-        let close_btn = button(icons::icon(icons::X).size(14).color(th::TEXT_DIM))
+        let title = text("Settings").size(18).color(th::accent());
+        let close_btn = button(icons::icon(icons::X).size(14).color(th::text_dim()))
             .on_press(Message::CloseSettings)
             .padding([4, 8])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border::default(),
                     ..Default::default()
                 }
@@ -37,7 +39,11 @@ impl App {
 
         // -- Tab bar --
         let make_tab_btn = |label: &'static str, tab: SettingsTab, is_active: bool| {
-            let color = if is_active { th::ACCENT } else { th::TEXT_DIM };
+            let color = if is_active {
+                th::accent()
+            } else {
+                th::text_dim()
+            };
             button(text(label).size(13).color(color))
                 .on_press(Message::SelectSettingsTab(tab))
                 .padding([6, 16])
@@ -47,7 +53,7 @@ impl App {
                     } else {
                         match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::BG_HOVER.into())
+                                Some(th::bg_hover().into())
                             }
                             _ => None,
                         }
@@ -57,7 +63,7 @@ impl App {
                         text_color: color,
                         border: iced::Border {
                             color: if is_active {
-                                th::ACCENT
+                                th::accent()
                             } else {
                                 Color::TRANSPARENT
                             },
@@ -102,14 +108,14 @@ impl App {
             header,
             container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
                 |_theme: &Theme| container::Style {
-                    background: Some(th::BORDER.into()),
+                    background: Some(th::border().into()),
                     ..Default::default()
                 }
             ),
             tab_bar,
             container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
                 |_theme: &Theme| container::Style {
-                    background: Some(th::BORDER.into()),
+                    background: Some(th::border().into()),
                     ..Default::default()
                 }
             ),
@@ -120,9 +126,9 @@ impl App {
         .width(Length::Fixed(480.0));
 
         let dialog = container(content).style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 8.0.into(),
             },
@@ -144,10 +150,10 @@ impl App {
     }
 
     pub(super) fn view_settings_audio_tab(&self) -> Element<'_, Message> {
-        let buf_label = text("Buffer Size").size(14).color(th::TEXT);
+        let buf_label = text("Buffer Size").size(14).color(th::text());
         let buf_hint = text("Lower = less latency, higher = more CPU headroom")
             .size(11)
-            .color(th::TEXT_DIM);
+            .color(th::text_dim());
 
         let sizes: &[u32] = &[64, 128, 256, 512, 1024, 2048, 4096];
         let mut buf_row = row![].spacing(4);
@@ -155,19 +161,19 @@ impl App {
             let is_selected = self.state.settings_buffer_size == size;
             let label = format!("{size}");
             let btn = button(text(label).size(11).color(if is_selected {
-                th::TEXT
+                th::text()
             } else {
-                th::TEXT_DIM
+                th::text_dim()
             }))
             .on_press(Message::SetBufferSize(size))
             .padding([6, 10])
             .style(move |_theme: &Theme, status| {
                 if is_selected {
                     button::Style {
-                        background: Some(th::ACCENT.into()),
-                        text_color: th::TEXT,
+                        background: Some(th::accent().into()),
+                        text_color: th::text(),
                         border: iced::Border {
-                            color: th::ACCENT,
+                            color: th::accent(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -176,15 +182,15 @@ impl App {
                 } else {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT_DIM,
+                        text_color: th::text_dim(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -195,41 +201,43 @@ impl App {
             buf_row = buf_row.push(btn);
         }
 
-        let sr_label = text("Sample Rate").size(14).color(th::TEXT);
+        let sr_label = text("Sample Rate").size(14).color(th::text());
         let sr_value = text(format!("{} Hz", self.state.transport.sample_rate))
             .size(13)
-            .color(th::TEXT_DIM);
+            .color(th::text_dim());
 
         // ---- MIDI input picker ----
-        let midi_label = text("MIDI Input").size(14).color(th::TEXT);
+        let midi_label = text("MIDI Input").size(14).color(th::text());
         let midi_hint = text(
             "External MIDI routes to the currently selected instrument track. \
              Plug your keyboard or Push in, hit Rescan, then pick the port.",
         )
         .size(11)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
 
         let current_port_line: Element<'_, Message> = match self.midi_input.as_ref() {
             Some(h) => text(format!("Connected: {}", h.port_name))
                 .size(12)
-                .color(th::ACCENT)
+                .color(th::accent())
                 .into(),
-            None => text("Not connected").size(12).color(th::TEXT_DIM).into(),
+            None => text("Not connected").size(12).color(th::text_dim()).into(),
         };
 
-        let rescan_btn = button(text("Rescan ports").size(11).color(th::TEXT))
+        let rescan_btn = button(text("Rescan ports").size(11).color(th::text()))
             .on_press(Message::RescanMidiInputs)
             .padding([4, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -237,19 +245,21 @@ impl App {
                 }
             });
 
-        let disconnect_btn = button(text("Disconnect").size(11).color(th::TEXT_DIM))
+        let disconnect_btn = button(text("Disconnect").size(11).color(th::text_dim()))
             .on_press(Message::CloseMidiInput)
             .padding([4, 10])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -276,30 +286,30 @@ impl App {
                     name.clone()
                 })
                 .size(11)
-                .color(if is_current { th::ACCENT } else { th::TEXT }),
+                .color(if is_current { th::accent() } else { th::text() }),
             )
             .on_press(Message::OpenMidiInput(label))
             .padding([4, 10])
             .width(Length::Fill)
             .style(move |_theme: &Theme, status| {
                 let bg = if is_current {
-                    Some(th::BG_HOVER.into())
+                    Some(th::bg_hover().into())
                 } else {
                     match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     }
                 };
                 button::Style {
                     background: bg,
-                    text_color: if is_current { th::ACCENT } else { th::TEXT },
+                    text_color: if is_current { th::accent() } else { th::text() },
                     border: iced::Border {
                         color: if is_current {
-                            th::ACCENT_DIM
+                            th::accent_dim()
                         } else {
-                            th::BORDER
+                            th::border()
                         },
                         width: 1.0,
                         radius: 4.0.into(),
@@ -318,7 +328,7 @@ impl App {
             sr_value,
             container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
                 |_theme: &Theme| container::Style {
-                    background: Some(th::BORDER.into()),
+                    background: Some(th::border().into()),
                     ..Default::default()
                 }
             ),
@@ -334,18 +344,18 @@ impl App {
 
     pub(super) fn view_settings_plugins_tab(&self) -> Element<'_, Message> {
         // Plugin section header
-        let plugin_title = text("Plugin Library").size(14).color(th::TEXT);
+        let plugin_title = text("Plugin Library").size(14).color(th::text());
 
         // Default paths checkbox
         let default_paths_label = if self.state.plugin_settings.scan_default_paths {
-            icons::icon(icons::CIRCLE_DOT).size(12).color(th::ACCENT)
+            icons::icon(icons::CIRCLE_DOT).size(12).color(th::accent())
         } else {
-            icons::icon(icons::CIRCLE).size(12).color(th::TEXT_DIM)
+            icons::icon(icons::CIRCLE).size(12).color(th::text_dim())
         };
         let default_paths_btn = button(
             row![
                 default_paths_label,
-                text("Scan default system paths").size(12).color(th::TEXT)
+                text("Scan default system paths").size(12).color(th::text())
             ]
             .spacing(6)
             .align_y(iced::Alignment::Center),
@@ -354,7 +364,7 @@ impl App {
         .padding([4, 8])
         .style(|_theme: &Theme, _status| button::Style {
             background: None,
-            text_color: th::TEXT,
+            text_color: th::text(),
             border: iced::Border::default(),
             ..Default::default()
         });
@@ -370,20 +380,20 @@ impl App {
         {
             let path_text = text(path.display().to_string())
                 .size(11)
-                .color(th::TEXT_DIM);
-            let remove_btn = button(icons::icon(icons::X).size(10).color(th::DANGER))
+                .color(th::text_dim());
+            let remove_btn = button(icons::icon(icons::X).size(10).color(th::danger()))
                 .on_press(Message::RemovePluginScanPath(i))
                 .padding([2, 6])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::DANGER,
+                        text_color: th::danger(),
                         border: iced::Border::default(),
                         ..Default::default()
                     }
@@ -397,8 +407,8 @@ impl App {
 
         let add_path_btn = button(
             row![
-                icons::icon(icons::PLUS).size(12).color(th::ACCENT),
-                text("Add Path").size(12).color(th::ACCENT)
+                icons::icon(icons::PLUS).size(12).color(th::accent()),
+                text("Add Path").size(12).color(th::accent())
             ]
             .spacing(4)
             .align_y(iced::Alignment::Center),
@@ -407,14 +417,14 @@ impl App {
         .padding([6, 12])
         .style(|_theme: &Theme, status| {
             let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
                 _ => None,
             };
             button::Style {
                 background: bg,
-                text_color: th::ACCENT,
+                text_color: th::accent(),
                 border: iced::Border {
-                    color: th::ACCENT_DIM,
+                    color: th::accent_dim(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -428,21 +438,21 @@ impl App {
         } else {
             "Scan Plugins"
         };
-        let scan_btn = button(text(scan_label).size(12).color(th::TEXT))
+        let scan_btn = button(text(scan_label).size(12).color(th::text()))
             .on_press(Message::ScanPlugins)
             .padding([8, 16])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
                     button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::ACCENT_DIM.into())
+                        Some(th::accent_dim().into())
                     }
-                    _ => Some(th::BG_ELEVATED.into()),
+                    _ => Some(th::bg_elevated().into()),
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -455,11 +465,11 @@ impl App {
         let status = if !self.state.plugin_scan_status.is_empty() {
             text(&self.state.plugin_scan_status)
                 .size(11)
-                .color(th::TEXT_DIM)
+                .color(th::text_dim())
         } else {
             text(format!("{cache_count} plugins cached"))
                 .size(11)
-                .color(th::TEXT_DIM)
+                .color(th::text_dim())
         };
 
         column![
@@ -476,32 +486,34 @@ impl App {
     }
 
     pub(super) fn view_settings_dropbox_tab(&self) -> Element<'_, Message> {
-        let title = text("Dropbox").size(14).color(th::TEXT);
+        let title = text("Dropbox").size(14).color(th::text());
         let hint = text(
             "Register an app at https://www.dropbox.com/developers/apps \
             (Scoped access, Full Dropbox). Paste the App key below.",
         )
         .size(11)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
 
         let app_key_input = text_input("App key", &self.state.browser.dropbox.app_key_input)
             .on_input(|s| Message::Browser(BrowserMsg::SetDropboxAppKey(s)))
             .on_submit(Message::SaveDropboxAppKey)
             .size(13)
             .width(Length::Fill);
-        let save_key_btn = button(text("Save").size(12).color(th::TEXT))
+        let save_key_btn = button(text("Save").size(12).color(th::text()))
             .on_press(Message::SaveDropboxAppKey)
             .padding([6, 12])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT,
+                    text_color: th::text(),
                     border: iced::Border {
-                        color: th::ACCENT_DIM,
+                        color: th::accent_dim(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -523,15 +535,15 @@ impl App {
                 .unwrap_or_else(|| "connected".into());
             text(format!("Connected: {email}"))
                 .size(12)
-                .color(th::ACCENT)
+                .color(th::accent())
                 .into()
         } else if self.state.browser.dropbox.auth_in_progress {
             text("Waiting for browser authorisation...")
                 .size(12)
-                .color(th::TEXT_DIM)
+                .color(th::text_dim())
                 .into()
         } else {
-            text("Not connected").size(12).color(th::TEXT_DIM).into()
+            text("Not connected").size(12).color(th::text_dim()).into()
         };
 
         let can_connect =
@@ -544,20 +556,22 @@ impl App {
             "Connect"
         };
         let connect_btn = {
-            let mut btn = button(text(connect_label).size(12).color(th::ACCENT));
+            let mut btn = button(text(connect_label).size(12).color(th::accent()));
             if can_connect {
                 btn = btn.on_press(Message::ConnectDropbox);
             }
             btn.padding([6, 12]).style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::ACCENT,
+                    text_color: th::accent(),
                     border: iced::Border {
-                        color: th::ACCENT_DIM,
+                        color: th::accent_dim(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -567,19 +581,19 @@ impl App {
         };
 
         let disconnect_btn: Element<'_, Message> = if self.state.browser.dropbox.connected {
-            button(text("Disconnect").size(12).color(th::TEXT_DIM))
+            button(text("Disconnect").size(12).color(th::text_dim()))
                 .on_press(Message::DisconnectDropbox)
                 .padding([6, 12])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT_DIM,
+                        text_color: th::text_dim(),
                         border: iced::Border::default(),
                         ..Default::default()
                     }
@@ -591,7 +605,7 @@ impl App {
 
         let error_line: Element<'_, Message> =
             if let Some(err) = self.state.browser.dropbox.last_error.clone() {
-                text(err).size(11).color(th::DANGER).into()
+                text(err).size(11).color(th::danger()).into()
             } else {
                 horizontal_space().width(Length::Shrink).into()
             };
@@ -611,24 +625,26 @@ impl App {
     }
 
     pub(super) fn view_settings_warping_tab(&self) -> Element<'_, Message> {
-        let title = text("Sample Warping").size(14).color(th::TEXT);
+        let title = text("Sample Warping").size(14).color(th::text());
         let hint = text(
             "Auto-warp detects BPM of each dropped sample and time-stretches it to \
              the project tempo, preserving pitch. Turn this off to keep samples at their \
              original speed.",
         )
         .size(11)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
 
         let toggle_icon = if self.state.auto_warp_on_import {
-            icons::icon(icons::CIRCLE_DOT).size(12).color(th::ACCENT)
+            icons::icon(icons::CIRCLE_DOT).size(12).color(th::accent())
         } else {
-            icons::icon(icons::CIRCLE).size(12).color(th::TEXT_DIM)
+            icons::icon(icons::CIRCLE).size(12).color(th::text_dim())
         };
         let toggle_btn = button(
             row![
                 toggle_icon,
-                text("Auto-warp samples on import").size(12).color(th::TEXT)
+                text("Auto-warp samples on import")
+                    .size(12)
+                    .color(th::text())
             ]
             .spacing(6)
             .align_y(iced::Alignment::Center),
@@ -637,7 +653,7 @@ impl App {
         .padding([4, 8])
         .style(|_theme: &Theme, _status| button::Style {
             background: None,
-            text_color: th::TEXT,
+            text_color: th::text(),
             border: iced::Border::default(),
             ..Default::default()
         });
@@ -645,33 +661,33 @@ impl App {
         let conf = self.state.warp_confidence_threshold;
         let conf_label = text("Detection confidence threshold")
             .size(12)
-            .color(th::TEXT);
-        let conf_value = text(format!("{:.2}", conf)).size(12).color(th::TEXT_DIM);
+            .color(th::text());
+        let conf_value = text(format!("{:.2}", conf)).size(12).color(th::text_dim());
         let conf_hint = text(
             "Higher = only warp when the detector is very sure. \
              Lower = warp even ambiguous clips.",
         )
         .size(11)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
         let conf_slider = slider(0.0..=1.0, conf, Message::SetWarpConfidenceThreshold).step(0.05);
 
         let rewarp_btn = button(
             text("Re-warp all clips to project tempo")
                 .size(12)
-                .color(th::TEXT),
+                .color(th::text()),
         )
         .on_press(Message::RewarpAllClips)
         .padding([6, 12])
         .style(|_theme: &Theme, status| {
             let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
                 _ => None,
             };
             button::Style {
                 background: bg,
-                text_color: th::TEXT,
+                text_color: th::text(),
                 border: iced::Border {
-                    color: th::ACCENT_DIM,
+                    color: th::accent_dim(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -685,7 +701,7 @@ impl App {
             toggle_btn,
             container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
                 |_theme: &Theme| container::Style {
-                    background: Some(th::BORDER.into()),
+                    background: Some(th::border().into()),
                     ..Default::default()
                 }
             ),
@@ -696,7 +712,7 @@ impl App {
                 .align_y(iced::Alignment::Center),
             container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
                 |_theme: &Theme| container::Style {
-                    background: Some(th::BORDER.into()),
+                    background: Some(th::border().into()),
                     ..Default::default()
                 }
             ),

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -73,17 +73,17 @@ impl App {
     }
 
     pub(super) fn view_header(&self) -> Element<'_, Message> {
-        let title = text("vibez").size(22).color(th::ACCENT);
+        let title = text("vibez").size(22).color(th::accent());
 
         // Workspace tabs
         let arrange_tab = {
             let active = self.state.view.workspace == Workspace::Arrange;
             let (bg, text_color, border_color) = if active {
-                (th::BG_ELEVATED, th::ACCENT, th::ACCENT_DIM)
+                (th::bg_elevated(), th::accent(), th::accent_dim())
             } else {
                 (
                     iced::Color::TRANSPARENT,
-                    th::TEXT_DIM,
+                    th::text_dim(),
                     iced::Color::TRANSPARENT,
                 )
             };
@@ -112,11 +112,11 @@ impl App {
         let mix_tab = {
             let active = self.state.view.workspace == Workspace::Mix;
             let (bg, text_color, border_color) = if active {
-                (th::BG_ELEVATED, th::ACCENT, th::ACCENT_DIM)
+                (th::bg_elevated(), th::accent(), th::accent_dim())
             } else {
                 (
                     iced::Color::TRANSPARENT,
-                    th::TEXT_DIM,
+                    th::text_dim(),
                     iced::Color::TRANSPARENT,
                 )
             };
@@ -146,17 +146,19 @@ impl App {
 
         let tabs = row![arrange_tab, mix_tab].spacing(4);
 
-        let file_btn = button(text("File").size(13).color(th::TEXT_DIM))
+        let file_btn = button(text("File").size(13).color(th::text_dim()))
             .on_press(Message::Project(ProjectMsg::ToggleFileMenu))
             .padding([6, 14])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border::default(),
                     ..Default::default()
                 }
@@ -168,14 +170,14 @@ impl App {
                 icons::icon(icons::AUDIO_WAVEFORM)
                     .size(13)
                     .color(if browser_active {
-                        th::ACCENT
+                        th::accent()
                     } else {
-                        th::TEXT_DIM
+                        th::text_dim()
                     }),
                 text("Browser").size(13).color(if browser_active {
-                    th::ACCENT
+                    th::accent()
                 } else {
-                    th::TEXT_DIM
+                    th::text_dim()
                 })
             ]
             .spacing(4)
@@ -185,23 +187,25 @@ impl App {
         .padding([6, 14])
         .style(move |_theme: &Theme, status| {
             let bg = if browser_active {
-                Some(th::BG_ELEVATED.into())
+                Some(th::bg_elevated().into())
             } else {
                 match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 }
             };
             button::Style {
                 background: bg,
                 text_color: if browser_active {
-                    th::ACCENT
+                    th::accent()
                 } else {
-                    th::TEXT_DIM
+                    th::text_dim()
                 },
                 border: iced::Border {
                     color: if browser_active {
-                        th::ACCENT_DIM
+                        th::accent_dim()
                     } else {
                         Color::TRANSPARENT
                     },
@@ -219,9 +223,9 @@ impl App {
         container(header)
             .width(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 0.0,
                     radius: 0.0.into(),
                 },
@@ -236,7 +240,7 @@ impl App {
         if self.state.arrangement.tracks.is_empty() {
             let prompt = text("Right-click or Ctrl+T to add a track")
                 .size(16)
-                .color(th::TEXT_DIM);
+                .color(th::text_dim());
 
             let centered = center(prompt).width(Length::Fill).height(Length::Fill);
 
@@ -245,7 +249,7 @@ impl App {
                     .width(Length::Fill)
                     .height(Length::FillPortion(5))
                     .style(|_theme: &Theme| container::Style {
-                        background: Some(th::BG_DARK.into()),
+                        background: Some(th::bg_dark().into()),
                         ..Default::default()
                     }),
             )
@@ -290,7 +294,7 @@ impl App {
             ))
             .height(Length::Fixed(28.0))
             .style(|_theme: &Theme| iced::widget::container::Style {
-                background: Some(crate::theme::BG_SURFACE.into()),
+                background: Some(crate::theme::bg_surface().into()),
                 ..Default::default()
             });
 
@@ -338,7 +342,7 @@ impl App {
             ))
             .height(Length::Fixed(40.0))
             .style(|_theme: &Theme| iced::widget::container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 ..Default::default()
             });
         let minimap_canvas: Element<'_, Message> = canvas(minimap)
@@ -452,7 +456,7 @@ impl App {
                 .width(Length::Fill)
                 .height(Length::FillPortion(5))
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_DARK.into()),
+                    background: Some(th::bg_dark().into()),
                     ..Default::default()
                 }),
         )
@@ -470,7 +474,7 @@ impl App {
         if self.state.arrangement.tracks.is_empty() {
             let prompt = text("Add a track to get started")
                 .size(16)
-                .color(th::TEXT_DIM);
+                .color(th::text_dim());
 
             let centered = center(prompt).width(Length::Fill).height(Length::Fill);
 
@@ -478,7 +482,7 @@ impl App {
                 .width(Length::Fill)
                 .height(Length::FillPortion(5))
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_DARK.into()),
+                    background: Some(th::bg_dark().into()),
                     ..Default::default()
                 })
                 .into();
@@ -517,7 +521,7 @@ impl App {
                 .width(Length::Fill)
                 .height(Length::FillPortion(5))
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_DARK.into()),
+                    background: Some(th::bg_dark().into()),
                     ..Default::default()
                 }),
         )
@@ -533,14 +537,14 @@ impl App {
 
     pub(super) fn view_transport(&self) -> Element<'_, Message> {
         // Skip back button
-        let skip_back_btn = button(icons::icon(icons::SKIP_BACK).size(16).color(th::TEXT))
+        let skip_back_btn = button(icons::icon(icons::SKIP_BACK).size(16).color(th::text()))
             .on_press(Message::Transport(TransportMsg::Stop))
             .padding([8, 12])
             .style(|_theme: &Theme, _status| button::Style {
-                background: Some(th::BG_ELEVATED.into()),
-                text_color: th::TEXT,
+                background: Some(th::bg_elevated().into()),
+                text_color: th::text(),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -549,28 +553,28 @@ impl App {
 
         // Play/Pause button
         let play_pause_btn = if self.state.transport.playing {
-            button(icons::icon(icons::PAUSE).size(16).color(th::ACCENT))
+            button(icons::icon(icons::PAUSE).size(16).color(th::accent()))
                 .on_press(Message::Transport(TransportMsg::Stop))
                 .padding([8, 14])
                 .style(|_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::ACCENT,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::accent(),
                     border: iced::Border {
-                        color: th::ACCENT_DIM,
+                        color: th::accent_dim(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
                     ..Default::default()
                 })
         } else {
-            button(icons::icon(icons::PLAY).size(16).color(th::SUCCESS))
+            button(icons::icon(icons::PLAY).size(16).color(th::success()))
                 .on_press(Message::Transport(TransportMsg::Play))
                 .padding([8, 14])
                 .style(|_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::SUCCESS,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::success(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -580,28 +584,28 @@ impl App {
 
         // Loop toggle button
         let loop_btn = if self.state.transport.loop_enabled {
-            button(icons::icon(icons::REPEAT).size(16).color(th::ACCENT))
+            button(icons::icon(icons::REPEAT).size(16).color(th::accent()))
                 .on_press(Message::Transport(TransportMsg::ToggleArrangementLoop))
                 .padding([8, 12])
                 .style(|_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::ACCENT,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::accent(),
                     border: iced::Border {
-                        color: th::ACCENT_DIM,
+                        color: th::accent_dim(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
                     ..Default::default()
                 })
         } else {
-            button(icons::icon(icons::REPEAT).size(16).color(th::TEXT_DIM))
+            button(icons::icon(icons::REPEAT).size(16).color(th::text_dim()))
                 .on_press(Message::Transport(TransportMsg::ToggleArrangementLoop))
                 .padding([8, 12])
                 .style(|_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::TEXT_DIM,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -618,7 +622,7 @@ impl App {
             AppState::format_time(self.state.duration_seconds()),
         ))
         .size(14)
-        .color(th::TEXT);
+        .color(th::text());
 
         // BPM
         let bpm_input = text_input("BPM", &self.state.transport.bpm_text)
@@ -628,19 +632,19 @@ impl App {
             .size(14);
 
         let bpm_nudge = |icon: char, delta: f64| {
-            button(icons::icon(icon).size(8).color(th::TEXT_DIM))
+            button(icons::icon(icon).size(8).color(th::text_dim()))
                 .on_press(Message::Transport(TransportMsg::NudgeBpm(delta)))
                 .padding([0, 4])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
                         _ => None,
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT_DIM,
+                        text_color: th::text_dim(),
                         border: iced::Border {
                             radius: 2.0.into(),
                             ..Default::default()
@@ -655,7 +659,7 @@ impl App {
         ]
         .spacing(1);
 
-        let bpm_label = text("BPM").size(12).color(th::TEXT_DIM);
+        let bpm_label = text("BPM").size(12).color(th::text_dim());
 
         // Master VU meter
         let master_meter = VuMeterWidget {
@@ -667,7 +671,7 @@ impl App {
             .height(Length::Fixed(28.0))
             .into();
 
-        let volume_icon = icons::icon(icons::VOLUME_2).size(14).color(th::TEXT_DIM);
+        let volume_icon = icons::icon(icons::VOLUME_2).size(14).color(th::text_dim());
 
         let transport = row![
             transport_buttons,
@@ -688,9 +692,9 @@ impl App {
         container(transport)
             .width(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 0.0.into(),
                 },
@@ -700,13 +704,13 @@ impl App {
     }
 
     pub(super) fn view_status(&self) -> Element<'_, Message> {
-        let status = text(&self.state.status_text).size(11).color(th::TEXT_DIM);
+        let status = text(&self.state.status_text).size(11).color(th::text_dim());
 
         container(status)
             .width(Length::Fill)
             .padding([3, 12])
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_DARK.into()),
+                background: Some(th::bg_dark().into()),
                 ..Default::default()
             })
             .into()
@@ -725,7 +729,7 @@ impl App {
 
         for lane in &track.automation {
             let label = target_label(&lane.target, track);
-            let remove = button(icons::icon(icons::TRASH_2).size(9).color(th::TEXT_DIM))
+            let remove = button(icons::icon(icons::TRASH_2).size(9).color(th::text_dim()))
                 .on_press(Message::Automation(AutomationMsg::RemoveLane {
                     track_id: track.id,
                     lane_id: lane.id,
@@ -733,13 +737,13 @@ impl App {
                 .padding([1, 4])
                 .style(|_theme: &Theme, _status| button::Style {
                     background: None,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border::default(),
                     ..Default::default()
                 });
             let lane_header = container(
                 row![
-                    text(label).size(11).color(th::TEXT_DIM),
+                    text(label).size(11).color(th::text_dim()),
                     horizontal_space(),
                     remove
                 ]
@@ -753,7 +757,7 @@ impl App {
             .height(Length::Fixed(LANE_HEIGHT))
             .align_y(iced::alignment::Vertical::Center)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 ..Default::default()
             });
 
@@ -862,23 +866,23 @@ impl App {
                 .size(11)
                 .padding([4, 8])
                 .style(|_theme: &Theme, _status| iced::widget::text_input::Style {
-                    background: th::BG_DARK.into(),
+                    background: th::bg_dark().into(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 3.0.into(),
                     },
-                    icon: th::TEXT_DIM,
-                    placeholder: th::TEXT_DIM,
-                    value: th::TEXT,
-                    selection: th::ACCENT,
+                    icon: th::text_dim(),
+                    placeholder: th::text_dim(),
+                    value: th::text(),
+                    selection: th::accent(),
                 });
-            let close = button(icons::icon(icons::X).size(10).color(th::TEXT_DIM))
+            let close = button(icons::icon(icons::X).size(10).color(th::text_dim()))
                 .on_press(Message::Automation(AutomationMsg::CloseLanePicker))
                 .padding([3, 6])
                 .style(|_theme: &Theme, _status| button::Style {
                     background: None,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border::default(),
                     ..Default::default()
                 });
@@ -888,7 +892,7 @@ impl App {
                 let target = choice.target;
                 let track_id = track.id;
                 list = list.push(
-                    button(text(choice.label).size(11).color(th::TEXT))
+                    button(text(choice.label).size(11).color(th::text()))
                         .on_press(Message::Automation(AutomationMsg::AddLane {
                             track_id,
                             target,
@@ -898,13 +902,13 @@ impl App {
                         .style(|_theme: &Theme, status| {
                             let bg = match status {
                                 button::Status::Hovered | button::Status::Pressed => {
-                                    Some(th::BG_HOVER.into())
+                                    Some(th::bg_hover().into())
                                 }
                                 _ => None,
                             };
                             button::Style {
                                 background: bg,
-                                text_color: th::TEXT,
+                                text_color: th::text(),
                                 border: iced::Border::default(),
                                 ..Default::default()
                             }
@@ -916,7 +920,7 @@ impl App {
                     container(
                         text(format!("{hidden} more \u{2014} refine the search"))
                             .size(10)
-                            .color(th::TEXT_DIM),
+                            .color(th::text_dim()),
                     )
                     .padding([3, 10]),
                 );
@@ -926,7 +930,7 @@ impl App {
                     container(
                         text("Everything is already automated")
                             .size(10)
-                            .color(th::TEXT_DIM),
+                            .color(th::text_dim()),
                     )
                     .padding([3, 10]),
                 );
@@ -944,9 +948,9 @@ impl App {
             .padding(8)
             .width(Length::Fill)
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_SURFACE.into()),
+                background: Some(th::bg_surface().into()),
                 border: iced::Border {
-                    color: th::BORDER,
+                    color: th::border(),
                     width: 1.0,
                     radius: 3.0.into(),
                 },
@@ -956,22 +960,22 @@ impl App {
         } else {
             let track_id = track.id;
             container(
-                button(text("+ Add automation").size(11).color(th::TEXT_DIM))
+                button(text("+ Add automation").size(11).color(th::text_dim()))
                     .on_press(Message::Automation(AutomationMsg::OpenLanePicker(track_id)))
                     .width(Length::Fill)
                     .padding([3, 10])
                     .style(|_theme: &Theme, status| {
                         let bg = match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::BG_HOVER.into())
+                                Some(th::bg_hover().into())
                             }
-                            _ => Some(th::BG_ELEVATED.into()),
+                            _ => Some(th::bg_elevated().into()),
                         };
                         button::Style {
                             background: bg,
-                            text_color: th::TEXT_DIM,
+                            text_color: th::text_dim(),
                             border: iced::Border {
-                                color: th::BORDER,
+                                color: th::border(),
                                 width: 1.0,
                                 radius: 3.0.into(),
                             },
@@ -995,7 +999,7 @@ impl App {
             container(panel)
                 .width(Length::Fixed(panel_width))
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_SURFACE.into()),
+                    background: Some(th::bg_surface().into()),
                     ..Default::default()
                 }),
             iced::widget::horizontal_space()

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -388,8 +388,14 @@ impl App {
 
             // Track header (iced widgets)
             let editing = self.state.view.editing_track_name == Some(track.id);
-            let header =
-                view_track_header(track, selected, editing, &self.state.view.edit_name_text);
+            let automation_open = self.state.automation_ui.expanded.contains(&track.id);
+            let header = view_track_header(
+                track,
+                selected,
+                editing,
+                &self.state.view.edit_name_text,
+                automation_open,
+            );
 
             // Clip canvas for this track
             let clip_canvas_widget = TrackClipCanvas::from_track(
@@ -425,6 +431,10 @@ impl App {
             let track_row = row![header, clip_canvas].height(Length::Fixed(70.0));
 
             track_rows = track_rows.push(track_row);
+
+            if automation_open {
+                track_rows = self.push_automation_lanes(track_rows, track, track_color);
+            }
         }
 
         let content = column![ruler_row, minimap_row, track_rows];
@@ -720,5 +730,143 @@ impl App {
                 ..Default::default()
             })
             .into()
+    }
+
+    /// Lane strip under an expanded track: one row per lane plus the
+    /// add-lane picker.
+    fn push_automation_lanes<'a>(
+        &'a self,
+        mut rows: iced::widget::Column<'a, Message>,
+        track: &'a crate::state::UiTrack,
+        track_color: iced::Color,
+    ) -> iced::widget::Column<'a, Message> {
+        use crate::domains::automation::{target_label, AutomationMsg};
+        use crate::widgets::automation_lane::{AutomationLaneWidget, LANE_HEIGHT};
+
+        for lane in &track.automation {
+            let label = target_label(&lane.target, track);
+            let remove = button(icons::icon(icons::TRASH_2).size(9).color(th::TEXT_DIM))
+                .on_press(Message::Automation(AutomationMsg::RemoveLane {
+                    track_id: track.id,
+                    lane_id: lane.id,
+                }))
+                .padding([1, 4])
+                .style(|_theme: &Theme, _status| button::Style {
+                    background: None,
+                    text_color: th::TEXT_DIM,
+                    border: iced::Border::default(),
+                    ..Default::default()
+                });
+            let lane_header = container(
+                row![
+                    text(label).size(11).color(th::TEXT_DIM),
+                    horizontal_space(),
+                    remove
+                ]
+                .spacing(4)
+                .align_y(iced::Alignment::Center),
+            )
+            .padding([0, 10])
+            .width(Length::Fixed(
+                crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH,
+            ))
+            .height(Length::Fixed(LANE_HEIGHT))
+            .align_y(iced::alignment::Vertical::Center)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::BG_SURFACE.into()),
+                ..Default::default()
+            });
+
+            let selected = match self.state.automation_ui.selected {
+                Some((t, l, i)) if t == track.id && l == lane.id => Some(i),
+                _ => None,
+            };
+            let widget = AutomationLaneWidget {
+                track_id: track.id,
+                lane_id: lane.id,
+                points: lane.points.clone(),
+                color: track_color,
+                zoom_level: self.state.view.zoom_level,
+                scroll_offset_beats: self.state.view.scroll_offset_beats,
+                selected,
+            };
+            let lane_canvas: Element<'_, Message> = canvas(widget)
+                .width(Length::Fill)
+                .height(Length::Fixed(LANE_HEIGHT))
+                .into();
+            rows = rows.push(row![lane_header, lane_canvas].height(Length::Fixed(LANE_HEIGHT)));
+        }
+
+        // Add-lane picker: gain/pan plus every built-in effect param.
+        let mut choices: Vec<LaneChoice> = vec![
+            LaneChoice {
+                label: "Volume".to_string(),
+                target: vibez_core::automation::AutomationTarget::TrackGain,
+            },
+            LaneChoice {
+                label: "Pan".to_string(),
+                target: vibez_core::automation::AutomationTarget::TrackPan,
+            },
+        ];
+        for effect in &track.effects {
+            for (param_index, d) in effect.descriptors.iter().enumerate() {
+                let effect_name = effect
+                    .plugin_name
+                    .clone()
+                    .unwrap_or_else(|| format!("{:?}", effect.effect_type));
+                choices.push(LaneChoice {
+                    label: format!("{effect_name}: {}", d.name),
+                    target: vibez_core::automation::AutomationTarget::EffectParam {
+                        effect_id: effect.id,
+                        param_index,
+                    },
+                });
+            }
+        }
+        choices.retain(|c| !track.automation.iter().any(|l| l.target == c.target));
+
+        let track_id = track.id;
+        let picker = iced::widget::pick_list(choices, None::<LaneChoice>, move |choice| {
+            Message::Automation(AutomationMsg::AddLane {
+                track_id,
+                target: choice.target,
+            })
+        })
+        .placeholder("+ Add automation")
+        .text_size(11)
+        .padding([2, 8]);
+
+        let picker_row = row![
+            container(picker)
+                .padding([2, 10])
+                .width(Length::Fixed(
+                    crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH,
+                ))
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(th::BG_SURFACE.into()),
+                    ..Default::default()
+                }),
+            container(text(""))
+                .width(Length::Fill)
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.18).into()),
+                    ..Default::default()
+                })
+        ]
+        .height(Length::Fixed(26.0));
+        rows.push(picker_row)
+    }
+}
+
+/// One option in the add-lane picker.
+#[derive(Debug, Clone, PartialEq)]
+struct LaneChoice {
+    label: String,
+    target: vibez_core::automation::AutomationTarget,
+}
+
+impl std::fmt::Display for LaneChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.label)
     }
 }

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -789,6 +789,7 @@ impl App {
                 color: track_color,
                 zoom_level: self.state.view.zoom_level,
                 scroll_offset_beats: self.state.view.scroll_offset_beats,
+                snap: self.state.view.snap_grid,
                 selected,
                 reference,
                 min_label,
@@ -808,6 +809,7 @@ impl App {
             Some((tid, q)) if *tid == track.id => Some(q.clone()),
             _ => None,
         };
+        let picker_open = picker_query.is_some();
 
         let panel: Element<'_, Message> = if let Some(query) = picker_query {
             let mut choices: Vec<LaneChoice> = vec![
@@ -976,6 +978,7 @@ impl App {
             container(
                 button(text("+ Add automation").size(11).color(th::TEXT_DIM))
                     .on_press(Message::Automation(AutomationMsg::OpenLanePicker(track_id)))
+                    .width(Length::Fill)
                     .padding([3, 10])
                     .style(|_theme: &Theme, status| {
                         let bg = match status {
@@ -1000,22 +1003,22 @@ impl App {
             .into()
         };
 
-        let filler = container(text(""))
-            .width(Length::Fill)
-            .style(|_theme: &Theme| container::Style {
-                background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.18).into()),
-                ..Default::default()
-            });
+        // Collapsed: the button sits inside the header column like a
+        // lane header. Open: the search panel widens over the lane
+        // area like a dropdown.
+        let panel_width = if picker_open {
+            crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH + 300.0
+        } else {
+            crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH
+        };
         let picker_row = row![
             container(panel)
-                .width(Length::Fixed(
-                    crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH + 220.0,
-                ))
+                .width(Length::Fixed(panel_width))
                 .style(|_theme: &Theme| container::Style {
                     background: Some(th::BG_SURFACE.into()),
                     ..Default::default()
                 }),
-            filler
+            iced::widget::horizontal_space()
         ];
         rows.push(picker_row)
     }

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -488,7 +488,8 @@ impl App {
         let mut strips = row![].spacing(4).padding(8).height(Length::Fill);
 
         for track in &self.state.arrangement.tracks {
-            let strip = view_mixer_strip(track);
+            let selected = self.state.arrangement.selected_track == Some(track.id);
+            let strip = view_mixer_strip(track, selected);
             strips = strips.push(strip);
         }
 

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -493,38 +493,17 @@ impl App {
             strips = strips.push(strip);
         }
 
-        // Master strip — pinned to far right
-        let master_label = text("Master").size(12).color(th::TEXT);
-        let master_meter = VuMeterWidget {
-            peak_l: self.state.peak_l,
-            peak_r: self.state.peak_r,
-        };
-        let master_meter_canvas: Element<'_, Message> = canvas(master_meter)
-            .width(Length::Fixed(32.0))
-            .height(Length::Fill)
-            .into();
+        // Master strip — a real channel, pinned to far right
+        let master_selected =
+            self.state.arrangement.selected_track == Some(vibez_core::id::TrackId::MASTER);
+        let master_strip = container(view_mixer_strip(
+            &self.state.arrangement.master,
+            master_selected,
+        ))
+        .padding(8)
+        .height(Length::Fill);
 
-        let master_col = column![master_label, master_meter_canvas]
-            .spacing(4)
-            .padding(8)
-            .width(Length::Fixed(100.0))
-            .height(Length::Fill)
-            .align_x(iced::Alignment::Center);
-
-        let master_container =
-            container(master_col)
-                .height(Length::Fill)
-                .style(|_theme: &Theme| container::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    border: iced::Border {
-                        color: th::BORDER,
-                        width: 1.0,
-                        radius: 2.0.into(),
-                    },
-                    ..Default::default()
-                });
-
-        let mixer_row = row![strips, horizontal_space(), master_container]
+        let mixer_row = row![strips, horizontal_space(), master_strip]
             .spacing(4)
             .padding([8, 4])
             .height(Length::Fill);

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -808,6 +808,35 @@ impl App {
                 target: vibez_core::automation::AutomationTarget::TrackPan,
             },
         ];
+        if !track.plugin_instrument_descriptors.is_empty() {
+            let name = track
+                .plugin_instrument_name
+                .clone()
+                .unwrap_or_else(|| "Plugin".to_string());
+            for (param_index, d) in track.plugin_instrument_descriptors.iter().enumerate() {
+                choices.push(LaneChoice {
+                    label: format!("{name}: {}", d.name),
+                    target: vibez_core::automation::AutomationTarget::InstrumentParam {
+                        param_index,
+                    },
+                });
+            }
+        }
+        if let Some(kind) = track.instrument_kind {
+            let instrument_name = match kind {
+                vibez_core::midi::InstrumentKind::SubtractiveSynth => "Synth",
+                vibez_core::midi::InstrumentKind::Sampler => "Sampler",
+                vibez_core::midi::InstrumentKind::DrumRack => "Drum Rack",
+            };
+            for (param_index, d) in vibez_instruments::descriptors_for(kind).iter().enumerate() {
+                choices.push(LaneChoice {
+                    label: format!("{instrument_name}: {}", d.name),
+                    target: vibez_core::automation::AutomationTarget::InstrumentParam {
+                        param_index,
+                    },
+                });
+            }
+        }
         for effect in &track.effects {
             for (param_index, d) in effect.descriptors.iter().enumerate() {
                 let effect_name = effect

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -781,6 +781,7 @@ impl App {
                 Some((t, l, i)) if t == track.id && l == lane.id => Some(i),
                 _ => None,
             };
+            let (reference, min_label, max_label, ref_label) = lane_scale(track, &lane.target);
             let widget = AutomationLaneWidget {
                 track_id: track.id,
                 lane_id: lane.id,
@@ -789,6 +790,10 @@ impl App {
                 zoom_level: self.state.view.zoom_level,
                 scroll_offset_beats: self.state.view.scroll_offset_beats,
                 selected,
+                reference,
+                min_label,
+                max_label,
+                ref_label,
             };
             let lane_canvas: Element<'_, Message> = canvas(widget)
                 .width(Length::Fill)
@@ -797,93 +802,281 @@ impl App {
             rows = rows.push(row![lane_header, lane_canvas].height(Length::Fixed(LANE_HEIGHT)));
         }
 
-        // Add-lane picker: gain/pan plus every built-in effect param.
-        let mut choices: Vec<LaneChoice> = vec![
-            LaneChoice {
-                label: "Volume".to_string(),
-                target: vibez_core::automation::AutomationTarget::TrackGain,
-            },
-            LaneChoice {
-                label: "Pan".to_string(),
-                target: vibez_core::automation::AutomationTarget::TrackPan,
-            },
-        ];
-        if !track.plugin_instrument_descriptors.is_empty() {
-            let name = track
-                .plugin_instrument_name
-                .clone()
-                .unwrap_or_else(|| "Plugin".to_string());
-            for (param_index, d) in track.plugin_instrument_descriptors.iter().enumerate() {
-                choices.push(LaneChoice {
-                    label: format!("{name}: {}", d.name),
-                    target: vibez_core::automation::AutomationTarget::InstrumentParam {
-                        param_index,
-                    },
-                });
-            }
-        }
-        if let Some(kind) = track.instrument_kind {
-            let instrument_name = match kind {
-                vibez_core::midi::InstrumentKind::SubtractiveSynth => "Synth",
-                vibez_core::midi::InstrumentKind::Sampler => "Sampler",
-                vibez_core::midi::InstrumentKind::DrumRack => "Drum Rack",
-            };
-            for (param_index, d) in vibez_instruments::descriptors_for(kind).iter().enumerate() {
-                choices.push(LaneChoice {
-                    label: format!("{instrument_name}: {}", d.name),
-                    target: vibez_core::automation::AutomationTarget::InstrumentParam {
-                        param_index,
-                    },
-                });
-            }
-        }
-        for effect in &track.effects {
-            for (param_index, d) in effect.descriptors.iter().enumerate() {
-                let effect_name = effect
-                    .plugin_name
+        // Add-lane entry: a button that opens a searchable picker
+        // panel (plugins can expose hundreds of parameters).
+        let picker_query = match &self.state.automation_ui.picker {
+            Some((tid, q)) if *tid == track.id => Some(q.clone()),
+            _ => None,
+        };
+
+        let panel: Element<'_, Message> = if let Some(query) = picker_query {
+            let mut choices: Vec<LaneChoice> = vec![
+                LaneChoice {
+                    label: "Volume".to_string(),
+                    target: vibez_core::automation::AutomationTarget::TrackGain,
+                },
+                LaneChoice {
+                    label: "Pan".to_string(),
+                    target: vibez_core::automation::AutomationTarget::TrackPan,
+                },
+            ];
+            if !track.plugin_instrument_descriptors.is_empty() {
+                let name = track
+                    .plugin_instrument_name
                     .clone()
-                    .unwrap_or_else(|| format!("{:?}", effect.effect_type));
-                choices.push(LaneChoice {
-                    label: format!("{effect_name}: {}", d.name),
-                    target: vibez_core::automation::AutomationTarget::EffectParam {
-                        effect_id: effect.id,
-                        param_index,
-                    },
-                });
+                    .unwrap_or_else(|| "Plugin".to_string());
+                for (param_index, d) in track.plugin_instrument_descriptors.iter().enumerate() {
+                    choices.push(LaneChoice {
+                        label: format!("{name}: {}", d.name),
+                        target: vibez_core::automation::AutomationTarget::InstrumentParam {
+                            param_index,
+                        },
+                    });
+                }
             }
-        }
-        choices.retain(|c| !track.automation.iter().any(|l| l.target == c.target));
+            if let Some(kind) = track.instrument_kind {
+                let instrument_name = match kind {
+                    vibez_core::midi::InstrumentKind::SubtractiveSynth => "Synth",
+                    vibez_core::midi::InstrumentKind::Sampler => "Sampler",
+                    vibez_core::midi::InstrumentKind::DrumRack => "Drum Rack",
+                };
+                for (param_index, d) in vibez_instruments::descriptors_for(kind).iter().enumerate()
+                {
+                    choices.push(LaneChoice {
+                        label: format!("{instrument_name}: {}", d.name),
+                        target: vibez_core::automation::AutomationTarget::InstrumentParam {
+                            param_index,
+                        },
+                    });
+                }
+            }
+            for effect in &track.effects {
+                for (param_index, d) in effect.descriptors.iter().enumerate() {
+                    let effect_name = effect
+                        .plugin_name
+                        .clone()
+                        .unwrap_or_else(|| format!("{:?}", effect.effect_type));
+                    choices.push(LaneChoice {
+                        label: format!("{effect_name}: {}", d.name),
+                        target: vibez_core::automation::AutomationTarget::EffectParam {
+                            effect_id: effect.id,
+                            param_index,
+                        },
+                    });
+                }
+            }
+            choices.retain(|c| !track.automation.iter().any(|l| l.target == c.target));
 
-        let track_id = track.id;
-        let picker = iced::widget::pick_list(choices, None::<LaneChoice>, move |choice| {
-            Message::Automation(AutomationMsg::AddLane {
-                track_id,
-                target: choice.target,
+            let needle = query.to_lowercase();
+            let total_before = choices.len();
+            if !needle.is_empty() {
+                choices.retain(|c| c.label.to_lowercase().contains(&needle));
+            }
+            let shown = choices.len().min(MAX_PICKER_RESULTS);
+            let hidden = choices.len() - shown;
+
+            let search = iced::widget::text_input("Search parameters\u{2026}", &query)
+                .on_input(|q| Message::Automation(AutomationMsg::LanePickerQuery(q)))
+                .size(11)
+                .padding([4, 8])
+                .style(|_theme: &Theme, _status| iced::widget::text_input::Style {
+                    background: th::BG_DARK.into(),
+                    border: iced::Border {
+                        color: th::BORDER,
+                        width: 1.0,
+                        radius: 3.0.into(),
+                    },
+                    icon: th::TEXT_DIM,
+                    placeholder: th::TEXT_DIM,
+                    value: th::TEXT,
+                    selection: th::ACCENT,
+                });
+            let close = button(icons::icon(icons::X).size(10).color(th::TEXT_DIM))
+                .on_press(Message::Automation(AutomationMsg::CloseLanePicker))
+                .padding([3, 6])
+                .style(|_theme: &Theme, _status| button::Style {
+                    background: None,
+                    text_color: th::TEXT_DIM,
+                    border: iced::Border::default(),
+                    ..Default::default()
+                });
+
+            let mut list = column![].spacing(1);
+            for choice in choices.into_iter().take(MAX_PICKER_RESULTS) {
+                let target = choice.target;
+                let track_id = track.id;
+                list = list.push(
+                    button(text(choice.label).size(11).color(th::TEXT))
+                        .on_press(Message::Automation(AutomationMsg::AddLane {
+                            track_id,
+                            target,
+                        }))
+                        .width(Length::Fill)
+                        .padding([3, 10])
+                        .style(|_theme: &Theme, status| {
+                            let bg = match status {
+                                button::Status::Hovered | button::Status::Pressed => {
+                                    Some(th::BG_HOVER.into())
+                                }
+                                _ => None,
+                            };
+                            button::Style {
+                                background: bg,
+                                text_color: th::TEXT,
+                                border: iced::Border::default(),
+                                ..Default::default()
+                            }
+                        }),
+                );
+            }
+            if hidden > 0 {
+                list = list.push(
+                    container(
+                        text(format!("{hidden} more \u{2014} refine the search"))
+                            .size(10)
+                            .color(th::TEXT_DIM),
+                    )
+                    .padding([3, 10]),
+                );
+            }
+            if total_before == 0 {
+                list = list.push(
+                    container(
+                        text("Everything is already automated")
+                            .size(10)
+                            .color(th::TEXT_DIM),
+                    )
+                    .padding([3, 10]),
+                );
+            }
+
+            container(
+                column![
+                    row![search, close]
+                        .spacing(6)
+                        .align_y(iced::Alignment::Center),
+                    iced::widget::scrollable(list).height(Length::Fixed(150.0)),
+                ]
+                .spacing(6),
+            )
+            .padding(8)
+            .width(Length::Fill)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::BG_SURFACE.into()),
+                border: iced::Border {
+                    color: th::BORDER,
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                ..Default::default()
             })
-        })
-        .placeholder("+ Add automation")
-        .text_size(11)
-        .padding([2, 8]);
+            .into()
+        } else {
+            let track_id = track.id;
+            container(
+                button(text("+ Add automation").size(11).color(th::TEXT_DIM))
+                    .on_press(Message::Automation(AutomationMsg::OpenLanePicker(track_id)))
+                    .padding([3, 10])
+                    .style(|_theme: &Theme, status| {
+                        let bg = match status {
+                            button::Status::Hovered | button::Status::Pressed => {
+                                Some(th::BG_HOVER.into())
+                            }
+                            _ => Some(th::BG_ELEVATED.into()),
+                        };
+                        button::Style {
+                            background: bg,
+                            text_color: th::TEXT_DIM,
+                            border: iced::Border {
+                                color: th::BORDER,
+                                width: 1.0,
+                                radius: 3.0.into(),
+                            },
+                            ..Default::default()
+                        }
+                    }),
+            )
+            .padding([2, 10])
+            .into()
+        };
 
+        let filler = container(text(""))
+            .width(Length::Fill)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.18).into()),
+                ..Default::default()
+            });
         let picker_row = row![
-            container(picker)
-                .padding([2, 10])
+            container(panel)
                 .width(Length::Fixed(
-                    crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH,
+                    crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH + 220.0,
                 ))
                 .style(|_theme: &Theme| container::Style {
                     background: Some(th::BG_SURFACE.into()),
                     ..Default::default()
                 }),
-            container(text(""))
-                .width(Length::Fill)
-                .style(|_theme: &Theme| container::Style {
-                    background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.18).into()),
-                    ..Default::default()
-                })
-        ]
-        .height(Length::Fixed(26.0));
+            filler
+        ];
         rows.push(picker_row)
+    }
+}
+
+const MAX_PICKER_RESULTS: usize = 40;
+
+/// Reference value plus scale labels for a lane's target.
+fn lane_scale(
+    track: &crate::state::UiTrack,
+    target: &vibez_core::automation::AutomationTarget,
+) -> (Option<f32>, String, String, String) {
+    use crate::domains::automation::{normalized_target_value, target_descriptor};
+    use vibez_core::automation::AutomationTarget;
+
+    let reference = normalized_target_value(target, track);
+    match target {
+        AutomationTarget::TrackGain => {
+            let r = reference
+                .map(|n| fmt_value(n * 2.0, ""))
+                .unwrap_or_default();
+            (reference, "0".into(), "2.0".into(), r)
+        }
+        AutomationTarget::TrackPan => {
+            let r = match reference {
+                Some(n) if (n - 0.5).abs() < 0.01 => "C".to_string(),
+                Some(n) => fmt_value(n * 2.0 - 1.0, ""),
+                None => String::new(),
+            };
+            (reference, "L".into(), "R".into(), r)
+        }
+        _ => match target_descriptor(target, track) {
+            Some(d) => {
+                let r = reference
+                    .map(|n| fmt_value(d.min + n * (d.max - d.min), d.unit))
+                    .unwrap_or_default();
+                (
+                    reference,
+                    fmt_value(d.min, d.unit),
+                    fmt_value(d.max, d.unit),
+                    r,
+                )
+            }
+            None => (reference, String::new(), String::new(), String::new()),
+        },
+    }
+}
+
+fn fmt_value(v: f32, unit: &str) -> String {
+    let num = if v.abs() >= 1000.0 {
+        format!("{:.0}k", v / 1000.0)
+    } else if v.abs() >= 100.0 {
+        format!("{v:.0}")
+    } else {
+        let s = format!("{v:.2}");
+        s.trim_end_matches('0').trim_end_matches('.').to_string()
+    };
+    if unit.is_empty() {
+        num
+    } else {
+        format!("{num} {unit}")
     }
 }
 

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -174,6 +174,31 @@ pub struct ArrangementCtx {
     pub playhead_beats: f64,
 }
 
+/// Every channel carries an SSL-style EQ, console style: create it
+/// flat (passthrough) alongside the track.
+fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut UiTrack) {
+    let effect_id = vibez_core::id::EffectId::new();
+    let effect_type = vibez_core::effect::EffectType::Eq;
+    let descriptors = vibez_dsp::factory::create_effect(effect_type, 48_000.0).param_descriptors();
+    let params: Vec<f32> = descriptors.iter().map(|d| d.default).collect();
+    track.effects.push(crate::state::UiEffect {
+        id: effect_id,
+        effect_type,
+        bypass: false,
+        params,
+        descriptors,
+        plugin_name: None,
+        has_plugin_gui: false,
+        plugin_ref: None,
+    });
+    engine.send(EngineCommand::AddEffect {
+        track_id: track.id,
+        effect_id,
+        effect_type,
+        position: None,
+    });
+}
+
 impl ArrangementState {
     fn find_track(&self, track_id: TrackId) -> Option<&UiTrack> {
         self.tracks.iter().find(|t| t.id == track_id)
@@ -228,7 +253,9 @@ impl ArrangementState {
                 let id = TrackId::new();
                 let name = format!("Track {track_num}");
                 engine.send(EngineCommand::AddTrack(id, name.clone()));
-                self.tracks.push(UiTrack::new(id, name, color_index));
+                let mut track = UiTrack::new(id, name, color_index);
+                attach_channel_eq(engine, &mut track);
+                self.tracks.push(track);
                 self.selected_track = Some(id);
                 action.status = Some(format!("{} tracks", self.tracks.len()));
             }
@@ -241,6 +268,7 @@ impl ArrangementState {
                 engine.send(EngineCommand::AddMidiTrack(id, name.clone()));
                 let mut track = UiTrack::new_instrument(id, name, TrackKind::Midi, color_index);
                 track.has_instrument = false;
+                attach_channel_eq(engine, &mut track);
                 self.tracks.push(track);
                 self.selected_track = Some(id);
                 action.status = Some(format!("{} tracks", self.tracks.len()));

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -175,8 +175,9 @@ pub struct ArrangementCtx {
 }
 
 /// Every channel carries an SSL-style EQ, console style: create it
-/// flat (passthrough) alongside the track.
-fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut UiTrack) {
+/// flat (passthrough) alongside the track. Also used for the master
+/// bus, which is why it is crate-visible.
+pub(crate) fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut UiTrack) {
     let effect_id = vibez_core::id::EffectId::new();
     let effect_type = vibez_core::effect::EffectType::Eq;
     let descriptors = vibez_dsp::factory::create_effect(effect_type, 48_000.0).param_descriptors();
@@ -201,6 +202,9 @@ fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut UiTrack) {
 
 impl ArrangementState {
     fn find_track(&self, track_id: TrackId) -> Option<&UiTrack> {
+        if track_id.is_master() {
+            return Some(&self.master);
+        }
         self.tracks.iter().find(|t| t.id == track_id)
     }
 
@@ -217,6 +221,9 @@ impl ArrangementState {
     }
 
     fn find_track_mut(&mut self, track_id: TrackId) -> Option<&mut UiTrack> {
+        if track_id.is_master() {
+            return Some(&mut self.master);
+        }
         self.tracks.iter_mut().find(|t| t.id == track_id)
     }
 
@@ -274,6 +281,10 @@ impl ArrangementState {
                 action.status = Some(format!("{} tracks", self.tracks.len()));
             }
             ArrangementMsg::RemoveTrack(track_id) => {
+                if track_id.is_master() {
+                    // The master bus cannot be deleted.
+                    return action;
+                }
                 let removed_name = self
                     .tracks
                     .iter()

--- a/crates/vibez-ui/src/domains/automation.rs
+++ b/crates/vibez-ui/src/domains/automation.rs
@@ -126,7 +126,26 @@ pub fn target_label(target: &AutomationTarget, track: &UiTrack) -> String {
                 None => format!("{effect_name}: P{param_index}"),
             }
         }
-        AutomationTarget::InstrumentParam { param_index } => format!("Instrument P{param_index}"),
+        AutomationTarget::InstrumentParam { param_index } => {
+            let (name, descriptors) = if !track.plugin_instrument_descriptors.is_empty() {
+                (
+                    track.plugin_instrument_name.as_deref().unwrap_or("Plugin"),
+                    track.plugin_instrument_descriptors,
+                )
+            } else {
+                (
+                    "Instrument",
+                    track
+                        .instrument_kind
+                        .map(vibez_instruments::descriptors_for)
+                        .unwrap_or(&[]),
+                )
+            };
+            match descriptors.get(*param_index) {
+                Some(d) => format!("{name}: {}", d.name),
+                None => format!("{name} P{param_index}"),
+            }
+        }
         AutomationTarget::PluginParam { .. } => "Plugin param".to_string(),
     }
 }

--- a/crates/vibez-ui/src/domains/automation.rs
+++ b/crates/vibez-ui/src/domains/automation.rs
@@ -1,0 +1,442 @@
+//! Automation domain: lane and point editing.
+//!
+//! Lanes live on [`UiTrack`] (the shared model) and mirror to the
+//! engine as whole-lane upserts: every edit clones the lane's points
+//! into a [`EngineCommand::SetAutomationLane`], so the allocation
+//! happens here on the UI thread and the audio thread only swaps
+//! vectors.
+
+use std::collections::HashSet;
+
+use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+use vibez_core::id::{LaneId, TrackId};
+use vibez_engine::commands::EngineCommand;
+
+use super::EngineHandle;
+use crate::state::UiTrack;
+
+/// Messages the automation domain handles.
+#[derive(Debug, Clone)]
+pub enum AutomationMsg {
+    /// Show/hide the lane strip under a track (view-only).
+    ToggleTrackLanes(TrackId),
+    AddLane {
+        track_id: TrackId,
+        target: AutomationTarget,
+    },
+    RemoveLane {
+        track_id: TrackId,
+        lane_id: LaneId,
+    },
+    AddPoint {
+        track_id: TrackId,
+        lane_id: LaneId,
+        beat: f64,
+        value: f32,
+    },
+    /// Move an existing point (drag release). The point keeps beat
+    /// order, so its index may change; selection follows it.
+    MovePoint {
+        track_id: TrackId,
+        lane_id: LaneId,
+        index: usize,
+        beat: f64,
+        value: f32,
+    },
+    RemovePoint {
+        track_id: TrackId,
+        lane_id: LaneId,
+        index: usize,
+    },
+    SelectPoint {
+        track_id: TrackId,
+        lane_id: LaneId,
+        index: Option<usize>,
+    },
+    /// Delete-key routing (higher priority than clip deletion when a
+    /// point is selected).
+    DeleteSelectedPoint,
+}
+
+impl AutomationMsg {
+    /// Whether this message edits the project (drives the dirty flag).
+    pub fn marks_dirty(&self) -> bool {
+        !matches!(
+            self,
+            AutomationMsg::ToggleTrackLanes(_) | AutomationMsg::SelectPoint { .. }
+        )
+    }
+}
+
+/// Cross-domain effects requested by an automation update.
+#[derive(Debug, Default, PartialEq)]
+pub struct AutomationAction {
+    /// Status bar text.
+    pub status: Option<String>,
+}
+
+/// Automation domain slice.
+#[derive(Debug, Default)]
+pub struct AutomationState {
+    /// Tracks whose lane strip is expanded.
+    pub expanded: HashSet<TrackId>,
+    /// The selected point: (track, lane, point index).
+    pub selected: Option<(TrackId, LaneId, usize)>,
+}
+
+fn find_lane_mut(
+    tracks: &mut [UiTrack],
+    track_id: TrackId,
+    lane_id: LaneId,
+) -> Option<&mut AutomationLane> {
+    tracks
+        .iter_mut()
+        .find(|t| t.id == track_id)?
+        .automation
+        .iter_mut()
+        .find(|l| l.id == lane_id)
+}
+
+fn sync_lane(engine: &mut impl EngineHandle, track_id: TrackId, lane: &AutomationLane) {
+    engine.send(EngineCommand::SetAutomationLane {
+        track_id,
+        lane: lane.clone(),
+    });
+}
+
+/// Human-readable name for a lane target, for lane headers and the
+/// add-lane picker.
+pub fn target_label(target: &AutomationTarget, track: &UiTrack) -> String {
+    match target {
+        AutomationTarget::TrackGain => "Volume".to_string(),
+        AutomationTarget::TrackPan => "Pan".to_string(),
+        AutomationTarget::EffectParam {
+            effect_id,
+            param_index,
+        } => {
+            let Some(effect) = track.effects.iter().find(|e| e.id == *effect_id) else {
+                return "Missing effect".to_string();
+            };
+            let effect_name = effect
+                .plugin_name
+                .clone()
+                .unwrap_or_else(|| format!("{:?}", effect.effect_type));
+            match effect.descriptors.get(*param_index) {
+                Some(d) => format!("{effect_name}: {}", d.name),
+                None => format!("{effect_name}: P{param_index}"),
+            }
+        }
+        AutomationTarget::InstrumentParam { param_index } => format!("Instrument P{param_index}"),
+        AutomationTarget::PluginParam { .. } => "Plugin param".to_string(),
+    }
+}
+
+impl AutomationState {
+    pub fn update(
+        &mut self,
+        msg: AutomationMsg,
+        engine: &mut impl EngineHandle,
+        tracks: &mut [UiTrack],
+    ) -> AutomationAction {
+        let mut action = AutomationAction::default();
+        match msg {
+            AutomationMsg::ToggleTrackLanes(track_id) => {
+                if !self.expanded.remove(&track_id) {
+                    self.expanded.insert(track_id);
+                }
+            }
+            AutomationMsg::AddLane { track_id, target } => {
+                let Some(track) = tracks.iter_mut().find(|t| t.id == track_id) else {
+                    return action;
+                };
+                if track.automation.iter().any(|l| l.target == target) {
+                    action.status = Some("That parameter already has a lane".to_string());
+                    return action;
+                }
+                let lane = AutomationLane::new(target);
+                sync_lane(engine, track_id, &lane);
+                let label = target_label(&target, track);
+                track.automation.push(lane);
+                self.expanded.insert(track_id);
+                action.status = Some(format!("Added automation lane: {label}"));
+            }
+            AutomationMsg::RemoveLane { track_id, lane_id } => {
+                if let Some(track) = tracks.iter_mut().find(|t| t.id == track_id) {
+                    track.automation.retain(|l| l.id != lane_id);
+                }
+                engine.send(EngineCommand::RemoveAutomationLane { track_id, lane_id });
+                if matches!(self.selected, Some((t, l, _)) if t == track_id && l == lane_id) {
+                    self.selected = None;
+                }
+                action.status = Some("Removed automation lane".to_string());
+            }
+            AutomationMsg::AddPoint {
+                track_id,
+                lane_id,
+                beat,
+                value,
+            } => {
+                let Some(lane) = find_lane_mut(tracks, track_id, lane_id) else {
+                    return action;
+                };
+                let point = AutomationPoint {
+                    beat: beat.max(0.0),
+                    value: value.clamp(0.0, 1.0),
+                };
+                lane.insert_point(point);
+                let index = lane
+                    .points
+                    .iter()
+                    .position(|p| p.beat == point.beat)
+                    .unwrap_or(0);
+                let lane = lane.clone();
+                sync_lane(engine, track_id, &lane);
+                self.selected = Some((track_id, lane_id, index));
+            }
+            AutomationMsg::MovePoint {
+                track_id,
+                lane_id,
+                index,
+                beat,
+                value,
+            } => {
+                let Some(lane) = find_lane_mut(tracks, track_id, lane_id) else {
+                    return action;
+                };
+                if index >= lane.points.len() {
+                    return action;
+                }
+                lane.points.remove(index);
+                let point = AutomationPoint {
+                    beat: beat.max(0.0),
+                    value: value.clamp(0.0, 1.0),
+                };
+                lane.insert_point(point);
+                let new_index = lane
+                    .points
+                    .iter()
+                    .position(|p| p.beat == point.beat)
+                    .unwrap_or(0);
+                let lane = lane.clone();
+                sync_lane(engine, track_id, &lane);
+                self.selected = Some((track_id, lane_id, new_index));
+            }
+            AutomationMsg::RemovePoint {
+                track_id,
+                lane_id,
+                index,
+            } => {
+                let Some(lane) = find_lane_mut(tracks, track_id, lane_id) else {
+                    return action;
+                };
+                if index >= lane.points.len() {
+                    return action;
+                }
+                lane.points.remove(index);
+                let lane = lane.clone();
+                sync_lane(engine, track_id, &lane);
+                if matches!(self.selected, Some((t, l, i)) if t == track_id && l == lane_id && i == index)
+                {
+                    self.selected = None;
+                }
+            }
+            AutomationMsg::SelectPoint {
+                track_id,
+                lane_id,
+                index,
+            } => {
+                self.selected = index.map(|i| (track_id, lane_id, i));
+            }
+            AutomationMsg::DeleteSelectedPoint => {
+                if let Some((track_id, lane_id, index)) = self.selected.take() {
+                    return self.update(
+                        AutomationMsg::RemovePoint {
+                            track_id,
+                            lane_id,
+                            index,
+                        },
+                        engine,
+                        tracks,
+                    );
+                }
+            }
+        }
+        action
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::RecordingEngine;
+    use super::*;
+
+    fn track() -> Vec<UiTrack> {
+        vec![UiTrack::new(TrackId::new(), "T1".to_string(), 0)]
+    }
+
+    #[test]
+    fn add_lane_syncs_and_expands() {
+        let mut a = AutomationState::default();
+        let mut engine = RecordingEngine::default();
+        let mut tracks = track();
+        let tid = tracks[0].id;
+        a.update(
+            AutomationMsg::AddLane {
+                track_id: tid,
+                target: AutomationTarget::TrackGain,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        assert_eq!(tracks[0].automation.len(), 1);
+        assert!(a.expanded.contains(&tid));
+        assert!(matches!(
+            engine.0[0],
+            EngineCommand::SetAutomationLane { .. }
+        ));
+
+        // Duplicate target refused.
+        let action = a.update(
+            AutomationMsg::AddLane {
+                track_id: tid,
+                target: AutomationTarget::TrackGain,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        assert_eq!(tracks[0].automation.len(), 1);
+        assert!(action.status.unwrap().contains("already"));
+    }
+
+    #[test]
+    fn point_lifecycle_add_move_delete() {
+        let mut a = AutomationState::default();
+        let mut engine = RecordingEngine::default();
+        let mut tracks = track();
+        let tid = tracks[0].id;
+        a.update(
+            AutomationMsg::AddLane {
+                track_id: tid,
+                target: AutomationTarget::TrackGain,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let lane_id = tracks[0].automation[0].id;
+
+        a.update(
+            AutomationMsg::AddPoint {
+                track_id: tid,
+                lane_id,
+                beat: 8.0,
+                value: 0.25,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        a.update(
+            AutomationMsg::AddPoint {
+                track_id: tid,
+                lane_id,
+                beat: 0.0,
+                value: 1.0,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let beats: Vec<f64> = tracks[0].automation[0]
+            .points
+            .iter()
+            .map(|p| p.beat)
+            .collect();
+        assert_eq!(beats, vec![0.0, 8.0]);
+        assert_eq!(a.selected, Some((tid, lane_id, 0)));
+
+        // Drag point 0 past point 1: selection follows to the end.
+        a.update(
+            AutomationMsg::MovePoint {
+                track_id: tid,
+                lane_id,
+                index: 0,
+                beat: 16.0,
+                value: 0.5,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let beats: Vec<f64> = tracks[0].automation[0]
+            .points
+            .iter()
+            .map(|p| p.beat)
+            .collect();
+        assert_eq!(beats, vec![8.0, 16.0]);
+        assert_eq!(a.selected, Some((tid, lane_id, 1)));
+
+        // Delete key removes the selected point.
+        a.update(AutomationMsg::DeleteSelectedPoint, &mut engine, &mut tracks);
+        assert_eq!(tracks[0].automation[0].points.len(), 1);
+        assert_eq!(a.selected, None);
+    }
+
+    #[test]
+    fn remove_lane_clears_engine_and_selection() {
+        let mut a = AutomationState::default();
+        let mut engine = RecordingEngine::default();
+        let mut tracks = track();
+        let tid = tracks[0].id;
+        a.update(
+            AutomationMsg::AddLane {
+                track_id: tid,
+                target: AutomationTarget::TrackPan,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let lane_id = tracks[0].automation[0].id;
+        a.selected = Some((tid, lane_id, 0));
+        a.update(
+            AutomationMsg::RemoveLane {
+                track_id: tid,
+                lane_id,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        assert!(tracks[0].automation.is_empty());
+        assert_eq!(a.selected, None);
+        assert!(matches!(
+            engine.0.last(),
+            Some(EngineCommand::RemoveAutomationLane { .. })
+        ));
+    }
+
+    #[test]
+    fn values_clamp_to_unit_range() {
+        let mut a = AutomationState::default();
+        let mut engine = RecordingEngine::default();
+        let mut tracks = track();
+        let tid = tracks[0].id;
+        a.update(
+            AutomationMsg::AddLane {
+                track_id: tid,
+                target: AutomationTarget::TrackGain,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let lane_id = tracks[0].automation[0].id;
+        a.update(
+            AutomationMsg::AddPoint {
+                track_id: tid,
+                lane_id,
+                beat: -3.0,
+                value: 7.0,
+            },
+            &mut engine,
+            &mut tracks,
+        );
+        let p = tracks[0].automation[0].points[0];
+        assert_eq!(p.beat, 0.0);
+        assert_eq!(p.value, 1.0);
+    }
+}

--- a/crates/vibez-ui/src/domains/automation.rs
+++ b/crates/vibez-ui/src/domains/automation.rs
@@ -56,6 +56,24 @@ pub enum AutomationMsg {
     /// Delete-key routing (higher priority than clip deletion when a
     /// point is selected).
     DeleteSelectedPoint,
+    /// Set the curve of the segment leaving point `index` (drag
+    /// release of an alt-drag; -1..1, 0 = linear).
+    SetCurve {
+        track_id: TrackId,
+        lane_id: LaneId,
+        index: usize,
+        curve: f32,
+    },
+    /// Remove every point in a beat range (ctrl-drag erase).
+    RemovePointsInRange {
+        track_id: TrackId,
+        lane_id: LaneId,
+        start_beat: f64,
+        end_beat: f64,
+    },
+    OpenLanePicker(TrackId),
+    LanePickerQuery(String),
+    CloseLanePicker,
 }
 
 impl AutomationMsg {
@@ -63,7 +81,11 @@ impl AutomationMsg {
     pub fn marks_dirty(&self) -> bool {
         !matches!(
             self,
-            AutomationMsg::ToggleTrackLanes(_) | AutomationMsg::SelectPoint { .. }
+            AutomationMsg::ToggleTrackLanes(_)
+                | AutomationMsg::SelectPoint { .. }
+                | AutomationMsg::OpenLanePicker(_)
+                | AutomationMsg::LanePickerQuery(_)
+                | AutomationMsg::CloseLanePicker
         )
     }
 }
@@ -82,6 +104,8 @@ pub struct AutomationState {
     pub expanded: HashSet<TrackId>,
     /// The selected point: (track, lane, point index).
     pub selected: Option<(TrackId, LaneId, usize)>,
+    /// The open add-lane picker, with its search query.
+    pub picker: Option<(TrackId, String)>,
 }
 
 fn find_lane_mut(
@@ -102,6 +126,73 @@ fn sync_lane(engine: &mut impl EngineHandle, track_id: TrackId, lane: &Automatio
         track_id,
         lane: lane.clone(),
     });
+}
+
+/// The target's CURRENT (un-automated) value, normalized 0..1.
+/// This seeds new lanes and draws the reference line. Track gain's
+/// native range is 0..2 (see the arrangement domain clamp).
+pub fn normalized_target_value(target: &AutomationTarget, track: &UiTrack) -> Option<f32> {
+    match target {
+        AutomationTarget::TrackGain => Some((track.gain / 2.0).clamp(0.0, 1.0)),
+        AutomationTarget::TrackPan => Some(track.pan.clamp(0.0, 1.0)),
+        AutomationTarget::EffectParam {
+            effect_id,
+            param_index,
+        } => {
+            let effect = track.effects.iter().find(|e| e.id == *effect_id)?;
+            let d = effect.descriptors.get(*param_index)?;
+            let v = effect
+                .params
+                .get(*param_index)
+                .copied()
+                .unwrap_or(d.default);
+            Some(((v - d.min) / (d.max - d.min).max(f32::EPSILON)).clamp(0.0, 1.0))
+        }
+        AutomationTarget::InstrumentParam { param_index } => {
+            if !track.plugin_instrument_descriptors.is_empty() {
+                let d = track.plugin_instrument_descriptors.get(*param_index)?;
+                // Plugin values are not mirrored UI-side; use the default.
+                Some(((d.default - d.min) / (d.max - d.min).max(f32::EPSILON)).clamp(0.0, 1.0))
+            } else {
+                let kind = track.instrument_kind?;
+                let d = vibez_instruments::descriptors_for(kind).get(*param_index)?;
+                let v = track
+                    .instrument_params
+                    .get(*param_index)
+                    .copied()
+                    .unwrap_or(d.default);
+                Some(((v - d.min) / (d.max - d.min).max(f32::EPSILON)).clamp(0.0, 1.0))
+            }
+        }
+        AutomationTarget::PluginParam { .. } => None,
+    }
+}
+
+/// The static descriptor behind a target, when one exists (effect
+/// and instrument params). Gain/pan have implicit ranges.
+pub fn target_descriptor(
+    target: &AutomationTarget,
+    track: &UiTrack,
+) -> Option<&'static vibez_core::effect::ParamDescriptor> {
+    match target {
+        AutomationTarget::EffectParam {
+            effect_id,
+            param_index,
+        } => track
+            .effects
+            .iter()
+            .find(|e| e.id == *effect_id)?
+            .descriptors
+            .get(*param_index),
+        AutomationTarget::InstrumentParam { param_index } => {
+            if !track.plugin_instrument_descriptors.is_empty() {
+                track.plugin_instrument_descriptors.get(*param_index)
+            } else {
+                vibez_instruments::descriptors_for(track.instrument_kind?).get(*param_index)
+            }
+        }
+        _ => None,
+    }
 }
 
 /// Human-readable name for a lane target, for lane headers and the
@@ -172,11 +263,20 @@ impl AutomationState {
                     action.status = Some("That parameter already has a lane".to_string());
                     return action;
                 }
-                let lane = AutomationLane::new(target);
+                let mut lane = AutomationLane::new(target);
+                // Start where the knob already is.
+                if let Some(value) = normalized_target_value(&target, track) {
+                    lane.insert_point(AutomationPoint {
+                        beat: 0.0,
+                        value,
+                        curve: 0.0,
+                    });
+                }
                 sync_lane(engine, track_id, &lane);
                 let label = target_label(&target, track);
                 track.automation.push(lane);
                 self.expanded.insert(track_id);
+                self.picker = None;
                 action.status = Some(format!("Added automation lane: {label}"));
             }
             AutomationMsg::RemoveLane { track_id, lane_id } => {
@@ -201,6 +301,7 @@ impl AutomationState {
                 let point = AutomationPoint {
                     beat: beat.max(0.0),
                     value: value.clamp(0.0, 1.0),
+                    curve: 0.0,
                 };
                 lane.insert_point(point);
                 let index = lane
@@ -225,10 +326,12 @@ impl AutomationState {
                 if index >= lane.points.len() {
                     return action;
                 }
+                let curve = lane.points[index].curve;
                 lane.points.remove(index);
                 let point = AutomationPoint {
                     beat: beat.max(0.0),
                     value: value.clamp(0.0, 1.0),
+                    curve,
                 };
                 lane.insert_point(point);
                 let new_index = lane
@@ -265,6 +368,58 @@ impl AutomationState {
                 index,
             } => {
                 self.selected = index.map(|i| (track_id, lane_id, i));
+            }
+            AutomationMsg::SetCurve {
+                track_id,
+                lane_id,
+                index,
+                curve,
+            } => {
+                let Some(lane) = find_lane_mut(tracks, track_id, lane_id) else {
+                    return action;
+                };
+                if index >= lane.points.len() {
+                    return action;
+                }
+                lane.points[index].curve = curve.clamp(-1.0, 1.0);
+                let lane = lane.clone();
+                sync_lane(engine, track_id, &lane);
+            }
+            AutomationMsg::RemovePointsInRange {
+                track_id,
+                lane_id,
+                start_beat,
+                end_beat,
+            } => {
+                let (lo, hi) = if start_beat <= end_beat {
+                    (start_beat, end_beat)
+                } else {
+                    (end_beat, start_beat)
+                };
+                let Some(lane) = find_lane_mut(tracks, track_id, lane_id) else {
+                    return action;
+                };
+                let before = lane.points.len();
+                lane.points.retain(|p| p.beat < lo || p.beat > hi);
+                if lane.points.len() != before {
+                    let lane = lane.clone();
+                    sync_lane(engine, track_id, &lane);
+                    if matches!(self.selected, Some((t, l, _)) if t == track_id && l == lane_id) {
+                        self.selected = None;
+                    }
+                    action.status = Some(format!("Erased {} point(s)", before - lane.points.len()));
+                }
+            }
+            AutomationMsg::OpenLanePicker(track_id) => {
+                self.picker = Some((track_id, String::new()));
+            }
+            AutomationMsg::LanePickerQuery(query) => {
+                if let Some((_, q)) = &mut self.picker {
+                    *q = query;
+                }
+            }
+            AutomationMsg::CloseLanePicker => {
+                self.picker = None;
             }
             AutomationMsg::DeleteSelectedPoint => {
                 if let Some((track_id, lane_id, index)) = self.selected.take() {

--- a/crates/vibez-ui/src/domains/devices.rs
+++ b/crates/vibez-ui/src/domains/devices.rs
@@ -31,6 +31,9 @@ pub enum DevicesMsg {
     AddEffect(TrackId, EffectType),
     RemoveEffect(TrackId, EffectId),
     SetEffectParam(TrackId, EffectId, usize, f32),
+    /// Set several parameters of one effect atomically (the EQ
+    /// display drags frequency and gain together).
+    SetEffectParams(TrackId, EffectId, Vec<(usize, f32)>),
     ToggleEffectBypass(TrackId, EffectId),
     MoveEffectUp(TrackId, EffectId),
     MoveEffectDown(TrackId, EffectId),
@@ -115,7 +118,14 @@ pub fn default_instrument_params(kind: InstrumentKind, sample_rate: f32) -> Vec<
         .collect()
 }
 
-fn find_track_mut(tracks: &mut [UiTrack], track_id: TrackId) -> Option<&mut UiTrack> {
+fn find_track_mut<'a>(
+    tracks: &'a mut [UiTrack],
+    master: &'a mut UiTrack,
+    track_id: TrackId,
+) -> Option<&'a mut UiTrack> {
+    if track_id.is_master() {
+        return Some(master);
+    }
     tracks.iter_mut().find(|t| t.id == track_id)
 }
 
@@ -147,6 +157,7 @@ impl DevicesState {
         msg: DevicesMsg,
         engine: &mut impl EngineHandle,
         tracks: &mut [UiTrack],
+        master: &mut UiTrack,
         sample_rate: u32,
     ) -> DevicesAction {
         let mut action = DevicesAction::default();
@@ -157,7 +168,7 @@ impl DevicesState {
                 let descriptors = fx.param_descriptors();
                 let params: Vec<f32> = descriptors.iter().map(|d| d.default).collect();
 
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     track.effects.push(UiEffect {
                         id: effect_id,
                         effect_type,
@@ -179,7 +190,7 @@ impl DevicesState {
                 action.status = Some(format!("Added {} effect", effect_type.name()));
             }
             DevicesMsg::RemoveEffect(track_id, effect_id) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     track.effects.retain(|e| e.id != effect_id);
                 }
                 engine.send(EngineCommand::RemoveEffect(track_id, effect_id));
@@ -190,7 +201,7 @@ impl DevicesState {
                 action.status = Some("Removed effect".to_string());
             }
             DevicesMsg::SetEffectParam(track_id, effect_id, param_index, value) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(effect) = track.effects.iter_mut().find(|e| e.id == effect_id) {
                         if param_index < effect.params.len() {
                             let desc = &effect.descriptors[param_index];
@@ -206,8 +217,27 @@ impl DevicesState {
                     }
                 }
             }
+            DevicesMsg::SetEffectParams(track_id, effect_id, updates) => {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
+                    if let Some(effect) = track.effects.iter_mut().find(|e| e.id == effect_id) {
+                        for (param_index, value) in updates {
+                            if param_index < effect.params.len() {
+                                let desc = &effect.descriptors[param_index];
+                                let clamped = value.clamp(desc.min, desc.max);
+                                effect.params[param_index] = clamped;
+                                engine.send(EngineCommand::SetEffectParam {
+                                    track_id,
+                                    effect_id,
+                                    param_index,
+                                    value: clamped,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
             DevicesMsg::ToggleEffectBypass(track_id, effect_id) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(effect) = track.effects.iter_mut().find(|e| e.id == effect_id) {
                         effect.bypass = !effect.bypass;
                         engine.send(EngineCommand::SetEffectBypass {
@@ -219,7 +249,7 @@ impl DevicesState {
                 }
             }
             DevicesMsg::MoveEffectUp(track_id, effect_id) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(idx) = track.effects.iter().position(|e| e.id == effect_id) {
                         if idx > 0 {
                             track.effects.swap(idx, idx - 1);
@@ -233,7 +263,7 @@ impl DevicesState {
                 }
             }
             DevicesMsg::MoveEffectDown(track_id, effect_id) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(idx) = track.effects.iter().position(|e| e.id == effect_id) {
                         if idx + 1 < track.effects.len() {
                             track.effects.swap(idx, idx + 1);
@@ -247,9 +277,13 @@ impl DevicesState {
                 }
             }
             DevicesMsg::SetTrackInstrument(track_id, instrument_kind) => {
+                if track_id.is_master() {
+                    // The master bus hosts effects only.
+                    return action;
+                }
                 let instrument_params =
                     default_instrument_params(instrument_kind, sample_rate as f32);
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     track.has_instrument = true;
                     track.instrument_kind = Some(instrument_kind);
                     track.sample_name = None;
@@ -271,7 +305,7 @@ impl DevicesState {
                 action.status = Some(format!("Added {}", instrument_kind.name()));
             }
             DevicesMsg::RemoveTrackInstrument(track_id) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     track.has_instrument = false;
                     track.instrument_kind = None;
                     track.sample_name = None;
@@ -287,7 +321,7 @@ impl DevicesState {
                 action.status = Some("Removed instrument".to_string());
             }
             DevicesMsg::SetInstrumentParam(track_id, param_index, value) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if param_index < track.instrument_params.len() {
                         track.instrument_params[param_index] = value;
                     }
@@ -314,14 +348,14 @@ impl DevicesState {
                     velocity: 100,
                     on: false,
                 });
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     let max_index = track.drum_rack_pads.len().saturating_sub(1);
                     track.selected_drum_pad = pad_index.min(max_index);
                 }
                 action.select_track = Some(track_id);
             }
             DevicesMsg::ClearDrumRackPad(track_id, pad_index) => {
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
                         *pad = UiDrumPad::default();
                     }
@@ -340,7 +374,7 @@ impl DevicesState {
                 value,
             } => {
                 let mut changed = false;
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
                         match param {
                             DrumPadParam::Gain => pad.gain = value.clamp(0.0, 2.0),
@@ -368,7 +402,7 @@ impl DevicesState {
                 one_shot,
             } => {
                 let mut changed = false;
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
                         pad.one_shot = one_shot;
                         changed = true;
@@ -385,7 +419,7 @@ impl DevicesState {
                 choke_group,
             } => {
                 let mut changed = false;
-                if let Some(track) = find_track_mut(tracks, track_id) {
+                if let Some(track) = find_track_mut(tracks, master, track_id) {
                     if let Some(pad) = track.drum_rack_pads.get_mut(pad_index) {
                         pad.choke_group = choke_group;
                         changed = true;
@@ -480,6 +514,7 @@ mod tests {
             DevicesMsg::RemoveEffect(track_id, effect_id),
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         assert!(tracks[0].effects.is_empty());
@@ -502,6 +537,7 @@ mod tests {
             DevicesMsg::SetEffectParam(track_id, effect_id, 0, 9999.0),
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         let max = tracks[0].effects[0].descriptors[0].max;
@@ -517,6 +553,7 @@ mod tests {
             DevicesMsg::MoveEffectUp(track_id, effect_id),
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         assert!(engine.0.is_empty());
@@ -532,6 +569,7 @@ mod tests {
             DevicesMsg::SelectDrumRackPad(track_id, 3),
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         assert_eq!(tracks[0].selected_drum_pad, 3);
@@ -561,6 +599,7 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         assert_eq!(tracks[0].drum_rack_pads[0].gain, 2.0); // clamped
@@ -583,6 +622,7 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         // MIDI track opens on the Instruments tab.
@@ -594,6 +634,7 @@ mod tests {
             DevicesMsg::DismissContextMenu,
             &mut engine,
             &mut tracks,
+            &mut crate::state::new_master_track(),
             44_100,
         );
         assert!(devices.context_menu.is_none());

--- a/crates/vibez-ui/src/domains/mod.rs
+++ b/crates/vibez-ui/src/domains/mod.rs
@@ -7,6 +7,7 @@
 //! Redux slices; `EngineHandle` is an injected service interface.
 
 pub mod arrangement;
+pub mod automation;
 pub mod browser;
 pub mod devices;
 pub mod piano_roll;

--- a/crates/vibez-ui/src/domains/project.rs
+++ b/crates/vibez-ui/src/domains/project.rs
@@ -98,7 +98,8 @@ pub fn collect_plugin_reload_requests(
     mut capture_state: impl FnMut(PluginGuiKey) -> Option<String>,
 ) -> PluginReloadRequests {
     let mut requests = PluginReloadRequests::default();
-    for track in &mut snapshot.tracks {
+    let (tracks, master) = (&mut snapshot.tracks, &mut snapshot.master);
+    for track in tracks.iter_mut().chain(std::iter::once(master)) {
         let track_id = track.id;
         for (chain_pos, effect) in track.effects.iter().enumerate() {
             if let Some(dev) = &effect.plugin_ref {
@@ -159,6 +160,7 @@ mod tests {
         track.effects = effects;
         ProjectSnapshot {
             tracks: vec![track],
+            master: crate::state::new_master_track(),
             bpm: 120.0,
             bpm_text: "120".to_string(),
             loop_enabled: false,

--- a/crates/vibez-ui/src/lib.rs
+++ b/crates/vibez-ui/src/lib.rs
@@ -7,6 +7,7 @@ mod services;
 mod spectrum;
 mod state;
 mod theme;
+mod themes;
 mod ui_settings;
 mod warp;
 pub mod widgets;

--- a/crates/vibez-ui/src/lib.rs
+++ b/crates/vibez-ui/src/lib.rs
@@ -4,6 +4,7 @@ pub mod icons;
 mod message;
 pub mod plugin_window;
 mod services;
+mod spectrum;
 mod state;
 mod theme;
 mod ui_settings;

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -155,6 +155,7 @@ pub enum Message {
     PianoRoll(crate::domains::piano_roll::PianoRollMsg),
     Browser(crate::domains::browser::BrowserMsg),
     Project(crate::domains::project::ProjectMsg),
+    Automation(crate::domains::automation::AutomationMsg),
     View(crate::domains::view::ViewMsg),
 
     // Workspace

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -221,7 +221,7 @@ pub enum Message {
     SaveProjectAs,
     ProjectOpenPathSelected(Option<PathBuf>),
     ProjectSavePathSelected(Option<PathBuf>),
-    ProjectLoaded(Result<ProjectLoadResult, String>),
+    ProjectLoaded(Box<Result<ProjectLoadResult, String>>),
     ProjectSaved(Result<PathBuf, String>),
     /// Settings: toggle auto-warp-on-import.
     ToggleAutoWarpOnImport,
@@ -391,6 +391,11 @@ impl Message {
     pub fn set_effect_param(t: TrackId, e: EffectId, i: usize, v: f32) -> Self {
         Self::Devices(crate::domains::devices::DevicesMsg::SetEffectParam(
             t, e, i, v,
+        ))
+    }
+    pub fn set_effect_params(t: TrackId, e: EffectId, updates: Vec<(usize, f32)>) -> Self {
+        Self::Devices(crate::domains::devices::DevicesMsg::SetEffectParams(
+            t, e, updates,
         ))
     }
     pub fn toggle_effect_bypass(t: TrackId, e: EffectId) -> Self {

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -237,6 +237,14 @@ pub enum Message {
     OpenMidiInput(String),
     /// Settings: close the currently-open MIDI input port.
     CloseMidiInput,
+    /// Appearance: activate a theme by name (built-in or user).
+    SelectTheme(String),
+    /// Appearance: rescan the themes directory for `.vzt` files.
+    RescanThemes,
+    /// Appearance: live edit of the save-as-theme name field.
+    ThemeSaveNameChanged(String),
+    /// Appearance: save the current palette as a user `.vzt`.
+    SaveCurrentTheme,
     AddSampleLibraryRoot,
     SampleLibraryRootSelected(Option<PathBuf>),
     RescanSampleLibrary,

--- a/crates/vibez-ui/src/spectrum.rs
+++ b/crates/vibez-ui/src/spectrum.rs
@@ -1,0 +1,251 @@
+//! Spectrum analyser for the channel EQ display.
+//!
+//! The engine streams post-effects mono samples for the tapped track
+//! through a lock-free ring; every UI tick the analyser ingests them
+//! into a sliding window, runs a Hann-windowed FFT, and folds the
+//! magnitudes into log-spaced display bins with fast-attack /
+//! slow-release smoothing (the familiar analyser ballistics).
+
+/// FFT window length (samples). Power of two for radix-2.
+const FFT_SIZE: usize = 2048;
+
+/// Number of log-spaced display bins between MIN_HZ and MAX_HZ.
+pub const DISPLAY_BINS: usize = 96;
+
+/// Display range, matching the EQ curve's frequency axis.
+pub const MIN_HZ: f32 = 20.0;
+pub const MAX_HZ: f32 = 20_000.0;
+
+/// Floor of the level axis in dB (0 dB = full scale).
+pub const FLOOR_DB: f32 = -66.0;
+
+/// Release rate in dB per tick (60 fps → ~1.6 s full-scale fall).
+const RELEASE_DB_PER_TICK: f32 = 0.66;
+
+#[derive(Debug, Clone)]
+pub struct SpectrumState {
+    /// Sliding window of the most recent mono samples.
+    window: Vec<f32>,
+    /// Smoothed display bins in dB (FLOOR_DB..0), ready to draw.
+    pub bins: Vec<f32>,
+    /// Anything above the floor to draw at all?
+    pub active: bool,
+}
+
+impl Default for SpectrumState {
+    fn default() -> Self {
+        Self {
+            window: Vec::with_capacity(FFT_SIZE),
+            bins: vec![FLOOR_DB; DISPLAY_BINS],
+            active: false,
+        }
+    }
+}
+
+impl SpectrumState {
+    /// Append freshly drained tap samples, keeping the last window.
+    pub fn ingest(&mut self, samples: &[f32]) {
+        self.window.extend_from_slice(samples);
+        let len = self.window.len();
+        if len > FFT_SIZE {
+            self.window.drain(..len - FFT_SIZE);
+        }
+    }
+
+    /// Drop all signal history (tap retargeted to another track).
+    pub fn reset(&mut self) {
+        self.window.clear();
+        self.bins.fill(FLOOR_DB);
+        self.active = false;
+    }
+
+    /// One tick of analysis: FFT the current window and update the
+    /// smoothed display bins.
+    pub fn analyse(&mut self, sample_rate: f32) {
+        let fresh = if self.window.len() >= FFT_SIZE {
+            compute_bins(&self.window[self.window.len() - FFT_SIZE..], sample_rate)
+        } else {
+            // No (or not enough) signal: release toward the floor.
+            vec![FLOOR_DB; DISPLAY_BINS]
+        };
+        let mut any = false;
+        for (cur, new) in self.bins.iter_mut().zip(fresh) {
+            if new > *cur {
+                *cur = new; // fast attack
+            } else {
+                *cur = (*cur - RELEASE_DB_PER_TICK).max(new).max(FLOOR_DB);
+            }
+            if *cur > FLOOR_DB + 0.5 {
+                any = true;
+            }
+        }
+        self.active = any;
+    }
+}
+
+/// Hann-window `input` (FFT_SIZE samples), FFT it, and fold the
+/// magnitude spectrum into DISPLAY_BINS log-spaced dB bins.
+fn compute_bins(input: &[f32], sample_rate: f32) -> Vec<f32> {
+    debug_assert_eq!(input.len(), FFT_SIZE);
+    let mut re: Vec<f32> = input
+        .iter()
+        .enumerate()
+        .map(|(i, &s)| {
+            let hann = 0.5 - 0.5 * (std::f32::consts::TAU * i as f32 / (FFT_SIZE - 1) as f32).cos();
+            s * hann
+        })
+        .collect();
+    let mut im = vec![0.0f32; FFT_SIZE];
+    fft_in_place(&mut re, &mut im);
+
+    // Coherent-gain normalization: a full-scale sine under a Hann
+    // window peaks at N/4 in the half-spectrum.
+    let norm = 4.0 / FFT_SIZE as f32;
+    let hz_per_fft_bin = sample_rate / FFT_SIZE as f32;
+    let log_min = MIN_HZ.ln();
+    let log_span = MAX_HZ.ln() - log_min;
+
+    let mut bins = vec![FLOOR_DB; DISPLAY_BINS];
+    for k in 1..FFT_SIZE / 2 {
+        let freq = k as f32 * hz_per_fft_bin;
+        if !(MIN_HZ..=MAX_HZ).contains(&freq) {
+            continue;
+        }
+        let pos = (freq.ln() - log_min) / log_span;
+        let bin = ((pos * DISPLAY_BINS as f32) as usize).min(DISPLAY_BINS - 1);
+        let mag = (re[k] * re[k] + im[k] * im[k]).sqrt() * norm;
+        let db = (20.0 * mag.max(1e-9).log10()).clamp(FLOOR_DB, 0.0);
+        if db > bins[bin] {
+            bins[bin] = db;
+        }
+    }
+    // Low display bins can be narrower than one FFT bin; fill gaps
+    // from the left neighbor so the trace stays continuous.
+    for i in 1..DISPLAY_BINS {
+        if bins[i] <= FLOOR_DB && bins[i - 1] > FLOOR_DB {
+            bins[i] = bins[i - 1] - 1.5;
+        }
+    }
+    bins
+}
+
+/// Iterative radix-2 Cooley-Tukey FFT, in place. `re.len()` must be a
+/// power of two and equal to `im.len()`.
+fn fft_in_place(re: &mut [f32], im: &mut [f32]) {
+    let n = re.len();
+    debug_assert!(n.is_power_of_two() && n == im.len());
+
+    // Bit-reversal permutation.
+    let bits = n.trailing_zeros();
+    for i in 0..n {
+        let j = (i as u32).reverse_bits() >> (32 - bits);
+        let j = j as usize;
+        if j > i {
+            re.swap(i, j);
+            im.swap(i, j);
+        }
+    }
+
+    let mut len = 2;
+    while len <= n {
+        let ang = -std::f32::consts::TAU / len as f32;
+        let (w_re, w_im) = (ang.cos(), ang.sin());
+        for start in (0..n).step_by(len) {
+            let (mut cur_re, mut cur_im) = (1.0f32, 0.0f32);
+            for k in 0..len / 2 {
+                let a = start + k;
+                let b = a + len / 2;
+                let t_re = re[b] * cur_re - im[b] * cur_im;
+                let t_im = re[b] * cur_im + im[b] * cur_re;
+                re[b] = re[a] - t_re;
+                im[b] = im[a] - t_im;
+                re[a] += t_re;
+                im[a] += t_im;
+                let next_re = cur_re * w_re - cur_im * w_im;
+                cur_im = cur_re * w_im + cur_im * w_re;
+                cur_re = next_re;
+            }
+        }
+        len <<= 1;
+    }
+}
+
+/// Normalized x position (0..1) of `freq` on the shared log axis.
+pub fn freq_to_norm(freq: f32) -> f32 {
+    ((freq.max(MIN_HZ).ln() - MIN_HZ.ln()) / (MAX_HZ.ln() - MIN_HZ.ln())).clamp(0.0, 1.0)
+}
+
+/// Inverse of [`freq_to_norm`].
+pub fn norm_to_freq(pos: f32) -> f32 {
+    (MIN_HZ.ln() + pos.clamp(0.0, 1.0) * (MAX_HZ.ln() - MIN_HZ.ln())).exp()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fft_finds_a_sine_peak() {
+        let sr = 48_000.0f32;
+        let freq = 1_000.0f32;
+        let samples: Vec<f32> = (0..FFT_SIZE)
+            .map(|i| (std::f32::consts::TAU * freq * i as f32 / sr).sin() * 0.8)
+            .collect();
+        let bins = compute_bins(&samples, sr);
+
+        // The display bin holding 1 kHz should carry the peak level.
+        let expect_bin =
+            ((freq_to_norm(freq) * DISPLAY_BINS as f32) as usize).min(DISPLAY_BINS - 1);
+        let peak = bins
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.total_cmp(b.1))
+            .unwrap();
+        assert!(
+            (peak.0 as i32 - expect_bin as i32).abs() <= 1,
+            "peak bin {} should sit at ~{expect_bin}",
+            peak.0
+        );
+        // 0.8 full scale ≈ -1.9 dB.
+        assert!(
+            (*peak.1 - (-1.9)).abs() < 1.5,
+            "peak level should read near -1.9 dB, got {}",
+            peak.1
+        );
+        // Far-away bins stay near the floor (100 Hz vs 1 kHz).
+        let far = bins[(freq_to_norm(100.0) * DISPLAY_BINS as f32) as usize];
+        assert!(far < -40.0, "off-peak bin should be quiet, got {far}");
+    }
+
+    #[test]
+    fn attack_is_instant_release_is_gradual() {
+        let sr = 48_000.0f32;
+        let mut state = SpectrumState::default();
+        let tone: Vec<f32> = (0..FFT_SIZE)
+            .map(|i| (std::f32::consts::TAU * 1_000.0 * i as f32 / sr).sin())
+            .collect();
+        state.ingest(&tone);
+        state.analyse(sr);
+        let peak_after_attack = state.bins.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!(peak_after_attack > -3.0, "attack should be instant");
+        assert!(state.active);
+
+        // Silence: the peak falls by the release rate per tick, not
+        // all at once.
+        state.window.clear();
+        state.analyse(sr);
+        let peak_after_release = state.bins.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!(
+            (peak_after_attack - peak_after_release - RELEASE_DB_PER_TICK).abs() < 1e-3,
+            "release should fall by exactly one tick's worth"
+        );
+    }
+
+    #[test]
+    fn freq_axis_roundtrips() {
+        for f in [20.0, 100.0, 1_000.0, 10_000.0, 20_000.0] {
+            let back = norm_to_freq(freq_to_norm(f));
+            assert!((back / f - 1.0).abs() < 1e-3, "{f} -> {back}");
+        }
+    }
+}

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -114,6 +114,7 @@ pub enum SettingsTab {
 #[derive(Debug, Clone)]
 pub struct ProjectSnapshot {
     pub tracks: Vec<UiTrack>,
+    pub master: UiTrack,
     pub bpm: f64,
     pub bpm_text: String,
     pub loop_enabled: bool,
@@ -303,11 +304,23 @@ impl Default for TransportState {
     }
 }
 
+/// The master bus as a track-shaped UI channel: gain plus an effect
+/// chain, no clips or instrument. Lives outside `tracks` so the
+/// arrangement never shows it, but `find_track` resolves it, so the
+/// mixer strip, device chain, and effect commands all work on it.
+pub fn new_master_track() -> UiTrack {
+    let mut master = UiTrack::new(TrackId::MASTER, "Master".to_string(), 0);
+    master.pan = 0.5;
+    master
+}
+
 /// Arrangement domain state: the track list (the shared model other
 /// domains receive explicitly), selection, and track numbering.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ArrangementState {
     pub tracks: Vec<UiTrack>,
+    /// The master bus channel (see [`new_master_track`]).
+    pub master: UiTrack,
     pub selected_track: Option<TrackId>,
     pub next_track_number: u32,
     pub selected_clips: HashSet<ArrangementSelection>,
@@ -326,6 +339,25 @@ pub struct ArrangementState {
     pub clip_bpm_edit: HashMap<ClipId, String>,
 }
 
+impl Default for ArrangementState {
+    fn default() -> Self {
+        Self {
+            tracks: Vec::new(),
+            master: new_master_track(),
+            selected_track: None,
+            next_track_number: 0,
+            selected_clips: HashSet::new(),
+            selected_note_clip: None,
+            time_selection_active: false,
+            selection_start_beats: 0.0,
+            selection_end_beats: 0.0,
+            time_selection_track: None,
+            drag_resize_active: false,
+            clip_bpm_edit: HashMap::new(),
+        }
+    }
+}
+
 pub struct AppState {
     // Transport domain slice (playback, tempo, arrangement loop).
     pub transport: TransportState,
@@ -333,6 +365,9 @@ pub struct AppState {
     // Metering (master)
     pub peak_l: f32,
     pub peak_r: f32,
+    /// Spectrum analyser fed by the engine's per-track tap (follows
+    /// the selected track); drawn behind the channel EQ curve.
+    pub spectrum: crate::spectrum::SpectrumState,
 
     // UI
     pub status_text: String,
@@ -383,6 +418,7 @@ impl Default for AppState {
             },
             peak_l: 0.0,
             peak_r: 0.0,
+            spectrum: crate::spectrum::SpectrumState::default(),
             status_text: "Ready — Add a track to get started".to_string(),
             view: ViewState::default(),
             piano_roll: PianoRollState::default(),
@@ -511,10 +547,16 @@ impl AppState {
     }
 
     pub fn find_track(&self, id: TrackId) -> Option<&UiTrack> {
+        if id.is_master() {
+            return Some(&self.arrangement.master);
+        }
         self.arrangement.tracks.iter().find(|t| t.id == id)
     }
 
     pub fn find_track_mut(&mut self, id: TrackId) -> Option<&mut UiTrack> {
+        if id.is_master() {
+            return Some(&mut self.arrangement.master);
+        }
         self.arrangement.tracks.iter_mut().find(|t| t.id == id)
     }
 

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -106,6 +106,7 @@ pub enum SettingsTab {
     Plugins,
     Dropbox,
     Warping,
+    Appearance,
 }
 
 /// A point-in-time snapshot of the editable project state, used to
@@ -402,6 +403,11 @@ pub struct AppState {
     // Browser domain slice (sample library, Dropbox, drag-drop).
     pub browser: BrowserState,
 
+    // Appearance / themes
+    pub current_theme_name: String,
+    pub user_themes: Vec<crate::themes::UserTheme>,
+    pub theme_save_name: String,
+
     // Plugin hosting
     pub plugin_settings: PluginSettings,
     pub plugin_scan_in_progress: bool,
@@ -435,6 +441,9 @@ impl Default for AppState {
             warp_confidence_threshold: 0.6,
             automation_ui: crate::domains::automation::AutomationState::default(),
             browser: BrowserState::default(),
+            current_theme_name: "Charcoal".to_string(),
+            user_themes: Vec::new(),
+            theme_save_name: String::new(),
             plugin_settings: PluginSettings::load(),
             plugin_scan_in_progress: false,
             plugin_scan_status: String::new(),

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -361,6 +361,9 @@ pub struct AppState {
     /// Minimum BPM-detect confidence required to auto-warp. Mirrored
     /// from `UiSettings::warp_confidence_threshold`.
     pub warp_confidence_threshold: f32,
+    // Automation domain slice (lane expansion, point selection).
+    pub automation_ui: crate::domains::automation::AutomationState,
+
     // Browser domain slice (sample library, Dropbox, drag-drop).
     pub browser: BrowserState,
 
@@ -394,6 +397,7 @@ impl Default for AppState {
             project: ProjectState::default(),
             auto_warp_on_import: false,
             warp_confidence_threshold: 0.6,
+            automation_ui: crate::domains::automation::AutomationState::default(),
             browser: BrowserState::default(),
             plugin_settings: PluginSettings::load(),
             plugin_scan_in_progress: false,

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -183,6 +183,9 @@ pub struct UiTrack {
     pub plugin_instrument_name: Option<String>,
     /// Persistent identity of the plugin instrument, if any.
     pub plugin_instrument_ref: Option<vibez_core::effect::PluginDeviceInfo>,
+    /// Parameters of the plugin instrument (leaked 'static by the
+    /// wrapper); empty for built-in instruments.
+    pub plugin_instrument_descriptors: &'static [vibez_core::effect::ParamDescriptor],
     /// Whether the plugin instrument has a native GUI.
     pub has_plugin_instrument_gui: bool,
 }
@@ -214,6 +217,7 @@ impl UiTrack {
             selected_drum_pad: 0,
             plugin_instrument_name: None,
             plugin_instrument_ref: None,
+            plugin_instrument_descriptors: &[],
             has_plugin_instrument_gui: false,
         }
     }
@@ -248,6 +252,7 @@ impl UiTrack {
             selected_drum_pad: 0,
             plugin_instrument_name: None,
             plugin_instrument_ref: None,
+            plugin_instrument_descriptors: &[],
             has_plugin_instrument_gui: false,
         }
     }

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -176,6 +176,8 @@ pub struct UiTrack {
     pub sample_audio: Option<Arc<DecodedAudio>>,
     pub instrument_params: Vec<f32>,
     pub drum_rack_pads: Vec<UiDrumPad>,
+    /// Automation lanes (mirrored to the engine like note clips).
+    pub automation: Vec<vibez_core::automation::AutomationLane>,
     pub selected_drum_pad: usize,
     /// Display name for external plugin instruments (e.g. "Dexed", "Surge XT").
     pub plugin_instrument_name: Option<String>,
@@ -208,6 +210,7 @@ impl UiTrack {
             sample_audio: None,
             instrument_params: Vec::new(),
             drum_rack_pads: default_drum_rack_pads(),
+            automation: Vec::new(),
             selected_drum_pad: 0,
             plugin_instrument_name: None,
             plugin_instrument_ref: None,
@@ -241,6 +244,7 @@ impl UiTrack {
             sample_audio: None,
             instrument_params: Vec::new(),
             drum_rack_pads: default_drum_rack_pads(),
+            automation: Vec::new(),
             selected_drum_pad: 0,
             plugin_instrument_name: None,
             plugin_instrument_ref: None,

--- a/crates/vibez-ui/src/theme.rs
+++ b/crates/vibez-ui/src/theme.rs
@@ -1,288 +1,385 @@
+//! Runtime theme system.
+//!
+//! Every color the UI paints comes from the current [`ThemePalette`],
+//! swapped at runtime by the Appearance settings. Accessors mirror
+//! the old constant names in snake_case (`th::accent()` was
+//! `th::ACCENT`), so call sites read the same and canvases pick up a
+//! theme switch on the next frame. A palette serializes to JSON with
+//! hex colors — that is exactly the `.vzt` theme file format.
+
+use std::sync::{LazyLock, RwLock};
+
 use iced::theme::Palette;
 use iced::{Color, Theme};
+use serde::{Deserialize, Serialize};
 
-// ── Main palette (dark charcoal) ──
+/// A complete vibez color scheme. Serialized as the `.vzt` file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThemePalette {
+    pub name: String,
 
-/// Near-black main background: #1a1a1a
-pub const BG_DARK: Color = Color {
-    r: 0.102,
-    g: 0.102,
-    b: 0.102,
-    a: 1.0,
-};
+    // ── Backgrounds ──
+    #[serde(with = "hex")]
+    pub bg_dark: Color,
+    #[serde(with = "hex")]
+    pub bg_surface: Color,
+    #[serde(with = "hex")]
+    pub bg_elevated: Color,
+    #[serde(with = "hex")]
+    pub bg_hover: Color,
 
-/// Panels, headers, strips: #242424
-pub const BG_SURFACE: Color = Color {
-    r: 0.141,
-    g: 0.141,
-    b: 0.141,
-    a: 1.0,
-};
+    // ── Text ──
+    #[serde(with = "hex")]
+    pub text: Color,
+    #[serde(with = "hex")]
+    pub text_dim: Color,
+    #[serde(with = "hex")]
+    pub text_muted: Color,
 
-/// Cards, effect slots, raised elements: #2d2d2d
-pub const BG_ELEVATED: Color = Color {
-    r: 0.176,
-    g: 0.176,
-    b: 0.176,
-    a: 1.0,
-};
+    // ── Accent ──
+    #[serde(with = "hex")]
+    pub accent: Color,
+    #[serde(with = "hex")]
+    pub accent_dim: Color,
 
-/// Hover state for interactive elements: #363636
-#[allow(dead_code)]
-pub const BG_HOVER: Color = Color {
-    r: 0.212,
-    g: 0.212,
-    b: 0.212,
-    a: 1.0,
-};
+    // ── Borders ──
+    #[serde(with = "hex")]
+    pub border: Color,
+    #[serde(with = "hex")]
+    pub border_light: Color,
+    #[serde(with = "hex")]
+    pub divider: Color,
 
-// ── Text ──
+    // ── Semantic ──
+    #[serde(with = "hex")]
+    pub success: Color,
+    #[serde(with = "hex")]
+    pub danger: Color,
+    #[serde(with = "hex")]
+    pub playhead: Color,
 
-/// Primary text: #e0e0e0
-pub const TEXT: Color = Color {
-    r: 0.878,
-    g: 0.878,
-    b: 0.878,
-    a: 1.0,
-};
+    // ── Meters ──
+    #[serde(with = "hex")]
+    pub meter_green: Color,
+    #[serde(with = "hex")]
+    pub meter_yellow: Color,
+    #[serde(with = "hex")]
+    pub meter_red: Color,
 
-/// Secondary text, labels: #808080
-pub const TEXT_DIM: Color = Color {
-    r: 0.502,
-    g: 0.502,
-    b: 0.502,
-    a: 1.0,
-};
+    /// Recessed display wells (mini waveforms, sample views).
+    #[serde(with = "hex")]
+    pub display_bg: Color,
 
-/// Disabled, placeholder: #505050
-pub const TEXT_MUTED: Color = Color {
-    r: 0.314,
-    g: 0.314,
-    b: 0.314,
-    a: 1.0,
-};
+    // ── Knobs / faders ──
+    #[serde(with = "hex")]
+    pub knob_arc: Color,
+    #[serde(with = "hex")]
+    pub knob_body: Color,
+    #[serde(with = "hex")]
+    pub knob_body_engaged: Color,
+    #[serde(with = "hex")]
+    pub knob_track: Color,
+    #[serde(with = "hex")]
+    pub fader_handle: Color,
 
-// ── Accent ──
+    // ── Track palette (auto-assigned per track, index wraps) ──
+    #[serde(with = "hex_array")]
+    pub track_colors: [Color; 8],
 
-/// Orange accent — transport active, selected: #ff8c00
-pub const ACCENT: Color = Color {
-    r: 1.0,
-    g: 0.549,
-    b: 0.0,
-    a: 1.0,
-};
+    // ── Channel EQ bands ──
+    #[serde(with = "hex")]
+    pub eq_lf: Color,
+    #[serde(with = "hex")]
+    pub eq_lmf: Color,
+    #[serde(with = "hex")]
+    pub eq_hmf: Color,
+    #[serde(with = "hex")]
+    pub eq_hf: Color,
 
-/// Accent at lower intensity: #995400
-pub const ACCENT_DIM: Color = Color {
-    r: 0.600,
-    g: 0.329,
-    b: 0.0,
-    a: 1.0,
-};
+    // ── Clips / waveforms ──
+    #[serde(with = "hex")]
+    pub clip_body: Color,
+    #[serde(with = "hex")]
+    pub clip_border: Color,
+    #[serde(with = "hex")]
+    pub waveform: Color,
+    #[serde(with = "hex")]
+    pub ruler_line: Color,
 
-// ── Borders / dividers ──
+    // ── Editor grid lines (bar / beat / subdivision) ──
+    #[serde(with = "hex")]
+    pub grid_bar: Color,
+    #[serde(with = "hex")]
+    pub grid_beat: Color,
+    #[serde(with = "hex")]
+    pub grid_sub: Color,
 
-/// Subtle panel borders: #3a3a3a
-pub const BORDER: Color = Color {
-    r: 0.227,
-    g: 0.227,
-    b: 0.227,
-    a: 1.0,
-};
+    // ── Piano roll ──
+    #[serde(with = "hex")]
+    pub piano_white_row: Color,
+    #[serde(with = "hex")]
+    pub piano_black_row: Color,
+    #[serde(with = "hex")]
+    pub piano_octave_line: Color,
+    #[serde(with = "hex")]
+    pub piano_grid: Color,
+    #[serde(with = "hex")]
+    pub piano_white_key: Color,
+    #[serde(with = "hex")]
+    pub piano_black_key: Color,
+    #[serde(with = "hex")]
+    pub piano_key_label: Color,
+}
 
-/// Stronger borders for cards: #4a4a4a
-#[allow(dead_code)]
-pub const BORDER_LIGHT: Color = Color {
-    r: 0.290,
-    g: 0.290,
-    b: 0.290,
-    a: 1.0,
-};
+/// Hex color (de)serialization: `#rrggbb` or `#rrggbbaa`.
+mod hex {
+    use iced::Color;
+    use serde::{Deserialize, Deserializer, Serializer};
 
-/// Section dividers: #2a2a2a
-pub const DIVIDER: Color = Color {
-    r: 0.165,
-    g: 0.165,
-    b: 0.165,
-    a: 1.0,
-};
+    pub fn to_hex(c: &Color) -> String {
+        let [r, g, b, a] = c.into_rgba8();
+        if a == 255 {
+            format!("#{r:02x}{g:02x}{b:02x}")
+        } else {
+            format!("#{r:02x}{g:02x}{b:02x}{a:02x}")
+        }
+    }
 
-// ── Semantic colors ──
+    pub fn parse(s: &str) -> Option<Color> {
+        let s = s.strip_prefix('#')?;
+        let byte = |i: usize| u8::from_str_radix(s.get(i..i + 2)?, 16).ok();
+        match s.len() {
+            6 => Some(Color::from_rgb8(byte(0)?, byte(2)?, byte(4)?)),
+            8 => Some(Color::from_rgba8(
+                byte(0)?,
+                byte(2)?,
+                byte(4)?,
+                byte(6)? as f32 / 255.0,
+            )),
+            _ => None,
+        }
+    }
 
-/// Success/green for play: #4ade80
-pub const SUCCESS: Color = Color {
-    r: 0.290,
-    g: 0.871,
-    b: 0.502,
-    a: 1.0,
-};
+    pub fn serialize<S: Serializer>(c: &Color, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&to_hex(c))
+    }
 
-/// Danger/red: #f87171
-pub const DANGER: Color = Color {
-    r: 0.973,
-    g: 0.443,
-    b: 0.443,
-    a: 1.0,
-};
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Color, D::Error> {
+        let s = String::deserialize(d)?;
+        parse(&s).ok_or_else(|| serde::de::Error::custom(format!("invalid hex color {s:?}")))
+    }
+}
 
-/// Playhead: white at 80% opacity
-pub const PLAYHEAD: Color = Color {
-    r: 1.0,
-    g: 1.0,
-    b: 1.0,
-    a: 0.8,
-};
+mod hex_array {
+    use iced::Color;
+    use serde::{Deserialize, Deserializer, Serializer};
 
-// ── Meter colors ──
+    pub fn serialize<S: Serializer>(colors: &[Color; 8], s: S) -> Result<S::Ok, S::Error> {
+        s.collect_seq(colors.iter().map(super::hex::to_hex))
+    }
 
-/// VU meter green: #4ade80
-pub const METER_GREEN: Color = Color {
-    r: 0.290,
-    g: 0.871,
-    b: 0.502,
-    a: 1.0,
-};
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[Color; 8], D::Error> {
+        let raw = Vec::<String>::deserialize(d)?;
+        if raw.len() != 8 {
+            return Err(serde::de::Error::custom(format!(
+                "track_colors needs exactly 8 entries, got {}",
+                raw.len()
+            )));
+        }
+        let mut out = [Color::BLACK; 8];
+        for (slot, s) in out.iter_mut().zip(&raw) {
+            *slot = super::hex::parse(s)
+                .ok_or_else(|| serde::de::Error::custom(format!("invalid hex color {s:?}")))?;
+        }
+        Ok(out)
+    }
+}
 
-/// VU meter yellow: #ffd700
-pub const METER_YELLOW: Color = Color {
-    r: 1.0,
-    g: 0.843,
-    b: 0.0,
-    a: 1.0,
-};
+const fn rgb(r: f32, g: f32, b: f32) -> Color {
+    Color { r, g, b, a: 1.0 }
+}
 
-/// VU meter red: #f87171
-pub const METER_RED: Color = Color {
-    r: 0.973,
-    g: 0.443,
-    b: 0.443,
-    a: 1.0,
-};
+const fn rgba(r: f32, g: f32, b: f32, a: f32) -> Color {
+    Color { r, g, b, a }
+}
 
-// ── Button state colors ──
+impl ThemePalette {
+    /// The founding vibez look: dark charcoal, orange accent.
+    pub fn charcoal() -> Self {
+        Self {
+            name: "Charcoal".to_string(),
+            bg_dark: rgb(0.102, 0.102, 0.102),
+            bg_surface: rgb(0.141, 0.141, 0.141),
+            bg_elevated: rgb(0.176, 0.176, 0.176),
+            bg_hover: rgb(0.212, 0.212, 0.212),
+            text: rgb(0.878, 0.878, 0.878),
+            text_dim: rgb(0.502, 0.502, 0.502),
+            text_muted: rgb(0.314, 0.314, 0.314),
+            accent: rgb(1.0, 0.549, 0.0),
+            accent_dim: rgb(0.600, 0.329, 0.0),
+            border: rgb(0.227, 0.227, 0.227),
+            border_light: rgb(0.290, 0.290, 0.290),
+            divider: rgb(0.165, 0.165, 0.165),
+            success: rgb(0.290, 0.871, 0.502),
+            danger: rgb(0.973, 0.443, 0.443),
+            playhead: rgba(1.0, 1.0, 1.0, 0.8),
+            meter_green: rgb(0.290, 0.871, 0.502),
+            meter_yellow: rgb(1.0, 0.843, 0.0),
+            meter_red: rgb(0.973, 0.443, 0.443),
+            display_bg: rgb(0.07, 0.07, 0.07),
+            knob_arc: rgb(0.533, 0.533, 0.533),
+            knob_body: rgb(0.12, 0.12, 0.12),
+            knob_body_engaged: rgb(0.16, 0.16, 0.16),
+            knob_track: rgb(0.22, 0.22, 0.22),
+            fader_handle: rgb(0.533, 0.533, 0.533),
+            track_colors: [
+                rgb(0.878, 0.376, 0.376), // red
+                rgb(0.878, 0.565, 0.251), // orange
+                rgb(0.816, 0.753, 0.251), // yellow
+                rgb(0.314, 0.690, 0.376), // green
+                rgb(0.251, 0.627, 0.690), // cyan
+                rgb(0.376, 0.502, 0.816), // blue
+                rgb(0.565, 0.376, 0.753), // purple
+                rgb(0.753, 0.376, 0.627), // pink
+            ],
+            eq_lf: rgb(0.65, 0.46, 0.28),
+            eq_lmf: rgb(0.36, 0.48, 0.72),
+            eq_hmf: rgb(0.33, 0.62, 0.38),
+            eq_hf: rgb(0.76, 0.33, 0.30),
+            clip_body: rgba(0.300, 0.480, 0.900, 0.6),
+            clip_border: rgba(0.380, 0.565, 1.0, 0.9),
+            waveform: rgba(0.380, 0.565, 1.0, 0.6),
+            ruler_line: rgba(0.227, 0.227, 0.227, 0.5),
+            grid_bar: rgb(0.376, 0.376, 0.376),
+            grid_beat: rgb(0.251, 0.251, 0.251),
+            grid_sub: rgb(0.216, 0.216, 0.216),
+            piano_white_row: rgb(0.145, 0.145, 0.145),
+            piano_black_row: rgb(0.110, 0.110, 0.110),
+            piano_octave_line: rgb(0.227, 0.227, 0.227),
+            piano_grid: rgb(0.165, 0.165, 0.165),
+            piano_white_key: rgb(0.784, 0.784, 0.784),
+            piano_black_key: rgb(0.102, 0.102, 0.102),
+            piano_key_label: rgb(0.35, 0.35, 0.35),
+        }
+    }
+}
 
-/// Mute active: #f87171 (red)
-pub const MUTE_ACTIVE: Color = DANGER;
+impl Default for ThemePalette {
+    fn default() -> Self {
+        Self::charcoal()
+    }
+}
 
-/// Solo active: #ffd700 (yellow)
-pub const SOLO_ACTIVE: Color = METER_YELLOW;
+static CURRENT: LazyLock<RwLock<ThemePalette>> =
+    LazyLock::new(|| RwLock::new(ThemePalette::charcoal()));
 
-// ── Knob / fader colors ──
+/// Swap the active theme; the next frame repaints everything.
+#[allow(dead_code)] // wired up by the Appearance settings
+pub fn set_theme(palette: ThemePalette) {
+    *CURRENT.write().unwrap() = palette;
+}
 
-/// Knob background: BG_ELEVATED
-pub const KNOB_BG: Color = BG_ELEVATED;
+/// Snapshot of the whole current palette (theme save, swatches).
+#[allow(dead_code)] // wired up by the Appearance settings
+pub fn current() -> ThemePalette {
+    CURRENT.read().unwrap().clone()
+}
 
-/// Default knob arc color (overridden by track color): #888888
-#[allow(dead_code)]
-pub const KNOB_ARC: Color = Color {
-    r: 0.533,
-    g: 0.533,
-    b: 0.533,
-    a: 1.0,
-};
+macro_rules! accessors {
+    ($($fn_name:ident => $field:ident),* $(,)?) => {
+        $(
+            #[allow(dead_code)]
+            pub fn $fn_name() -> Color {
+                CURRENT.read().unwrap().$field
+            }
+        )*
+    };
+}
 
-/// Fader track color: BG_ELEVATED
-pub const FADER_TRACK: Color = BG_ELEVATED;
+accessors! {
+    bg_dark => bg_dark,
+    bg_surface => bg_surface,
+    bg_elevated => bg_elevated,
+    bg_hover => bg_hover,
+    text => text,
+    text_dim => text_dim,
+    text_muted => text_muted,
+    accent => accent,
+    accent_dim => accent_dim,
+    border => border,
+    border_light => border_light,
+    divider => divider,
+    success => success,
+    danger => danger,
+    playhead => playhead,
+    meter_green => meter_green,
+    meter_yellow => meter_yellow,
+    meter_red => meter_red,
+    display_bg => display_bg,
+    knob_arc => knob_arc,
+    knob_body => knob_body,
+    knob_body_engaged => knob_body_engaged,
+    knob_track => knob_track,
+    fader_handle => fader_handle,
+    eq_lf => eq_lf,
+    eq_lmf => eq_lmf,
+    eq_hmf => eq_hmf,
+    eq_hf => eq_hf,
+    clip_body => clip_body,
+    clip_border => clip_border,
+    waveform => waveform,
+    ruler_line => ruler_line,
+    grid_bar => grid_bar,
+    grid_beat => grid_beat,
+    grid_sub => grid_sub,
+    piano_white_row => piano_white_row,
+    piano_black_row => piano_black_row,
+    piano_octave_line => piano_octave_line,
+    piano_grid => piano_grid,
+    piano_white_key => piano_white_key,
+    piano_black_key => piano_black_key,
+    piano_key_label => piano_key_label,
+}
 
-/// Fader handle color: #888888
-pub const FADER_HANDLE: Color = Color {
-    r: 0.533,
-    g: 0.533,
-    b: 0.533,
-    a: 1.0,
-};
+// ── Derived roles (aliases of palette fields) ──
 
-// ── Track colors (auto-assigned per track) ──
+pub fn mute_active() -> Color {
+    danger()
+}
 
-pub const TRACK_COLORS: [Color; 8] = [
-    // Red: #e06060
-    Color {
-        r: 0.878,
-        g: 0.376,
-        b: 0.376,
-        a: 1.0,
-    },
-    // Orange: #e09040
-    Color {
-        r: 0.878,
-        g: 0.565,
-        b: 0.251,
-        a: 1.0,
-    },
-    // Yellow: #d0c040
-    Color {
-        r: 0.816,
-        g: 0.753,
-        b: 0.251,
-        a: 1.0,
-    },
-    // Green: #50b060
-    Color {
-        r: 0.314,
-        g: 0.690,
-        b: 0.376,
-        a: 1.0,
-    },
-    // Cyan: #40a0b0
-    Color {
-        r: 0.251,
-        g: 0.627,
-        b: 0.690,
-        a: 1.0,
-    },
-    // Blue: #6080d0
-    Color {
-        r: 0.376,
-        g: 0.502,
-        b: 0.816,
-        a: 1.0,
-    },
-    // Purple: #9060c0
-    Color {
-        r: 0.565,
-        g: 0.376,
-        b: 0.753,
-        a: 1.0,
-    },
-    // Pink: #c060a0
-    Color {
-        r: 0.753,
-        g: 0.376,
-        b: 0.627,
-        a: 1.0,
-    },
-];
+pub fn solo_active() -> Color {
+    meter_yellow()
+}
+
+pub fn knob_bg() -> Color {
+    bg_elevated()
+}
+
+pub fn fader_track() -> Color {
+    bg_elevated()
+}
+
+pub fn track_bg() -> Color {
+    bg_dark()
+}
+
+pub fn track_bg_selected() -> Color {
+    bg_elevated()
+}
+
+pub fn ruler_bg() -> Color {
+    bg_surface()
+}
+
+pub fn ruler_text() -> Color {
+    text_dim()
+}
 
 /// Get a track color by index (wraps around).
 pub fn track_color(index: u8) -> Color {
-    TRACK_COLORS[index as usize % TRACK_COLORS.len()]
+    let palette = CURRENT.read().unwrap();
+    palette.track_colors[index as usize % palette.track_colors.len()]
 }
-
-// ── Channel EQ band colors (console convention, muted) ──
-pub const EQ_HF: Color = Color {
-    r: 0.76,
-    g: 0.33,
-    b: 0.30,
-    a: 1.0,
-};
-pub const EQ_HMF: Color = Color {
-    r: 0.33,
-    g: 0.62,
-    b: 0.38,
-    a: 1.0,
-};
-pub const EQ_LMF: Color = Color {
-    r: 0.36,
-    g: 0.48,
-    b: 0.72,
-    a: 1.0,
-};
-pub const EQ_LF: Color = Color {
-    r: 0.65,
-    g: 0.46,
-    b: 0.28,
-    a: 1.0,
-};
 
 /// Darken a color by a factor (for borders, etc.)
 pub fn darken(color: Color, factor: f32) -> Color {
@@ -295,68 +392,23 @@ pub fn darken(color: Color, factor: f32) -> Color {
 }
 
 /// Apply alpha to a color.
+#[allow(dead_code)]
 pub fn with_alpha(color: Color, alpha: f32) -> Color {
     Color { a: alpha, ..color }
 }
 
-// ── Aliases for backward compatibility in widgets ──
-
-/// Track lane background
-pub const TRACK_BG: Color = BG_DARK;
-
-/// Selected track background
-pub const TRACK_BG_SELECTED: Color = BG_ELEVATED;
-
-/// Clip body color (default, overridden by track color)
-#[allow(dead_code)]
-pub const CLIP_BODY: Color = Color {
-    r: 0.300,
-    g: 0.480,
-    b: 0.900,
-    a: 0.6,
-};
-
-/// Clip border color (default, overridden by track color)
-#[allow(dead_code)]
-pub const CLIP_BORDER: Color = Color {
-    r: 0.380,
-    g: 0.565,
-    b: 1.0,
-    a: 0.9,
-};
-
-/// Waveform display color (default, overridden by track color)
-pub const WAVEFORM: Color = Color {
-    r: 0.380,
-    g: 0.565,
-    b: 1.0,
-    a: 0.6,
-};
-
-/// Ruler background
-pub const RULER_BG: Color = BG_SURFACE;
-
-/// Ruler text
-pub const RULER_TEXT: Color = TEXT_DIM;
-
-/// Ruler line
-#[allow(dead_code)]
-pub const RULER_LINE: Color = Color {
-    r: 0.227,
-    g: 0.227,
-    b: 0.227,
-    a: 0.5,
-};
-
+/// iced theme derived from the current palette (built-in widget
+/// chrome: scrollbars, text inputs, pick lists).
 pub fn vibez_theme() -> Theme {
+    let p = CURRENT.read().unwrap();
     Theme::custom(
-        "Vibez".to_string(),
+        p.name.clone(),
         Palette {
-            background: BG_DARK,
-            text: TEXT,
-            primary: ACCENT,
-            success: SUCCESS,
-            danger: DANGER,
+            background: p.bg_dark,
+            text: p.text,
+            primary: p.accent,
+            success: p.success,
+            danger: p.danger,
         },
     )
 }
@@ -364,3 +416,42 @@ pub fn vibez_theme() -> Theme {
 /// Uniform device-card body height across the device chain: the
 /// panel scrolls horizontally, so cards share one rack height.
 pub const DEVICE_BODY_H: f32 = 184.0;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_roundtrip() {
+        for c in [
+            rgb(0.102, 0.102, 0.102),
+            rgb(1.0, 0.549, 0.0),
+            rgba(1.0, 1.0, 1.0, 0.8),
+        ] {
+            let s = hex::to_hex(&c);
+            let back = hex::parse(&s).unwrap();
+            let [r1, g1, b1, a1] = c.into_rgba8();
+            let [r2, g2, b2, a2] = back.into_rgba8();
+            assert_eq!((r1, g1, b1, a1), (r2, g2, b2, a2), "{s}");
+        }
+        assert!(hex::parse("#12345").is_none());
+        assert!(hex::parse("nope").is_none());
+    }
+
+    #[test]
+    fn palette_serializes_as_vzt_json_and_loads_back() {
+        let p = ThemePalette::charcoal();
+        let json = serde_json::to_string_pretty(&p).unwrap();
+        assert!(json.contains("\"accent\": \"#ff8c00\""));
+        let back: ThemePalette = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.name, "Charcoal");
+        assert_eq!(hex::to_hex(&back.accent), "#ff8c00");
+        assert_eq!(back.track_colors.len(), 8);
+    }
+
+    #[test]
+    fn missing_field_is_a_load_error_not_a_panic() {
+        let result = serde_json::from_str::<ThemePalette>("{\"name\": \"Broken\"}");
+        assert!(result.is_err());
+    }
+}

--- a/crates/vibez-ui/src/theme.rs
+++ b/crates/vibez-ui/src/theme.rs
@@ -258,6 +258,32 @@ pub fn track_color(index: u8) -> Color {
     TRACK_COLORS[index as usize % TRACK_COLORS.len()]
 }
 
+// ── Channel EQ band colors (console convention, muted) ──
+pub const EQ_HF: Color = Color {
+    r: 0.76,
+    g: 0.33,
+    b: 0.30,
+    a: 1.0,
+};
+pub const EQ_HMF: Color = Color {
+    r: 0.33,
+    g: 0.62,
+    b: 0.38,
+    a: 1.0,
+};
+pub const EQ_LMF: Color = Color {
+    r: 0.36,
+    g: 0.48,
+    b: 0.72,
+    a: 1.0,
+};
+pub const EQ_LF: Color = Color {
+    r: 0.65,
+    g: 0.46,
+    b: 0.28,
+    a: 1.0,
+};
+
 /// Darken a color by a factor (for borders, etc.)
 pub fn darken(color: Color, factor: f32) -> Color {
     Color {

--- a/crates/vibez-ui/src/themes.rs
+++ b/crates/vibez-ui/src/themes.rs
@@ -1,0 +1,631 @@
+//! The built-in theme collection and the `.vzt` user-theme service.
+//!
+//! Built-ins are authored from a handful of seeds through the
+//! dark/light builders below, so every theme fills the complete
+//! [`ThemePalette`]. User themes are plain `.vzt` JSON files scanned
+//! from the config themes directory, plugin-cache style.
+
+use std::path::PathBuf;
+
+use iced::Color;
+
+use crate::theme::ThemePalette;
+
+const fn rgb8(r: u8, g: u8, b: u8) -> Color {
+    Color {
+        r: r as f32 / 255.0,
+        g: g as f32 / 255.0,
+        b: b as f32 / 255.0,
+        a: 1.0,
+    }
+}
+
+/// Move `c` toward white by `f` (0..1).
+fn lighten(c: Color, f: f32) -> Color {
+    Color {
+        r: c.r + (1.0 - c.r) * f,
+        g: c.g + (1.0 - c.g) * f,
+        b: c.b + (1.0 - c.b) * f,
+        a: c.a,
+    }
+}
+
+/// Move `c` toward black by `f` (0..1).
+fn darken(c: Color, f: f32) -> Color {
+    Color {
+        r: c.r * (1.0 - f),
+        g: c.g * (1.0 - f),
+        b: c.b * (1.0 - f),
+        a: c.a,
+    }
+}
+
+fn alpha(c: Color, a: f32) -> Color {
+    Color { a, ..c }
+}
+
+/// Console-convention EQ band colors (LF brown, LMF blue, HMF green,
+/// HF red), shared by most themes.
+const EQ_CONSOLE: [Color; 4] = [
+    Color {
+        r: 0.65,
+        g: 0.46,
+        b: 0.28,
+        a: 1.0,
+    },
+    Color {
+        r: 0.36,
+        g: 0.48,
+        b: 0.72,
+        a: 1.0,
+    },
+    Color {
+        r: 0.33,
+        g: 0.62,
+        b: 0.38,
+        a: 1.0,
+    },
+    Color {
+        r: 0.76,
+        g: 0.33,
+        b: 0.30,
+        a: 1.0,
+    },
+];
+
+/// The default track rainbow (charcoal's).
+const TRACKS_CLASSIC: [Color; 8] = [
+    rgb8(224, 96, 96),
+    rgb8(224, 144, 64),
+    rgb8(208, 192, 64),
+    rgb8(80, 176, 96),
+    rgb8(64, 160, 176),
+    rgb8(96, 128, 208),
+    rgb8(144, 96, 192),
+    rgb8(192, 96, 160),
+];
+
+const TRACKS_NEON: [Color; 8] = [
+    rgb8(255, 64, 96),
+    rgb8(255, 144, 0),
+    rgb8(230, 255, 0),
+    rgb8(57, 255, 20),
+    rgb8(0, 255, 213),
+    rgb8(0, 160, 255),
+    rgb8(191, 64, 255),
+    rgb8(255, 64, 208),
+];
+
+const TRACKS_PASTEL: [Color; 8] = [
+    rgb8(243, 139, 168),
+    rgb8(250, 179, 135),
+    rgb8(249, 226, 175),
+    rgb8(166, 227, 161),
+    rgb8(148, 226, 213),
+    rgb8(137, 180, 250),
+    rgb8(203, 166, 247),
+    rgb8(245, 194, 231),
+];
+
+const TRACKS_WARM: [Color; 8] = [
+    rgb8(204, 102, 84),
+    rgb8(214, 143, 84),
+    rgb8(199, 178, 90),
+    rgb8(143, 158, 96),
+    rgb8(114, 150, 137),
+    rgb8(122, 138, 176),
+    rgb8(158, 118, 160),
+    rgb8(186, 118, 132),
+];
+
+const TRACKS_MONO: [Color; 8] = [
+    rgb8(220, 220, 220),
+    rgb8(190, 190, 190),
+    rgb8(160, 160, 160),
+    rgb8(200, 200, 200),
+    rgb8(150, 150, 150),
+    rgb8(210, 210, 210),
+    rgb8(170, 170, 170),
+    rgb8(140, 140, 140),
+];
+
+struct Seed {
+    name: &'static str,
+    bg: Color,
+    accent: Color,
+    text: Color,
+    tracks: [Color; 8],
+    eq: [Color; 4],
+}
+
+/// Fill a complete palette from a dark seed: surfaces step up from
+/// the background, text tiers step down, grids sit between.
+fn dark(seed: Seed) -> ThemePalette {
+    let bg = seed.bg;
+    ThemePalette {
+        name: seed.name.to_string(),
+        bg_dark: bg,
+        bg_surface: lighten(bg, 0.045),
+        bg_elevated: lighten(bg, 0.085),
+        bg_hover: lighten(bg, 0.125),
+        text: seed.text,
+        text_dim: darken(seed.text, 0.43),
+        text_muted: darken(seed.text, 0.64),
+        accent: seed.accent,
+        accent_dim: darken(seed.accent, 0.4),
+        border: lighten(bg, 0.14),
+        border_light: lighten(bg, 0.21),
+        divider: lighten(bg, 0.07),
+        success: rgb8(74, 222, 128),
+        danger: rgb8(248, 113, 113),
+        playhead: alpha(Color::WHITE, 0.8),
+        meter_green: rgb8(74, 222, 128),
+        meter_yellow: rgb8(255, 215, 0),
+        meter_red: rgb8(248, 113, 113),
+        display_bg: darken(bg, 0.32),
+        knob_arc: lighten(bg, 0.48),
+        knob_body: lighten(bg, 0.02),
+        knob_body_engaged: lighten(bg, 0.065),
+        knob_track: lighten(bg, 0.13),
+        fader_handle: lighten(bg, 0.48),
+        track_colors: seed.tracks,
+        eq_lf: seed.eq[0],
+        eq_lmf: seed.eq[1],
+        eq_hmf: seed.eq[2],
+        eq_hf: seed.eq[3],
+        clip_body: alpha(seed.accent, 0.35),
+        clip_border: alpha(lighten(seed.accent, 0.2), 0.9),
+        waveform: alpha(lighten(seed.accent, 0.2), 0.6),
+        ruler_line: alpha(lighten(bg, 0.14), 0.5),
+        grid_bar: lighten(bg, 0.30),
+        grid_beat: lighten(bg, 0.17),
+        grid_sub: lighten(bg, 0.13),
+        piano_white_row: lighten(bg, 0.05),
+        piano_black_row: lighten(bg, 0.01),
+        piano_octave_line: lighten(bg, 0.14),
+        piano_grid: lighten(bg, 0.07),
+        piano_white_key: rgb8(200, 200, 200),
+        piano_black_key: darken(bg, 0.15),
+        piano_key_label: lighten(bg, 0.32),
+    }
+}
+
+/// Fill a complete palette from a light seed: surfaces step down
+/// from the background, text is ink, grids darker than paper.
+fn light(seed: Seed) -> ThemePalette {
+    let bg = seed.bg;
+    ThemePalette {
+        name: seed.name.to_string(),
+        bg_dark: bg,
+        bg_surface: darken(bg, 0.035),
+        bg_elevated: darken(bg, 0.065),
+        bg_hover: darken(bg, 0.10),
+        text: seed.text,
+        text_dim: lighten(seed.text, 0.38),
+        text_muted: lighten(seed.text, 0.58),
+        accent: seed.accent,
+        accent_dim: lighten(seed.accent, 0.3),
+        border: darken(bg, 0.14),
+        border_light: darken(bg, 0.22),
+        divider: darken(bg, 0.07),
+        success: rgb8(34, 154, 82),
+        danger: rgb8(205, 60, 60),
+        playhead: alpha(Color::BLACK, 0.7),
+        meter_green: rgb8(46, 178, 99),
+        meter_yellow: rgb8(212, 165, 8),
+        meter_red: rgb8(205, 60, 60),
+        display_bg: darken(bg, 0.05),
+        knob_arc: darken(bg, 0.45),
+        knob_body: darken(bg, 0.05),
+        knob_body_engaged: darken(bg, 0.10),
+        knob_track: darken(bg, 0.18),
+        fader_handle: darken(bg, 0.45),
+        track_colors: seed.tracks,
+        eq_lf: darken(seed.eq[0], 0.12),
+        eq_lmf: darken(seed.eq[1], 0.12),
+        eq_hmf: darken(seed.eq[2], 0.12),
+        eq_hf: darken(seed.eq[3], 0.12),
+        clip_body: alpha(seed.accent, 0.35),
+        clip_border: alpha(darken(seed.accent, 0.2), 0.9),
+        waveform: alpha(darken(seed.accent, 0.25), 0.65),
+        ruler_line: alpha(darken(bg, 0.14), 0.5),
+        grid_bar: darken(bg, 0.32),
+        grid_beat: darken(bg, 0.18),
+        grid_sub: darken(bg, 0.12),
+        piano_white_row: darken(bg, 0.02),
+        piano_black_row: darken(bg, 0.075),
+        piano_octave_line: darken(bg, 0.20),
+        piano_grid: darken(bg, 0.10),
+        piano_white_key: rgb8(250, 250, 250),
+        piano_black_key: rgb8(40, 40, 40),
+        piano_key_label: darken(bg, 0.45),
+    }
+}
+
+/// All built-in themes, default first.
+pub fn builtins() -> Vec<ThemePalette> {
+    let mut themes = vec![ThemePalette::charcoal()];
+    themes.extend([
+        dark(Seed {
+            name: "Obsidian",
+            bg: rgb8(10, 10, 12),
+            accent: rgb8(125, 200, 255),
+            text: rgb8(222, 226, 230),
+            tracks: TRACKS_CLASSIC,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Berlin",
+            bg: rgb8(6, 6, 6),
+            accent: rgb8(192, 57, 43),
+            text: rgb8(200, 200, 200),
+            tracks: TRACKS_MONO,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Acid",
+            bg: rgb8(8, 10, 6),
+            accent: rgb8(170, 255, 0),
+            text: rgb8(214, 230, 202),
+            tracks: TRACKS_NEON,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Vaporwave",
+            bg: rgb8(24, 14, 42),
+            accent: rgb8(255, 113, 206),
+            text: rgb8(230, 220, 245),
+            tracks: TRACKS_NEON,
+            eq: [
+                rgb8(255, 113, 206),
+                rgb8(1, 205, 254),
+                rgb8(5, 255, 161),
+                rgb8(185, 103, 255),
+            ],
+        }),
+        dark(Seed {
+            name: "Nord",
+            bg: rgb8(46, 52, 64),
+            accent: rgb8(136, 192, 208),
+            text: rgb8(216, 222, 233),
+            tracks: [
+                rgb8(191, 97, 106),
+                rgb8(208, 135, 112),
+                rgb8(235, 203, 139),
+                rgb8(163, 190, 140),
+                rgb8(143, 188, 187),
+                rgb8(129, 161, 193),
+                rgb8(180, 142, 173),
+                rgb8(94, 129, 172),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Dracula",
+            bg: rgb8(40, 42, 54),
+            accent: rgb8(189, 147, 249),
+            text: rgb8(248, 248, 242),
+            tracks: [
+                rgb8(255, 85, 85),
+                rgb8(255, 184, 108),
+                rgb8(241, 250, 140),
+                rgb8(80, 250, 123),
+                rgb8(139, 233, 253),
+                rgb8(98, 114, 164),
+                rgb8(189, 147, 249),
+                rgb8(255, 121, 198),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Gruvbox",
+            bg: rgb8(40, 40, 40),
+            accent: rgb8(254, 128, 25),
+            text: rgb8(235, 219, 178),
+            tracks: [
+                rgb8(204, 36, 29),
+                rgb8(214, 93, 14),
+                rgb8(215, 153, 33),
+                rgb8(152, 151, 26),
+                rgb8(104, 157, 106),
+                rgb8(69, 133, 136),
+                rgb8(177, 98, 134),
+                rgb8(254, 128, 25),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Solarized Dark",
+            bg: rgb8(0, 43, 54),
+            accent: rgb8(38, 139, 210),
+            text: rgb8(147, 161, 161),
+            tracks: [
+                rgb8(220, 50, 47),
+                rgb8(203, 75, 22),
+                rgb8(181, 137, 0),
+                rgb8(133, 153, 0),
+                rgb8(42, 161, 152),
+                rgb8(38, 139, 210),
+                rgb8(108, 113, 196),
+                rgb8(211, 54, 130),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Monokai",
+            bg: rgb8(39, 40, 34),
+            accent: rgb8(166, 226, 46),
+            text: rgb8(248, 248, 242),
+            tracks: [
+                rgb8(249, 38, 114),
+                rgb8(253, 151, 31),
+                rgb8(230, 219, 116),
+                rgb8(166, 226, 46),
+                rgb8(102, 217, 239),
+                rgb8(118, 149, 216),
+                rgb8(174, 129, 255),
+                rgb8(249, 38, 114),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Tokyo Night",
+            bg: rgb8(26, 27, 38),
+            accent: rgb8(122, 162, 247),
+            text: rgb8(192, 202, 245),
+            tracks: [
+                rgb8(247, 118, 142),
+                rgb8(255, 158, 100),
+                rgb8(224, 175, 104),
+                rgb8(158, 206, 106),
+                rgb8(115, 218, 202),
+                rgb8(122, 162, 247),
+                rgb8(187, 154, 247),
+                rgb8(255, 117, 127),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Catppuccin",
+            bg: rgb8(30, 30, 46),
+            accent: rgb8(203, 166, 247),
+            text: rgb8(205, 214, 244),
+            tracks: TRACKS_PASTEL,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "One Dark",
+            bg: rgb8(40, 44, 52),
+            accent: rgb8(97, 175, 239),
+            text: rgb8(171, 178, 191),
+            tracks: [
+                rgb8(224, 108, 117),
+                rgb8(209, 154, 102),
+                rgb8(229, 192, 123),
+                rgb8(152, 195, 121),
+                rgb8(86, 182, 194),
+                rgb8(97, 175, 239),
+                rgb8(198, 120, 221),
+                rgb8(190, 80, 70),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Deep Sea",
+            bg: rgb8(11, 26, 36),
+            accent: rgb8(46, 196, 182),
+            text: rgb8(202, 220, 228),
+            tracks: [
+                rgb8(231, 111, 81),
+                rgb8(244, 162, 97),
+                rgb8(233, 196, 106),
+                rgb8(138, 177, 125),
+                rgb8(42, 157, 143),
+                rgb8(69, 123, 157),
+                rgb8(131, 111, 168),
+                rgb8(190, 111, 130),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Espresso",
+            bg: rgb8(36, 26, 20),
+            accent: rgb8(212, 163, 115),
+            text: rgb8(230, 218, 205),
+            tracks: TRACKS_WARM,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Slate",
+            bg: rgb8(28, 33, 40),
+            accent: rgb8(83, 155, 245),
+            text: rgb8(205, 217, 229),
+            tracks: TRACKS_CLASSIC,
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "Rose Pine",
+            bg: rgb8(25, 23, 36),
+            accent: rgb8(235, 188, 186),
+            text: rgb8(224, 222, 244),
+            tracks: [
+                rgb8(235, 111, 146),
+                rgb8(246, 193, 119),
+                rgb8(234, 154, 151),
+                rgb8(49, 116, 143),
+                rgb8(156, 207, 216),
+                rgb8(196, 167, 231),
+                rgb8(144, 122, 169),
+                rgb8(235, 188, 186),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        dark(Seed {
+            name: "High Contrast",
+            bg: rgb8(0, 0, 0),
+            accent: rgb8(255, 215, 0),
+            text: rgb8(255, 255, 255),
+            tracks: TRACKS_NEON,
+            eq: EQ_CONSOLE,
+        }),
+        light(Seed {
+            name: "Solarized Light",
+            bg: rgb8(253, 246, 227),
+            accent: rgb8(38, 139, 210),
+            text: rgb8(88, 110, 117),
+            tracks: [
+                rgb8(220, 50, 47),
+                rgb8(203, 75, 22),
+                rgb8(181, 137, 0),
+                rgb8(133, 153, 0),
+                rgb8(42, 161, 152),
+                rgb8(38, 139, 210),
+                rgb8(108, 113, 196),
+                rgb8(211, 54, 130),
+            ],
+            eq: EQ_CONSOLE,
+        }),
+        light(Seed {
+            name: "Porcelain",
+            bg: rgb8(242, 242, 240),
+            accent: rgb8(235, 120, 15),
+            text: rgb8(40, 42, 46),
+            tracks: TRACKS_CLASSIC,
+            eq: EQ_CONSOLE,
+        }),
+    ]);
+    themes
+}
+
+/// Look a built-in up by name.
+pub fn builtin_by_name(name: &str) -> Option<ThemePalette> {
+    builtins().into_iter().find(|t| t.name == name)
+}
+
+// ── User theme (.vzt) service ──────────────────────────────────────
+
+/// A user theme scanned from the themes directory.
+#[derive(Debug, Clone)]
+pub struct UserTheme {
+    /// Source file; kept for future delete/reveal actions.
+    #[allow(dead_code)]
+    pub path: PathBuf,
+    pub palette: ThemePalette,
+}
+
+/// `~/.config/vibez/themes`, created on first use.
+pub fn themes_dir() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("vibez")
+        .join("themes")
+}
+
+/// Scan the themes directory for `.vzt` files, plugin-cache style.
+/// Unreadable or malformed files are skipped with a warning list so
+/// one broken theme never hides the rest.
+pub fn scan_user_themes() -> (Vec<UserTheme>, Vec<String>) {
+    let mut themes = Vec::new();
+    let mut warnings = Vec::new();
+    let dir = themes_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(_) => return (themes, warnings), // no dir yet: no themes
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("vzt") {
+            continue;
+        }
+        match std::fs::read_to_string(&path)
+            .map_err(|e| e.to_string())
+            .and_then(|s| serde_json::from_str::<ThemePalette>(&s).map_err(|e| e.to_string()))
+        {
+            Ok(palette) => themes.push(UserTheme {
+                path: path.clone(),
+                palette,
+            }),
+            Err(e) => warnings.push(format!("{}: {e}", path.display())),
+        }
+    }
+    themes.sort_by(|a, b| {
+        a.palette
+            .name
+            .to_lowercase()
+            .cmp(&b.palette.name.to_lowercase())
+    });
+    (themes, warnings)
+}
+
+/// Save a palette into the themes directory as `<slug>.vzt`.
+pub fn save_user_theme(palette: &ThemePalette) -> Result<PathBuf, String> {
+    let dir = themes_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let slug: String = palette
+        .name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    let slug = if slug.is_empty() {
+        "custom".to_string()
+    } else {
+        slug
+    };
+    let path = dir.join(format!("{slug}.vzt"));
+    let json = serde_json::to_string_pretty(palette).map_err(|e| e.to_string())?;
+    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn twenty_builtins_with_unique_names() {
+        let themes = builtins();
+        assert_eq!(themes.len(), 20, "the collection ships 20 themes");
+        let mut names: Vec<&str> = themes.iter().map(|t| t.name.as_str()).collect();
+        names.sort();
+        names.dedup();
+        assert_eq!(names.len(), themes.len(), "names must be unique");
+        assert_eq!(themes[0].name, "Charcoal", "default first");
+    }
+
+    #[test]
+    fn builtin_text_contrasts_with_background() {
+        // Cheap luminance gate: every theme's primary text must sit
+        // far from its background, dark or light.
+        fn luma(c: Color) -> f32 {
+            0.2126 * c.r + 0.7152 * c.g + 0.0722 * c.b
+        }
+        for t in builtins() {
+            let d = (luma(t.text) - luma(t.bg_dark)).abs();
+            assert!(d > 0.45, "theme {} text/bg contrast too low: {d}", t.name);
+        }
+    }
+
+    #[test]
+    fn vzt_roundtrip_through_the_service() {
+        let dir = tempfile::tempdir().unwrap();
+        // Redirect the service to a temp dir via direct file ops:
+        // save_user_theme always writes to the real config dir, so
+        // exercise the same serialize/parse path manually here.
+        let mut palette = ThemePalette::charcoal();
+        palette.name = "Test Custom".to_string();
+        let json = serde_json::to_string_pretty(&palette).unwrap();
+        let path = dir.path().join("test-custom.vzt");
+        std::fs::write(&path, &json).unwrap();
+        let back: ThemePalette =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(back.name, "Test Custom");
+    }
+}

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -23,6 +23,10 @@ pub struct UiSettings {
     /// startup. `None` means auto-pick the first visible port.
     #[serde(default)]
     pub preferred_midi_input: Option<String>,
+    /// Selected theme name (built-in or user `.vzt`); `None` means
+    /// the default Charcoal.
+    #[serde(default)]
+    pub theme: Option<String>,
 }
 
 impl Default for UiSettings {
@@ -33,6 +37,7 @@ impl Default for UiSettings {
             auto_warp_on_import: false,
             warp_confidence_threshold: default_warp_confidence_threshold(),
             preferred_midi_input: None,
+            theme: None,
         }
     }
 }

--- a/crates/vibez-ui/src/widgets/audio_clip_detail.rs
+++ b/crates/vibez-ui/src/widgets/audio_clip_detail.rs
@@ -39,7 +39,7 @@ impl canvas::Program<Message> for AudioClipDetailWidget {
         let h = bounds.height;
 
         // Background
-        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::BG_DARK);
+        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::bg_dark());
 
         // Center line
         let center_y = h / 2.0;
@@ -52,7 +52,7 @@ impl canvas::Program<Message> for AudioClipDetailWidget {
             canvas::Stroke::default()
                 .with_color(Color {
                     a: 0.3,
-                    ..theme::TEXT_DIM
+                    ..theme::text_dim()
                 })
                 .with_width(1.0),
         );
@@ -183,7 +183,7 @@ impl canvas::Program<Message> for AudioClipDetailWidget {
             frame.stroke(
                 &playhead_line,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(2.0),
             );
         }

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -173,7 +173,10 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                         offset: 0,
                     },
                     ..canvas::Stroke::default()
-                        .with_color(Color::from_rgba(0.85, 0.83, 0.78, 0.35))
+                        .with_color(Color {
+                            a: 0.35,
+                            ..th::text()
+                        })
                         .with_width(1.0)
                 },
             );
@@ -184,7 +187,10 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         let label = |content: &str, position: Point, bottom: bool| canvas::Text {
             content: content.to_string(),
             position,
-            color: Color::from_rgba(0.75, 0.73, 0.68, 0.55),
+            color: Color {
+                a: 0.55,
+                ..th::text()
+            },
             size: iced::Pixels(9.0),
             vertical_alignment: if bottom {
                 iced::alignment::Vertical::Bottom
@@ -262,9 +268,9 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                     || (state.drag.is_none() && self.selected == Some(i));
                 let handle = canvas::Path::circle(center, HANDLE_RADIUS);
                 if selected {
-                    frame.fill(&handle, th::ACCENT);
+                    frame.fill(&handle, th::accent());
                 } else {
-                    frame.fill(&handle, Color::from_rgba(0.09, 0.09, 0.1, 1.0));
+                    frame.fill(&handle, th::bg_dark());
                     frame.stroke(
                         &handle,
                         canvas::Stroke::default()
@@ -284,7 +290,10 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                 frame.fill_rectangle(
                     Point::new(x0, 0.0),
                     iced::Size::new(x1 - x0, h),
-                    Color::from_rgba(0.9, 0.35, 0.25, 0.18),
+                    Color {
+                        a: 0.18,
+                        ..th::danger()
+                    },
                 );
             }
         }

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -1,0 +1,295 @@
+//! Automation lane canvas: breakpoints over time, aligned with the
+//! arrangement timeline (same pixels-per-beat and scroll offset).
+//!
+//! Interactions: double-click adds a point, drag moves one (the
+//! move commits on release; a ghost renders during the drag), click
+//! selects, Delete removes via the global delete-key priority.
+
+use std::time::Instant;
+
+use iced::widget::canvas;
+use iced::{mouse, Color, Point, Rectangle, Renderer, Theme};
+use vibez_core::automation::AutomationPoint;
+use vibez_core::id::{LaneId, TrackId};
+
+use crate::domains::automation::AutomationMsg;
+use crate::message::Message;
+use crate::theme as th;
+
+pub const LANE_HEIGHT: f32 = 56.0;
+const HANDLE_RADIUS: f32 = 5.0;
+const HIT_RADIUS: f32 = 9.0;
+const PAD_TOP: f32 = 8.0;
+const PAD_BOTTOM: f32 = 8.0;
+
+pub struct AutomationLaneWidget {
+    pub track_id: TrackId,
+    pub lane_id: LaneId,
+    pub points: Vec<AutomationPoint>,
+    pub color: Color,
+    pub zoom_level: f32,
+    pub scroll_offset_beats: f64,
+    pub selected: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LaneInteraction {
+    /// Point index being dragged and its current ghost position.
+    drag: Option<(usize, f64, f32)>,
+    /// Last left press, for double-click detection.
+    last_click: Option<(Instant, Point)>,
+}
+
+impl AutomationLaneWidget {
+    fn pixels_per_beat(&self) -> f32 {
+        20.0 * self.zoom_level
+    }
+
+    fn beat_to_x(&self, beat: f64) -> f32 {
+        ((beat - self.scroll_offset_beats) * self.pixels_per_beat() as f64) as f32
+    }
+
+    fn x_to_beat(&self, x: f32) -> f64 {
+        (x as f64 / self.pixels_per_beat() as f64 + self.scroll_offset_beats).max(0.0)
+    }
+
+    fn value_to_y(&self, value: f32, height: f32) -> f32 {
+        let usable = height - PAD_TOP - PAD_BOTTOM;
+        PAD_TOP + (1.0 - value.clamp(0.0, 1.0)) * usable
+    }
+
+    fn y_to_value(&self, y: f32, height: f32) -> f32 {
+        let usable = height - PAD_TOP - PAD_BOTTOM;
+        (1.0 - (y - PAD_TOP) / usable).clamp(0.0, 1.0)
+    }
+
+    fn hit_point(&self, pos: Point, height: f32) -> Option<usize> {
+        self.points.iter().position(|p| {
+            let px = self.beat_to_x(p.beat);
+            let py = self.value_to_y(p.value, height);
+            (px - pos.x).powi(2) + (py - pos.y).powi(2) <= HIT_RADIUS * HIT_RADIUS
+        })
+    }
+}
+
+impl canvas::Program<Message> for AutomationLaneWidget {
+    type State = LaneInteraction;
+
+    fn draw(
+        &self,
+        state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let h = bounds.height;
+
+        // Ground and midline.
+        frame.fill_rectangle(
+            Point::ORIGIN,
+            bounds.size(),
+            Color::from_rgba(0.0, 0.0, 0.0, 0.18),
+        );
+        let mid = self.value_to_y(0.5, h);
+        frame.stroke(
+            &canvas::Path::line(Point::new(0.0, mid), Point::new(bounds.width, mid)),
+            canvas::Stroke::default()
+                .with_color(Color::from_rgba(1.0, 1.0, 1.0, 0.06))
+                .with_width(1.0),
+        );
+
+        // The curve, with the dragged point replaced by its ghost.
+        let mut pts: Vec<AutomationPoint> = self.points.clone();
+        if let Some((idx, beat, value)) = state.drag {
+            if idx < pts.len() {
+                pts.remove(idx);
+                let insert_at = pts.partition_point(|p| p.beat < beat);
+                pts.insert(insert_at, AutomationPoint { beat, value });
+            }
+        }
+
+        let curve_color = self.color;
+        if !pts.is_empty() {
+            let mut path = canvas::path::Builder::new();
+            let first_y = self.value_to_y(pts[0].value, h);
+            path.move_to(Point::new(0.0, first_y));
+            path.line_to(Point::new(self.beat_to_x(pts[0].beat), first_y));
+            for p in &pts {
+                path.line_to(Point::new(
+                    self.beat_to_x(p.beat),
+                    self.value_to_y(p.value, h),
+                ));
+            }
+            let last = pts[pts.len() - 1];
+            let last_y = self.value_to_y(last.value, h);
+            path.line_to(Point::new(bounds.width, last_y));
+            frame.stroke(
+                &path.build(),
+                canvas::Stroke::default()
+                    .with_color(curve_color)
+                    .with_width(2.0),
+            );
+
+            for (i, p) in pts.iter().enumerate() {
+                let center = Point::new(self.beat_to_x(p.beat), self.value_to_y(p.value, h));
+                let selected = state.drag.map(|(d, _, _)| d == i).unwrap_or(false)
+                    || (state.drag.is_none() && self.selected == Some(i));
+                let handle = canvas::Path::circle(center, HANDLE_RADIUS);
+                if selected {
+                    frame.fill(&handle, th::ACCENT);
+                } else {
+                    frame.fill(&handle, Color::from_rgba(0.09, 0.09, 0.1, 1.0));
+                    frame.stroke(
+                        &handle,
+                        canvas::Stroke::default()
+                            .with_color(curve_color)
+                            .with_width(2.0),
+                    );
+                }
+            }
+        } else {
+            frame.stroke(
+                &canvas::Path::line(
+                    Point::new(0.0, self.value_to_y(1.0, h)),
+                    Point::new(bounds.width, self.value_to_y(1.0, h)),
+                ),
+                canvas::Stroke::default()
+                    .with_color(Color {
+                        a: 0.35,
+                        ..curve_color
+                    })
+                    .with_width(1.5),
+            );
+        }
+
+        vec![frame.into_geometry()]
+    }
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: canvas::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<Message>) {
+        let Some(pos) = cursor.position_in(bounds) else {
+            // Commit an in-flight drag even if the release lands
+            // outside the lane.
+            if let canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) = event {
+                if let Some((index, beat, value)) = state.drag.take() {
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::Automation(AutomationMsg::MovePoint {
+                            track_id: self.track_id,
+                            lane_id: self.lane_id,
+                            index,
+                            beat,
+                            value,
+                        })),
+                    );
+                }
+            }
+            return (canvas::event::Status::Ignored, None);
+        };
+        let h = bounds.height;
+
+        match event {
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                if let Some(index) = self.hit_point(pos, h) {
+                    let p = self.points[index];
+                    state.drag = Some((index, p.beat, p.value));
+                    state.last_click = None;
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::Automation(AutomationMsg::SelectPoint {
+                            track_id: self.track_id,
+                            lane_id: self.lane_id,
+                            index: Some(index),
+                        })),
+                    );
+                }
+                // Double-click on empty lane space adds a point.
+                let now = Instant::now();
+                if let Some((t, p)) = state.last_click {
+                    let close = (p.x - pos.x).abs() < 6.0 && (p.y - pos.y).abs() < 6.0;
+                    if close && now.duration_since(t).as_millis() < 400 {
+                        state.last_click = None;
+                        return (
+                            canvas::event::Status::Captured,
+                            Some(Message::Automation(AutomationMsg::AddPoint {
+                                track_id: self.track_id,
+                                lane_id: self.lane_id,
+                                beat: self.x_to_beat(pos.x),
+                                value: self.y_to_value(pos.y, h),
+                            })),
+                        );
+                    }
+                }
+                state.last_click = Some((now, pos));
+                (
+                    canvas::event::Status::Captured,
+                    Some(Message::Automation(AutomationMsg::SelectPoint {
+                        track_id: self.track_id,
+                        lane_id: self.lane_id,
+                        index: None,
+                    })),
+                )
+            }
+            canvas::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                if let Some((index, _, _)) = state.drag {
+                    state.drag = Some((index, self.x_to_beat(pos.x), self.y_to_value(pos.y, h)));
+                    return (canvas::event::Status::Captured, None);
+                }
+                (canvas::event::Status::Ignored, None)
+            }
+            canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                if let Some((index, beat, value)) = state.drag.take() {
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::Automation(AutomationMsg::MovePoint {
+                            track_id: self.track_id,
+                            lane_id: self.lane_id,
+                            index,
+                            beat,
+                            value,
+                        })),
+                    );
+                }
+                (canvas::event::Status::Ignored, None)
+            }
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Right)) => {
+                if let Some(index) = self.hit_point(pos, h) {
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::Automation(AutomationMsg::RemovePoint {
+                            track_id: self.track_id,
+                            lane_id: self.lane_id,
+                            index,
+                        })),
+                    );
+                }
+                (canvas::event::Status::Ignored, None)
+            }
+            _ => (canvas::event::Status::Ignored, None),
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if state.drag.is_some() {
+            return mouse::Interaction::Grabbing;
+        }
+        if let Some(pos) = cursor.position_in(bounds) {
+            if self.hit_point(pos, bounds.height).is_some() {
+                return mouse::Interaction::Grab;
+            }
+        }
+        mouse::Interaction::default()
+    }
+}

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -1,15 +1,22 @@
 //! Automation lane canvas: breakpoints over time, aligned with the
 //! arrangement timeline (same pixels-per-beat and scroll offset).
 //!
-//! Interactions: double-click adds a point, drag moves one (the
-//! move commits on release; a ghost renders during the drag), click
-//! selects, Delete removes via the global delete-key priority.
+//! Interactions:
+//! - double-click adds a point; drag moves one (ghost while
+//!   dragging, commit on release); right-click or Delete removes
+//! - alt-drag a segment bends its curve (alt-double-click resets it
+//!   straight); the cursor switches to a vertical-resize arrow
+//! - ctrl-drag sweeps a beat range and erases every point inside
+//!   (crosshair cursor)
+//!
+//! The dotted line is the parameter's current (un-automated) value;
+//! min/max labels give the scale.
 
 use std::time::Instant;
 
 use iced::widget::canvas;
 use iced::{mouse, Color, Point, Rectangle, Renderer, Theme};
-use vibez_core::automation::AutomationPoint;
+use vibez_core::automation::{shape, AutomationPoint};
 use vibez_core::id::{LaneId, TrackId};
 
 use crate::domains::automation::AutomationMsg;
@@ -19,8 +26,11 @@ use crate::theme as th;
 pub const LANE_HEIGHT: f32 = 56.0;
 const HANDLE_RADIUS: f32 = 5.0;
 const HIT_RADIUS: f32 = 9.0;
+const SEGMENT_HIT: f32 = 10.0;
 const PAD_TOP: f32 = 8.0;
 const PAD_BOTTOM: f32 = 8.0;
+/// Vertical drag distance for a full curve sweep.
+const CURVE_DRAG_RANGE: f32 = 90.0;
 
 pub struct AutomationLaneWidget {
     pub track_id: TrackId,
@@ -30,14 +40,26 @@ pub struct AutomationLaneWidget {
     pub zoom_level: f32,
     pub scroll_offset_beats: f64,
     pub selected: Option<usize>,
+    /// The parameter's current un-automated value (normalized), for
+    /// the dotted reference line.
+    pub reference: Option<f32>,
+    pub min_label: String,
+    pub max_label: String,
+    pub ref_label: String,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct LaneInteraction {
     /// Point index being dragged and its current ghost position.
     drag: Option<(usize, f64, f32)>,
+    /// (segment index, original curve, press y, ghost curve).
+    curve_drag: Option<(usize, f32, f32, f32)>,
+    /// (start beat, current beat) of a ctrl-drag erase sweep.
+    erase_drag: Option<(f64, f64)>,
     /// Last left press, for double-click detection.
     last_click: Option<(Instant, Point)>,
+    alt: bool,
+    ctrl: bool,
 }
 
 impl AutomationLaneWidget {
@@ -70,6 +92,40 @@ impl AutomationLaneWidget {
             (px - pos.x).powi(2) + (py - pos.y).powi(2) <= HIT_RADIUS * HIT_RADIUS
         })
     }
+
+    /// The segment (index of its left point) under the cursor, if the
+    /// cursor is horizontally inside it and vertically near the curve.
+    fn hit_segment(&self, pos: Point, height: f32) -> Option<usize> {
+        for i in 0..self.points.len().saturating_sub(1) {
+            let a = self.points[i];
+            let b = self.points[i + 1];
+            let x0 = self.beat_to_x(a.beat);
+            let x1 = self.beat_to_x(b.beat);
+            if pos.x < x0 || pos.x > x1 || x1 - x0 < 2.0 {
+                continue;
+            }
+            let t = (pos.x - x0) / (x1 - x0);
+            let value = a.value + (b.value - a.value) * shape(t, a.curve);
+            let y = self.value_to_y(value, height);
+            if (y - pos.y).abs() <= SEGMENT_HIT {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    /// Ghost curve from a vertical drag, oriented so dragging down
+    /// always bulges the segment downward.
+    fn curve_from_drag(&self, index: usize, orig: f32, press_y: f32, y: f32) -> f32 {
+        let rising = self
+            .points
+            .get(index + 1)
+            .zip(self.points.get(index))
+            .map(|(b, a)| b.value >= a.value)
+            .unwrap_or(true);
+        let dir = if rising { 1.0 } else { -1.0 };
+        (orig + (y - press_y) / CURVE_DRAG_RANGE * dir).clamp(-1.0, 1.0)
+    }
 }
 
 impl canvas::Program<Message> for AutomationLaneWidget {
@@ -86,27 +142,71 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         let mut frame = canvas::Frame::new(renderer, bounds.size());
         let h = bounds.height;
 
-        // Ground and midline.
         frame.fill_rectangle(
             Point::ORIGIN,
             bounds.size(),
             Color::from_rgba(0.0, 0.0, 0.0, 0.18),
         );
-        let mid = self.value_to_y(0.5, h);
-        frame.stroke(
-            &canvas::Path::line(Point::new(0.0, mid), Point::new(bounds.width, mid)),
-            canvas::Stroke::default()
-                .with_color(Color::from_rgba(1.0, 1.0, 1.0, 0.06))
-                .with_width(1.0),
-        );
 
-        // The curve, with the dragged point replaced by its ghost.
+        // Dotted reference: where the knob sits without automation.
+        if let Some(reference) = self.reference {
+            let y = self.value_to_y(reference, h);
+            frame.stroke(
+                &canvas::Path::line(Point::new(0.0, y), Point::new(bounds.width, y)),
+                canvas::Stroke {
+                    line_dash: canvas::LineDash {
+                        segments: &[3.0, 5.0],
+                        offset: 0,
+                    },
+                    ..canvas::Stroke::default()
+                        .with_color(Color::from_rgba(0.85, 0.83, 0.78, 0.35))
+                        .with_width(1.0)
+                },
+            );
+        }
+
+        // Scale labels: max top-left, min bottom-left, reference value
+        // against the right edge on its line.
+        let label = |content: &str, position: Point, bottom: bool| canvas::Text {
+            content: content.to_string(),
+            position,
+            color: Color::from_rgba(0.75, 0.73, 0.68, 0.55),
+            size: iced::Pixels(9.0),
+            vertical_alignment: if bottom {
+                iced::alignment::Vertical::Bottom
+            } else {
+                iced::alignment::Vertical::Top
+            },
+            ..canvas::Text::default()
+        };
+        frame.fill_text(label(&self.max_label, Point::new(6.0, 2.0), false));
+        frame.fill_text(label(&self.min_label, Point::new(6.0, h - 2.0), true));
+        if let Some(reference) = self.reference {
+            if !self.ref_label.is_empty() {
+                let y = self.value_to_y(reference, h);
+                let mut t = label(
+                    &self.ref_label,
+                    Point::new(bounds.width - 6.0, y - 3.0),
+                    true,
+                );
+                t.horizontal_alignment = iced::alignment::Horizontal::Right;
+                frame.fill_text(t);
+            }
+        }
+
+        // Working copy with drag ghosts applied.
         let mut pts: Vec<AutomationPoint> = self.points.clone();
         if let Some((idx, beat, value)) = state.drag {
             if idx < pts.len() {
+                let curve = pts[idx].curve;
                 pts.remove(idx);
                 let insert_at = pts.partition_point(|p| p.beat < beat);
-                pts.insert(insert_at, AutomationPoint { beat, value });
+                pts.insert(insert_at, AutomationPoint { beat, value, curve });
+            }
+        }
+        if let Some((idx, _, _, ghost)) = state.curve_drag {
+            if idx < pts.len() {
+                pts[idx].curve = ghost;
             }
         }
 
@@ -116,11 +216,21 @@ impl canvas::Program<Message> for AutomationLaneWidget {
             let first_y = self.value_to_y(pts[0].value, h);
             path.move_to(Point::new(0.0, first_y));
             path.line_to(Point::new(self.beat_to_x(pts[0].beat), first_y));
-            for p in &pts {
-                path.line_to(Point::new(
-                    self.beat_to_x(p.beat),
-                    self.value_to_y(p.value, h),
-                ));
+            for i in 0..pts.len() - 1 {
+                let a = pts[i];
+                let b = pts[i + 1];
+                let x0 = self.beat_to_x(a.beat);
+                let x1 = self.beat_to_x(b.beat);
+                if a.curve == 0.0 {
+                    path.line_to(Point::new(x1, self.value_to_y(b.value, h)));
+                } else {
+                    const STEPS: usize = 24;
+                    for step in 1..=STEPS {
+                        let t = step as f32 / STEPS as f32;
+                        let v = a.value + (b.value - a.value) * shape(t, a.curve);
+                        path.line_to(Point::new(x0 + (x1 - x0) * t, self.value_to_y(v, h)));
+                    }
+                }
             }
             let last = pts[pts.len() - 1];
             let last_y = self.value_to_y(last.value, h);
@@ -149,19 +259,20 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                     );
                 }
             }
-        } else {
-            frame.stroke(
-                &canvas::Path::line(
-                    Point::new(0.0, self.value_to_y(1.0, h)),
-                    Point::new(bounds.width, self.value_to_y(1.0, h)),
-                ),
-                canvas::Stroke::default()
-                    .with_color(Color {
-                        a: 0.35,
-                        ..curve_color
-                    })
-                    .with_width(1.5),
-            );
+        }
+
+        // Erase sweep overlay.
+        if let Some((b0, b1)) = state.erase_drag {
+            let (lo, hi) = if b0 <= b1 { (b0, b1) } else { (b1, b0) };
+            let x0 = self.beat_to_x(lo).max(0.0);
+            let x1 = self.beat_to_x(hi).min(bounds.width);
+            if x1 > x0 {
+                frame.fill_rectangle(
+                    Point::new(x0, 0.0),
+                    iced::Size::new(x1 - x0, h),
+                    Color::from_rgba(0.9, 0.35, 0.25, 0.18),
+                );
+            }
         }
 
         vec![frame.into_geometry()]
@@ -174,21 +285,51 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> (canvas::event::Status, Option<Message>) {
+        // Modifier tracking works regardless of cursor position.
+        if let canvas::Event::Keyboard(iced::keyboard::Event::ModifiersChanged(m)) = event {
+            state.alt = m.alt();
+            state.ctrl = m.control();
+            return (canvas::event::Status::Ignored, None);
+        }
+
+        let commit_release = |state: &mut Self::State| -> Option<Message> {
+            if let Some((index, beat, value)) = state.drag.take() {
+                return Some(Message::Automation(AutomationMsg::MovePoint {
+                    track_id: self.track_id,
+                    lane_id: self.lane_id,
+                    index,
+                    beat,
+                    value,
+                }));
+            }
+            if let Some((index, orig, _, ghost)) = state.curve_drag.take() {
+                if (ghost - orig).abs() > 0.001 {
+                    return Some(Message::Automation(AutomationMsg::SetCurve {
+                        track_id: self.track_id,
+                        lane_id: self.lane_id,
+                        index,
+                        curve: ghost,
+                    }));
+                }
+                return None;
+            }
+            if let Some((b0, b1)) = state.erase_drag.take() {
+                if (b1 - b0).abs() > 0.01 {
+                    return Some(Message::Automation(AutomationMsg::RemovePointsInRange {
+                        track_id: self.track_id,
+                        lane_id: self.lane_id,
+                        start_beat: b0,
+                        end_beat: b1,
+                    }));
+                }
+            }
+            None
+        };
+
         let Some(pos) = cursor.position_in(bounds) else {
-            // Commit an in-flight drag even if the release lands
-            // outside the lane.
             if let canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) = event {
-                if let Some((index, beat, value)) = state.drag.take() {
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(Message::Automation(AutomationMsg::MovePoint {
-                            track_id: self.track_id,
-                            lane_id: self.lane_id,
-                            index,
-                            beat,
-                            value,
-                        })),
-                    );
+                if let Some(msg) = commit_release(state) {
+                    return (canvas::event::Status::Captured, Some(msg));
                 }
             }
             return (canvas::event::Status::Ignored, None);
@@ -197,6 +338,40 @@ impl canvas::Program<Message> for AutomationLaneWidget {
 
         match event {
             canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                // Ctrl: sweep-erase.
+                if state.ctrl {
+                    let beat = self.x_to_beat(pos.x);
+                    state.erase_drag = Some((beat, beat));
+                    state.last_click = None;
+                    return (canvas::event::Status::Captured, None);
+                }
+                // Alt: bend a segment (alt-double-click resets it).
+                if state.alt {
+                    if let Some(index) = self.hit_segment(pos, h) {
+                        let now = Instant::now();
+                        if let Some((t, p)) = state.last_click {
+                            let close = (p.x - pos.x).abs() < 6.0 && (p.y - pos.y).abs() < 6.0;
+                            if close && now.duration_since(t).as_millis() < 400 {
+                                state.last_click = None;
+                                state.curve_drag = None;
+                                return (
+                                    canvas::event::Status::Captured,
+                                    Some(Message::Automation(AutomationMsg::SetCurve {
+                                        track_id: self.track_id,
+                                        lane_id: self.lane_id,
+                                        index,
+                                        curve: 0.0,
+                                    })),
+                                );
+                            }
+                        }
+                        state.last_click = Some((now, pos));
+                        let orig = self.points[index].curve;
+                        state.curve_drag = Some((index, orig, pos.y, orig));
+                        return (canvas::event::Status::Captured, None);
+                    }
+                    return (canvas::event::Status::Ignored, None);
+                }
                 if let Some(index) = self.hit_point(pos, h) {
                     let p = self.points[index];
                     state.drag = Some((index, p.beat, p.value));
@@ -242,22 +417,22 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                     state.drag = Some((index, self.x_to_beat(pos.x), self.y_to_value(pos.y, h)));
                     return (canvas::event::Status::Captured, None);
                 }
+                if let Some((index, orig, press_y, _)) = state.curve_drag {
+                    let ghost = self.curve_from_drag(index, orig, press_y, pos.y);
+                    state.curve_drag = Some((index, orig, press_y, ghost));
+                    return (canvas::event::Status::Captured, None);
+                }
+                if let Some((b0, _)) = state.erase_drag {
+                    state.erase_drag = Some((b0, self.x_to_beat(pos.x)));
+                    return (canvas::event::Status::Captured, None);
+                }
                 (canvas::event::Status::Ignored, None)
             }
             canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
-                if let Some((index, beat, value)) = state.drag.take() {
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(Message::Automation(AutomationMsg::MovePoint {
-                            track_id: self.track_id,
-                            lane_id: self.lane_id,
-                            index,
-                            beat,
-                            value,
-                        })),
-                    );
+                match commit_release(state) {
+                    Some(msg) => (canvas::event::Status::Captured, Some(msg)),
+                    None => (canvas::event::Status::Ignored, None),
                 }
-                (canvas::event::Status::Ignored, None)
             }
             canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Right)) => {
                 if let Some(index) = self.hit_point(pos, h) {
@@ -285,7 +460,22 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         if state.drag.is_some() {
             return mouse::Interaction::Grabbing;
         }
+        if state.curve_drag.is_some() {
+            return mouse::Interaction::ResizingVertically;
+        }
+        if state.erase_drag.is_some() {
+            return mouse::Interaction::Crosshair;
+        }
         if let Some(pos) = cursor.position_in(bounds) {
+            if state.ctrl {
+                return mouse::Interaction::Crosshair;
+            }
+            if state.alt {
+                if self.hit_segment(pos, bounds.height).is_some() {
+                    return mouse::Interaction::ResizingVertically;
+                }
+                return mouse::Interaction::default();
+            }
             if self.hit_point(pos, bounds.height).is_some() {
                 return mouse::Interaction::Grab;
             }

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -21,6 +21,7 @@ use vibez_core::id::{LaneId, TrackId};
 
 use crate::domains::automation::AutomationMsg;
 use crate::message::Message;
+use crate::state::SnapGrid;
 use crate::theme as th;
 
 pub const LANE_HEIGHT: f32 = 56.0;
@@ -39,6 +40,8 @@ pub struct AutomationLaneWidget {
     pub color: Color,
     pub zoom_level: f32,
     pub scroll_offset_beats: f64,
+    /// Grid for beat snapping (hold shift to bypass).
+    pub snap: SnapGrid,
     pub selected: Option<usize>,
     /// The parameter's current un-automated value (normalized), for
     /// the dotted reference line.
@@ -60,6 +63,7 @@ pub struct LaneInteraction {
     last_click: Option<(Instant, Point)>,
     alt: bool,
     ctrl: bool,
+    shift: bool,
 }
 
 impl AutomationLaneWidget {
@@ -73,6 +77,16 @@ impl AutomationLaneWidget {
 
     fn x_to_beat(&self, x: f32) -> f64 {
         (x as f64 / self.pixels_per_beat() as f64 + self.scroll_offset_beats).max(0.0)
+    }
+
+    /// Cursor x to beat, snapped to the grid unless shift is held.
+    fn x_to_snapped_beat(&self, x: f32, state: &LaneInteraction) -> f64 {
+        let beat = self.x_to_beat(x);
+        if state.shift {
+            beat
+        } else {
+            self.snap.snap_beat(beat).max(0.0)
+        }
     }
 
     fn value_to_y(&self, value: f32, height: f32) -> f32 {
@@ -289,6 +303,7 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         if let canvas::Event::Keyboard(iced::keyboard::Event::ModifiersChanged(m)) = event {
             state.alt = m.alt();
             state.ctrl = m.control();
+            state.shift = m.shift();
             return (canvas::event::Status::Ignored, None);
         }
 
@@ -340,7 +355,7 @@ impl canvas::Program<Message> for AutomationLaneWidget {
             canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 // Ctrl: sweep-erase.
                 if state.ctrl {
-                    let beat = self.x_to_beat(pos.x);
+                    let beat = self.x_to_snapped_beat(pos.x, state);
                     state.erase_drag = Some((beat, beat));
                     state.last_click = None;
                     return (canvas::event::Status::Captured, None);
@@ -396,7 +411,7 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                             Some(Message::Automation(AutomationMsg::AddPoint {
                                 track_id: self.track_id,
                                 lane_id: self.lane_id,
-                                beat: self.x_to_beat(pos.x),
+                                beat: self.x_to_snapped_beat(pos.x, state),
                                 value: self.y_to_value(pos.y, h),
                             })),
                         );
@@ -414,7 +429,11 @@ impl canvas::Program<Message> for AutomationLaneWidget {
             }
             canvas::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
                 if let Some((index, _, _)) = state.drag {
-                    state.drag = Some((index, self.x_to_beat(pos.x), self.y_to_value(pos.y, h)));
+                    state.drag = Some((
+                        index,
+                        self.x_to_snapped_beat(pos.x, state),
+                        self.y_to_value(pos.y, h),
+                    ));
                     return (canvas::event::Status::Captured, None);
                 }
                 if let Some((index, orig, press_y, _)) = state.curve_drag {
@@ -423,7 +442,7 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                     return (canvas::event::Status::Captured, None);
                 }
                 if let Some((b0, _)) = state.erase_drag {
-                    state.erase_drag = Some((b0, self.x_to_beat(pos.x)));
+                    state.erase_drag = Some((b0, self.x_to_snapped_beat(pos.x, state)));
                     return (canvas::event::Status::Captured, None);
                 }
                 (canvas::event::Status::Ignored, None)

--- a/crates/vibez-ui/src/widgets/effect_knob.rs
+++ b/crates/vibez-ui/src/widgets/effect_knob.rs
@@ -172,8 +172,8 @@ pub fn param_column<'a>(
         .into();
     column![
         knob_canvas,
-        text(label).size(9).color(theme::TEXT_DIM),
-        text(value_text).size(9).color(theme::TEXT),
+        text(label).size(9).color(theme::text_dim()),
+        text(value_text).size(9).color(theme::text()),
     ]
     .spacing(2)
     .width(Length::Fixed(PARAM_COLUMN_WIDTH))
@@ -239,14 +239,7 @@ impl canvas::Program<Message> for EffectKnobWidget {
         let bg_arc = build_arc(center, arc_radius, ARC_START, ARC_END);
         frame.stroke(
             &bg_arc,
-            round
-                .with_color(Color {
-                    r: 0.22,
-                    g: 0.22,
-                    b: 0.22,
-                    a: 1.0,
-                })
-                .with_width(2.5),
+            round.with_color(theme::knob_track()).with_width(2.5),
         );
 
         if norm > 0.005 {
@@ -269,19 +262,9 @@ impl canvas::Program<Message> for EffectKnobWidget {
         frame.fill(
             &body,
             if engaged {
-                Color {
-                    r: 0.16,
-                    g: 0.16,
-                    b: 0.16,
-                    a: 1.0,
-                }
+                theme::knob_body_engaged()
             } else {
-                Color {
-                    r: 0.12,
-                    g: 0.12,
-                    b: 0.12,
-                    a: 1.0,
-                }
+                theme::knob_body()
             },
         );
 
@@ -303,9 +286,9 @@ impl canvas::Program<Message> for EffectKnobWidget {
             &pointer,
             round
                 .with_color(if engaged {
-                    theme::TEXT
+                    theme::text()
                 } else {
-                    theme::TEXT_DIM
+                    theme::text_dim()
                 })
                 .with_width(2.0),
         );

--- a/crates/vibez-ui/src/widgets/effect_slot.rs
+++ b/crates/vibez-ui/src/widgets/effect_slot.rs
@@ -26,7 +26,7 @@ pub fn view_effect_slot<'a>(
     let is_plugin = effect.plugin_name.is_some();
 
     let dot_color = if is_bypassed {
-        th::TEXT_MUTED
+        th::text_muted()
     } else {
         track_color
     };
@@ -37,7 +37,7 @@ pub fn view_effect_slot<'a>(
         .padding([2, 3])
         .style(move |_theme: &Theme, status| {
             let bg = match status {
-                button::Status::Hovered => Some(th::BG_HOVER.into()),
+                button::Status::Hovered => Some(th::bg_hover().into()),
                 _ => None,
             };
             button::Style {
@@ -55,7 +55,11 @@ pub fn view_effect_slot<'a>(
         .plugin_name
         .as_deref()
         .unwrap_or_else(|| effect.effect_type.name());
-    let name_color = if is_bypassed { th::TEXT_DIM } else { th::TEXT };
+    let name_color = if is_bypassed {
+        th::text_dim()
+    } else {
+        th::text()
+    };
 
     let name_elem = text(display_name).size(11).color(name_color);
 
@@ -73,19 +77,19 @@ pub fn view_effect_slot<'a>(
             effect_id: effect.id,
         };
         Some(
-            button(text("Edit").size(9).color(th::TEXT_DIM))
+            button(text("Edit").size(9).color(th::text_dim()))
                 .on_press(Message::OpenPluginGui(gui_key))
                 .padding([2, 5])
                 .style(|_theme: &Theme, status| {
                     let (bg, tc) = match status {
-                        button::Status::Hovered => (Some(th::BG_HOVER.into()), th::ACCENT),
-                        _ => (None, th::TEXT_DIM),
+                        button::Status::Hovered => (Some(th::bg_hover().into()), th::accent()),
+                        _ => (None, th::text_dim()),
                     };
                     button::Style {
                         background: bg,
                         text_color: tc,
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 3.0.into(),
                         },
@@ -97,9 +101,9 @@ pub fn view_effect_slot<'a>(
 
     let bypass_label = if is_bypassed { "Off" } else { "On" };
     let bypass_color = if is_bypassed {
-        th::TEXT_MUTED
+        th::text_muted()
     } else {
-        th::SUCCESS
+        th::success()
     };
     let make_bypass = move || {
         button(text(bypass_label).size(9).color(bypass_color))
@@ -107,7 +111,7 @@ pub fn view_effect_slot<'a>(
             .padding([2, 5])
             .style(move |_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered => Some(th::bg_hover().into()),
                     _ => None,
                 };
                 button::Style {
@@ -115,9 +119,9 @@ pub fn view_effect_slot<'a>(
                     text_color: bypass_color,
                     border: iced::Border {
                         color: if is_bypassed {
-                            th::BORDER
+                            th::border()
                         } else {
-                            th::darken(th::SUCCESS, 0.5)
+                            th::darken(th::success(), 0.5)
                         },
                         width: 1.0,
                         radius: 3.0.into(),
@@ -130,8 +134,8 @@ pub fn view_effect_slot<'a>(
     let make_move_up = || -> Element<'a, Message> {
         action_btn(
             icons::CHEVRON_UP,
-            th::TEXT_DIM,
-            th::TEXT,
+            th::text_dim(),
+            th::text(),
             Message::move_effect_up(track_id, effect.id),
         )
         .into()
@@ -139,16 +143,16 @@ pub fn view_effect_slot<'a>(
     let make_move_down = || -> Element<'a, Message> {
         action_btn(
             icons::CHEVRON_DOWN,
-            th::TEXT_DIM,
-            th::TEXT,
+            th::text_dim(),
+            th::text(),
             Message::move_effect_down(track_id, effect.id),
         )
         .into()
     };
     let remove: Element<'a, Message> = action_btn(
         icons::X,
-        th::TEXT_DIM,
-        th::DANGER,
+        th::text_dim(),
+        th::danger(),
         Message::remove_effect(track_id, effect.id),
     )
     .into();
@@ -175,7 +179,7 @@ pub fn view_effect_slot<'a>(
         .padding([4, 6])
         .width(Length::Fill)
         .style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             ..Default::default()
         });
 
@@ -188,7 +192,7 @@ pub fn view_effect_slot<'a>(
             .into()
     } else if has_params && !has_gui {
         let knob_color = if is_bypassed {
-            th::TEXT_MUTED
+            th::text_muted()
         } else {
             track_color
         };
@@ -226,12 +230,12 @@ pub fn view_effect_slot<'a>(
             .as_ref()
             .map(|d| d.format.to_uppercase())
             .unwrap_or_else(|| "PLUGIN".to_string());
-        let badge = container(text(format_label).size(8).color(th::ACCENT))
+        let badge = container(text(format_label).size(8).color(th::accent()))
             .padding([2, 8])
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_DARK.into()),
+                background: Some(th::bg_dark().into()),
                 border: iced::Border {
-                    color: th::ACCENT_DIM,
+                    color: th::accent_dim(),
                     width: 1.0,
                     radius: 3.0.into(),
                 },
@@ -279,9 +283,9 @@ pub fn view_effect_slot<'a>(
 
     container(card)
         .style(|_theme: &Theme| container::Style {
-            background: Some(th::BG_ELEVATED.into()),
+            background: Some(th::bg_elevated().into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 4.0.into(),
             },
@@ -302,8 +306,8 @@ fn action_btn(
         .padding([3, 4])
         .style(move |_theme: &Theme, status| {
             let (bg, tc) = match status {
-                button::Status::Hovered => (Some(th::BG_HOVER.into()), hover_color),
-                button::Status::Pressed => (Some(th::BG_DARK.into()), hover_color),
+                button::Status::Hovered => (Some(th::bg_hover().into()), hover_color),
+                button::Status::Pressed => (Some(th::bg_dark().into()), hover_color),
                 _ => (None, color),
             };
             button::Style {

--- a/crates/vibez-ui/src/widgets/effect_slot.rs
+++ b/crates/vibez-ui/src/widgets/effect_slot.rs
@@ -10,10 +10,15 @@ use vibez_core::id::TrackId;
 use vibez_plugin_host::gui::PluginGuiKey;
 
 /// Render an Ableton-style device card for the detail panel.
+///
+/// `custom_body` swaps the generic knob-row body for a purpose-built
+/// one (the channel EQ's display panel) while keeping the shared
+/// title-bar chrome; the second element is the card width.
 pub fn view_effect_slot<'a>(
     track_id: TrackId,
     effect: &'a UiEffect,
     track_color: Color,
+    custom_body: Option<(Element<'a, Message>, f32)>,
 ) -> Element<'a, Message> {
     let is_bypassed = effect.bypass;
     let has_params = !effect.descriptors.is_empty();
@@ -175,7 +180,13 @@ pub fn view_effect_slot<'a>(
         });
 
     // ── Body ─────────────────────────────────────────────────
-    let body: Element<'a, Message> = if has_params && !has_gui {
+    let custom_w = custom_body.as_ref().map(|(_, w)| *w);
+    let body: Element<'a, Message> = if let Some((custom, _)) = custom_body {
+        container(custom)
+            .padding([8, 10])
+            .height(Length::Fixed(th::DEVICE_BODY_H))
+            .into()
+    } else if has_params && !has_gui {
         let knob_color = if is_bypassed {
             th::TEXT_MUTED
         } else {
@@ -257,7 +268,9 @@ pub fn view_effect_slot<'a>(
     } else {
         0
     };
-    let card_w = if is_plugin {
+    let card_w = if let Some(w) = custom_w {
+        w
+    } else if is_plugin {
         190.0
     } else {
         (knob_count as f32 * 62.0 + 24.0).max(150.0)

--- a/crates/vibez-ui/src/widgets/eq_display.rs
+++ b/crates/vibez-ui/src/widgets/eq_display.rs
@@ -1,0 +1,449 @@
+//! Channel EQ display: frequency response curve over a live spectrum
+//! analyser, with draggable band handles (drag sets frequency and
+//! gain, scroll trims Q on the parametric mids, double-click zeroes
+//! the band).
+
+use std::time::Instant;
+
+use iced::mouse;
+use iced::widget::canvas;
+use iced::{Color, Point, Rectangle, Renderer, Theme};
+
+use crate::message::Message;
+use crate::spectrum::{freq_to_norm, norm_to_freq, DISPLAY_BINS, FLOOR_DB};
+use crate::theme as th;
+use vibez_core::effect::ParamDescriptor;
+use vibez_core::id::{EffectId, TrackId};
+
+/// Vertical range of the response axis in dB (curve clamps to it).
+const RANGE_DB: f32 = 18.0;
+/// Handle hit/draw radius.
+const HANDLE_R: f32 = 6.0;
+/// Double-click window in milliseconds.
+const DOUBLE_CLICK_MS: u128 = 300;
+/// Points sampled along the response curve.
+const CURVE_POINTS: usize = 128;
+
+/// One EQ band's parameter wiring: (gain index, freq index, Q index
+/// when the band has a sweepable Q).
+struct Band {
+    gain_i: usize,
+    freq_i: usize,
+    q_i: Option<usize>,
+    color: Color,
+}
+
+const BANDS: [Band; 4] = [
+    Band {
+        gain_i: 0,
+        freq_i: 1,
+        q_i: None,
+        color: th::EQ_LF,
+    },
+    Band {
+        gain_i: 3,
+        freq_i: 4,
+        q_i: Some(5),
+        color: th::EQ_LMF,
+    },
+    Band {
+        gain_i: 6,
+        freq_i: 7,
+        q_i: Some(8),
+        color: th::EQ_HMF,
+    },
+    Band {
+        gain_i: 9,
+        freq_i: 10,
+        q_i: Some(11),
+        color: th::EQ_HF,
+    },
+];
+
+pub struct EqDisplayWidget {
+    pub track_id: TrackId,
+    pub effect_id: EffectId,
+    pub params: Vec<f32>,
+    pub descriptors: &'static [ParamDescriptor],
+    pub bypass: bool,
+    pub sample_rate: f32,
+    /// Smoothed analyser bins in dB (FLOOR_DB..0), log-spaced.
+    pub spectrum: Vec<f32>,
+    pub spectrum_active: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct EqDisplayState {
+    drag: Option<usize>,
+    hover: Option<usize>,
+    last_click: Option<Instant>,
+}
+
+impl EqDisplayWidget {
+    fn param(&self, i: usize) -> f32 {
+        self.params
+            .get(i)
+            .copied()
+            .unwrap_or_else(|| self.descriptors.get(i).map(|d| d.default).unwrap_or(0.0))
+    }
+
+    fn db_to_y(&self, db: f32, h: f32) -> f32 {
+        let half = h / 2.0;
+        half - (db.clamp(-RANGE_DB, RANGE_DB) / RANGE_DB) * (half - 8.0)
+    }
+
+    fn y_to_db(&self, y: f32, h: f32) -> f32 {
+        let half = h / 2.0;
+        ((half - y) / (half - 8.0) * RANGE_DB).clamp(-RANGE_DB, RANGE_DB)
+    }
+
+    fn handle_pos(&self, band: &Band, bounds: Rectangle) -> Point {
+        let x = freq_to_norm(self.param(band.freq_i)) * bounds.width;
+        let y = self.db_to_y(self.param(band.gain_i), bounds.height);
+        Point::new(x, y)
+    }
+
+    /// Band index whose handle sits under `pos` (widget-local).
+    fn band_at(&self, pos: Point, bounds: Rectangle) -> Option<usize> {
+        BANDS
+            .iter()
+            .enumerate()
+            .map(|(i, b)| (i, self.handle_pos(b, bounds)))
+            .filter(|(_, hp)| {
+                let (dx, dy) = (hp.x - pos.x, hp.y - pos.y);
+                (dx * dx + dy * dy).sqrt() <= HANDLE_R + 3.0
+            })
+            .min_by(|a, b| {
+                let d = |hp: &Point| (hp.x - pos.x).powi(2) + (hp.y - pos.y).powi(2);
+                d(&a.1).total_cmp(&d(&b.1))
+            })
+            .map(|(i, _)| i)
+    }
+
+    fn drag_message(&self, band_idx: usize, pos: Point, bounds: Rectangle) -> Message {
+        let band = &BANDS[band_idx];
+        let freq = norm_to_freq((pos.x / bounds.width).clamp(0.0, 1.0));
+        let gain = self.y_to_db(pos.y, bounds.height);
+        // Descriptor clamps happen again in the domain; pre-clamp so
+        // the handle never visually detaches from the cursor's band.
+        let fd = &self.descriptors[band.freq_i];
+        let gd = &self.descriptors[band.gain_i];
+        Message::set_effect_params(
+            self.track_id,
+            self.effect_id,
+            vec![
+                (band.freq_i, freq.clamp(fd.min, fd.max)),
+                (band.gain_i, gain.clamp(gd.min, gd.max)),
+            ],
+        )
+    }
+}
+
+impl canvas::Program<Message> for EqDisplayWidget {
+    type State = EqDisplayState;
+
+    fn draw(
+        &self,
+        state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let (w, h) = (bounds.width, bounds.height);
+
+        // ── Panel ──
+        frame.fill(
+            &canvas::Path::rounded_rectangle(Point::ORIGIN, bounds.size(), 3.0.into()),
+            th::BG_DARK,
+        );
+
+        // ── Grid: decade frequency lines + dB lines ──
+        let grid = Color {
+            a: 0.35,
+            ..th::BORDER
+        };
+        let labeled: [(f32, &str); 3] = [(100.0, "100"), (1_000.0, "1k"), (10_000.0, "10k")];
+        for f in [
+            30.0, 50.0, 100.0, 200.0, 300.0, 500.0, 1e3, 2e3, 3e3, 5e3, 10e3,
+        ] {
+            let x = freq_to_norm(f) * w;
+            frame.stroke(
+                &canvas::Path::line(Point::new(x, 0.0), Point::new(x, h)),
+                canvas::Stroke::default().with_color(grid).with_width(1.0),
+            );
+        }
+        for (f, label) in labeled {
+            frame.fill_text(canvas::Text {
+                content: label.to_string(),
+                position: Point::new(freq_to_norm(f) * w + 3.0, h - 2.0),
+                color: th::TEXT_MUTED,
+                size: 8.0.into(),
+                vertical_alignment: iced::alignment::Vertical::Bottom,
+                ..canvas::Text::default()
+            });
+        }
+        for db in [-12.0f32, -6.0, 6.0, 12.0] {
+            let y = self.db_to_y(db, h);
+            frame.stroke(
+                &canvas::Path::line(Point::new(0.0, y), Point::new(w, y)),
+                canvas::Stroke::default().with_color(grid).with_width(1.0),
+            );
+        }
+        // Unity line, slightly brighter.
+        let y0 = self.db_to_y(0.0, h);
+        frame.stroke(
+            &canvas::Path::line(Point::new(0.0, y0), Point::new(w, y0)),
+            canvas::Stroke::default()
+                .with_color(Color {
+                    a: 0.8,
+                    ..th::BORDER
+                })
+                .with_width(1.0),
+        );
+
+        // ── Spectrum (behind the curve) ──
+        if self.spectrum_active && self.spectrum.len() == DISPLAY_BINS {
+            let bin_y = |db: f32| -> f32 { h - ((db - FLOOR_DB) / -FLOOR_DB) * h };
+            let path = canvas::Path::new(|b| {
+                b.move_to(Point::new(0.0, h));
+                for (i, &db) in self.spectrum.iter().enumerate() {
+                    let x = (i as f32 + 0.5) / DISPLAY_BINS as f32 * w;
+                    b.line_to(Point::new(x, bin_y(db)));
+                }
+                b.line_to(Point::new(w, h));
+                b.close();
+            });
+            frame.fill(
+                &path,
+                Color {
+                    a: 0.13,
+                    ..th::TEXT_DIM
+                },
+            );
+            frame.stroke(
+                &path,
+                canvas::Stroke::default()
+                    .with_color(Color {
+                        a: 0.30,
+                        ..th::TEXT_DIM
+                    })
+                    .with_width(1.0),
+            );
+        }
+
+        // ── Response curve ──
+        let eq = vibez_dsp::eq::EqEffect::from_params(self.sample_rate, &self.params);
+        let curve_pts: Vec<Point> = (0..CURVE_POINTS)
+            .map(|i| {
+                let pos = i as f32 / (CURVE_POINTS - 1) as f32;
+                let db = eq.response_db(norm_to_freq(pos));
+                Point::new(pos * w, self.db_to_y(db, h))
+            })
+            .collect();
+
+        if !self.bypass {
+            // Soft fill between the curve and unity.
+            let fill = canvas::Path::new(|b| {
+                b.move_to(Point::new(0.0, y0));
+                for p in &curve_pts {
+                    b.line_to(*p);
+                }
+                b.line_to(Point::new(w, y0));
+                b.close();
+            });
+            frame.fill(
+                &fill,
+                Color {
+                    a: 0.10,
+                    ..th::ACCENT
+                },
+            );
+        }
+
+        let curve = canvas::Path::new(|b| {
+            b.move_to(curve_pts[0]);
+            for p in &curve_pts[1..] {
+                b.line_to(*p);
+            }
+        });
+        let (curve_color, curve_w) = if self.bypass {
+            (th::TEXT_MUTED, 1.5)
+        } else {
+            (th::TEXT, 2.0)
+        };
+        frame.stroke(
+            &curve,
+            canvas::Stroke {
+                line_join: canvas::LineJoin::Round,
+                ..canvas::Stroke::default()
+            }
+            .with_color(curve_color)
+            .with_width(curve_w),
+        );
+
+        // ── Band handles ──
+        for (i, band) in BANDS.iter().enumerate() {
+            let p = self.handle_pos(band, bounds);
+            let engaged = state.drag == Some(i) || (state.drag.is_none() && state.hover == Some(i));
+            let color = if self.bypass {
+                th::TEXT_MUTED
+            } else {
+                band.color
+            };
+            frame.fill(&canvas::Path::circle(p, HANDLE_R), color);
+            frame.fill(&canvas::Path::circle(p, HANDLE_R - 2.5), th::BG_DARK);
+            if engaged {
+                frame.stroke(
+                    &canvas::Path::circle(p, HANDLE_R + 2.0),
+                    canvas::Stroke::default()
+                        .with_color(th::TEXT)
+                        .with_width(1.0),
+                );
+                // Readout: freq / gain / Q next to the handle.
+                let freq = self.param(band.freq_i);
+                let mut readout = format!(
+                    "{}  {:+.1} dB",
+                    crate::widgets::effect_knob::format_value(freq, "Hz"),
+                    self.param(band.gain_i),
+                );
+                if let Some(q_i) = band.q_i {
+                    readout.push_str(&format!("  Q {:.2}", self.param(q_i)));
+                }
+                let above = p.y > 24.0;
+                frame.fill_text(canvas::Text {
+                    content: readout,
+                    position: Point::new(
+                        p.x.clamp(60.0, w - 80.0),
+                        if above { p.y - 12.0 } else { p.y + 12.0 },
+                    ),
+                    color: th::TEXT,
+                    size: 9.0.into(),
+                    horizontal_alignment: iced::alignment::Horizontal::Center,
+                    vertical_alignment: if above {
+                        iced::alignment::Vertical::Bottom
+                    } else {
+                        iced::alignment::Vertical::Top
+                    },
+                    ..canvas::Text::default()
+                });
+            }
+        }
+
+        // ── Frame border ──
+        frame.stroke(
+            &canvas::Path::rounded_rectangle(Point::ORIGIN, bounds.size(), 3.0.into()),
+            canvas::Stroke::default()
+                .with_color(th::BORDER)
+                .with_width(1.0),
+        );
+
+        vec![frame.into_geometry()]
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if state.drag.is_some() {
+            mouse::Interaction::Grabbing
+        } else if cursor
+            .position_in(bounds)
+            .and_then(|p| self.band_at(p, bounds))
+            .is_some()
+        {
+            mouse::Interaction::Grab
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: canvas::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<Message>) {
+        let local = cursor.position_in(bounds);
+        match event {
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                if let Some(pos) = local {
+                    if let Some(band_idx) = self.band_at(pos, bounds) {
+                        let now = Instant::now();
+                        if let Some(last) = state.last_click {
+                            if now.duration_since(last).as_millis() < DOUBLE_CLICK_MS {
+                                // Double-click: zero the band's gain.
+                                state.last_click = None;
+                                state.drag = None;
+                                return (
+                                    canvas::event::Status::Captured,
+                                    Some(Message::set_effect_param(
+                                        self.track_id,
+                                        self.effect_id,
+                                        BANDS[band_idx].gain_i,
+                                        0.0,
+                                    )),
+                                );
+                            }
+                        }
+                        state.last_click = Some(now);
+                        state.drag = Some(band_idx);
+                        return (canvas::event::Status::Captured, None);
+                    }
+                }
+            }
+            canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                if state.drag.take().is_some() {
+                    return (canvas::event::Status::Captured, None);
+                }
+            }
+            canvas::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                if let Some(band_idx) = state.drag {
+                    // Track the cursor even slightly outside bounds.
+                    if let Some(abs) = cursor.position() {
+                        let pos = Point::new(abs.x - bounds.x, abs.y - bounds.y);
+                        return (
+                            canvas::event::Status::Captured,
+                            Some(self.drag_message(band_idx, pos, bounds)),
+                        );
+                    }
+                }
+                if let Some(pos) = local {
+                    state.hover = self.band_at(pos, bounds);
+                }
+            }
+            canvas::Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if let Some(pos) = local {
+                    if let Some(band_idx) = self.band_at(pos, bounds).or(state.drag) {
+                        if let Some(q_i) = BANDS[band_idx].q_i {
+                            let scroll_y = match delta {
+                                mouse::ScrollDelta::Lines { y, .. } => y,
+                                mouse::ScrollDelta::Pixels { y, .. } => y / 20.0,
+                            };
+                            let d = &self.descriptors[q_i];
+                            let q = (self.param(q_i) * 1.10f32.powf(scroll_y)).clamp(d.min, d.max);
+                            return (
+                                canvas::event::Status::Captured,
+                                Some(Message::set_effect_param(
+                                    self.track_id,
+                                    self.effect_id,
+                                    q_i,
+                                    q,
+                                )),
+                            );
+                        }
+                        // Bands without a Q swallow the scroll so the
+                        // panel underneath doesn't pan.
+                        return (canvas::event::Status::Captured, None);
+                    }
+                }
+            }
+            _ => {}
+        }
+        (canvas::event::Status::Ignored, None)
+    }
+}

--- a/crates/vibez-ui/src/widgets/eq_display.rs
+++ b/crates/vibez-ui/src/widgets/eq_display.rs
@@ -30,7 +30,6 @@ struct Band {
     gain_i: usize,
     freq_i: usize,
     q_i: Option<usize>,
-    color: Color,
 }
 
 const BANDS: [Band; 4] = [
@@ -38,27 +37,33 @@ const BANDS: [Band; 4] = [
         gain_i: 0,
         freq_i: 1,
         q_i: None,
-        color: th::EQ_LF,
     },
     Band {
         gain_i: 3,
         freq_i: 4,
         q_i: Some(5),
-        color: th::EQ_LMF,
     },
     Band {
         gain_i: 6,
         freq_i: 7,
         q_i: Some(8),
-        color: th::EQ_HMF,
     },
     Band {
         gain_i: 9,
         freq_i: 10,
         q_i: Some(11),
-        color: th::EQ_HF,
     },
 ];
+
+/// Band color from the current theme, by BANDS index (LF..HF).
+fn band_color(idx: usize) -> Color {
+    match idx {
+        0 => th::eq_lf(),
+        1 => th::eq_lmf(),
+        2 => th::eq_hmf(),
+        _ => th::eq_hf(),
+    }
+}
 
 pub struct EqDisplayWidget {
     pub track_id: TrackId,
@@ -156,13 +161,13 @@ impl canvas::Program<Message> for EqDisplayWidget {
         // ── Panel ──
         frame.fill(
             &canvas::Path::rounded_rectangle(Point::ORIGIN, bounds.size(), 3.0.into()),
-            th::BG_DARK,
+            th::bg_dark(),
         );
 
         // ── Grid: decade frequency lines + dB lines ──
         let grid = Color {
             a: 0.35,
-            ..th::BORDER
+            ..th::border()
         };
         let labeled: [(f32, &str); 3] = [(100.0, "100"), (1_000.0, "1k"), (10_000.0, "10k")];
         for f in [
@@ -178,7 +183,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
             frame.fill_text(canvas::Text {
                 content: label.to_string(),
                 position: Point::new(freq_to_norm(f) * w + 3.0, h - 2.0),
-                color: th::TEXT_MUTED,
+                color: th::text_muted(),
                 size: 8.0.into(),
                 vertical_alignment: iced::alignment::Vertical::Bottom,
                 ..canvas::Text::default()
@@ -198,7 +203,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
             canvas::Stroke::default()
                 .with_color(Color {
                     a: 0.8,
-                    ..th::BORDER
+                    ..th::border()
                 })
                 .with_width(1.0),
         );
@@ -219,7 +224,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
                 &path,
                 Color {
                     a: 0.13,
-                    ..th::TEXT_DIM
+                    ..th::text_dim()
                 },
             );
             frame.stroke(
@@ -227,7 +232,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
                 canvas::Stroke::default()
                     .with_color(Color {
                         a: 0.30,
-                        ..th::TEXT_DIM
+                        ..th::text_dim()
                     })
                     .with_width(1.0),
             );
@@ -257,7 +262,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
                 &fill,
                 Color {
                     a: 0.10,
-                    ..th::ACCENT
+                    ..th::accent()
                 },
             );
         }
@@ -269,9 +274,9 @@ impl canvas::Program<Message> for EqDisplayWidget {
             }
         });
         let (curve_color, curve_w) = if self.bypass {
-            (th::TEXT_MUTED, 1.5)
+            (th::text_muted(), 1.5)
         } else {
-            (th::TEXT, 2.0)
+            (th::text(), 2.0)
         };
         frame.stroke(
             &curve,
@@ -288,17 +293,17 @@ impl canvas::Program<Message> for EqDisplayWidget {
             let p = self.handle_pos(band, bounds);
             let engaged = state.drag == Some(i) || (state.drag.is_none() && state.hover == Some(i));
             let color = if self.bypass {
-                th::TEXT_MUTED
+                th::text_muted()
             } else {
-                band.color
+                band_color(i)
             };
             frame.fill(&canvas::Path::circle(p, HANDLE_R), color);
-            frame.fill(&canvas::Path::circle(p, HANDLE_R - 2.5), th::BG_DARK);
+            frame.fill(&canvas::Path::circle(p, HANDLE_R - 2.5), th::bg_dark());
             if engaged {
                 frame.stroke(
                     &canvas::Path::circle(p, HANDLE_R + 2.0),
                     canvas::Stroke::default()
-                        .with_color(th::TEXT)
+                        .with_color(th::text())
                         .with_width(1.0),
                 );
                 // Readout: freq / gain / Q next to the handle.
@@ -318,7 +323,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
                         p.x.clamp(60.0, w - 80.0),
                         if above { p.y - 12.0 } else { p.y + 12.0 },
                     ),
-                    color: th::TEXT,
+                    color: th::text(),
                     size: 9.0.into(),
                     horizontal_alignment: iced::alignment::Horizontal::Center,
                     vertical_alignment: if above {
@@ -335,7 +340,7 @@ impl canvas::Program<Message> for EqDisplayWidget {
         frame.stroke(
             &canvas::Path::rounded_rectangle(Point::ORIGIN, bounds.size(), 3.0.into()),
             canvas::Stroke::default()
-                .with_color(th::BORDER)
+                .with_color(th::border())
                 .with_width(1.0),
         );
 

--- a/crates/vibez-ui/src/widgets/fader.rs
+++ b/crates/vibez-ui/src/widgets/fader.rs
@@ -56,7 +56,7 @@ impl canvas::Program<Message> for HorizontalFaderWidget {
         frame.fill_rectangle(
             iced::Point::new(track_left, track_y),
             iced::Size::new(track_w, track_h),
-            theme::FADER_TRACK,
+            theme::fader_track(),
         );
 
         // Unity gain mark (at 0.5 of the track = gain 1.0)
@@ -68,7 +68,7 @@ impl canvas::Program<Message> for HorizontalFaderWidget {
         frame.stroke(
             &unity_line,
             canvas::Stroke::default()
-                .with_color(theme::TEXT_DIM)
+                .with_color(theme::text_dim())
                 .with_width(1.0),
         );
 
@@ -93,7 +93,7 @@ impl canvas::Program<Message> for HorizontalFaderWidget {
         frame.fill_rectangle(
             iced::Point::new(handle_x - handle_w / 2.0, handle_y),
             iced::Size::new(handle_w, handle_h),
-            theme::FADER_HANDLE,
+            theme::fader_handle(),
         );
 
         vec![frame.into_geometry()]
@@ -205,7 +205,7 @@ impl canvas::Program<Message> for FaderWidget {
         frame.fill_rectangle(
             iced::Point::new(track_x, track_top),
             iced::Size::new(track_w, track_h),
-            theme::FADER_TRACK,
+            theme::fader_track(),
         );
 
         // Unity gain mark (at 0.5 of the track = gain 1.0)
@@ -217,7 +217,7 @@ impl canvas::Program<Message> for FaderWidget {
         frame.stroke(
             &unity_line,
             canvas::Stroke::default()
-                .with_color(theme::TEXT_DIM)
+                .with_color(theme::text_dim())
                 .with_width(1.0),
         );
 
@@ -242,7 +242,7 @@ impl canvas::Program<Message> for FaderWidget {
         frame.fill_rectangle(
             iced::Point::new(handle_x, handle_y - handle_h / 2.0),
             iced::Size::new(handle_w, handle_h),
-            theme::FADER_HANDLE,
+            theme::fader_handle(),
         );
 
         vec![frame.into_geometry()]

--- a/crates/vibez-ui/src/widgets/knob.rs
+++ b/crates/vibez-ui/src/widgets/knob.rs
@@ -82,7 +82,7 @@ impl canvas::Program<Message> for KnobWidget {
 
         // Background circle
         let bg_circle = canvas::Path::circle(center, radius);
-        frame.fill(&bg_circle, theme::KNOB_BG);
+        frame.fill(&bg_circle, theme::knob_bg());
 
         let arc_radius = radius - 2.0;
 
@@ -91,7 +91,7 @@ impl canvas::Program<Message> for KnobWidget {
         frame.stroke(
             &bg_arc,
             canvas::Stroke::default()
-                .with_color(theme::FADER_TRACK)
+                .with_color(theme::fader_track())
                 .with_width(3.0),
         );
 
@@ -123,7 +123,7 @@ impl canvas::Program<Message> for KnobWidget {
         frame.stroke(
             &pointer,
             canvas::Stroke::default()
-                .with_color(theme::TEXT)
+                .with_color(theme::text())
                 .with_width(2.0),
         );
 
@@ -143,7 +143,7 @@ impl canvas::Program<Message> for KnobWidget {
         frame.stroke(
             &tick,
             canvas::Stroke::default()
-                .with_color(theme::TEXT_DIM)
+                .with_color(theme::text_dim())
                 .with_width(1.0),
         );
 

--- a/crates/vibez-ui/src/widgets/mini_waveform.rs
+++ b/crates/vibez-ui/src/widgets/mini_waveform.rs
@@ -79,15 +79,7 @@ impl canvas::Program<Message> for MiniWaveform {
                 iced::Size::new(w, h),
                 3.0.into(),
             );
-            frame.fill(
-                &bg,
-                Color {
-                    r: 0.07,
-                    g: 0.07,
-                    b: 0.07,
-                    a: 1.0,
-                },
-            );
+            frame.fill(&bg, theme::display_bg());
 
             let Some(audio) = &self.audio else {
                 // Empty state: flat center line.
@@ -98,7 +90,7 @@ impl canvas::Program<Message> for MiniWaveform {
                 frame.stroke(
                     &line,
                     canvas::Stroke::default()
-                        .with_color(theme::BORDER)
+                        .with_color(theme::border())
                         .with_width(1.0),
                 );
                 return;
@@ -163,7 +155,7 @@ impl canvas::Program<Message> for MiniWaveform {
                     frame.stroke(
                         &line,
                         canvas::Stroke::default()
-                            .with_color(theme::TEXT_DIM)
+                            .with_color(theme::text_dim())
                             .with_width(1.0),
                     );
                 }
@@ -197,15 +189,7 @@ impl canvas::Program<Message> for OscScope {
 
         let bg =
             canvas::Path::rounded_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), 3.0.into());
-        frame.fill(
-            &bg,
-            Color {
-                r: 0.07,
-                g: 0.07,
-                b: 0.07,
-                a: 1.0,
-            },
-        );
+        frame.fill(&bg, theme::display_bg());
 
         let mid = h / 2.0;
         let amp = h / 2.0 - 4.0;
@@ -285,15 +269,7 @@ impl canvas::Program<Message> for AdsrScope {
 
         let bg =
             canvas::Path::rounded_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), 3.0.into());
-        frame.fill(
-            &bg,
-            Color {
-                r: 0.07,
-                g: 0.07,
-                b: 0.07,
-                a: 1.0,
-            },
-        );
+        frame.fill(&bg, theme::display_bg());
 
         let pad = 3.0;
         let top = pad;

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -3,8 +3,11 @@ use iced::{Element, Length, Theme};
 
 use crate::icons;
 use crate::message::Message;
-use crate::state::UiTrack;
+use vibez_core::effect::EffectType;
+
+use crate::state::{UiEffect, UiTrack};
 use crate::theme as th;
+use crate::widgets::effect_knob::EffectKnobWidget;
 use crate::widgets::fader::FaderWidget;
 use crate::widgets::knob::KnobWidget;
 use crate::widgets::vu_meter::VuMeterWidget;
@@ -136,17 +139,20 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
         .spacing(2)
         .height(Length::Fill);
 
+    let eq_section = view_strip_eq(track);
+
     let strip = column![
         name_row,
         knob_canvas,
         pan_label,
+        eq_section,
         fader_meter,
         gain_label,
         mute_solo_row,
     ]
     .spacing(4)
     .padding(8)
-    .width(Length::Fixed(90.0))
+    .width(Length::Fixed(108.0))
     .height(Length::Fill)
     .align_x(iced::Alignment::Center);
 
@@ -162,6 +168,181 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
             ..Default::default()
         })
         .into()
+}
+
+/// SSL-style channel EQ: the strip renders the track's first
+/// built-in EQ effect as four color-coded bands (HF red, HMF green,
+/// LMF blue, LF brown, like the console), with bell toggles on the
+/// outer bands and an IN (bypass) button. The EQ is an ordinary
+/// device on the chain, so automation and persistence come free.
+fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
+    let eq = track
+        .effects
+        .iter()
+        .find(|e| e.effect_type == EffectType::Eq && e.plugin_ref.is_none());
+
+    let Some(eq) = eq else {
+        return container(
+            button(text("+ EQ").size(10).color(th::TEXT_DIM))
+                .on_press(Message::add_effect(track.id, EffectType::Eq))
+                .padding([2, 10])
+                .style(|_theme: &Theme, status| {
+                    let bg = match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::BG_HOVER.into())
+                        }
+                        _ => Some(th::BG_ELEVATED.into()),
+                    };
+                    button::Style {
+                        background: bg,
+                        text_color: th::TEXT_DIM,
+                        border: iced::Border {
+                            color: th::BORDER,
+                            width: 1.0,
+                            radius: 2.0.into(),
+                        },
+                        ..Default::default()
+                    }
+                }),
+        )
+        .padding([4, 0])
+        .into();
+    };
+
+    // Console band colors, muted for the theme.
+    const HF: iced::Color = iced::Color::from_rgb(0.76, 0.33, 0.30);
+    const HMF: iced::Color = iced::Color::from_rgb(0.33, 0.62, 0.38);
+    const LMF: iced::Color = iced::Color::from_rgb(0.36, 0.48, 0.72);
+    const LF: iced::Color = iced::Color::from_rgb(0.65, 0.46, 0.28);
+
+    let mut bands = column![].spacing(2).align_x(iced::Alignment::Center);
+
+    // Header: EQ label + IN (bypass) toggle.
+    let in_btn = {
+        let active = !eq.bypass;
+        let label = text("IN").size(8);
+        button(if active {
+            label.color(th::BG_DARK)
+        } else {
+            label.color(th::TEXT_DIM)
+        })
+        .on_press(Message::toggle_effect_bypass(track.id, eq.id))
+        .padding([1, 5])
+        .style(move |_theme: &Theme, _status| button::Style {
+            background: Some(if active {
+                th::ACCENT.into()
+            } else {
+                th::BG_ELEVATED.into()
+            }),
+            text_color: if active { th::BG_DARK } else { th::TEXT_DIM },
+            border: iced::Border {
+                color: th::BORDER,
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            ..Default::default()
+        })
+    };
+    bands = bands.push(
+        row![text("EQ").size(9).color(th::TEXT_DIM), in_btn]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+    );
+
+    // (gain idx, freq idx, q/bell idx, bell?, color, label)
+    let rows: [(usize, usize, usize, bool, iced::Color, &str); 4] = [
+        (9, 10, 11, true, HF, "HF"),
+        (6, 7, 8, false, HMF, "HMF"),
+        (3, 4, 5, false, LMF, "LMF"),
+        (0, 1, 2, true, LF, "LF"),
+    ];
+    for (gain_i, freq_i, third_i, is_bell_toggle, color, label) in rows {
+        bands = bands.push(view_eq_band(
+            track.id,
+            eq,
+            gain_i,
+            freq_i,
+            third_i,
+            is_bell_toggle,
+            color,
+            label,
+        ));
+    }
+
+    container(bands).padding([4, 0]).width(Length::Fill).into()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn view_eq_band<'a>(
+    track_id: vibez_core::id::TrackId,
+    eq: &'a UiEffect,
+    gain_i: usize,
+    freq_i: usize,
+    third_i: usize,
+    bell_toggle: bool,
+    color: iced::Color,
+    label: &'static str,
+) -> Element<'a, Message> {
+    let knob = |i: usize| -> Element<'a, Message> {
+        let d = &eq.descriptors[i];
+        let w = EffectKnobWidget::new(
+            track_id,
+            eq.id,
+            i,
+            eq.params.get(i).copied().unwrap_or(d.default),
+            d.min,
+            d.max,
+            d.default,
+            color,
+        );
+        canvas(w)
+            .width(Length::Fixed(24.0))
+            .height(Length::Fixed(24.0))
+            .into()
+    };
+
+    let third: Element<'a, Message> = if bell_toggle {
+        let bell_on = eq.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
+        button(
+            text("B")
+                .size(8)
+                .color(if bell_on { th::BG_DARK } else { th::TEXT_DIM }),
+        )
+        .on_press(Message::set_effect_param(
+            track_id,
+            eq.id,
+            third_i,
+            if bell_on { 0.0 } else { 1.0 },
+        ))
+        .padding([2, 4])
+        .style(move |_theme: &Theme, _status| button::Style {
+            background: Some(if bell_on {
+                color.into()
+            } else {
+                th::BG_ELEVATED.into()
+            }),
+            text_color: if bell_on { th::BG_DARK } else { th::TEXT_DIM },
+            border: iced::Border {
+                color: th::BORDER,
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
+    } else {
+        knob(third_i)
+    };
+
+    column![
+        text(label).size(8).color(color),
+        row![knob(gain_i), knob(freq_i), third]
+            .spacing(3)
+            .align_y(iced::Alignment::Center),
+    ]
+    .spacing(1)
+    .align_x(iced::Alignment::Center)
+    .into()
 }
 
 fn format_pan(pan: f32) -> String {

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -351,7 +351,7 @@ fn view_eq_band<'a>(
             third_i,
             if bell_on { 0.0 } else { 1.0 },
         ))
-        .padding([2, 3])
+        .padding([3, 6])
         .style(move |_theme: &Theme, _status| button::Style {
             background: Some(if bell_on {
                 color.into()
@@ -368,7 +368,7 @@ fn view_eq_band<'a>(
         })
         .into()
     } else {
-        column![text("Q").size(7).color(dim), knob(third_i, 16.0)]
+        column![text("Q").size(7).color(dim), knob(third_i, 22.0)]
             .spacing(1)
             .align_x(iced::Alignment::Center)
             .into()

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -14,7 +14,7 @@ use crate::widgets::vu_meter::VuMeterWidget;
 use vibez_core::midi::TrackKind;
 
 /// Render a single mixer channel strip for a track.
-pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
+pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message> {
     let track_color = th::track_color(track.color_index);
 
     // Track name + type icon
@@ -156,17 +156,24 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
     .height(Length::Fill)
     .align_x(iced::Alignment::Center);
 
-    container(strip)
+    let body = container(strip)
         .height(Length::Fill)
         .style(move |_theme: &Theme| container::Style {
             background: Some(th::BG_SURFACE.into()),
             border: iced::Border {
-                color: th::BORDER,
+                color: if selected { th::ACCENT } else { th::BORDER },
                 width: 1.0,
                 radius: 2.0.into(),
             },
             ..Default::default()
-        })
+        });
+
+    // Clicking anywhere on the strip chrome selects the track, so
+    // the detail panel follows the mixer like it follows the
+    // arrangement headers. Knobs, faders, and buttons still win
+    // their own clicks.
+    iced::widget::mouse_area(body)
+        .on_press(Message::select_track(track.id))
         .into()
 }
 

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -256,13 +256,12 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         (3, 4, 5, false, LMF, "LMF"),
         (0, 1, 2, true, LF, "LF"),
     ];
-    for (i, (gain_i, freq_i, third_i, is_bell_toggle, color, label)) in
-        rows.into_iter().enumerate()
+    for (i, (gain_i, freq_i, third_i, is_bell_toggle, color, label)) in rows.into_iter().enumerate()
     {
         if i > 0 {
             bands = bands.push(
                 container(text(""))
-                    .width(Length::Fixed(72.0))
+                    .width(Length::Fixed(88.0))
                     .height(Length::Fixed(1.0))
                     .style(|_theme: &Theme| container::Style {
                         background: Some(
@@ -341,11 +340,11 @@ fn view_eq_band<'a>(
 
     let third_el: Element<'a, Message> = if bell_toggle {
         let bell_on = eq.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
-        button(text("BELL").size(6).color(if bell_on {
-            th::BG_DARK
-        } else {
-            th::TEXT_DIM
-        }))
+        button(
+            text("BELL")
+                .size(6)
+                .color(if bell_on { th::BG_DARK } else { th::TEXT_DIM }),
+        )
         .on_press(Message::set_effect_param(
             track_id,
             eq.id,
@@ -376,9 +375,13 @@ fn view_eq_band<'a>(
     };
 
     let freq_col = column![
-        text(if freq_i == 10 || freq_i == 7 { "kHz" } else { "Hz" })
-            .size(7)
-            .color(dim),
+        text(if freq_i == 10 || freq_i == 7 {
+            "kHz"
+        } else {
+            "Hz"
+        })
+        .size(7)
+        .color(dim),
         knob(freq_i, 26.0),
     ]
     .spacing(1)
@@ -388,9 +391,11 @@ fn view_eq_band<'a>(
         column![gain_col, third_el]
             .spacing(3)
             .align_x(iced::Alignment::Center),
+        iced::widget::horizontal_space(),
         column![text("").size(10), freq_col].align_x(iced::Alignment::Center),
     ]
-    .spacing(8)
+    .width(Length::Fill)
+    .padding([0, 6])
     .align_y(iced::Alignment::Start)
     .into()
 }

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -152,7 +152,7 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
     ]
     .spacing(4)
     .padding(8)
-    .width(Length::Fixed(108.0))
+    .width(Length::Fixed(112.0))
     .height(Length::Fill)
     .align_x(iced::Alignment::Center);
 
@@ -215,7 +215,7 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
     const LMF: iced::Color = iced::Color::from_rgb(0.36, 0.48, 0.72);
     const LF: iced::Color = iced::Color::from_rgb(0.65, 0.46, 0.28);
 
-    let mut bands = column![].spacing(2).align_x(iced::Alignment::Center);
+    let mut bands = column![].spacing(4).align_x(iced::Alignment::Center);
 
     // Header: EQ label + IN (bypass) toggle.
     let in_btn = {
@@ -256,7 +256,26 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         (3, 4, 5, false, LMF, "LMF"),
         (0, 1, 2, true, LF, "LF"),
     ];
-    for (gain_i, freq_i, third_i, is_bell_toggle, color, label) in rows {
+    for (i, (gain_i, freq_i, third_i, is_bell_toggle, color, label)) in
+        rows.into_iter().enumerate()
+    {
+        if i > 0 {
+            bands = bands.push(
+                container(text(""))
+                    .width(Length::Fixed(72.0))
+                    .height(Length::Fixed(1.0))
+                    .style(|_theme: &Theme| container::Style {
+                        background: Some(
+                            iced::Color {
+                                a: 0.5,
+                                ..th::BORDER
+                            }
+                            .into(),
+                        ),
+                        ..Default::default()
+                    }),
+            );
+        }
         bands = bands.push(view_eq_band(
             track.id,
             eq,
@@ -283,7 +302,7 @@ fn view_eq_band<'a>(
     color: iced::Color,
     label: &'static str,
 ) -> Element<'a, Message> {
-    let knob = |i: usize| -> Element<'a, Message> {
+    let knob = |i: usize, size: f32| -> Element<'a, Message> {
         let d = &eq.descriptors[i];
         let w = EffectKnobWidget::new(
             track_id,
@@ -296,25 +315,44 @@ fn view_eq_band<'a>(
             color,
         );
         canvas(w)
-            .width(Length::Fixed(24.0))
-            .height(Length::Fixed(24.0))
+            .width(Length::Fixed(size))
+            .height(Length::Fixed(size))
             .into()
     };
 
-    let third: Element<'a, Message> = if bell_toggle {
+    // Console stagger: the gain knob rides high on the left, the
+    // frequency knob sits low on the right, Q (or the bell switch)
+    // tucks under the gain. The eye zig-zags down the strip.
+    let dim = iced::Color {
+        a: 0.75,
+        ..th::TEXT_DIM
+    };
+    let gain_col = column![
+        row![
+            text(label).size(8).color(color),
+            text("dB").size(7).color(dim)
+        ]
+        .spacing(3)
+        .align_y(iced::Alignment::Center),
+        knob(gain_i, 30.0),
+    ]
+    .spacing(1)
+    .align_x(iced::Alignment::Center);
+
+    let third_el: Element<'a, Message> = if bell_toggle {
         let bell_on = eq.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
-        button(
-            text("B")
-                .size(8)
-                .color(if bell_on { th::BG_DARK } else { th::TEXT_DIM }),
-        )
+        button(text("BELL").size(6).color(if bell_on {
+            th::BG_DARK
+        } else {
+            th::TEXT_DIM
+        }))
         .on_press(Message::set_effect_param(
             track_id,
             eq.id,
             third_i,
             if bell_on { 0.0 } else { 1.0 },
         ))
-        .padding([2, 4])
+        .padding([2, 3])
         .style(move |_theme: &Theme, _status| button::Style {
             background: Some(if bell_on {
                 color.into()
@@ -331,17 +369,29 @@ fn view_eq_band<'a>(
         })
         .into()
     } else {
-        knob(third_i)
+        column![text("Q").size(7).color(dim), knob(third_i, 20.0)]
+            .spacing(1)
+            .align_x(iced::Alignment::Center)
+            .into()
     };
 
-    column![
-        text(label).size(8).color(color),
-        row![knob(gain_i), knob(freq_i), third]
-            .spacing(3)
-            .align_y(iced::Alignment::Center),
+    let freq_col = column![
+        text(if freq_i == 10 || freq_i == 7 { "kHz" } else { "Hz" })
+            .size(7)
+            .color(dim),
+        knob(freq_i, 26.0),
     ]
     .spacing(1)
-    .align_x(iced::Alignment::Center)
+    .align_x(iced::Alignment::Center);
+
+    row![
+        column![gain_col, third_el]
+            .spacing(3)
+            .align_x(iced::Alignment::Center),
+        column![text("").size(10), freq_col].align_x(iced::Alignment::Center),
+    ]
+    .spacing(8)
+    .align_y(iced::Alignment::Start)
     .into()
 }
 

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -152,7 +152,7 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
     ]
     .spacing(4)
     .padding(8)
-    .width(Length::Fixed(112.0))
+    .width(Length::Fixed(94.0))
     .height(Length::Fill)
     .align_x(iced::Alignment::Center);
 
@@ -215,7 +215,7 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
     const LMF: iced::Color = iced::Color::from_rgb(0.36, 0.48, 0.72);
     const LF: iced::Color = iced::Color::from_rgb(0.65, 0.46, 0.28);
 
-    let mut bands = column![].spacing(4).align_x(iced::Alignment::Center);
+    let mut bands = column![].spacing(2).align_x(iced::Alignment::Center);
 
     // Header: EQ label + IN (bypass) toggle.
     let in_btn = {
@@ -261,7 +261,7 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         if i > 0 {
             bands = bands.push(
                 container(text(""))
-                    .width(Length::Fixed(88.0))
+                    .width(Length::Fixed(74.0))
                     .height(Length::Fixed(1.0))
                     .style(|_theme: &Theme| container::Style {
                         background: Some(
@@ -333,7 +333,7 @@ fn view_eq_band<'a>(
         ]
         .spacing(3)
         .align_y(iced::Alignment::Center),
-        knob(gain_i, 30.0),
+        knob(gain_i, 26.0),
     ]
     .spacing(1)
     .align_x(iced::Alignment::Center);
@@ -368,7 +368,7 @@ fn view_eq_band<'a>(
         })
         .into()
     } else {
-        column![text("Q").size(7).color(dim), knob(third_i, 20.0)]
+        column![text("Q").size(7).color(dim), knob(third_i, 16.0)]
             .spacing(1)
             .align_x(iced::Alignment::Center)
             .into()
@@ -382,20 +382,18 @@ fn view_eq_band<'a>(
         })
         .size(7)
         .color(dim),
-        knob(freq_i, 26.0),
+        knob(freq_i, 22.0),
     ]
     .spacing(1)
     .align_x(iced::Alignment::Center);
 
     row![
         column![gain_col, third_el]
-            .spacing(3)
+            .spacing(2)
             .align_x(iced::Alignment::Center),
-        iced::widget::horizontal_space(),
-        column![text("").size(10), freq_col].align_x(iced::Alignment::Center),
+        column![text("").size(6), freq_col].align_x(iced::Alignment::Center),
     ]
-    .width(Length::Fill)
-    .padding([0, 6])
+    .spacing(9)
     .align_y(iced::Alignment::Start)
     .into()
 }

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -143,9 +143,9 @@ pub fn view_mixer_strip(track: &UiTrack) -> Element<'_, Message> {
 
     let strip = column![
         name_row,
+        eq_section,
         knob_canvas,
         pan_label,
-        eq_section,
         fader_meter,
         gain_label,
         mute_solo_row,

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -13,17 +13,28 @@ use crate::widgets::knob::KnobWidget;
 use crate::widgets::vu_meter::VuMeterWidget;
 use vibez_core::midi::TrackKind;
 
-/// Render a single mixer channel strip for a track.
+/// Render a single mixer channel strip for a track. The master bus
+/// renders through the same strip: EQ, fader, and meter, minus the
+/// controls that make no sense on a sum (pan, mute, solo).
 pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message> {
-    let track_color = th::track_color(track.color_index);
+    let is_master = track.id.is_master();
+    let track_color = if is_master {
+        th::ACCENT
+    } else {
+        th::track_color(track.color_index)
+    };
 
     // Track name + type icon
-    let type_icon = match track.kind {
-        TrackKind::Audio => icons::icon(icons::AUDIO_WAVEFORM)
-            .size(10)
-            .color(track_color),
-        TrackKind::Instrument(_) | TrackKind::Midi => {
-            icons::icon(icons::MUSIC).size(10).color(track_color)
+    let type_icon = if is_master {
+        icons::icon(icons::VOLUME_2).size(10).color(track_color)
+    } else {
+        match track.kind {
+            TrackKind::Audio => icons::icon(icons::AUDIO_WAVEFORM)
+                .size(10)
+                .color(track_color),
+            TrackKind::Instrument(_) | TrackKind::Midi => {
+                icons::icon(icons::MUSIC).size(10).color(track_color)
+            }
         }
     };
 
@@ -141,15 +152,32 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
 
     let eq_section = view_strip_eq(track);
 
-    let strip = column![
-        name_row,
-        eq_section,
-        knob_canvas,
-        pan_label,
-        fader_meter,
-        gain_label,
-        mute_solo_row,
-    ]
+    let strip = if is_master {
+        // No pan, mute, or solo on the sum: a MASTER tag keeps the
+        // strip's vertical rhythm instead.
+        let badge = container(text("MASTER").size(8).color(th::ACCENT))
+            .padding([3, 8])
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::BG_ELEVATED.into()),
+                border: iced::Border {
+                    color: th::ACCENT_DIM,
+                    width: 1.0,
+                    radius: 2.0.into(),
+                },
+                ..Default::default()
+            });
+        column![name_row, eq_section, badge, fader_meter, gain_label]
+    } else {
+        column![
+            name_row,
+            eq_section,
+            knob_canvas,
+            pan_label,
+            fader_meter,
+            gain_label,
+            mute_solo_row,
+        ]
+    }
     .spacing(4)
     .padding(8)
     .width(Length::Fixed(94.0))
@@ -217,10 +245,10 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
     };
 
     // Console band colors, muted for the theme.
-    const HF: iced::Color = iced::Color::from_rgb(0.76, 0.33, 0.30);
-    const HMF: iced::Color = iced::Color::from_rgb(0.33, 0.62, 0.38);
-    const LMF: iced::Color = iced::Color::from_rgb(0.36, 0.48, 0.72);
-    const LF: iced::Color = iced::Color::from_rgb(0.65, 0.46, 0.28);
+    const HF: iced::Color = th::EQ_HF;
+    const HMF: iced::Color = th::EQ_HMF;
+    const LMF: iced::Color = th::EQ_LMF;
+    const LF: iced::Color = th::EQ_LF;
 
     let mut bands = column![].spacing(2).align_x(iced::Alignment::Center);
 

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -19,7 +19,7 @@ use vibez_core::midi::TrackKind;
 pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message> {
     let is_master = track.id.is_master();
     let track_color = if is_master {
-        th::ACCENT
+        th::accent()
     } else {
         th::track_color(track.color_index)
     };
@@ -40,7 +40,7 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
 
     let name = text(&track.name)
         .size(12)
-        .color(th::TEXT)
+        .color(th::text())
         .width(Length::Fill);
 
     let name_row = row![type_icon, name]
@@ -54,7 +54,7 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
         .height(Length::Fixed(36.0))
         .into();
 
-    let pan_label = text(format_pan(track.pan)).size(10).color(th::TEXT_DIM);
+    let pan_label = text(format_pan(track.pan)).size(10).color(th::text_dim());
 
     // Fader (wider)
     let fader = FaderWidget::new(track.id, track.gain, track_color);
@@ -65,7 +65,7 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
 
     let gain_label = text(format_gain_db(track.gain))
         .size(11)
-        .color(th::TEXT_DIM);
+        .color(th::text_dim());
 
     // VU meter (wider)
     let meter = VuMeterWidget {
@@ -81,12 +81,12 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
     let mute_btn = {
         let label = text("M").size(11);
         if track.mute {
-            button(label.color(th::BG_DARK))
+            button(label.color(th::bg_dark()))
                 .on_press(Message::set_track_mute(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::MUTE_ACTIVE.into()),
-                    text_color: th::BG_DARK,
+                    background: Some(th::mute_active().into()),
+                    text_color: th::bg_dark(),
                     border: iced::Border {
                         radius: 2.0.into(),
                         ..Default::default()
@@ -94,14 +94,14 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
                     ..Default::default()
                 })
         } else {
-            button(label.color(th::TEXT_DIM))
+            button(label.color(th::text_dim()))
                 .on_press(Message::set_track_mute(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::TEXT_DIM,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 2.0.into(),
                     },
@@ -114,12 +114,12 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
     let solo_btn = {
         let label = text("S").size(11);
         if track.solo {
-            button(label.color(th::BG_DARK))
+            button(label.color(th::bg_dark()))
                 .on_press(Message::set_track_solo(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::SOLO_ACTIVE.into()),
-                    text_color: th::BG_DARK,
+                    background: Some(th::solo_active().into()),
+                    text_color: th::bg_dark(),
                     border: iced::Border {
                         radius: 2.0.into(),
                         ..Default::default()
@@ -127,14 +127,14 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
                     ..Default::default()
                 })
         } else {
-            button(label.color(th::TEXT_DIM))
+            button(label.color(th::text_dim()))
                 .on_press(Message::set_track_solo(track.id))
                 .padding([4, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::TEXT_DIM,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 2.0.into(),
                     },
@@ -155,12 +155,12 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
     let strip = if is_master {
         // No pan, mute, or solo on the sum: a MASTER tag keeps the
         // strip's vertical rhythm instead.
-        let badge = container(text("MASTER").size(8).color(th::ACCENT))
+        let badge = container(text("MASTER").size(8).color(th::accent()))
             .padding([3, 8])
             .style(|_theme: &Theme| container::Style {
-                background: Some(th::BG_ELEVATED.into()),
+                background: Some(th::bg_elevated().into()),
                 border: iced::Border {
-                    color: th::ACCENT_DIM,
+                    color: th::accent_dim(),
                     width: 1.0,
                     radius: 2.0.into(),
                 },
@@ -187,9 +187,9 @@ pub fn view_mixer_strip(track: &UiTrack, selected: bool) -> Element<'_, Message>
     let body = container(strip)
         .height(Length::Fill)
         .style(move |_theme: &Theme| container::Style {
-            background: Some(th::BG_SURFACE.into()),
+            background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: if selected { th::ACCENT } else { th::BORDER },
+                color: if selected { th::accent() } else { th::border() },
                 width: 1.0,
                 radius: 2.0.into(),
             },
@@ -218,21 +218,21 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
 
     let Some(eq) = eq else {
         return container(
-            button(text("+ EQ").size(10).color(th::TEXT_DIM))
+            button(text("+ EQ").size(10).color(th::text_dim()))
                 .on_press(Message::add_effect(track.id, EffectType::Eq))
                 .padding([2, 10])
                 .style(|_theme: &Theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::BG_HOVER.into())
+                            Some(th::bg_hover().into())
                         }
-                        _ => Some(th::BG_ELEVATED.into()),
+                        _ => Some(th::bg_elevated().into()),
                     };
                     button::Style {
                         background: bg,
-                        text_color: th::TEXT_DIM,
+                        text_color: th::text_dim(),
                         border: iced::Border {
-                            color: th::BORDER,
+                            color: th::border(),
                             width: 1.0,
                             radius: 2.0.into(),
                         },
@@ -244,11 +244,11 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         .into();
     };
 
-    // Console band colors, muted for the theme.
-    const HF: iced::Color = th::EQ_HF;
-    const HMF: iced::Color = th::EQ_HMF;
-    const LMF: iced::Color = th::EQ_LMF;
-    const LF: iced::Color = th::EQ_LF;
+    // Console band colors, from the current theme.
+    let hf = th::eq_hf();
+    let hmf = th::eq_hmf();
+    let lmf = th::eq_lmf();
+    let lf = th::eq_lf();
 
     let mut bands = column![].spacing(2).align_x(iced::Alignment::Center);
 
@@ -257,21 +257,25 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         let active = !eq.bypass;
         let label = text("IN").size(8);
         button(if active {
-            label.color(th::BG_DARK)
+            label.color(th::bg_dark())
         } else {
-            label.color(th::TEXT_DIM)
+            label.color(th::text_dim())
         })
         .on_press(Message::toggle_effect_bypass(track.id, eq.id))
         .padding([1, 5])
         .style(move |_theme: &Theme, _status| button::Style {
             background: Some(if active {
-                th::ACCENT.into()
+                th::accent().into()
             } else {
-                th::BG_ELEVATED.into()
+                th::bg_elevated().into()
             }),
-            text_color: if active { th::BG_DARK } else { th::TEXT_DIM },
+            text_color: if active {
+                th::bg_dark()
+            } else {
+                th::text_dim()
+            },
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 2.0.into(),
             },
@@ -279,17 +283,17 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
         })
     };
     bands = bands.push(
-        row![text("EQ").size(9).color(th::TEXT_DIM), in_btn]
+        row![text("EQ").size(9).color(th::text_dim()), in_btn]
             .spacing(6)
             .align_y(iced::Alignment::Center),
     );
 
     // (gain idx, freq idx, q/bell idx, bell?, color, label)
     let rows: [(usize, usize, usize, bool, iced::Color, &str); 4] = [
-        (9, 10, 11, true, HF, "HF"),
-        (6, 7, 8, false, HMF, "HMF"),
-        (3, 4, 5, false, LMF, "LMF"),
-        (0, 1, 2, true, LF, "LF"),
+        (9, 10, 11, true, hf, "HF"),
+        (6, 7, 8, false, hmf, "HMF"),
+        (3, 4, 5, false, lmf, "LMF"),
+        (0, 1, 2, true, lf, "LF"),
     ];
     for (i, (gain_i, freq_i, third_i, is_bell_toggle, color, label)) in rows.into_iter().enumerate()
     {
@@ -302,7 +306,7 @@ fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
                         background: Some(
                             iced::Color {
                                 a: 0.5,
-                                ..th::BORDER
+                                ..th::border()
                             }
                             .into(),
                         ),
@@ -359,7 +363,7 @@ fn view_eq_band<'a>(
     // tucks under the gain. The eye zig-zags down the strip.
     let dim = iced::Color {
         a: 0.75,
-        ..th::TEXT_DIM
+        ..th::text_dim()
     };
     let gain_col = column![
         row![
@@ -375,11 +379,11 @@ fn view_eq_band<'a>(
 
     let third_el: Element<'a, Message> = if bell_toggle {
         let bell_on = eq.params.get(third_i).copied().unwrap_or(0.0) >= 0.5;
-        button(
-            text("BELL")
-                .size(6)
-                .color(if bell_on { th::BG_DARK } else { th::TEXT_DIM }),
-        )
+        button(text("BELL").size(6).color(if bell_on {
+            th::bg_dark()
+        } else {
+            th::text_dim()
+        }))
         .on_press(Message::set_effect_param(
             track_id,
             eq.id,
@@ -391,11 +395,15 @@ fn view_eq_band<'a>(
             background: Some(if bell_on {
                 color.into()
             } else {
-                th::BG_ELEVATED.into()
+                th::bg_elevated().into()
             }),
-            text_color: if bell_on { th::BG_DARK } else { th::TEXT_DIM },
+            text_color: if bell_on {
+                th::bg_dark()
+            } else {
+                th::text_dim()
+            },
             border: iced::Border {
-                color: th::BORDER,
+                color: th::border(),
                 width: 1.0,
                 radius: 2.0.into(),
             },

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -2,6 +2,7 @@ pub mod audio_clip_detail;
 pub mod automation_lane;
 pub mod effect_knob;
 pub mod effect_slot;
+pub mod eq_display;
 pub mod fader;
 pub mod knob;
 pub mod mini_waveform;

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -1,4 +1,5 @@
 pub mod audio_clip_detail;
+pub mod automation_lane;
 pub mod effect_knob;
 pub mod effect_slot;
 pub mod fader;

--- a/crates/vibez-ui/src/widgets/piano_roll/draw.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/draw.rs
@@ -36,7 +36,7 @@ impl PianoRollWidget {
         let grid_ppb = grid_width / total as f32;
 
         // Full background
-        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::BG_DARK);
+        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::bg_dark());
 
         // Determine visible row range for culling
         let first_visible = (self.scroll_y / KEY_HEIGHT).floor() as usize;
@@ -54,7 +54,11 @@ impl PianoRollWidget {
             }
 
             let is_black = is_black_key(pitch);
-            let row_bg = if is_black { BLACK_ROW_BG } else { WHITE_ROW_BG };
+            let row_bg = if is_black {
+                theme::piano_black_row()
+            } else {
+                theme::piano_white_row()
+            };
 
             frame.fill_rectangle(
                 iced::Point::new(KEY_WIDTH, y),
@@ -65,9 +69,9 @@ impl PianoRollWidget {
             // Horizontal grid line
             let is_c = pitch.is_multiple_of(12);
             let (line_color, line_width) = if is_c {
-                (OCTAVE_LINE, 1.0)
+                (theme::piano_octave_line(), 1.0)
             } else {
-                (GRID_LINE, 0.5)
+                (theme::piano_grid(), 0.5)
             };
             let hline = canvas::Path::line(
                 iced::Point::new(KEY_WIDTH, y + KEY_HEIGHT),
@@ -97,10 +101,10 @@ impl PianoRollWidget {
                 } else if hovered_pitch == Some(pitch) {
                     Color {
                         a: 0.75,
-                        ..WHITE_KEY_COLOR
+                        ..theme::piano_white_key()
                     }
                 } else {
-                    WHITE_KEY_COLOR
+                    theme::piano_white_key()
                 };
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
@@ -116,7 +120,7 @@ impl PianoRollWidget {
                 frame.stroke(
                     &border,
                     canvas::Stroke::default()
-                        .with_color(theme::DIVIDER)
+                        .with_color(theme::divider())
                         .with_width(0.5),
                 );
             }
@@ -137,26 +141,16 @@ impl PianoRollWidget {
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
                     iced::Size::new(KEY_WIDTH, KEY_HEIGHT),
-                    Color {
-                        r: 0.14,
-                        g: 0.14,
-                        b: 0.14,
-                        a: 1.0,
-                    },
+                    theme::piano_white_row(),
                 );
 
                 // Black key itself
                 let fill = if pressed_pitch == Some(pitch) {
                     self.track_color
                 } else if hovered_pitch == Some(pitch) {
-                    Color {
-                        r: 0.35,
-                        g: 0.35,
-                        b: 0.35,
-                        a: 1.0,
-                    }
+                    theme::border_light()
                 } else {
-                    BLACK_KEY_COLOR
+                    theme::piano_black_key()
                 };
                 frame.fill_rectangle(
                     iced::Point::new(0.0, y),
@@ -172,7 +166,7 @@ impl PianoRollWidget {
                 frame.stroke(
                     &border,
                     canvas::Stroke::default()
-                        .with_color(theme::DIVIDER)
+                        .with_color(theme::divider())
                         .with_width(0.5),
                 );
             }
@@ -192,7 +186,7 @@ impl PianoRollWidget {
                 frame.fill_text(canvas::Text {
                     content: label,
                     position: iced::Point::new(black_key_width + 3.0, y + 2.0),
-                    color: KEY_LABEL_COLOR,
+                    color: theme::piano_key_label(),
                     size: iced::Pixels(10.0),
                     ..Default::default()
                 });
@@ -207,7 +201,7 @@ impl PianoRollWidget {
         frame.stroke(
             &sep,
             canvas::Stroke::default()
-                .with_color(theme::BORDER)
+                .with_color(theme::border())
                 .with_width(1.0),
         );
 
@@ -227,35 +221,11 @@ impl PianoRollWidget {
             let is_beat = beat_int % 1000 == 0;
 
             let (line_color, line_width) = if is_bar {
-                (
-                    Color {
-                        r: 0.376,
-                        g: 0.376,
-                        b: 0.376,
-                        a: 1.0,
-                    },
-                    1.5,
-                ) // #606060
+                (theme::grid_bar(), 1.5)
             } else if is_beat {
-                (
-                    Color {
-                        r: 0.251,
-                        g: 0.251,
-                        b: 0.251,
-                        a: 1.0,
-                    },
-                    1.0,
-                ) // #404040
+                (theme::grid_beat(), 1.0)
             } else {
-                (
-                    Color {
-                        r: 0.216,
-                        g: 0.216,
-                        b: 0.216,
-                        a: 1.0,
-                    },
-                    1.0,
-                ) // #373737
+                (theme::grid_sub(), 1.0)
             };
 
             let vline =
@@ -270,7 +240,7 @@ impl PianoRollWidget {
 
         // ── Draw notes ──
         if let Some(ref clip_data) = self.clip {
-            let selected_color = theme::SOLO_ACTIVE;
+            let selected_color = theme::solo_active();
             let looping =
                 clip_data.loop_enabled && clip_data.loop_end_beats > clip_data.loop_start_beats;
             let loop_len = if looping {
@@ -483,7 +453,7 @@ impl PianoRollWidget {
             frame.stroke(
                 &playhead_line,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(1.5),
             );
         }
@@ -493,7 +463,7 @@ impl PianoRollWidget {
         frame.fill_rectangle(
             iced::Point::ORIGIN,
             iced::Size::new(w, RULER_HEIGHT),
-            theme::BG_SURFACE,
+            theme::bg_surface(),
         );
 
         // Bottom border
@@ -504,7 +474,7 @@ impl PianoRollWidget {
         frame.stroke(
             &ruler_border,
             canvas::Stroke::default()
-                .with_color(theme::BORDER)
+                .with_color(theme::border())
                 .with_width(1.0),
         );
 
@@ -529,13 +499,13 @@ impl PianoRollWidget {
                 frame.stroke(
                     &tick,
                     canvas::Stroke::default()
-                        .with_color(theme::TEXT_MUTED)
+                        .with_color(theme::text_muted())
                         .with_width(1.0),
                 );
                 frame.fill_text(canvas::Text {
                     content: format!("{bar_num}"),
                     position: iced::Point::new(x + 3.0, 3.0),
-                    color: theme::TEXT_DIM,
+                    color: theme::text_dim(),
                     size: iced::Pixels(10.0),
                     ..Default::default()
                 });
@@ -550,13 +520,13 @@ impl PianoRollWidget {
                 frame.stroke(
                     &tick,
                     canvas::Stroke::default()
-                        .with_color(theme::TEXT_MUTED)
+                        .with_color(theme::text_muted())
                         .with_width(0.5),
                 );
                 frame.fill_text(canvas::Text {
                     content: format!("{}.{}", bar_index + 1, beat_in_bar),
                     position: iced::Point::new(x + 2.0, 5.0),
-                    color: theme::TEXT_MUTED,
+                    color: theme::text_muted(),
                     size: iced::Pixels(8.0),
                     ..Default::default()
                 });
@@ -572,7 +542,7 @@ impl PianoRollWidget {
             frame.stroke(
                 &marker,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(1.5),
             );
         }

--- a/crates/vibez-ui/src/widgets/piano_roll/mod.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/mod.rs
@@ -218,64 +218,6 @@ pub struct PianoRollState {
     audition_pitch: Option<u8>,
 }
 
-// ── Grid row colors ──
-
-/// White key row background: #252525
-const WHITE_ROW_BG: Color = Color {
-    r: 0.145,
-    g: 0.145,
-    b: 0.145,
-    a: 1.0,
-};
-
-/// Black key row background: #1c1c1c
-const BLACK_ROW_BG: Color = Color {
-    r: 0.110,
-    g: 0.110,
-    b: 0.110,
-    a: 1.0,
-};
-
-/// Octave boundary line color: #3a3a3a
-const OCTAVE_LINE: Color = Color {
-    r: 0.227,
-    g: 0.227,
-    b: 0.227,
-    a: 1.0,
-};
-
-/// Normal horizontal grid line: #2a2a2a
-const GRID_LINE: Color = Color {
-    r: 0.165,
-    g: 0.165,
-    b: 0.165,
-    a: 1.0,
-};
-
-/// White key fill for piano: #c8c8c8
-const WHITE_KEY_COLOR: Color = Color {
-    r: 0.784,
-    g: 0.784,
-    b: 0.784,
-    a: 1.0,
-};
-
-/// Black key fill for piano: #1a1a1a
-const BLACK_KEY_COLOR: Color = Color {
-    r: 0.102,
-    g: 0.102,
-    b: 0.102,
-    a: 1.0,
-};
-
-/// Piano key label color for C notes
-const KEY_LABEL_COLOR: Color = Color {
-    r: 0.35,
-    g: 0.35,
-    b: 0.35,
-    a: 1.0,
-};
-
 impl canvas::Program<Message> for PianoRollWidget {
     type State = PianoRollState;
 

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -26,11 +26,11 @@ impl TrackClipCanvas {
 
         // Background
         let bg_color = if drop_hover {
-            theme::ACCENT_DIM
+            theme::accent_dim()
         } else if self.selected {
-            theme::TRACK_BG_SELECTED
+            theme::track_bg_selected()
         } else {
-            theme::TRACK_BG
+            theme::track_bg()
         };
         frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), bg_color);
 
@@ -54,7 +54,7 @@ impl TrackClipCanvas {
                     frame.stroke(
                         &vline,
                         canvas::Stroke::default()
-                            .with_color(theme::BORDER)
+                            .with_color(theme::border())
                             .with_width(1.0),
                     );
                 } else if ppb >= 40.0 {
@@ -64,7 +64,7 @@ impl TrackClipCanvas {
                     frame.stroke(
                         &vline,
                         canvas::Stroke::default()
-                            .with_color(theme::DIVIDER)
+                            .with_color(theme::divider())
                             .with_width(0.5),
                     );
                 }
@@ -82,12 +82,7 @@ impl TrackClipCanvas {
                             frame.stroke(
                                 &sub_line,
                                 canvas::Stroke::default()
-                                    .with_color(Color {
-                                        r: 0.13,
-                                        g: 0.13,
-                                        b: 0.13,
-                                        a: 1.0,
-                                    })
+                                    .with_color(theme::divider())
                                     .with_width(0.3),
                             );
                         }
@@ -180,7 +175,7 @@ impl TrackClipCanvas {
                         frame.fill_text(canvas::Text {
                             content: "L".to_string(),
                             position: iced::Point::new(clip_x + clip_w - 14.0, clip_y + 3.0),
-                            color: theme::ACCENT,
+                            color: theme::accent(),
                             size: iced::Pixels(9.0),
                             ..Default::default()
                         });
@@ -190,7 +185,7 @@ impl TrackClipCanvas {
                 // Selection highlight
                 let is_selected = self.selected_clips.contains(&clip.clip_id);
                 let border_color = if is_selected {
-                    theme::ACCENT
+                    theme::accent()
                 } else {
                     clip_border_color
                 };
@@ -226,7 +221,7 @@ impl TrackClipCanvas {
                     frame.fill_text(canvas::Text {
                         content: clip.name.clone(),
                         position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
-                        color: theme::TEXT,
+                        color: theme::text(),
                         size: iced::Pixels(11.0),
                         ..Default::default()
                     });
@@ -237,7 +232,7 @@ impl TrackClipCanvas {
                 // opacity so the waveform and clip colour remain
                 // legible, but strong enough to catch the eye.
                 if clip.warp_stale && clip_w > 4.0 {
-                    let stripe_color = theme::with_alpha(theme::METER_YELLOW, 0.22);
+                    let stripe_color = theme::with_alpha(theme::meter_yellow(), 0.22);
                     let stripe_spacing = 8.0f32;
                     let stripe_stroke = 1.5f32;
                     let mut offset = -clip_h;
@@ -389,7 +384,7 @@ impl TrackClipCanvas {
                         frame.fill_text(canvas::Text {
                             content: "L".to_string(),
                             position: iced::Point::new(clip_x + clip_w - 14.0, clip_y + 3.0),
-                            color: theme::ACCENT,
+                            color: theme::accent(),
                             size: iced::Pixels(9.0),
                             ..Default::default()
                         });
@@ -399,7 +394,7 @@ impl TrackClipCanvas {
                 // Selection highlight
                 let is_selected = self.selected_clips.contains(&note_clip.clip_id);
                 let border_color = if is_selected {
-                    theme::ACCENT
+                    theme::accent()
                 } else {
                     theme::darken(self.track_color, 0.7)
                 };
@@ -435,7 +430,7 @@ impl TrackClipCanvas {
                     frame.fill_text(canvas::Text {
                         content: note_clip.name.clone(),
                         position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
-                        color: theme::TEXT,
+                        color: theme::text(),
                         size: iced::Pixels(11.0),
                         ..Default::default()
                     });
@@ -453,7 +448,7 @@ impl TrackClipCanvas {
                 frame.fill_rectangle(
                     iced::Point::new(fill_x, 0.0),
                     iced::Size::new(fill_w, h),
-                    theme::with_alpha(theme::ACCENT, 0.06),
+                    theme::with_alpha(theme::accent(), 0.06),
                 );
             }
         }
@@ -476,7 +471,7 @@ impl TrackClipCanvas {
                 frame.fill_rectangle(
                     iced::Point::new(fill_x, 0.0),
                     iced::Size::new(fill_w, h),
-                    theme::with_alpha(theme::ACCENT, 0.04),
+                    theme::with_alpha(theme::accent(), 0.04),
                 );
             }
         }
@@ -491,7 +486,7 @@ impl TrackClipCanvas {
             frame.stroke(
                 &playhead_line,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(2.0),
             );
         }
@@ -501,7 +496,7 @@ impl TrackClipCanvas {
         frame.stroke(
             &sep,
             canvas::Stroke::default()
-                .with_color(theme::DIVIDER)
+                .with_color(theme::divider())
                 .with_width(1.0),
         );
 
@@ -516,7 +511,7 @@ impl TrackClipCanvas {
             frame.stroke(
                 &outline,
                 canvas::Stroke::default()
-                    .with_color(theme::ACCENT)
+                    .with_color(theme::accent())
                     .with_width(2.0),
             );
             if let Some(local) = cursor.position_in(bounds) {
@@ -530,7 +525,7 @@ impl TrackClipCanvas {
                     frame.stroke(
                         &drop_line,
                         canvas::Stroke::default()
-                            .with_color(theme::ACCENT)
+                            .with_color(theme::accent())
                             .with_width(2.0),
                     );
                 }
@@ -539,7 +534,7 @@ impl TrackClipCanvas {
             frame.fill_text(canvas::Text {
                 content: format!("Drop on: {}", self.track_name),
                 position: iced::Point::new(8.0, 8.0),
-                color: theme::ACCENT,
+                color: theme::accent(),
                 size: 14.0.into(),
                 ..Default::default()
             });

--- a/crates/vibez-ui/src/widgets/timeline/minimap.rs
+++ b/crates/vibez-ui/src/widgets/timeline/minimap.rs
@@ -68,7 +68,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
         frame.fill_rectangle(
             iced::Point::ORIGIN,
             iced::Size::new(w, h),
-            theme::BG_ELEVATED,
+            theme::bg_elevated(),
         );
 
         if self.total_beats <= 0.0 || self.tracks.is_empty() {
@@ -107,7 +107,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
                 frame.fill_rectangle(
                     iced::Point::new(fill_x, 0.0),
                     iced::Size::new(fill_w, h),
-                    theme::with_alpha(theme::ACCENT, 0.15),
+                    theme::with_alpha(theme::accent(), 0.15),
                 );
             }
         }
@@ -124,10 +124,8 @@ impl canvas::Program<Message> for ArrangementMinimap {
                 iced::Point::new(vx, 0.0),
                 iced::Size::new(vw, h),
                 Color {
-                    r: 1.0,
-                    g: 1.0,
-                    b: 1.0,
                     a: 0.05,
+                    ..theme::text()
                 },
             );
             // Orange border
@@ -141,7 +139,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
             frame.stroke(
                 &rect_path,
                 canvas::Stroke::default()
-                    .with_color(theme::ACCENT)
+                    .with_color(theme::accent())
                     .with_width(1.5),
             );
         }
@@ -154,7 +152,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
             frame.stroke(
                 &playhead,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(1.0),
             );
         }
@@ -165,7 +163,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
         frame.stroke(
             &border,
             canvas::Stroke::default()
-                .with_color(theme::BORDER)
+                .with_color(theme::border())
                 .with_width(1.0),
         );
 

--- a/crates/vibez-ui/src/widgets/timeline/ruler.rs
+++ b/crates/vibez-ui/src/widgets/timeline/ruler.rs
@@ -70,7 +70,11 @@ impl canvas::Program<Message> for RulerWidget {
         let h = bounds.height;
 
         // Background
-        frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::RULER_BG);
+        frame.fill_rectangle(
+            iced::Point::ORIGIN,
+            iced::Size::new(w, h),
+            theme::ruler_bg(),
+        );
 
         if self.bpm > 0.0 {
             let beats_per_bar = 4.0_f64;
@@ -122,7 +126,7 @@ impl canvas::Program<Message> for RulerWidget {
                         frame.stroke(
                             &tick,
                             canvas::Stroke::default()
-                                .with_color(theme::BORDER)
+                                .with_color(theme::border())
                                 .with_width(1.5),
                         );
                     }
@@ -135,7 +139,7 @@ impl canvas::Program<Message> for RulerWidget {
                             frame.fill_text(canvas::Text {
                                 content: label,
                                 position: iced::Point::new(x + 4.0, 3.0),
-                                color: theme::RULER_TEXT,
+                                color: theme::ruler_text(),
                                 size: iced::Pixels(12.0),
                                 ..Default::default()
                             });
@@ -145,7 +149,7 @@ impl canvas::Program<Message> for RulerWidget {
                             frame.fill_text(canvas::Text {
                                 content: label,
                                 position: iced::Point::new(x + 4.0, 3.0),
-                                color: theme::RULER_TEXT,
+                                color: theme::ruler_text(),
                                 size: iced::Pixels(12.0),
                                 ..Default::default()
                             });
@@ -158,7 +162,7 @@ impl canvas::Program<Message> for RulerWidget {
                     frame.stroke(
                         &tick,
                         canvas::Stroke::default()
-                            .with_color(theme::DIVIDER)
+                            .with_color(theme::divider())
                             .with_width(0.5),
                     );
 
@@ -168,7 +172,7 @@ impl canvas::Program<Message> for RulerWidget {
                         frame.fill_text(canvas::Text {
                             content: label,
                             position: iced::Point::new(x + 2.0, 6.0),
-                            color: theme::TEXT_MUTED,
+                            color: theme::text_muted(),
                             size: iced::Pixels(9.0),
                             ..Default::default()
                         });
@@ -188,7 +192,7 @@ impl canvas::Program<Message> for RulerWidget {
                             frame.stroke(
                                 &sub_tick,
                                 canvas::Stroke::default()
-                                    .with_color(theme::DIVIDER)
+                                    .with_color(theme::divider())
                                     .with_width(0.3),
                             );
                         }
@@ -202,7 +206,7 @@ impl canvas::Program<Message> for RulerWidget {
             frame.stroke(
                 &bottom_border,
                 canvas::Stroke::default()
-                    .with_color(theme::BORDER)
+                    .with_color(theme::border())
                     .with_width(1.0),
             );
         }
@@ -218,7 +222,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.fill_rectangle(
                     iced::Point::new(fill_x, 0.0),
                     iced::Size::new(fill_w, h),
-                    theme::with_alpha(theme::ACCENT, 0.15),
+                    theme::with_alpha(theme::accent(), 0.15),
                 );
 
                 // REPEAT icon centered in the loop region
@@ -226,7 +230,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.fill_text(canvas::Text {
                     content: crate::icons::REPEAT.to_string(),
                     position: iced::Point::new(center_x - 6.0, (h - 12.0) / 2.0),
-                    color: theme::with_alpha(theme::ACCENT, 0.7),
+                    color: theme::with_alpha(theme::accent(), 0.7),
                     size: iced::Pixels(12.0),
                     font: crate::icons::ICON_FONT,
                     ..Default::default()
@@ -242,7 +246,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.stroke(
                     &bracket,
                     canvas::Stroke::default()
-                        .with_color(theme::ACCENT)
+                        .with_color(theme::accent())
                         .with_width(2.0),
                 );
             }
@@ -254,7 +258,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.stroke(
                     &bracket,
                     canvas::Stroke::default()
-                        .with_color(theme::ACCENT)
+                        .with_color(theme::accent())
                         .with_width(2.0),
                 );
             }
@@ -271,7 +275,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.fill_rectangle(
                     iced::Point::new(fill_x, 0.0),
                     iced::Size::new(fill_w, h),
-                    theme::with_alpha(theme::ACCENT, 0.10),
+                    theme::with_alpha(theme::accent(), 0.10),
                 );
             }
 
@@ -282,7 +286,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.stroke(
                     &bracket,
                     canvas::Stroke::default()
-                        .with_color(theme::ACCENT)
+                        .with_color(theme::accent())
                         .with_width(1.0),
                 );
             }
@@ -292,7 +296,7 @@ impl canvas::Program<Message> for RulerWidget {
                 frame.stroke(
                     &bracket,
                     canvas::Stroke::default()
-                        .with_color(theme::ACCENT)
+                        .with_color(theme::accent())
                         .with_width(1.0),
                 );
             }
@@ -308,7 +312,7 @@ impl canvas::Program<Message> for RulerWidget {
             frame.stroke(
                 &playhead_line,
                 canvas::Stroke::default()
-                    .with_color(theme::PLAYHEAD)
+                    .with_color(theme::playhead())
                     .with_width(2.0),
             );
         }

--- a/crates/vibez-ui/src/widgets/track_header.rs
+++ b/crates/vibez-ui/src/widgets/track_header.rs
@@ -49,7 +49,11 @@ pub fn view_track_header<'a>(
             .width(Length::Fill)
             .into()
     } else {
-        let name_color = if track.mute { th::TEXT_DIM } else { th::TEXT };
+        let name_color = if track.mute {
+            th::text_dim()
+        } else {
+            th::text()
+        };
         let msg = if selected {
             Message::View(ViewMsg::StartEditingTrackName(track.id))
         } else {
@@ -60,7 +64,7 @@ pub fn view_track_header<'a>(
             .padding(0)
             .style(|_theme: &Theme, _status| button::Style {
                 background: None,
-                text_color: th::TEXT,
+                text_color: th::text(),
                 border: iced::Border::default(),
                 ..Default::default()
             })
@@ -68,11 +72,11 @@ pub fn view_track_header<'a>(
     };
 
     let add_btn = match track.kind {
-        TrackKind::Audio => button(icons::icon(icons::PLUS).size(11).color(th::TEXT_DIM))
+        TrackKind::Audio => button(icons::icon(icons::PLUS).size(11).color(th::text_dim()))
             .on_press(Message::AddClipToTrack(track.id))
             .padding([2, 6]),
         TrackKind::Instrument(_) | TrackKind::Midi => {
-            button(icons::icon(icons::PLUS).size(11).color(th::TEXT_DIM))
+            button(icons::icon(icons::PLUS).size(11).color(th::text_dim()))
                 .on_press(Message::PianoRoll(PianoRollMsg::AddNoteClipToTrack(
                     track.id,
                 )))
@@ -80,17 +84,17 @@ pub fn view_track_header<'a>(
         }
     };
 
-    let delete_btn = button(icons::icon(icons::TRASH_2).size(10).color(th::TEXT_DIM))
+    let delete_btn = button(icons::icon(icons::TRASH_2).size(10).color(th::text_dim()))
         .on_press(Message::remove_track(track.id))
         .padding([2, 4])
         .style(|_theme: &Theme, status| {
             let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
                 _ => None,
             };
             button::Style {
                 background: bg,
-                text_color: th::TEXT_DIM,
+                text_color: th::text_dim(),
                 border: iced::Border::default(),
                 ..Default::default()
             }
@@ -98,9 +102,9 @@ pub fn view_track_header<'a>(
 
     let auto_btn = {
         let color = if automation_open {
-            th::ACCENT
+            th::accent()
         } else {
-            th::TEXT_DIM
+            th::text_dim()
         };
         button(icons::icon(icons::SLIDERS_VERTICAL).size(10).color(color))
             .on_press(Message::Automation(AutomationMsg::ToggleTrackLanes(
@@ -109,12 +113,14 @@ pub fn view_track_header<'a>(
             .padding([2, 4])
             .style(|_theme: &Theme, status| {
                 let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
                     _ => None,
                 };
                 button::Style {
                     background: bg,
-                    text_color: th::TEXT_DIM,
+                    text_color: th::text_dim(),
                     border: iced::Border::default(),
                     ..Default::default()
                 }
@@ -136,12 +142,12 @@ pub fn view_track_header<'a>(
     let mute_btn = {
         let label = text("M").size(11);
         if track.mute {
-            button(label.color(th::BG_DARK))
+            button(label.color(th::bg_dark()))
                 .on_press(Message::set_track_mute(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::MUTE_ACTIVE.into()),
-                    text_color: th::BG_DARK,
+                    background: Some(th::mute_active().into()),
+                    text_color: th::bg_dark(),
                     border: iced::Border {
                         radius: 2.0.into(),
                         ..Default::default()
@@ -149,14 +155,14 @@ pub fn view_track_header<'a>(
                     ..Default::default()
                 })
         } else {
-            button(label.color(th::TEXT_DIM))
+            button(label.color(th::text_dim()))
                 .on_press(Message::set_track_mute(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::TEXT_DIM,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 2.0.into(),
                     },
@@ -168,12 +174,12 @@ pub fn view_track_header<'a>(
     let solo_btn = {
         let label = text("S").size(11);
         if track.solo {
-            button(label.color(th::BG_DARK))
+            button(label.color(th::bg_dark()))
                 .on_press(Message::set_track_solo(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::SOLO_ACTIVE.into()),
-                    text_color: th::BG_DARK,
+                    background: Some(th::solo_active().into()),
+                    text_color: th::bg_dark(),
                     border: iced::Border {
                         radius: 2.0.into(),
                         ..Default::default()
@@ -181,14 +187,14 @@ pub fn view_track_header<'a>(
                     ..Default::default()
                 })
         } else {
-            button(label.color(th::TEXT_DIM))
+            button(label.color(th::text_dim()))
                 .on_press(Message::set_track_solo(track.id))
                 .padding([3, 8])
                 .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(th::BG_ELEVATED.into()),
-                    text_color: th::TEXT_DIM,
+                    background: Some(th::bg_elevated().into()),
+                    text_color: th::text_dim(),
                     border: iced::Border {
-                        color: th::BORDER,
+                        color: th::border(),
                         width: 1.0,
                         radius: 2.0.into(),
                     },
@@ -232,14 +238,18 @@ pub fn view_track_header<'a>(
     let card = container(header_with_bar).style(move |_theme: &Theme| container::Style {
         background: Some(
             if selected {
-                th::TRACK_BG_SELECTED
+                th::track_bg_selected()
             } else {
-                th::BG_SURFACE
+                th::bg_surface()
             }
             .into(),
         ),
         border: iced::Border {
-            color: if selected { th::ACCENT_DIM } else { th::BORDER },
+            color: if selected {
+                th::accent_dim()
+            } else {
+                th::border()
+            },
             width: if selected { 1.0 } else { 0.0 },
             radius: 0.0.into(),
         },

--- a/crates/vibez-ui/src/widgets/track_header.rs
+++ b/crates/vibez-ui/src/widgets/track_header.rs
@@ -3,6 +3,7 @@ use iced::widget::{
 };
 use iced::{Element, Length, Theme};
 
+use crate::domains::automation::AutomationMsg;
 use crate::domains::piano_roll::PianoRollMsg;
 use crate::domains::view::ViewMsg;
 use crate::icons;
@@ -25,6 +26,7 @@ pub fn view_track_header<'a>(
     selected: bool,
     editing_name: bool,
     edit_text: &'a str,
+    automation_open: bool,
 ) -> Element<'a, Message> {
     let track_color = th::track_color(track.color_index);
 
@@ -94,10 +96,36 @@ pub fn view_track_header<'a>(
             }
         });
 
+    let auto_btn = {
+        let color = if automation_open {
+            th::ACCENT
+        } else {
+            th::TEXT_DIM
+        };
+        button(icons::icon(icons::SLIDERS_VERTICAL).size(10).color(color))
+            .on_press(Message::Automation(AutomationMsg::ToggleTrackLanes(
+                track.id,
+            )))
+            .padding([2, 4])
+            .style(|_theme: &Theme, status| {
+                let bg = match status {
+                    button::Status::Hovered | button::Status::Pressed => Some(th::BG_HOVER.into()),
+                    _ => None,
+                };
+                button::Style {
+                    background: bg,
+                    text_color: th::TEXT_DIM,
+                    border: iced::Border::default(),
+                    ..Default::default()
+                }
+            })
+    };
+
     let name_row = row![
         type_icon,
         name_widget,
         horizontal_space(),
+        auto_btn,
         add_btn,
         delete_btn
     ]

--- a/crates/vibez-ui/src/widgets/vu_meter.rs
+++ b/crates/vibez-ui/src/widgets/vu_meter.rs
@@ -44,7 +44,7 @@ impl canvas::Program<crate::message::Message> for VuMeterWidget {
         frame.fill_rectangle(
             iced::Point::ORIGIN,
             iced::Size::new(w, h),
-            theme::BG_ELEVATED,
+            theme::bg_elevated(),
         );
 
         let bar_width = (w / 2.0 - 3.0).max(4.0);
@@ -62,7 +62,7 @@ impl canvas::Program<crate::message::Message> for VuMeterWidget {
                 frame.fill_rectangle(
                     iced::Point::new(x, h - padding - green_h),
                     iced::Size::new(bar_width, green_h),
-                    theme::METER_GREEN,
+                    theme::meter_green(),
                 );
 
                 // Yellow portion (0.6..0.85)
@@ -73,7 +73,7 @@ impl canvas::Program<crate::message::Message> for VuMeterWidget {
                     frame.fill_rectangle(
                         iced::Point::new(x, yellow_y),
                         iced::Size::new(bar_width, yellow_h),
-                        theme::METER_YELLOW,
+                        theme::meter_yellow(),
                     );
                 }
 
@@ -84,7 +84,7 @@ impl canvas::Program<crate::message::Message> for VuMeterWidget {
                     frame.fill_rectangle(
                         iced::Point::new(x, red_y),
                         iced::Size::new(bar_width, red_h),
-                        theme::METER_RED,
+                        theme::meter_red(),
                     );
                 }
             }
@@ -138,7 +138,7 @@ impl canvas::Program<crate::message::Message> for HorizontalVuMeterWidget {
         frame.fill_rectangle(
             iced::Point::ORIGIN,
             iced::Size::new(w, h),
-            theme::BG_ELEVATED,
+            theme::bg_elevated(),
         );
 
         let padding = 1.0;
@@ -152,9 +152,9 @@ impl canvas::Program<crate::message::Message> for HorizontalVuMeterWidget {
                 let bar_w = (level * max_width).clamp(0.0, max_width);
                 // Use track color with brightness modulated by level
                 let color = if level > 0.85 {
-                    theme::METER_RED
+                    theme::meter_red()
                 } else if level > 0.6 {
-                    theme::METER_YELLOW
+                    theme::meter_yellow()
                 } else {
                     track_color
                 };

--- a/crates/vibez-ui/src/widgets/waveform.rs
+++ b/crates/vibez-ui/src/widgets/waveform.rs
@@ -59,7 +59,7 @@ impl canvas::Program<crate::message::Message> for WaveformWidget {
             frame.fill_rectangle(
                 iced::Point::ORIGIN,
                 iced::Size::new(w, h),
-                theme::BG_SURFACE,
+                theme::bg_surface(),
             );
 
             // Center line
@@ -73,7 +73,7 @@ impl canvas::Program<crate::message::Message> for WaveformWidget {
                 canvas::Stroke::default()
                     .with_color(Color {
                         a: 0.3,
-                        ..theme::TEXT_DIM
+                        ..theme::text_dim()
                     })
                     .with_width(1.0),
             );
@@ -113,7 +113,7 @@ impl canvas::Program<crate::message::Message> for WaveformWidget {
                     frame.fill_rectangle(
                         iced::Point::new(x as f32, y_top),
                         iced::Size::new(1.0, height),
-                        theme::WAVEFORM,
+                        theme::waveform(),
                     );
                 }
             }
@@ -131,7 +131,7 @@ impl canvas::Program<crate::message::Message> for WaveformWidget {
                 frame.stroke(
                     &playhead_line,
                     canvas::Stroke::default()
-                        .with_color(theme::PLAYHEAD)
+                        .with_color(theme::playhead())
                         .with_width(1.5),
                 );
             }


### PR DESCRIPTION
Everything on dev since v0.0.2-alpha, ready for main.

## Automation (#40)
- Automation lanes on any track: volume, pan, built-in instrument and effect parameters, and third-party plugin parameters (CLAP param events + VST3 IParameterChanges — both hosts previously dropped param changes silently)
- Per-segment curves (alt-drag bends, alt-double-click resets), ctrl-drag range erase, grid snapping with shift bypass
- Searchable themed parameter picker; lanes seed at the current knob value; dotted reference line with native min/max labels
- Save/load/undo/redo covered; engine fix: effect chains process while the transport is stopped so param edits reach plugins and tails ring out

## Console mixer + SSL-style channel EQ (#41, #42)
- Every channel carries a four-band SSL-style EQ (LF/LMF/HMF/HF, bell toggles on the outer bands), rendered console-style on the strip with the zigzag knob layout
- Clicking a strip selects the track; the detail panel follows the mixer like it follows arrangement headers

## Master channel + EQ display (#42)
- Master is a real channel: gain + insert chain (built-ins and plugins) on the summed mix, its own strip with channel EQ, fader and meter, selectable with a device panel — persisted, undoable, applied to exports
- The EQ device card grew a frequency response curve with draggable band handles (drag = freq + gain, scroll = Q, double-click zeroes) and a live spectrum analyser fed by a lock-free engine tap

## Themes (#43)
- 20 built-in themes in Settings → Appearance, switching instantly across every widget and canvas, track palette included
- User themes as .vzt JSON files scanned from ~/.config/vibez/themes, with Rescan and Save Current
- Projects now save as .vzp; legacy .vibez files load unchanged

Suggest tagging v0.0.3-alpha once merged.