### PR TITLE
feat: complete arrangement clip management

### DIFF
--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -483,6 +483,7 @@ impl AudioEngine {
                 }
                 EngineCommand::SetBpm(bpm) => {
                     self.transport.set_bpm(bpm);
+                    self.recalculate_audio_length();
                 }
                 EngineCommand::LoadAudio(audio) => {
                     let len = audio.num_frames() as u64;
@@ -620,6 +621,7 @@ impl AudioEngine {
                 // -- Infrastructure --
                 EngineCommand::SetSampleRate(sr) => {
                     self.sample_rate = sr;
+                    self.recalculate_audio_length();
                 }
                 EngineCommand::SetSpectrumTap(target) => {
                     self.spectrum_track = target;
@@ -736,6 +738,7 @@ impl AudioEngine {
                         }
                         track.flush_notes();
                     }
+                    self.recalculate_audio_length();
                 }
                 EngineCommand::AddNoteClip {
                     track_id,
@@ -757,6 +760,7 @@ impl AudioEngine {
                             loop_end_beats,
                         });
                     }
+                    self.recalculate_audio_length();
                 }
                 EngineCommand::RemoveNoteClip(track_id, clip_id) => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
@@ -766,6 +770,7 @@ impl AudioEngine {
                         // forever.
                         track.flush_notes();
                     }
+                    self.recalculate_audio_length();
                 }
                 EngineCommand::MoveNoteClip {
                     track_id,
@@ -777,6 +782,7 @@ impl AudioEngine {
                             clip.position_beats = new_position_beats;
                         }
                     }
+                    self.recalculate_audio_length();
                 }
                 EngineCommand::AddNote {
                     track_id,
@@ -1078,7 +1084,12 @@ impl AudioEngine {
     }
 
     fn recalculate_audio_length(&mut self) {
-        let total = calculate_total_length(&self.tracks);
+        let samples_per_beat = if self.transport.bpm() > 0.0 {
+            self.sample_rate as f64 * 60.0 / self.transport.bpm()
+        } else {
+            0.0
+        };
+        let total = calculate_total_length(&self.tracks, samples_per_beat);
         if total > 0 {
             self.transport.set_audio_length(Some(total));
         } else if self.audio.is_none() {

--- a/crates/vibez-engine/src/engine_stuck_note_tests.rs
+++ b/crates/vibez-engine/src/engine_stuck_note_tests.rs
@@ -339,6 +339,19 @@ fn arrangement_loop_wrap_kills_sounding_notes() {
 }
 
 #[test]
+fn midi_only_arrangement_loop_retriggers_at_loop_start() {
+    let events = run_scenario((false, 0.0, 0.0), Some((0, 2048)), 8.0, 12);
+    let note_ons = events
+        .iter()
+        .filter(|(on, pitch)| *on && *pitch == 60)
+        .count();
+    assert!(
+        note_ons >= 2,
+        "MIDI-only arrangement loop must retrigger its first note: {events:?}"
+    );
+}
+
+#[test]
 fn stop_kills_sounding_notes() {
     let (mut engine, mut cmd_tx, events, _tid) = engine_with_held_note();
     cmd_tx.push(EngineCommand::Stop).unwrap();

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -40,6 +40,47 @@ fn process_outputs_silence_when_stopped() {
 }
 
 #[test]
+fn midi_clip_commands_keep_project_length_in_sync() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let clip_id = ClipId::new();
+    cmd_tx
+        .push(EngineCommand::AddMidiTrack(track_id, "MIDI".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddNoteClip {
+            track_id,
+            clip_id,
+            position_beats: 2.0,
+            duration_beats: 4.0,
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+        })
+        .unwrap();
+    let mut output = [0.0; 2];
+    engine.process(&mut output, 2);
+    assert_eq!(engine.transport().audio_length(), Some(132_300));
+
+    cmd_tx.push(EngineCommand::SetBpm(60.0)).unwrap();
+    cmd_tx
+        .push(EngineCommand::MoveNoteClip {
+            track_id,
+            clip_id,
+            new_position_beats: 4.0,
+        })
+        .unwrap();
+    engine.process(&mut output, 2);
+    assert_eq!(engine.transport().audio_length(), Some(352_800));
+
+    cmd_tx
+        .push(EngineCommand::RemoveNoteClip(track_id, clip_id))
+        .unwrap();
+    engine.process(&mut output, 2);
+    assert_eq!(engine.transport().audio_length(), None);
+}
+
+#[test]
 fn play_command_starts_transport() {
     let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
 

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -627,14 +627,25 @@ pub fn any_solo(tracks: &[EngineTrack]) -> bool {
     tracks.iter().any(|t| t.solo)
 }
 
-/// Calculate the total length of audio across all tracks (max clip end position).
-pub fn calculate_total_length(tracks: &[EngineTrack]) -> u64 {
-    tracks
+/// Calculate the total arrangement length across audio and note clips.
+pub fn calculate_total_length(tracks: &[EngineTrack], samples_per_beat: f64) -> u64 {
+    let audio_end = tracks
         .iter()
         .flat_map(|t| t.clips.iter())
         .map(|c| c.end_position())
         .max()
-        .unwrap_or(0)
+        .unwrap_or(0);
+    let note_end = if samples_per_beat.is_finite() && samples_per_beat > 0.0 {
+        tracks
+            .iter()
+            .flat_map(|t| t.note_clips.iter())
+            .map(|c| ((c.position_beats + c.duration_beats) * samples_per_beat).round() as u64)
+            .max()
+            .unwrap_or(0)
+    } else {
+        0
+    };
+    audio_end.max(note_end)
 }
 
 #[cfg(test)]
@@ -757,13 +768,29 @@ mod tests {
             loop_end: 0,
         });
 
-        assert_eq!(calculate_total_length(&tracks), 150);
+        assert_eq!(calculate_total_length(&tracks, 22_050.0), 150);
     }
 
     #[test]
     fn total_length_empty_tracks() {
         let tracks: Vec<EngineTrack> = vec![];
-        assert_eq!(calculate_total_length(&tracks), 0);
+        assert_eq!(calculate_total_length(&tracks, 22_050.0), 0);
+    }
+
+    #[test]
+    fn total_length_includes_note_clips() {
+        let mut tracks = vec![EngineTrack::new(TrackId::new())];
+        tracks[0].note_clips.push(EngineNoteClip {
+            id: ClipId::new(),
+            position_beats: 2.0,
+            duration_beats: 4.0,
+            notes: Vec::new(),
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+        });
+
+        assert_eq!(calculate_total_length(&tracks, 22_050.0), 132_300);
     }
 
     #[test]

--- a/crates/vibez-engine/src/transport.rs
+++ b/crates/vibez-engine/src/transport.rs
@@ -63,13 +63,11 @@ impl Transport {
         self.bpm
     }
 
-    /// Seek to an absolute sample position.  If `audio_length` is set the
-    /// position is clamped to `[0, audio_length]`.
+    /// Seek to an absolute sample position. Arrangement editing may place
+    /// the playhead beyond the current content end; `audio_length` only
+    /// controls automatic stopping during playback.
     pub fn seek(&mut self, pos: u64) {
-        self.position = match self.audio_length {
-            Some(len) => pos.min(len),
-            None => pos,
-        };
+        self.position = pos;
     }
 
     /// Set the tempo, clamped to `[MIN_BPM, MAX_BPM]`.
@@ -77,14 +75,10 @@ impl Transport {
         self.bpm = bpm.clamp(MIN_BPM, MAX_BPM);
     }
 
-    /// Set the total audio length.  Passing `None` removes the length
-    /// constraint.  If the current position exceeds the new length it is
-    /// clamped.
+    /// Set the total audio length used for automatic stopping. Passing
+    /// `None` removes that playback boundary without moving the playhead.
     pub fn set_audio_length(&mut self, length: Option<u64>) {
         self.audio_length = length;
-        if let Some(len) = length {
-            self.position = self.position.min(len);
-        }
     }
 
     /// The total audio length, if set.
@@ -199,11 +193,11 @@ mod tests {
     }
 
     #[test]
-    fn seek_with_audio_length_clamps() {
+    fn seek_with_audio_length_allows_empty_arrangement_space() {
         let mut t = Transport::new();
         t.set_audio_length(Some(44_100));
         t.seek(50_000);
-        assert_eq!(t.position(), 44_100);
+        assert_eq!(t.position(), 50_000);
         t.seek(22_050);
         assert_eq!(t.position(), 22_050);
     }
@@ -266,11 +260,11 @@ mod tests {
     }
 
     #[test]
-    fn set_audio_length_clamps_position() {
+    fn set_audio_length_does_not_move_playhead() {
         let mut t = Transport::new();
         t.seek(5000);
         t.set_audio_length(Some(2000));
-        assert_eq!(t.position(), 2000);
+        assert_eq!(t.position(), 5000);
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -66,6 +66,9 @@ pub(crate) fn global_key_handler(
             Some(Message::Arrangement(ArrangementMsg::MoveSelectedTrackDown))
         }
         iced::keyboard::Key::Character(ref c) => match c.as_str() {
+            "c" | "C" => Some(Message::Arrangement(ArrangementMsg::CopySelectedClips)),
+            "x" | "X" => Some(Message::Arrangement(ArrangementMsg::CutSelectedClips)),
+            "v" | "V" => Some(Message::Arrangement(ArrangementMsg::PasteClipsAtPlayhead)),
             "t" | "T" => {
                 if modifiers.shift() {
                     Some(Message::Arrangement(ArrangementMsg::AddInstrumentTrack))
@@ -76,7 +79,13 @@ pub(crate) fn global_key_handler(
             "m" => Some(Message::create_clip_from_selection()),
             "e" => Some(Message::split_selected_at_playhead()),
             "j" => Some(Message::join_selected_clips()),
-            "l" => Some(Message::Transport(TransportMsg::ToggleArrangementLoop)),
+            "l" | "L" => {
+                if modifiers.shift() {
+                    Some(Message::Arrangement(ArrangementMsg::ToggleSelectedClipLoop))
+                } else {
+                    Some(Message::Transport(TransportMsg::ToggleArrangementLoop))
+                }
+            }
             "0" => Some(Message::View(ViewMsg::ZoomToFit)),
             "z" | "Z" => {
                 if modifiers.shift() {

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -24,6 +24,11 @@ use super::*;
 
 impl App {
     pub(super) fn update(&mut self, message: Message) -> Task<Message> {
+        if self.state.view.edit_menu_open
+            && !matches!(&message, Message::View(ViewMsg::ToggleEditMenu))
+        {
+            self.state.view.edit_menu_open = false;
+        }
         // Auto-dismiss context menu on any action except tick/engine/menu events
         if self.state.view.context_menu.is_some() {
             let keep_menu = matches!(
@@ -193,6 +198,9 @@ impl App {
                 }
             }
             Message::View(msg) => {
+                if matches!(&msg, ViewMsg::ToggleEditMenu) {
+                    self.state.project.file_menu_open = false;
+                }
                 let ctx = crate::domains::view::ViewCtx {
                     total_beats: self.state.total_beats(),
                 };
@@ -203,6 +211,9 @@ impl App {
                 return self.apply_view_action(action);
             }
             Message::Project(msg) => {
+                if matches!(&msg, ProjectMsg::ToggleFileMenu) {
+                    self.state.view.edit_menu_open = false;
+                }
                 let ctx = crate::domains::project::ProjectCtx {
                     snapshot_now: self.take_snapshot(),
                 };

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -24,10 +24,22 @@ use super::*;
 
 impl App {
     pub(super) fn update(&mut self, message: Message) -> Task<Message> {
-        if self.state.view.edit_menu_open
-            && !matches!(&message, Message::View(ViewMsg::ToggleEditMenu))
-        {
-            self.state.view.edit_menu_open = false;
+        if self.state.view.edit_menu_open {
+            let keep_menu = matches!(
+                &message,
+                Message::Tick
+                    | Message::Transport(TransportMsg::EnginePosition(_))
+                    | Message::EngineMetering { .. }
+                    | Message::Transport(TransportMsg::EngineStopped)
+                    | Message::Arrangement(ArrangementMsg::EngineTrackMeter { .. })
+                    | Message::View(ViewMsg::ToggleEditMenu)
+                    | Message::View(ViewMsg::CursorMoved(_, _))
+                    | Message::View(ViewMsg::WindowResized(_, _))
+                    | Message::View(ViewMsg::MouseReleased)
+            );
+            if !keep_menu {
+                self.state.view.edit_menu_open = false;
+            }
         }
         // Auto-dismiss context menu on any action except tick/engine/menu events
         if self.state.view.context_menu.is_some() {

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -24,6 +24,104 @@ use crate::theme as th;
 use super::*;
 
 impl App {
+    pub(super) fn view_edit_menu_overlay(&self) -> Element<'_, Message> {
+        let item = |icon: char, label: &'static str, shortcut: &'static str, message: Message| {
+            button(
+                row![
+                    icons::icon(icon).size(12).color(th::text()),
+                    text(label).size(12).color(th::text()),
+                    horizontal_space(),
+                    text(shortcut).size(10).color(th::text_dim()),
+                ]
+                .spacing(8)
+                .align_y(iced::Alignment::Center),
+            )
+            .on_press(message)
+            .padding([7, 12])
+            .width(Length::Fill)
+            .style(|_theme: &Theme, status| button::Style {
+                background: match status {
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => None,
+                },
+                text_color: th::text(),
+                border: iced::Border::default(),
+                ..Default::default()
+            })
+        };
+
+        let menu = column![
+            item(
+                icons::COPY,
+                "Copy",
+                "Ctrl+C",
+                Message::Arrangement(ArrangementMsg::CopySelectedClips),
+            ),
+            item(
+                icons::SCISSORS,
+                "Cut",
+                "Ctrl+X",
+                Message::Arrangement(ArrangementMsg::CutSelectedClips),
+            ),
+            item(
+                icons::COPY,
+                "Paste at Playhead",
+                "Ctrl+V",
+                Message::Arrangement(ArrangementMsg::PasteClipsAtPlayhead),
+            ),
+            item(
+                icons::COPY,
+                "Duplicate",
+                "",
+                Message::Arrangement(ArrangementMsg::DuplicateSelectedClip),
+            ),
+            item(
+                icons::REPEAT,
+                "Toggle Clip Loop",
+                "Ctrl+Shift+L",
+                Message::Arrangement(ArrangementMsg::ToggleSelectedClipLoop),
+            ),
+            item(
+                icons::SCISSORS,
+                "Split Selection",
+                "Ctrl+E",
+                Message::split_selected_at_playhead(),
+            ),
+            item(
+                icons::COPY,
+                "Join Clips",
+                "Ctrl+J",
+                Message::join_selected_clips(),
+            ),
+        ]
+        .spacing(1)
+        .padding(4)
+        .width(Length::Fixed(260.0));
+
+        let card = container(menu).style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_surface().into()),
+            border: iced::Border {
+                color: th::border(),
+                width: 1.0,
+                radius: 4.0.into(),
+            },
+            ..Default::default()
+        });
+        let positioned = column![
+            vertical_space().height(Length::Fixed(42.0)),
+            row![horizontal_space().width(Length::Fixed(112.0)), card]
+        ];
+        mouse_area(
+            container(positioned)
+                .width(Length::Fill)
+                .height(Length::Fill),
+        )
+        .on_press(Message::View(ViewMsg::DismissEditMenu))
+        .into()
+    }
+
     pub(super) fn view_device_context_menu_overlay(&self) -> Element<'_, Message> {
         use crate::state::DeviceMenuCategory;
 

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -590,7 +590,7 @@ impl App {
                 let clip_id = *clip_id;
                 let is_note_clip = *is_note_clip;
 
-                let mut col = column![].spacing(0).width(Length::Fixed(200.0));
+                let mut col = column![].spacing(0).width(Length::Fixed(220.0));
 
                 col = col.push(menu_btn(
                     icons::TRASH_2,
@@ -599,26 +599,34 @@ impl App {
                 ));
                 col = col.push(menu_btn(
                     icons::COPY,
+                    "Copy".into(),
+                    Message::Arrangement(ArrangementMsg::CopySelectedClips),
+                ));
+                col = col.push(menu_btn(
+                    icons::SCISSORS,
+                    "Cut".into(),
+                    Message::Arrangement(ArrangementMsg::CutSelectedClips),
+                ));
+                col = col.push(menu_btn(
+                    icons::COPY,
                     "Duplicate".into(),
                     Message::Arrangement(ArrangementMsg::DuplicateSelectedClip),
                 ));
-
-                // Split at playhead
-                let playhead_beats = self.state.position_beats();
-                if is_note_clip {
-                    col = col.push(menu_btn(
-                        icons::SCISSORS,
-                        "Split at Playhead".into(),
-                        Message::split_note_clip(track_id, clip_id, playhead_beats),
-                    ));
-                } else {
-                    let split_sample = self.state.transport.position_samples;
-                    col = col.push(menu_btn(
-                        icons::SCISSORS,
-                        "Split at Playhead".into(),
-                        Message::split_audio_clip(track_id, clip_id, split_sample),
-                    ));
-                }
+                col = col.push(menu_btn(
+                    icons::REPEAT,
+                    "Toggle Loop".into(),
+                    Message::Arrangement(ArrangementMsg::ToggleSelectedClipLoop),
+                ));
+                col = col.push(menu_btn(
+                    icons::SCISSORS,
+                    "Split Selection (Ctrl+E)".into(),
+                    Message::split_selected_at_playhead(),
+                ));
+                col = col.push(menu_btn(
+                    icons::COPY,
+                    "Join Clips (Ctrl+J)".into(),
+                    Message::join_selected_clips(),
+                ));
 
                 // Rename clip
                 col = col.push(menu_btn(

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -675,7 +675,8 @@ impl App {
         )
         .size(11)
         .color(th::text_dim());
-        let conf_slider = slider(0.0..=1.0, conf, Message::SetWarpConfidenceThreshold).step(0.05);
+        let conf_slider =
+            slider(0.0..=1.0, conf, Message::SetWarpConfidenceThreshold).step(0.05_f32);
 
         let rewarp_btn = button(
             text("Re-warp all clips to project tempo")

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -61,6 +61,8 @@ impl App {
             stack![base_layout, self.view_settings_modal()].into()
         } else if self.state.project.file_menu_open {
             stack![base_layout, self.view_file_menu_overlay()].into()
+        } else if self.state.view.edit_menu_open {
+            stack![base_layout, self.view_edit_menu_overlay()].into()
         } else if self.state.view.context_menu.is_some() {
             stack![base_layout, self.view_context_menu_overlay()].into()
         } else if self.state.view.editing_clip_name.is_some() {
@@ -164,6 +166,24 @@ impl App {
                 }
             });
 
+        let edit_btn = button(text("Edit").size(13).color(th::text_dim()))
+            .on_press(Message::View(ViewMsg::ToggleEditMenu))
+            .padding([6, 14])
+            .style(|_theme: &Theme, status| {
+                let background = match status {
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => None,
+                };
+                button::Style {
+                    background,
+                    text_color: th::text_dim(),
+                    border: iced::Border::default(),
+                    ..Default::default()
+                }
+            });
+
         let browser_active = self.state.browser.open;
         let browser_btn = button(
             row![
@@ -216,7 +236,15 @@ impl App {
             }
         });
 
-        let header_row = row![title, file_btn, browser_btn, tabs, horizontal_space()].spacing(8);
+        let header_row = row![
+            title,
+            file_btn,
+            edit_btn,
+            browser_btn,
+            tabs,
+            horizontal_space()
+        ]
+        .spacing(8);
 
         let header = header_row.padding(10).align_y(iced::Alignment::Center);
 

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -82,6 +82,14 @@ pub enum ArrangementMsg {
     SetSelectionAsLoop,
     DeleteSelectedClip,
     DuplicateSelectedClip,
+    CopySelectedClips,
+    CutSelectedClips,
+    PasteClipsAtPlayhead,
+    ToggleSelectedClipLoop,
+    ResizeSelectedClips {
+        anchor: ArrangementSelection,
+        new_duration_beats: f64,
+    },
     DuplicateNoteClip(TrackId, ClipId),
     SplitAudioClip {
         track_id: TrackId,
@@ -138,6 +146,7 @@ impl ArrangementMsg {
                 | ArrangementMsg::SetTimeSelection { .. }
                 | ArrangementMsg::SetTimeSelectionActive(_)
                 | ArrangementMsg::SetSelectionAsLoop
+                | ArrangementMsg::CopySelectedClips
                 | ArrangementMsg::ClipBpmInputChanged { .. }
         )
     }
@@ -817,6 +826,38 @@ impl ArrangementState {
                         format!("Duplicated {count} clips")
                     });
                 }
+            }
+            ArrangementMsg::CopySelectedClips => {
+                return self.op_copy_selected_clips(ctx);
+            }
+            ArrangementMsg::CutSelectedClips => {
+                let start = self.selection_start_beats;
+                let end = self.selection_end_beats;
+                let track_id = self.time_selection_track;
+                let ranged = self.time_selection_active && end > start;
+                let copy = self.op_copy_selected_clips(ctx);
+                if copy.status.as_deref() == Some("Nothing to copy") {
+                    return copy;
+                }
+                let mut result = if ranged {
+                    self.op_delete_clips_in_region(engine, ctx, start, end, track_id)
+                } else {
+                    self.update(ArrangementMsg::DeleteSelectedClip, engine, ctx)
+                };
+                result.status = Some("Cut to clipboard".to_string());
+                return result;
+            }
+            ArrangementMsg::PasteClipsAtPlayhead => {
+                return self.op_paste_clips_at_playhead(engine, ctx);
+            }
+            ArrangementMsg::ToggleSelectedClipLoop => {
+                return self.op_toggle_selected_clip_loop(engine);
+            }
+            ArrangementMsg::ResizeSelectedClips {
+                anchor,
+                new_duration_beats,
+            } => {
+                return self.op_resize_selected_clips(engine, ctx, anchor, new_duration_beats);
             }
             ArrangementMsg::SetTimeSelection {
                 start_beats,

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -706,7 +706,7 @@ impl ArrangementState {
                                     track.clips.iter().find(|c| c.id == *clip_id).map(|clip| {
                                         let mut duplicate = clip.clone();
                                         duplicate.id = ClipId::new();
-                                        duplicate.name = format!("{} (copy)", clip.name);
+                                        duplicate.name = clip.name.clone();
                                         duplicate.position =
                                             clip.position.saturating_add(clip.duration);
                                         duplicate
@@ -741,7 +741,7 @@ impl ArrangementState {
                                             |clip| {
                                                 let mut duplicate = clip.clone();
                                                 duplicate.id = ClipId::new();
-                                                duplicate.name = format!("{} (copy)", clip.name);
+                                                duplicate.name = clip.name.clone();
                                                 duplicate.position_beats =
                                                     clip.position_beats + clip.duration_beats;
                                                 duplicate.selected_notes.clear();
@@ -858,7 +858,7 @@ impl ArrangementState {
                         new_clip_data = Some((
                             UiNoteClip {
                                 id: new_clip_id,
-                                name: format!("{} (copy)", clip.name),
+                                name: clip.name.clone(),
                                 position_beats: new_pos,
                                 duration_beats: clip.duration_beats,
                                 notes: clip.notes.clone(),

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -14,7 +14,7 @@ use vibez_core::midi::TrackKind;
 use vibez_engine::commands::EngineCommand;
 
 use super::EngineHandle;
-use crate::state::{ArrangementSelection, ArrangementState, UiClip, UiNoteClip, UiTrack};
+use crate::state::{ArrangementSelection, ArrangementState, UiNoteClip, UiTrack};
 
 /// Messages the arrangement domain handles (track tranche).
 #[derive(Debug, Clone)]
@@ -702,60 +702,31 @@ impl ArrangementState {
                     for selection in &selections {
                         match selection {
                             ArrangementSelection::AudioClip { track_id, clip_id } => {
-                                let mut dup_data = None;
-                                if let Some(track) = self.find_track(*track_id) {
-                                    if let Some(clip) =
-                                        track.clips.iter().find(|c| c.id == *clip_id)
-                                    {
-                                        let new_pos = clip.position + clip.duration;
-                                        dup_data = Some((
-                                            Arc::clone(&clip.audio),
-                                            clip.name.clone(),
-                                            clip.source.clone(),
-                                            new_pos,
-                                            clip.source_offset,
-                                            clip.duration,
-                                        ));
-                                    }
-                                }
-                                if let Some((
-                                    audio,
-                                    name,
-                                    source,
-                                    position,
-                                    source_offset,
-                                    duration,
-                                )) = dup_data
-                                {
-                                    let new_id = ClipId::new();
+                                let duplicate = self.find_track(*track_id).and_then(|track| {
+                                    track.clips.iter().find(|c| c.id == *clip_id).map(|clip| {
+                                        let mut duplicate = clip.clone();
+                                        duplicate.id = ClipId::new();
+                                        duplicate.name = format!("{} (copy)", clip.name);
+                                        duplicate.position =
+                                            clip.position.saturating_add(clip.duration);
+                                        duplicate
+                                    })
+                                });
+                                if let Some(duplicate) = duplicate {
                                     engine.send(EngineCommand::AddClip {
                                         track_id: *track_id,
-                                        clip_id: new_id,
-                                        audio: Arc::clone(&audio),
-                                        position,
-                                        source_offset,
-                                        duration,
-                                        loop_enabled: false,
-                                        loop_start: 0,
-                                        loop_end: 0,
+                                        clip_id: duplicate.id,
+                                        audio: Arc::clone(&duplicate.audio),
+                                        position: duplicate.position,
+                                        source_offset: duplicate.source_offset,
+                                        duration: duplicate.duration,
+                                        loop_enabled: duplicate.loop_enabled,
+                                        loop_start: duplicate.loop_start,
+                                        loop_end: duplicate.loop_end,
                                     });
+                                    let new_id = duplicate.id;
                                     if let Some(track) = self.find_track_mut(*track_id) {
-                                        track.clips.push(UiClip {
-                                            id: new_id,
-                                            name: format!("{name} (copy)"),
-                                            audio,
-                                            source,
-                                            position,
-                                            source_offset,
-                                            duration,
-                                            loop_enabled: false,
-                                            loop_start: 0,
-                                            loop_end: 0,
-                                            original_bpm: None,
-                                            warped: false,
-                                            warped_to_bpm: None,
-                                            original_audio: None,
-                                        });
+                                        track.clips.push(duplicate);
                                     }
                                     new_selections.insert(ArrangementSelection::AudioClip {
                                         track_id: *track_id,
@@ -764,50 +735,40 @@ impl ArrangementState {
                                 }
                             }
                             ArrangementSelection::NoteClip { track_id, clip_id } => {
-                                // Duplicate note clip inline
-                                let mut dup_data = None;
-                                if let Some(track) = self.find_track(*track_id) {
-                                    if let Some(clip) =
-                                        track.note_clips.iter().find(|c| c.id == *clip_id)
-                                    {
-                                        dup_data = Some((
-                                            clip.name.clone(),
-                                            clip.position_beats + clip.duration_beats,
-                                            clip.duration_beats,
-                                            clip.notes.clone(),
-                                        ));
-                                    }
-                                }
-                                if let Some((name, new_pos, dur, notes)) = dup_data {
-                                    let new_id = ClipId::new();
+                                let duplicate =
+                                    self.find_track(*track_id).and_then(|track| {
+                                        track.note_clips.iter().find(|c| c.id == *clip_id).map(
+                                            |clip| {
+                                                let mut duplicate = clip.clone();
+                                                duplicate.id = ClipId::new();
+                                                duplicate.name = format!("{} (copy)", clip.name);
+                                                duplicate.position_beats =
+                                                    clip.position_beats + clip.duration_beats;
+                                                duplicate.selected_notes.clear();
+                                                duplicate
+                                            },
+                                        )
+                                    });
+                                if let Some(duplicate) = duplicate {
                                     engine.send(EngineCommand::AddNoteClip {
                                         track_id: *track_id,
-                                        clip_id: new_id,
-                                        position_beats: new_pos,
-                                        duration_beats: dur,
-                                        loop_enabled: false,
-                                        loop_start_beats: 0.0,
-                                        loop_end_beats: 0.0,
+                                        clip_id: duplicate.id,
+                                        position_beats: duplicate.position_beats,
+                                        duration_beats: duplicate.duration_beats,
+                                        loop_enabled: duplicate.loop_enabled,
+                                        loop_start_beats: duplicate.loop_start_beats,
+                                        loop_end_beats: duplicate.loop_end_beats,
                                     });
-                                    for note in &notes {
+                                    for note in &duplicate.notes {
                                         engine.send(EngineCommand::AddNote {
                                             track_id: *track_id,
-                                            clip_id: new_id,
+                                            clip_id: duplicate.id,
                                             note: *note,
                                         });
                                     }
+                                    let new_id = duplicate.id;
                                     if let Some(track) = self.find_track_mut(*track_id) {
-                                        track.note_clips.push(UiNoteClip {
-                                            id: new_id,
-                                            name: format!("{name} (copy)"),
-                                            position_beats: new_pos,
-                                            duration_beats: dur,
-                                            notes,
-                                            selected_notes: HashSet::new(),
-                                            loop_enabled: false,
-                                            loop_start_beats: 0.0,
-                                            loop_end_beats: 0.0,
-                                        });
+                                        track.note_clips.push(duplicate);
                                     }
                                     new_selections.insert(ArrangementSelection::NoteClip {
                                         track_id: *track_id,
@@ -909,11 +870,16 @@ impl ArrangementState {
                             new_pos,
                             clip.duration_beats,
                             clip.notes.clone(),
+                            clip.loop_enabled,
+                            clip.loop_start_beats,
+                            clip.loop_end_beats,
                         ));
                     }
                 }
 
-                if let Some((new_clip, pos, dur, notes)) = new_clip_data {
+                if let Some((new_clip, pos, dur, notes, loop_enabled, loop_start, loop_end)) =
+                    new_clip_data
+                {
                     if let Some(track) = self.find_track_mut(track_id) {
                         track.note_clips.push(new_clip);
                     }
@@ -922,9 +888,9 @@ impl ArrangementState {
                         clip_id: new_clip_id,
                         position_beats: pos,
                         duration_beats: dur,
-                        loop_enabled: false,
-                        loop_start_beats: 0.0,
-                        loop_end_beats: 0.0,
+                        loop_enabled,
+                        loop_start_beats: loop_start,
+                        loop_end_beats: loop_end,
                     });
                     for note in &notes {
                         engine.send(EngineCommand::AddNote {

--- a/crates/vibez-ui/src/domains/arrangement/ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/ops.rs
@@ -1121,7 +1121,6 @@ impl ArrangementState {
                         continue;
                     }
                     clip.id = ClipId::new();
-                    clip.name = format!("{} (copy)", clip.name);
                     clip.position = ctx.playhead_samples.saturating_add(
                         (offset_beats * ctx.samples_per_beat).round().max(0.0) as u64,
                     );
@@ -1151,7 +1150,6 @@ impl ArrangementState {
                         continue;
                     }
                     clip.id = ClipId::new();
-                    clip.name = format!("{} (copy)", clip.name);
                     clip.position_beats = ctx.playhead_beats + offset_beats;
                     engine.send(EngineCommand::AddNoteClip {
                         track_id,

--- a/crates/vibez-ui/src/domains/arrangement/ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/ops.rs
@@ -11,7 +11,9 @@ use vibez_core::midi::MidiNote;
 use vibez_engine::commands::EngineCommand;
 
 use super::EngineHandle;
-use crate::state::{ArrangementSelection, ArrangementState, UiClip, UiNoteClip};
+use crate::state::{
+    ArrangementSelection, ArrangementState, ClipClipboard, ClipboardClip, UiClip, UiNoteClip,
+};
 
 use super::*;
 
@@ -733,6 +735,9 @@ impl ArrangementState {
         };
         let target_track = track_id;
         let spb = ctx.samples_per_beat;
+        // Preserve material outside the range. Splitting first turns
+        // the selected span into whole clips that can be removed.
+        let _ = self.op_split_clips_at_region(engine, ctx, start_beats, end_beats, track_id);
         // Collect clip IDs to remove
         let mut audio_removals: Vec<(TrackId, ClipId)> = Vec::new();
         let mut note_removals: Vec<(TrackId, ClipId)> = Vec::new();
@@ -746,14 +751,14 @@ impl ArrangementState {
                 for clip in &track.clips {
                     let clip_start = clip.position as f64 / spb;
                     let clip_end = (clip.position + clip.duration) as f64 / spb;
-                    if clip_start < end_beats && clip_end > start_beats {
+                    if clip_start >= start_beats - 1e-9 && clip_end <= end_beats + 1e-9 {
                         audio_removals.push((track.id, clip.id));
                     }
                 }
             }
             for nc in &track.note_clips {
                 let clip_end = nc.position_beats + nc.duration_beats;
-                if nc.position_beats < end_beats && clip_end > start_beats {
+                if nc.position_beats >= start_beats - 1e-9 && clip_end <= end_beats + 1e-9 {
                     note_removals.push((track.id, nc.id));
                 }
             }
@@ -980,5 +985,452 @@ impl ArrangementState {
             action.status = Some("Join requires same type and track".to_string());
         }
         action
+    }
+
+    pub(super) fn op_copy_selected_clips(&mut self, ctx: ArrangementCtx) -> ArrangementAction {
+        let mut copied = Vec::new();
+        let spb = ctx.samples_per_beat;
+
+        if self.time_selection_active
+            && self.selection_end_beats > self.selection_start_beats
+            && spb > 0.0
+        {
+            let start = self.selection_start_beats;
+            let end = self.selection_end_beats;
+            for track in self
+                .tracks
+                .iter()
+                .filter(|t| self.time_selection_track.is_none_or(|tid| t.id == tid))
+            {
+                for clip in &track.clips {
+                    let clip_start = clip.position as f64 / spb;
+                    let clip_end = (clip.position + clip.duration) as f64 / spb;
+                    let overlap_start = clip_start.max(start);
+                    let overlap_end = clip_end.min(end);
+                    if overlap_end <= overlap_start {
+                        continue;
+                    }
+                    let delta = ((overlap_start - clip_start) * spb).round() as u64;
+                    let duration = ((overlap_end - overlap_start) * spb).round() as u64;
+                    let mut fragment = clip.clone();
+                    fragment.position = 0;
+                    fragment.duration = duration.max(1);
+                    let raw_offset = clip.source_offset.saturating_add(delta);
+                    fragment.source_offset = if clip.loop_enabled && clip.loop_end > clip.loop_start
+                    {
+                        if raw_offset >= clip.loop_end {
+                            clip.loop_start
+                                + (raw_offset - clip.loop_start) % (clip.loop_end - clip.loop_start)
+                        } else {
+                            raw_offset
+                        }
+                    } else {
+                        raw_offset
+                    };
+                    copied.push(ClipboardClip::Audio {
+                        track_id: track.id,
+                        offset_beats: overlap_start - start,
+                        clip: fragment,
+                    });
+                }
+
+                for clip in &track.note_clips {
+                    let clip_end = clip.position_beats + clip.duration_beats;
+                    let overlap_start = clip.position_beats.max(start);
+                    let overlap_end = clip_end.min(end);
+                    if overlap_end <= overlap_start {
+                        continue;
+                    }
+                    let local_start = overlap_start - clip.position_beats;
+                    let local_end = overlap_end - clip.position_beats;
+                    let mut notes = Vec::new();
+                    let looping = clip.loop_enabled && clip.loop_end_beats > clip.loop_start_beats;
+                    for note in &clip.notes {
+                        let mut occurrences = vec![note.start_beat];
+                        if looping
+                            && note.start_beat >= clip.loop_start_beats
+                            && note.start_beat < clip.loop_end_beats
+                        {
+                            let loop_len = clip.loop_end_beats - clip.loop_start_beats;
+                            let mut occurrence = note.start_beat + loop_len;
+                            while occurrence < local_end {
+                                occurrences.push(occurrence);
+                                occurrence += loop_len;
+                            }
+                        }
+                        for occurrence in occurrences {
+                            let note_end = occurrence + note.duration_beats;
+                            let kept_start = occurrence.max(local_start);
+                            let kept_end = note_end.min(local_end);
+                            if kept_end > kept_start {
+                                notes.push(MidiNote {
+                                    start_beat: kept_start - local_start,
+                                    duration_beats: kept_end - kept_start,
+                                    ..*note
+                                });
+                            }
+                        }
+                    }
+                    let mut fragment = clip.clone();
+                    fragment.position_beats = 0.0;
+                    fragment.duration_beats = overlap_end - overlap_start;
+                    fragment.notes = notes;
+                    fragment.selected_notes.clear();
+                    fragment.loop_enabled = false;
+                    fragment.loop_start_beats = 0.0;
+                    fragment.loop_end_beats = 0.0;
+                    copied.push(ClipboardClip::Note {
+                        track_id: track.id,
+                        offset_beats: overlap_start - start,
+                        clip: fragment,
+                    });
+                }
+            }
+        } else {
+            let mut starts = Vec::new();
+            for selection in &self.selected_clips {
+                match selection {
+                    ArrangementSelection::AudioClip { track_id, clip_id } if spb > 0.0 => {
+                        if let Some(clip) = self
+                            .find_track(*track_id)
+                            .and_then(|t| t.clips.iter().find(|c| c.id == *clip_id))
+                        {
+                            starts.push(clip.position as f64 / spb);
+                        }
+                    }
+                    ArrangementSelection::NoteClip { track_id, clip_id } => {
+                        if let Some(clip) = self
+                            .find_track(*track_id)
+                            .and_then(|t| t.note_clips.iter().find(|c| c.id == *clip_id))
+                        {
+                            starts.push(clip.position_beats);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let anchor = starts.into_iter().reduce(f64::min).unwrap_or(0.0);
+            for selection in &self.selected_clips {
+                match selection {
+                    ArrangementSelection::AudioClip { track_id, clip_id } if spb > 0.0 => {
+                        if let Some(clip) = self
+                            .find_track(*track_id)
+                            .and_then(|t| t.clips.iter().find(|c| c.id == *clip_id))
+                        {
+                            copied.push(ClipboardClip::Audio {
+                                track_id: *track_id,
+                                offset_beats: clip.position as f64 / spb - anchor,
+                                clip: clip.clone(),
+                            });
+                        }
+                    }
+                    ArrangementSelection::NoteClip { track_id, clip_id } => {
+                        if let Some(clip) = self
+                            .find_track(*track_id)
+                            .and_then(|t| t.note_clips.iter().find(|c| c.id == *clip_id))
+                        {
+                            copied.push(ClipboardClip::Note {
+                                track_id: *track_id,
+                                offset_beats: clip.position_beats - anchor,
+                                clip: clip.clone(),
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        let count = copied.len();
+        if count > 0 {
+            self.clipboard = ClipClipboard { clips: copied };
+        }
+        ArrangementAction {
+            status: Some(if count == 0 {
+                "Nothing to copy".to_string()
+            } else if count == 1 {
+                "Copied clip".to_string()
+            } else {
+                format!("Copied {count} clips")
+            }),
+            ..Default::default()
+        }
+    }
+
+    pub(super) fn op_paste_clips_at_playhead(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        ctx: ArrangementCtx,
+    ) -> ArrangementAction {
+        if self.clipboard.clips.is_empty() || ctx.samples_per_beat <= 0.0 {
+            return ArrangementAction {
+                status: Some("Clipboard is empty".to_string()),
+                ..Default::default()
+            };
+        }
+        let entries = self.clipboard.clips.clone();
+        let mut selected = HashSet::new();
+        for entry in entries {
+            match entry {
+                ClipboardClip::Audio {
+                    track_id,
+                    offset_beats,
+                    mut clip,
+                } => {
+                    if self.find_track(track_id).is_none() {
+                        continue;
+                    }
+                    clip.id = ClipId::new();
+                    clip.name = format!("{} (copy)", clip.name);
+                    clip.position = ctx.playhead_samples.saturating_add(
+                        (offset_beats * ctx.samples_per_beat).round().max(0.0) as u64,
+                    );
+                    engine.send(EngineCommand::AddClip {
+                        track_id,
+                        clip_id: clip.id,
+                        audio: Arc::clone(&clip.audio),
+                        position: clip.position,
+                        source_offset: clip.source_offset,
+                        duration: clip.duration,
+                        loop_enabled: clip.loop_enabled,
+                        loop_start: clip.loop_start,
+                        loop_end: clip.loop_end,
+                    });
+                    selected.insert(ArrangementSelection::AudioClip {
+                        track_id,
+                        clip_id: clip.id,
+                    });
+                    self.find_track_mut(track_id).unwrap().clips.push(clip);
+                }
+                ClipboardClip::Note {
+                    track_id,
+                    offset_beats,
+                    mut clip,
+                } => {
+                    if self.find_track(track_id).is_none() {
+                        continue;
+                    }
+                    clip.id = ClipId::new();
+                    clip.name = format!("{} (copy)", clip.name);
+                    clip.position_beats = ctx.playhead_beats + offset_beats;
+                    engine.send(EngineCommand::AddNoteClip {
+                        track_id,
+                        clip_id: clip.id,
+                        position_beats: clip.position_beats,
+                        duration_beats: clip.duration_beats,
+                        loop_enabled: clip.loop_enabled,
+                        loop_start_beats: clip.loop_start_beats,
+                        loop_end_beats: clip.loop_end_beats,
+                    });
+                    for note in &clip.notes {
+                        engine.send(EngineCommand::AddNote {
+                            track_id,
+                            clip_id: clip.id,
+                            note: *note,
+                        });
+                    }
+                    selected.insert(ArrangementSelection::NoteClip {
+                        track_id,
+                        clip_id: clip.id,
+                    });
+                    self.find_track_mut(track_id).unwrap().note_clips.push(clip);
+                }
+            }
+        }
+        let count = selected.len();
+        self.selected_clips = selected;
+        self.time_selection_active = false;
+        ArrangementAction {
+            status: Some(if count == 1 {
+                "Pasted clip".to_string()
+            } else {
+                format!("Pasted {count} clips")
+            }),
+            ..Default::default()
+        }
+    }
+
+    pub(super) fn op_toggle_selected_clip_loop(
+        &mut self,
+        engine: &mut impl EngineHandle,
+    ) -> ArrangementAction {
+        let selections: Vec<_> = self.selected_clips.iter().copied().collect();
+        let enable = selections.iter().any(|selection| match selection {
+            ArrangementSelection::AudioClip { track_id, clip_id } => self
+                .find_track(*track_id)
+                .and_then(|t| t.clips.iter().find(|c| c.id == *clip_id))
+                .is_some_and(|c| !c.loop_enabled),
+            ArrangementSelection::NoteClip { track_id, clip_id } => self
+                .find_track(*track_id)
+                .and_then(|t| t.note_clips.iter().find(|c| c.id == *clip_id))
+                .is_some_and(|c| !c.loop_enabled),
+        });
+        let mut changed = 0;
+        for selection in selections {
+            match selection {
+                ArrangementSelection::AudioClip { track_id, clip_id } => {
+                    let mut command = None;
+                    if let Some(clip) = self
+                        .find_track_mut(track_id)
+                        .and_then(|t| t.clips.iter_mut().find(|c| c.id == clip_id))
+                    {
+                        clip.loop_enabled = enable;
+                        if enable && clip.loop_end <= clip.loop_start {
+                            clip.loop_start = clip.source_offset;
+                            clip.loop_end = clip.source_offset.saturating_add(clip.duration);
+                        }
+                        command = Some((clip.loop_start, clip.loop_end));
+                        changed += 1;
+                    }
+                    if let Some((loop_start, loop_end)) = command {
+                        engine.send(EngineCommand::SetClipLoop {
+                            track_id,
+                            clip_id,
+                            enabled: enable,
+                            loop_start,
+                            loop_end,
+                        });
+                    }
+                }
+                ArrangementSelection::NoteClip { track_id, clip_id } => {
+                    let mut command = None;
+                    if let Some(clip) = self
+                        .find_track_mut(track_id)
+                        .and_then(|t| t.note_clips.iter_mut().find(|c| c.id == clip_id))
+                    {
+                        clip.loop_enabled = enable;
+                        if enable && clip.loop_end_beats <= clip.loop_start_beats {
+                            clip.loop_start_beats = 0.0;
+                            clip.loop_end_beats = clip.duration_beats;
+                        }
+                        command = Some((clip.loop_start_beats, clip.loop_end_beats));
+                        changed += 1;
+                    }
+                    if let Some((loop_start_beats, loop_end_beats)) = command {
+                        engine.send(EngineCommand::SetNoteClipLoop {
+                            track_id,
+                            clip_id,
+                            enabled: enable,
+                            loop_start_beats,
+                            loop_end_beats,
+                        });
+                    }
+                }
+            }
+        }
+        ArrangementAction {
+            status: (changed > 0).then(|| {
+                format!(
+                    "{} loop for {changed} clip{}",
+                    if enable { "Enabled" } else { "Disabled" },
+                    if changed == 1 { "" } else { "s" }
+                )
+            }),
+            ..Default::default()
+        }
+    }
+
+    pub(super) fn op_resize_selected_clips(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        ctx: ArrangementCtx,
+        anchor: ArrangementSelection,
+        new_duration_beats: f64,
+    ) -> ArrangementAction {
+        if ctx.samples_per_beat <= 0.0 {
+            return ArrangementAction::default();
+        }
+        let anchor_duration = match anchor {
+            ArrangementSelection::AudioClip { track_id, clip_id } => self
+                .find_track(track_id)
+                .and_then(|t| t.clips.iter().find(|c| c.id == clip_id))
+                .map(|c| c.duration as f64 / ctx.samples_per_beat),
+            ArrangementSelection::NoteClip { track_id, clip_id } => self
+                .find_track(track_id)
+                .and_then(|t| t.note_clips.iter().find(|c| c.id == clip_id))
+                .map(|c| c.duration_beats),
+        };
+        let Some(anchor_duration) = anchor_duration else {
+            return ArrangementAction::default();
+        };
+        let delta = new_duration_beats - anchor_duration;
+        let targets: Vec<_> = if self.selected_clips.contains(&anchor) {
+            self.selected_clips.iter().copied().collect()
+        } else {
+            vec![anchor]
+        };
+        let mut max_end = None::<f64>;
+        for target in targets {
+            match target {
+                ArrangementSelection::AudioClip { track_id, clip_id } => {
+                    let old = self
+                        .find_track(track_id)
+                        .and_then(|t| t.clips.iter().find(|c| c.id == clip_id))
+                        .map(|c| c.duration as f64 / ctx.samples_per_beat);
+                    if let Some(old) = old {
+                        let duration =
+                            ((old + delta).max(0.25) * ctx.samples_per_beat).round() as u64;
+                        let action = self.update(
+                            ArrangementMsg::ResizeAudioClip {
+                                track_id,
+                                clip_id,
+                                new_duration: duration.max(1),
+                            },
+                            engine,
+                            ctx,
+                        );
+                        max_end = match (max_end, action.scroll_to_beat) {
+                            (Some(a), Some(b)) => Some(a.max(b)),
+                            (None, value) | (value, None) => value,
+                        };
+                    }
+                }
+                ArrangementSelection::NoteClip { track_id, clip_id } => {
+                    let mut sync = None;
+                    if let Some(clip) = self
+                        .find_track_mut(track_id)
+                        .and_then(|t| t.note_clips.iter_mut().find(|c| c.id == clip_id))
+                    {
+                        clip.duration_beats = (clip.duration_beats + delta).max(0.25);
+                        if clip.loop_enabled && clip.loop_end_beats > clip.duration_beats {
+                            clip.loop_end_beats = clip.duration_beats;
+                            if clip.loop_start_beats >= clip.loop_end_beats {
+                                clip.loop_start_beats = 0.0;
+                            }
+                        }
+                        sync = Some(clip.clone());
+                        max_end = Some(
+                            max_end
+                                .unwrap_or(0.0)
+                                .max(clip.position_beats + clip.duration_beats),
+                        );
+                    }
+                    if let Some(clip) = sync {
+                        engine.send(EngineCommand::RemoveNoteClip(track_id, clip_id));
+                        engine.send(EngineCommand::AddNoteClip {
+                            track_id,
+                            clip_id,
+                            position_beats: clip.position_beats,
+                            duration_beats: clip.duration_beats,
+                            loop_enabled: clip.loop_enabled,
+                            loop_start_beats: clip.loop_start_beats,
+                            loop_end_beats: clip.loop_end_beats,
+                        });
+                        for note in clip.notes {
+                            engine.send(EngineCommand::AddNote {
+                                track_id,
+                                clip_id,
+                                note,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        self.drag_resize_active = true;
+        ArrangementAction {
+            scroll_to_beat: max_end,
+            ..Default::default()
+        }
     }
 }

--- a/crates/vibez-ui/src/domains/arrangement/ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/ops.rs
@@ -17,6 +17,52 @@ use crate::state::{
 
 use super::*;
 
+fn audio_source_frame(clip: &UiClip, local_frame: u64) -> usize {
+    let raw = clip.source_offset.saturating_add(local_frame);
+    if clip.loop_enabled && clip.loop_end > clip.loop_start && raw >= clip.loop_end {
+        let loop_len = clip.loop_end - clip.loop_start;
+        (clip.loop_start + (raw - clip.loop_start) % loop_len) as usize
+    } else {
+        raw as usize
+    }
+}
+
+fn visible_notes(clip: &UiNoteClip, local_start: f64, local_end: f64) -> Vec<MidiNote> {
+    let looping = clip.loop_enabled && clip.loop_end_beats > clip.loop_start_beats;
+    let mut visible = Vec::new();
+    for note in &clip.notes {
+        let mut occurrence = note.start_beat;
+        loop {
+            let note_end = occurrence + note.duration_beats;
+            let kept_start = occurrence.max(local_start);
+            let kept_end = note_end.min(local_end);
+            if kept_end > kept_start {
+                visible.push(MidiNote {
+                    start_beat: kept_start - local_start,
+                    duration_beats: kept_end - kept_start,
+                    ..*note
+                });
+            }
+            if !looping
+                || note.start_beat < clip.loop_start_beats
+                || note.start_beat >= clip.loop_end_beats
+            {
+                break;
+            }
+            occurrence += clip.loop_end_beats - clip.loop_start_beats;
+            if occurrence >= local_end {
+                break;
+            }
+        }
+    }
+    visible.sort_by(|a, b| {
+        a.start_beat
+            .partial_cmp(&b.start_beat)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    visible
+}
+
 impl ArrangementState {
     /// A background warp finished: swap in the stretched audio and
     /// record the warp geometry on the clip.
@@ -255,17 +301,11 @@ impl ArrangementState {
             })
             .collect();
 
-        let mut clip_data: Vec<(u64, u64, u64, Arc<vibez_core::audio_buffer::DecodedAudio>)> =
-            Vec::new();
+        let mut clip_data: Vec<UiClip> = Vec::new();
         if let Some(track) = self.find_track(track_id) {
             for cid in &clip_ids {
                 if let Some(clip) = track.clips.iter().find(|c| c.id == *cid) {
-                    clip_data.push((
-                        clip.position,
-                        clip.source_offset,
-                        clip.duration,
-                        Arc::clone(&clip.audio),
-                    ));
+                    clip_data.push(clip.clone());
                 }
             }
         }
@@ -275,40 +315,42 @@ impl ArrangementState {
         }
 
         // Sort by position
-        clip_data.sort_by_key(|(pos, _, _, _)| *pos);
+        clip_data.sort_by_key(|clip| clip.position);
 
-        let start_pos = clip_data[0].0;
+        let start_pos = clip_data[0].position;
         let end_pos = clip_data
             .iter()
-            .map(|(pos, _, dur, _)| pos + dur)
+            .map(|clip| clip.position.saturating_add(clip.duration))
             .max()
             .unwrap_or(start_pos);
         let total_duration = end_pos - start_pos;
+        let joined_loop_enabled = clip_data.iter().any(|clip| clip.loop_enabled);
 
         // Determine channel count from first clip
-        let channels = clip_data[0].3.num_channels();
-        let sr = clip_data[0].3.sample_rate;
+        let channels = clip_data[0].audio.num_channels();
+        let sr = clip_data[0].audio.sample_rate;
 
         // Create joined buffer filled with silence
         let mut joined_channels: Vec<Vec<f32>> = (0..channels)
             .map(|_| vec![0.0f32; total_duration as usize])
             .collect();
 
-        // Copy each clip's audio into the correct offset
-        for (pos, source_offset, duration, audio) in &clip_data {
-            let offset_in_joined = (*pos - start_pos) as usize;
-            let src_off = *source_offset as usize;
-            let dur = *duration as usize;
-            let ch_count = channels.min(audio.num_channels());
+        // Consolidate the audible arrangement result, including source
+        // wrapping for clips whose visible duration exceeds their loop.
+        for clip in &clip_data {
+            let offset_in_joined = (clip.position - start_pos) as usize;
+            let dur = clip.duration as usize;
+            let ch_count = channels.min(clip.audio.num_channels());
             for (ch, dst) in joined_channels.iter_mut().enumerate().take(ch_count) {
-                let src = &audio.channels[ch];
-                let src_end = (src_off + dur).min(src.len());
-                let copy_len = src_end.saturating_sub(src_off);
-                let dst_end = (offset_in_joined + copy_len).min(dst.len());
-                let actual_len = dst_end.saturating_sub(offset_in_joined);
-                if actual_len > 0 {
-                    dst[offset_in_joined..offset_in_joined + actual_len]
-                        .copy_from_slice(&src[src_off..src_off + actual_len]);
+                for local in 0..dur {
+                    let dst_frame = offset_in_joined + local;
+                    if dst_frame >= dst.len() {
+                        break;
+                    }
+                    let source_frame = audio_source_frame(clip, local as u64);
+                    if let Some(sample) = clip.audio.channels[ch].get(source_frame) {
+                        dst[dst_frame] = *sample;
+                    }
                 }
             }
         }
@@ -336,9 +378,9 @@ impl ArrangementState {
             position: start_pos,
             source_offset: 0,
             duration: total_duration,
-            loop_enabled: false,
+            loop_enabled: joined_loop_enabled,
             loop_start: 0,
-            loop_end: 0,
+            loop_end: total_duration,
         });
         if let Some(track) = self.find_track_mut(track_id) {
             track.clips.push(UiClip {
@@ -349,9 +391,9 @@ impl ArrangementState {
                 position: start_pos,
                 source_offset: 0,
                 duration: total_duration,
-                loop_enabled: false,
+                loop_enabled: joined_loop_enabled,
                 loop_start: 0,
-                loop_end: 0,
+                loop_end: total_duration,
                 original_bpm: None,
                 warped: false,
                 warped_to_bpm: None,
@@ -381,11 +423,11 @@ impl ArrangementState {
             })
             .collect();
 
-        let mut clip_data: Vec<(f64, f64, Vec<MidiNote>)> = Vec::new();
+        let mut clip_data: Vec<UiNoteClip> = Vec::new();
         if let Some(track) = self.find_track(track_id) {
             for cid in &clip_ids {
                 if let Some(clip) = track.note_clips.iter().find(|c| c.id == *cid) {
-                    clip_data.push((clip.position_beats, clip.duration_beats, clip.notes.clone()));
+                    clip_data.push(clip.clone());
                 }
             }
         }
@@ -395,23 +437,28 @@ impl ArrangementState {
         }
 
         // Sort by position
-        clip_data.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        clip_data.sort_by(|a, b| {
+            a.position_beats
+                .partial_cmp(&b.position_beats)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
-        let start_pos = clip_data[0].0;
+        let start_pos = clip_data[0].position_beats;
         let end_pos = clip_data
             .iter()
-            .map(|(pos, dur, _)| pos + dur)
+            .map(|clip| clip.position_beats + clip.duration_beats)
             .fold(0.0_f64, f64::max);
         let total_duration = end_pos - start_pos;
+        let joined_loop_enabled = clip_data.iter().any(|clip| clip.loop_enabled);
 
-        // Merge notes with adjusted offsets
+        // Merge the audible notes, expanding repeated loop occurrences.
         let mut merged_notes: Vec<MidiNote> = Vec::new();
-        for (pos, _, notes) in &clip_data {
-            let offset = pos - start_pos;
-            for note in notes {
+        for clip in &clip_data {
+            let offset = clip.position_beats - start_pos;
+            for note in visible_notes(clip, 0.0, clip.duration_beats) {
                 merged_notes.push(MidiNote {
                     start_beat: note.start_beat + offset,
-                    ..*note
+                    ..note
                 });
             }
         }
@@ -431,9 +478,9 @@ impl ArrangementState {
             clip_id: new_id,
             position_beats: start_pos,
             duration_beats: total_duration,
-            loop_enabled: false,
+            loop_enabled: joined_loop_enabled,
             loop_start_beats: 0.0,
-            loop_end_beats: 0.0,
+            loop_end_beats: total_duration,
         });
         for note in &merged_notes {
             engine.send(EngineCommand::AddNote {
@@ -450,9 +497,9 @@ impl ArrangementState {
                 duration_beats: total_duration,
                 notes: merged_notes,
                 selected_notes: HashSet::new(),
-                loop_enabled: false,
+                loop_enabled: joined_loop_enabled,
                 loop_start_beats: 0.0,
-                loop_end_beats: 0.0,
+                loop_end_beats: total_duration,
             });
         }
 
@@ -474,112 +521,53 @@ impl ArrangementState {
         split_position: u64,
     ) -> ArrangementAction {
         let mut action = ArrangementAction::default();
-        let mut split_data = None;
-        if let Some(track) = self.find_track(track_id) {
-            if let Some(clip) = track.clips.iter().find(|c| c.id == clip_id) {
-                if split_position > clip.position && split_position < clip.position + clip.duration
-                {
-                    let left_dur = split_position - clip.position;
-                    let right_dur = clip.duration - left_dur;
-                    let right_source_offset = clip.source_offset + left_dur;
-                    split_data = Some((
-                        Arc::clone(&clip.audio),
-                        clip.name.clone(),
-                        clip.source.clone(),
-                        clip.position,
-                        clip.source_offset,
-                        left_dur,
-                        split_position,
-                        right_source_offset,
-                        right_dur,
-                    ));
-                }
-            }
-        }
-        if let Some((
-            audio,
-            name,
-            source,
-            orig_pos,
-            orig_offset,
-            left_dur,
-            right_pos,
-            right_offset,
-            right_dur,
-        )) = split_data
-        {
-            let left_id = ClipId::new();
-            let right_id = ClipId::new();
+        let split = self
+            .find_track(track_id)
+            .and_then(|track| track.clips.iter().find(|clip| clip.id == clip_id))
+            .filter(|clip| {
+                split_position > clip.position
+                    && split_position < clip.position.saturating_add(clip.duration)
+            })
+            .map(|clip| {
+                let left_duration = split_position - clip.position;
+                let mut left = clip.clone();
+                left.id = ClipId::new();
+                left.name = format!("{} L", clip.name);
+                left.duration = left_duration;
 
-            // Remove original
+                let mut right = clip.clone();
+                right.id = ClipId::new();
+                right.name = format!("{} R", clip.name);
+                right.position = split_position;
+                right.duration = clip.duration - left_duration;
+                right.source_offset = audio_source_frame(clip, left_duration) as u64;
+                (left, right)
+            });
+        if let Some((left, right)) = split {
+            let left_id = left.id;
+
             engine.send(EngineCommand::RemoveClip(track_id, clip_id));
             if let Some(track) = self.find_track_mut(track_id) {
                 track.clips.retain(|c| c.id != clip_id);
             }
 
-            // Add left half
-            engine.send(EngineCommand::AddClip {
-                track_id,
-                clip_id: left_id,
-                audio: Arc::clone(&audio),
-                position: orig_pos,
-                source_offset: orig_offset,
-                duration: left_dur,
-                loop_enabled: false,
-                loop_start: 0,
-                loop_end: 0,
-            });
-            if let Some(track) = self.find_track_mut(track_id) {
-                track.clips.push(UiClip {
-                    id: left_id,
-                    name: format!("{name} L"),
-                    audio: Arc::clone(&audio),
-                    source: source.clone(),
-                    position: orig_pos,
-                    source_offset: orig_offset,
-                    duration: left_dur,
-                    loop_enabled: false,
-                    loop_start: 0,
-                    loop_end: 0,
-                    original_bpm: None,
-                    warped: false,
-                    warped_to_bpm: None,
-                    original_audio: None,
+            for clip in [&left, &right] {
+                engine.send(EngineCommand::AddClip {
+                    track_id,
+                    clip_id: clip.id,
+                    audio: Arc::clone(&clip.audio),
+                    position: clip.position,
+                    source_offset: clip.source_offset,
+                    duration: clip.duration,
+                    loop_enabled: clip.loop_enabled,
+                    loop_start: clip.loop_start,
+                    loop_end: clip.loop_end,
                 });
             }
-
-            // Add right half
-            engine.send(EngineCommand::AddClip {
-                track_id,
-                clip_id: right_id,
-                audio: Arc::clone(&audio),
-                position: right_pos,
-                source_offset: right_offset,
-                duration: right_dur,
-                loop_enabled: false,
-                loop_start: 0,
-                loop_end: 0,
-            });
             if let Some(track) = self.find_track_mut(track_id) {
-                track.clips.push(UiClip {
-                    id: right_id,
-                    name: format!("{name} R"),
-                    audio,
-                    source,
-                    position: right_pos,
-                    source_offset: right_offset,
-                    duration: right_dur,
-                    loop_enabled: false,
-                    loop_start: 0,
-                    loop_end: 0,
-                    original_bpm: None,
-                    warped: false,
-                    warped_to_bpm: None,
-                    original_audio: None,
-                });
+                track.clips.extend([left, right]);
             }
 
-            // Update selection: remove original, add left half
             self.selected_clips
                 .remove(&ArrangementSelection::AudioClip { track_id, clip_id });
             self.selected_clips.insert(ArrangementSelection::AudioClip {
@@ -600,115 +588,67 @@ impl ArrangementState {
         split_beat: f64,
     ) -> ArrangementAction {
         let mut action = ArrangementAction::default();
-        let mut split_data = None;
-        if let Some(track) = self.find_track(track_id) {
-            if let Some(clip) = track.note_clips.iter().find(|c| c.id == clip_id) {
-                let clip_end = clip.position_beats + clip.duration_beats;
-                if split_beat > clip.position_beats && split_beat < clip_end {
-                    let local_split = split_beat - clip.position_beats;
-                    let left_dur = local_split;
-                    let right_dur = clip.duration_beats - local_split;
+        let split = self
+            .find_track(track_id)
+            .and_then(|track| track.note_clips.iter().find(|clip| clip.id == clip_id))
+            .filter(|clip| {
+                split_beat > clip.position_beats
+                    && split_beat < clip.position_beats + clip.duration_beats
+            })
+            .map(|clip| {
+                let local_split = split_beat - clip.position_beats;
+                let mut left = clip.clone();
+                left.id = ClipId::new();
+                left.name = format!("{} L", clip.name);
+                left.duration_beats = local_split;
+                left.notes = visible_notes(clip, 0.0, local_split);
+                left.selected_notes.clear();
 
-                    let mut left_notes = Vec::new();
-                    let mut right_notes = Vec::new();
-                    for note in &clip.notes {
-                        if note.start_beat < local_split {
-                            left_notes.push(*note);
-                        } else {
-                            right_notes.push(MidiNote {
-                                start_beat: note.start_beat - local_split,
-                                ..*note
-                            });
-                        }
-                    }
+                let mut right = clip.clone();
+                right.id = ClipId::new();
+                right.name = format!("{} R", clip.name);
+                right.position_beats = split_beat;
+                right.duration_beats = clip.duration_beats - local_split;
+                right.notes = visible_notes(clip, local_split, clip.duration_beats);
+                right.selected_notes.clear();
 
-                    split_data = Some((
-                        clip.name.clone(),
-                        clip.position_beats,
-                        left_dur,
-                        split_beat,
-                        right_dur,
-                        left_notes,
-                        right_notes,
-                    ));
+                if clip.loop_enabled {
+                    left.loop_start_beats = 0.0;
+                    left.loop_end_beats = left.duration_beats;
+                    right.loop_start_beats = 0.0;
+                    right.loop_end_beats = right.duration_beats;
                 }
-            }
-        }
-        if let Some((name, orig_pos, left_dur, right_pos, right_dur, left_notes, right_notes)) =
-            split_data
-        {
-            let left_id = ClipId::new();
-            let right_id = ClipId::new();
-
-            // Remove original
+                (left, right)
+            });
+        if let Some((left, right)) = split {
+            let left_id = left.id;
             engine.send(EngineCommand::RemoveNoteClip(track_id, clip_id));
             if let Some(track) = self.find_track_mut(track_id) {
                 track.note_clips.retain(|c| c.id != clip_id);
             }
 
-            // Add left half
-            engine.send(EngineCommand::AddNoteClip {
-                track_id,
-                clip_id: left_id,
-                position_beats: orig_pos,
-                duration_beats: left_dur,
-                loop_enabled: false,
-                loop_start_beats: 0.0,
-                loop_end_beats: 0.0,
-            });
-            for note in &left_notes {
-                engine.send(EngineCommand::AddNote {
+            for clip in [&left, &right] {
+                engine.send(EngineCommand::AddNoteClip {
                     track_id,
-                    clip_id: left_id,
-                    note: *note,
+                    clip_id: clip.id,
+                    position_beats: clip.position_beats,
+                    duration_beats: clip.duration_beats,
+                    loop_enabled: clip.loop_enabled,
+                    loop_start_beats: clip.loop_start_beats,
+                    loop_end_beats: clip.loop_end_beats,
                 });
+                for note in &clip.notes {
+                    engine.send(EngineCommand::AddNote {
+                        track_id,
+                        clip_id: clip.id,
+                        note: *note,
+                    });
+                }
             }
             if let Some(track) = self.find_track_mut(track_id) {
-                track.note_clips.push(UiNoteClip {
-                    id: left_id,
-                    name: format!("{name} L"),
-                    position_beats: orig_pos,
-                    duration_beats: left_dur,
-                    notes: left_notes,
-                    selected_notes: HashSet::new(),
-                    loop_enabled: false,
-                    loop_start_beats: 0.0,
-                    loop_end_beats: 0.0,
-                });
+                track.note_clips.extend([left, right]);
             }
 
-            // Add right half
-            engine.send(EngineCommand::AddNoteClip {
-                track_id,
-                clip_id: right_id,
-                position_beats: right_pos,
-                duration_beats: right_dur,
-                loop_enabled: false,
-                loop_start_beats: 0.0,
-                loop_end_beats: 0.0,
-            });
-            for note in &right_notes {
-                engine.send(EngineCommand::AddNote {
-                    track_id,
-                    clip_id: right_id,
-                    note: *note,
-                });
-            }
-            if let Some(track) = self.find_track_mut(track_id) {
-                track.note_clips.push(UiNoteClip {
-                    id: right_id,
-                    name: format!("{name} R"),
-                    position_beats: right_pos,
-                    duration_beats: right_dur,
-                    notes: right_notes,
-                    selected_notes: HashSet::new(),
-                    loop_enabled: false,
-                    loop_start_beats: 0.0,
-                    loop_end_beats: 0.0,
-                });
-            }
-
-            // Update selection: remove original, add left half
             self.selected_clips
                 .remove(&ArrangementSelection::NoteClip { track_id, clip_id });
             self.selected_clips.insert(ArrangementSelection::NoteClip {

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::domains::test_support::RecordingEngine;
+use crate::state::UiClip;
 use vibez_core::midi::MidiNote;
 
 fn arrangement_with_tracks(n: usize) -> ArrangementState {
@@ -398,6 +399,7 @@ fn copy_and_paste_multiple_clips_at_playhead_preserves_layout_and_loops() {
     assert_eq!(pasted[0].position, 1_000);
     assert_eq!(pasted[1].position, 1_200);
     assert!(pasted[0].loop_enabled);
+    assert!(pasted.iter().all(|clip| clip.name == "Clip"));
     assert_eq!(a.selected_clips.len(), 2);
 }
 
@@ -590,6 +592,66 @@ fn duplicate_preserves_audio_and_midi_loop_settings() {
             ..
         }
     )));
+}
+
+#[test]
+fn repeated_duplicate_keeps_the_source_clip_name_readable() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut a, 0, 0, 100);
+    a.tracks[0].clips[0].name = "OTH_128_Hub_Full.wav".to_string();
+    a.selected_clips
+        .insert(ArrangementSelection::AudioClip { track_id, clip_id });
+    let mut engine = RecordingEngine::default();
+
+    for _ in 0..4 {
+        a.update(
+            ArrangementMsg::DuplicateSelectedClip,
+            &mut engine,
+            ArrangementCtx::default(),
+        );
+    }
+
+    assert!(a.tracks[0]
+        .clips
+        .iter()
+        .all(|clip| clip.name == "OTH_128_Hub_Full.wav"));
+}
+
+#[test]
+fn midi_duplicate_keeps_the_source_clip_name_readable() {
+    let mut a = arrangement_with_tracks(1);
+    let mut engine = RecordingEngine::default();
+    a.update(
+        ArrangementMsg::AddMidiTrack,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    let track_id = a.tracks[1].id;
+    let clip_id = ClipId::new();
+    a.tracks[1].note_clips.push(UiNoteClip {
+        id: clip_id,
+        name: "Pattern 1".to_string(),
+        position_beats: 0.0,
+        duration_beats: 4.0,
+        notes: Vec::new(),
+        selected_notes: HashSet::new(),
+        loop_enabled: false,
+        loop_start_beats: 0.0,
+        loop_end_beats: 0.0,
+    });
+    a.selected_clips
+        .insert(ArrangementSelection::NoteClip { track_id, clip_id });
+
+    a.update(
+        ArrangementMsg::DuplicateSelectedClip,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    assert!(a.tracks[1]
+        .note_clips
+        .iter()
+        .all(|clip| clip.name == "Pattern 1"));
 }
 
 #[test]

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -513,3 +513,232 @@ fn loop_toggle_and_resize_apply_to_the_whole_clip_selection() {
     assert_eq!(a.tracks[0].clips[0].duration, 400);
     assert_eq!(a.tracks[1].clips[0].duration, 500);
 }
+
+#[test]
+fn duplicate_preserves_audio_and_midi_loop_settings() {
+    let mut a = arrangement_with_tracks(1);
+    let (audio_tid, audio_id) = add_audio_clip(&mut a, 0, 0, 300);
+    let audio = &mut a.tracks[0].clips[0];
+    audio.loop_enabled = true;
+    audio.loop_start = 10;
+    audio.loop_end = 110;
+
+    let mut engine = RecordingEngine::default();
+    a.update(
+        ArrangementMsg::AddMidiTrack,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    let midi_tid = a.tracks[1].id;
+    let midi_id = ClipId::new();
+    a.tracks[1].note_clips.push(UiNoteClip {
+        id: midi_id,
+        name: "Loop".to_string(),
+        position_beats: 0.0,
+        duration_beats: 8.0,
+        notes: vec![MidiNote {
+            pitch: 60,
+            velocity: 100,
+            start_beat: 0.0,
+            duration_beats: 1.0,
+        }],
+        selected_notes: HashSet::new(),
+        loop_enabled: true,
+        loop_start_beats: 0.0,
+        loop_end_beats: 4.0,
+    });
+    a.selected_clips.insert(ArrangementSelection::AudioClip {
+        track_id: audio_tid,
+        clip_id: audio_id,
+    });
+    a.selected_clips.insert(ArrangementSelection::NoteClip {
+        track_id: midi_tid,
+        clip_id: midi_id,
+    });
+    engine.0.clear();
+
+    a.update(
+        ArrangementMsg::DuplicateSelectedClip,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    let audio_copy = a.tracks[0].clips.last().unwrap();
+    assert!(audio_copy.loop_enabled);
+    assert_eq!((audio_copy.loop_start, audio_copy.loop_end), (10, 110));
+    let midi_copy = a.tracks[1].note_clips.last().unwrap();
+    assert!(midi_copy.loop_enabled);
+    assert_eq!(
+        (midi_copy.loop_start_beats, midi_copy.loop_end_beats),
+        (0.0, 4.0)
+    );
+    assert!(engine.0.iter().any(|command| matches!(
+        command,
+        EngineCommand::AddClip {
+            loop_enabled: true,
+            loop_start: 10,
+            loop_end: 110,
+            ..
+        }
+    )));
+    assert!(engine.0.iter().any(|command| matches!(
+        command,
+        EngineCommand::AddNoteClip {
+            loop_enabled: true,
+            loop_start_beats: 0.0,
+            loop_end_beats: 4.0,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn split_looped_audio_preserves_source_phase() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut a, 0, 0, 300);
+    let clip = &mut a.tracks[0].clips[0];
+    clip.loop_enabled = true;
+    clip.loop_start = 0;
+    clip.loop_end = 100;
+    let mut engine = RecordingEngine::default();
+
+    a.update(
+        ArrangementMsg::SplitAudioClip {
+            track_id,
+            clip_id,
+            split_position: 150,
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    let mut halves: Vec<_> = a.tracks[0].clips.iter().collect();
+    halves.sort_by_key(|clip| clip.position);
+    assert!(halves.iter().all(|clip| clip.loop_enabled));
+    assert_eq!(halves[1].source_offset, 50);
+    assert_eq!((halves[1].loop_start, halves[1].loop_end), (0, 100));
+}
+
+#[test]
+fn split_looped_midi_materializes_both_looped_halves() {
+    let mut a = arrangement_with_tracks(1);
+    let mut engine = RecordingEngine::default();
+    a.update(
+        ArrangementMsg::AddMidiTrack,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    let track_id = a.tracks[1].id;
+    let clip_id = ClipId::new();
+    a.tracks[1].note_clips.push(UiNoteClip {
+        id: clip_id,
+        name: "Pattern".to_string(),
+        position_beats: 0.0,
+        duration_beats: 8.0,
+        notes: vec![MidiNote {
+            pitch: 60,
+            velocity: 100,
+            start_beat: 2.0,
+            duration_beats: 1.0,
+        }],
+        selected_notes: HashSet::new(),
+        loop_enabled: true,
+        loop_start_beats: 0.0,
+        loop_end_beats: 4.0,
+    });
+
+    a.update(
+        ArrangementMsg::SplitNoteClip {
+            track_id,
+            clip_id,
+            split_beat: 5.0,
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    let mut halves: Vec<_> = a.tracks[1].note_clips.iter().collect();
+    halves.sort_by(|a, b| a.position_beats.partial_cmp(&b.position_beats).unwrap());
+    assert!(halves.iter().all(|clip| clip.loop_enabled));
+    assert_eq!(halves[0].loop_end_beats, 5.0);
+    assert_eq!(halves[1].loop_end_beats, 3.0);
+    assert_eq!(halves[1].notes[0].start_beat, 1.0);
+}
+
+#[test]
+fn join_looped_audio_consolidates_wrapped_samples_and_remains_looped() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, first_id) = add_audio_clip(&mut a, 0, 0, 200);
+    let (_, second_id) = add_audio_clip(&mut a, 0, 200, 100);
+    let source = Arc::new(vibez_core::audio_buffer::DecodedAudio {
+        channels: vec![(0..100).map(|frame| frame as f32).collect()],
+        sample_rate: 44_100,
+    });
+    for clip in &mut a.tracks[0].clips {
+        clip.audio = Arc::clone(&source);
+        clip.loop_enabled = true;
+        clip.loop_start = 0;
+        clip.loop_end = 100;
+    }
+    for clip_id in [first_id, second_id] {
+        a.selected_clips
+            .insert(ArrangementSelection::AudioClip { track_id, clip_id });
+    }
+    let mut engine = RecordingEngine::default();
+
+    a.update(
+        ArrangementMsg::JoinSelectedClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    let joined = &a.tracks[0].clips[0];
+    assert!(joined.loop_enabled);
+    assert_eq!((joined.loop_start, joined.loop_end), (0, 300));
+    assert_eq!(joined.audio.channels[0][150], 50.0);
+}
+
+#[test]
+fn join_looped_midi_expands_repetitions_and_remains_looped() {
+    let mut a = arrangement_with_tracks(1);
+    let mut engine = RecordingEngine::default();
+    a.update(
+        ArrangementMsg::AddMidiTrack,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    let track_id = a.tracks[1].id;
+    for position_beats in [0.0, 8.0] {
+        let clip_id = ClipId::new();
+        a.tracks[1].note_clips.push(UiNoteClip {
+            id: clip_id,
+            name: "Pattern".to_string(),
+            position_beats,
+            duration_beats: 8.0,
+            notes: vec![MidiNote {
+                pitch: 60,
+                velocity: 100,
+                start_beat: 0.0,
+                duration_beats: 1.0,
+            }],
+            selected_notes: HashSet::new(),
+            loop_enabled: true,
+            loop_start_beats: 0.0,
+            loop_end_beats: 4.0,
+        });
+        a.selected_clips
+            .insert(ArrangementSelection::NoteClip { track_id, clip_id });
+    }
+
+    a.update(
+        ArrangementMsg::JoinSelectedClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    let joined = &a.tracks[1].note_clips[0];
+    assert!(joined.loop_enabled);
+    assert_eq!(joined.loop_end_beats, 16.0);
+    let starts: Vec<_> = joined.notes.iter().map(|note| note.start_beat).collect();
+    assert_eq!(starts, vec![0.0, 4.0, 8.0, 12.0]);
+}

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -479,15 +479,17 @@ fn cut_time_selection_preserves_material_outside_the_range() {
 
 #[test]
 fn loop_toggle_and_resize_apply_to_the_whole_clip_selection() {
-    let mut a = arrangement_with_tracks(1);
+    let mut a = arrangement_with_tracks(2);
     let (tid, first) = add_audio_clip(&mut a, 0, 0, 200);
-    let (_, second) = add_audio_clip(&mut a, 0, 300, 300);
-    for clip_id in [first, second] {
-        a.selected_clips.insert(ArrangementSelection::AudioClip {
-            track_id: tid,
-            clip_id,
-        });
-    }
+    let (second_tid, second) = add_audio_clip(&mut a, 1, 300, 300);
+    a.selected_clips.insert(ArrangementSelection::AudioClip {
+        track_id: tid,
+        clip_id: first,
+    });
+    a.selected_clips.insert(ArrangementSelection::AudioClip {
+        track_id: second_tid,
+        clip_id: second,
+    });
     let mut engine = RecordingEngine::default();
     let ctx = ArrangementCtx {
         samples_per_beat: 100.0,
@@ -495,7 +497,7 @@ fn loop_toggle_and_resize_apply_to_the_whole_clip_selection() {
     };
 
     a.update(ArrangementMsg::ToggleSelectedClipLoop, &mut engine, ctx);
-    assert!(a.tracks[0].clips.iter().all(|clip| clip.loop_enabled));
+    assert!(a.tracks.iter().all(|track| track.clips[0].loop_enabled));
     a.update(
         ArrangementMsg::ResizeSelectedClips {
             anchor: ArrangementSelection::AudioClip {
@@ -509,5 +511,5 @@ fn loop_toggle_and_resize_apply_to_the_whole_clip_selection() {
     );
 
     assert_eq!(a.tracks[0].clips[0].duration, 400);
-    assert_eq!(a.tracks[0].clips[1].duration, 500);
+    assert_eq!(a.tracks[1].clips[0].duration, 500);
 }

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::domains::test_support::RecordingEngine;
+use vibez_core::midi::MidiNote;
 
 fn arrangement_with_tracks(n: usize) -> ArrangementState {
     let mut a = ArrangementState {
@@ -366,4 +367,147 @@ fn submit_clip_bpm_parses_and_rejects_garbage() {
     );
     assert!(!action.mark_dirty);
     assert_eq!(a.tracks[0].clips[0].original_bpm, Some(140.5));
+}
+
+#[test]
+fn copy_and_paste_multiple_clips_at_playhead_preserves_layout_and_loops() {
+    let mut a = arrangement_with_tracks(1);
+    let (tid, first) = add_audio_clip(&mut a, 0, 0, 100);
+    let (_, second) = add_audio_clip(&mut a, 0, 200, 100);
+    a.tracks[0].clips[0].loop_enabled = true;
+    a.tracks[0].clips[0].loop_end = 100;
+    for clip_id in [first, second] {
+        a.selected_clips.insert(ArrangementSelection::AudioClip {
+            track_id: tid,
+            clip_id,
+        });
+    }
+    let mut engine = RecordingEngine::default();
+    let ctx = ArrangementCtx {
+        samples_per_beat: 100.0,
+        playhead_samples: 1_000,
+        playhead_beats: 10.0,
+    };
+
+    a.update(ArrangementMsg::CopySelectedClips, &mut engine, ctx);
+    a.update(ArrangementMsg::PasteClipsAtPlayhead, &mut engine, ctx);
+
+    assert_eq!(a.tracks[0].clips.len(), 4);
+    let mut pasted: Vec<_> = a.tracks[0].clips[2..].iter().collect();
+    pasted.sort_by_key(|clip| clip.position);
+    assert_eq!(pasted[0].position, 1_000);
+    assert_eq!(pasted[1].position, 1_200);
+    assert!(pasted[0].loop_enabled);
+    assert_eq!(a.selected_clips.len(), 2);
+}
+
+#[test]
+fn partial_time_selection_copies_audio_and_trimmed_midi() {
+    let mut a = arrangement_with_tracks(1);
+    let (audio_tid, _) = add_audio_clip(&mut a, 0, 100, 600);
+    let mut engine = RecordingEngine::default();
+    a.update(
+        ArrangementMsg::AddMidiTrack,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    let midi_tid = a.tracks[1].id;
+    let note_id = ClipId::new();
+    a.tracks[1].note_clips.push(UiNoteClip {
+        id: note_id,
+        name: "Notes".to_string(),
+        position_beats: 1.0,
+        duration_beats: 6.0,
+        notes: vec![MidiNote {
+            pitch: 60,
+            velocity: 100,
+            start_beat: 0.0,
+            duration_beats: 3.0,
+        }],
+        selected_notes: HashSet::new(),
+        loop_enabled: false,
+        loop_start_beats: 0.0,
+        loop_end_beats: 0.0,
+    });
+    a.time_selection_active = true;
+    a.selection_start_beats = 2.0;
+    a.selection_end_beats = 5.0;
+    a.time_selection_track = None;
+    let ctx = ArrangementCtx {
+        samples_per_beat: 100.0,
+        playhead_samples: 1_000,
+        playhead_beats: 10.0,
+    };
+
+    a.update(ArrangementMsg::CopySelectedClips, &mut engine, ctx);
+    a.update(ArrangementMsg::PasteClipsAtPlayhead, &mut engine, ctx);
+
+    let audio = a.find_track(audio_tid).unwrap().clips.last().unwrap();
+    assert_eq!(audio.position, 1_000);
+    assert_eq!(audio.duration, 300);
+    assert_eq!(audio.source_offset, 100);
+    let notes = a.find_track(midi_tid).unwrap().note_clips.last().unwrap();
+    assert_eq!(notes.position_beats, 10.0);
+    assert_eq!(notes.duration_beats, 3.0);
+    assert_eq!(notes.notes[0].start_beat, 0.0);
+    assert_eq!(notes.notes[0].duration_beats, 2.0);
+}
+
+#[test]
+fn cut_time_selection_preserves_material_outside_the_range() {
+    let mut a = arrangement_with_tracks(1);
+    add_audio_clip(&mut a, 0, 0, 800);
+    a.time_selection_active = true;
+    a.selection_start_beats = 2.0;
+    a.selection_end_beats = 5.0;
+    a.time_selection_track = Some(a.tracks[0].id);
+    let mut engine = RecordingEngine::default();
+    let ctx = ArrangementCtx {
+        samples_per_beat: 100.0,
+        ..Default::default()
+    };
+
+    a.update(ArrangementMsg::CutSelectedClips, &mut engine, ctx);
+
+    let mut remaining: Vec<_> = a.tracks[0].clips.iter().collect();
+    remaining.sort_by_key(|clip| clip.position);
+    assert_eq!(remaining.len(), 2);
+    assert_eq!((remaining[0].position, remaining[0].duration), (0, 200));
+    assert_eq!((remaining[1].position, remaining[1].duration), (500, 300));
+    assert_eq!(a.clipboard.clips.len(), 1);
+}
+
+#[test]
+fn loop_toggle_and_resize_apply_to_the_whole_clip_selection() {
+    let mut a = arrangement_with_tracks(1);
+    let (tid, first) = add_audio_clip(&mut a, 0, 0, 200);
+    let (_, second) = add_audio_clip(&mut a, 0, 300, 300);
+    for clip_id in [first, second] {
+        a.selected_clips.insert(ArrangementSelection::AudioClip {
+            track_id: tid,
+            clip_id,
+        });
+    }
+    let mut engine = RecordingEngine::default();
+    let ctx = ArrangementCtx {
+        samples_per_beat: 100.0,
+        ..Default::default()
+    };
+
+    a.update(ArrangementMsg::ToggleSelectedClipLoop, &mut engine, ctx);
+    assert!(a.tracks[0].clips.iter().all(|clip| clip.loop_enabled));
+    a.update(
+        ArrangementMsg::ResizeSelectedClips {
+            anchor: ArrangementSelection::AudioClip {
+                track_id: tid,
+                clip_id: first,
+            },
+            new_duration_beats: 4.0,
+        },
+        &mut engine,
+        ctx,
+    );
+
+    assert_eq!(a.tracks[0].clips[0].duration, 400);
+    assert_eq!(a.tracks[0].clips[1].duration, 500);
 }

--- a/crates/vibez-ui/src/domains/transport.rs
+++ b/crates/vibez-ui/src/domains/transport.rs
@@ -20,6 +20,8 @@ pub enum TransportMsg {
     TogglePlayback,
     /// Seek to a normalized [0, 1] position on the timeline.
     Seek(f64),
+    /// Seek to an absolute musical position on the arrangement ruler.
+    SeekToBeat(f64),
     BpmChanged(String),
     BpmSubmit,
     /// Increment/decrement project BPM by a whole beat-per-minute.
@@ -103,6 +105,17 @@ impl TransportState {
                     self.position_samples = sample_pos;
                     engine.send(EngineCommand::Seek(sample_pos));
                 }
+                TransportAction::ClearTimeSelection
+            }
+            TransportMsg::SeekToBeat(beat) => {
+                let samples_per_beat = if self.bpm > 0.0 {
+                    self.sample_rate as f64 * 60.0 / self.bpm
+                } else {
+                    0.0
+                };
+                let sample_pos = (beat.max(0.0) * samples_per_beat).round() as u64;
+                self.position_samples = sample_pos;
+                engine.send(EngineCommand::Seek(sample_pos));
                 TransportAction::ClearTimeSelection
             }
             TransportMsg::BpmChanged(text) => {
@@ -260,6 +273,22 @@ mod tests {
         let action = t.update(TransportMsg::Seek(2.0), &mut engine, ctx);
         assert_eq!(t.position_samples, 1000);
         assert_eq!(action, TransportAction::ClearTimeSelection);
+    }
+
+    #[test]
+    fn beat_seek_uses_absolute_ruler_position() {
+        let mut t = transport();
+        let mut engine = RecordingEngine::default();
+
+        let action = t.update(
+            TransportMsg::SeekToBeat(3.5),
+            &mut engine,
+            TransportCtx::default(),
+        );
+
+        assert_eq!(t.position_samples, 77_175);
+        assert_eq!(action, TransportAction::ClearTimeSelection);
+        assert!(matches!(engine.0[0], EngineCommand::Seek(77_175)));
     }
 
     #[test]

--- a/crates/vibez-ui/src/domains/view.rs
+++ b/crates/vibez-ui/src/domains/view.rs
@@ -27,6 +27,8 @@ pub enum ViewMsg {
         target: ContextMenuTarget,
     },
     DismissContextMenu,
+    ToggleEditMenu,
+    DismissEditMenu,
     StartEditingTrackName(TrackId),
     StartEditingClipName(TrackId, ClipId),
     EditNameText(String),
@@ -140,6 +142,12 @@ impl ViewState {
             }
             ViewMsg::DismissContextMenu => {
                 self.context_menu = None;
+            }
+            ViewMsg::ToggleEditMenu => {
+                self.edit_menu_open = !self.edit_menu_open;
+            }
+            ViewMsg::DismissEditMenu => {
+                self.edit_menu_open = false;
             }
             ViewMsg::StartEditingTrackName(track_id) => {
                 if let Some(track) = find_track(tracks, track_id) {

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -20,6 +20,7 @@ pub struct ViewState {
     pub scroll_offset_beats: f64,
     pub snap_grid: SnapGrid,
     pub context_menu: Option<ContextMenu>,
+    pub edit_menu_open: bool,
     /// Cursor tracking (for right-click positioning from mouse_area).
     pub cursor_x: f32,
     pub cursor_y: f32,
@@ -41,6 +42,7 @@ impl Default for ViewState {
             scroll_offset_beats: 0.0,
             snap_grid: SnapGrid::Eighth,
             context_menu: None,
+            edit_menu_open: false,
             cursor_x: 0.0,
             cursor_y: 0.0,
             window_width: 1400.0,
@@ -326,6 +328,7 @@ pub struct ArrangementState {
     pub next_track_number: u32,
     pub selected_clips: HashSet<ArrangementSelection>,
     pub selected_note_clip: Option<(TrackId, ClipId)>,
+    pub clipboard: ClipClipboard,
     // Time selection (visible brackets; independent from the loop).
     pub time_selection_active: bool,
     pub selection_start_beats: f64,
@@ -349,6 +352,7 @@ impl Default for ArrangementState {
             next_track_number: 0,
             selected_clips: HashSet::new(),
             selected_note_clip: None,
+            clipboard: ClipClipboard::default(),
             time_selection_active: false,
             selection_start_beats: 0.0,
             selection_end_beats: 0.0,

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -151,6 +151,25 @@ pub struct UiNoteClip {
     pub loop_end_beats: f64,
 }
 
+#[derive(Debug, Clone)]
+pub enum ClipboardClip {
+    Audio {
+        track_id: TrackId,
+        offset_beats: f64,
+        clip: UiClip,
+    },
+    Note {
+        track_id: TrackId,
+        offset_beats: f64,
+        clip: UiNoteClip,
+    },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ClipClipboard {
+    pub clips: Vec<ClipboardClip>,
+}
+
 /// A track as represented in the UI.
 #[derive(Debug, Clone)]
 pub struct UiTrack {

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -9,7 +9,6 @@ use iced::{Color, Rectangle, Renderer, Theme};
 
 use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::browser::BrowserMsg;
-use crate::domains::piano_roll::PianoRollMsg;
 use crate::domains::transport::TransportMsg;
 use crate::domains::view::ViewMsg;
 use crate::message::Message;
@@ -592,24 +591,26 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 if *is_note_clip {
                                     return (
                                         canvas::event::Status::Captured,
-                                        Some(Message::PianoRoll(
-                                            PianoRollMsg::ResizeNoteClipDuration {
-                                                track_id,
-                                                clip_id: *clip_id,
+                                        Some(Message::Arrangement(
+                                            ArrangementMsg::ResizeSelectedClips {
+                                                anchor: ArrangementSelection::NoteClip {
+                                                    track_id,
+                                                    clip_id: *clip_id,
+                                                },
                                                 new_duration_beats: snapped,
                                             },
                                         )),
                                     );
                                 } else {
-                                    let spb = self.spb();
-                                    let new_dur_samples = (snapped * spb) as u64;
                                     return (
                                         canvas::event::Status::Captured,
                                         Some(Message::Arrangement(
-                                            ArrangementMsg::ResizeAudioClip {
-                                                track_id,
-                                                clip_id: *clip_id,
-                                                new_duration: new_dur_samples.max(1),
+                                            ArrangementMsg::ResizeSelectedClips {
+                                                anchor: ArrangementSelection::AudioClip {
+                                                    track_id,
+                                                    clip_id: *clip_id,
+                                                },
+                                                new_duration_beats: snapped,
                                             },
                                         )),
                                     );

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -347,12 +347,20 @@ impl canvas::Program<Message> for TrackClipCanvas {
 
                         return (
                             canvas::event::Status::Captured,
-                            Some(Message::Arrangement(
-                                ArrangementMsg::SelectArrangementClip {
-                                    selection,
-                                    shift_held: state.shift_held,
-                                },
-                            )),
+                            if near_right
+                                && in_title_bar
+                                && self.selected_clips.contains(&clip_id)
+                                && !state.shift_held
+                            {
+                                None
+                            } else {
+                                Some(Message::Arrangement(
+                                    ArrangementMsg::SelectArrangementClip {
+                                        selection,
+                                        shift_held: state.shift_held,
+                                    },
+                                ))
+                            },
                         );
                     }
 
@@ -648,12 +656,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                     let msg = match drag {
                         ClipDragAction::PendingSeek { beat, .. } => {
                             // Short click → seek + clear selection
-                            if self.total_beats > 0.0 {
-                                let normalized = (*beat / self.total_beats).clamp(0.0, 1.0);
-                                Some(Message::Transport(TransportMsg::Seek(normalized)))
-                            } else {
-                                None
-                            }
+                            Some(Message::Transport(TransportMsg::SeekToBeat(*beat)))
                         }
                         ClipDragAction::RegionSelect { .. } => {
                             Some(Message::set_time_selection_active(true))

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -8,6 +8,48 @@ use crate::theme;
 
 use super::*;
 
+fn fit_clip_title(name: &str, clip_width: f32, loop_icon_visible: bool) -> Option<String> {
+    if clip_width <= 40.0 {
+        return None;
+    }
+    const HORIZONTAL_PADDING: f32 = 8.0;
+    const LOOP_ICON_WIDTH: f32 = 18.0;
+    const APPROX_GLYPH_WIDTH: f32 = 6.5;
+    let reserved = HORIZONTAL_PADDING
+        + if loop_icon_visible {
+            LOOP_ICON_WIDTH
+        } else {
+            0.0
+        };
+    let max_chars = ((clip_width - reserved).max(0.0) / APPROX_GLYPH_WIDTH).floor() as usize;
+    if max_chars < 4 {
+        return None;
+    }
+    if name.chars().count() <= max_chars {
+        Some(name.to_string())
+    } else {
+        let prefix: String = name.chars().take(max_chars - 2).collect();
+        Some(format!("{prefix}.."))
+    }
+}
+
+fn visible_pixel_columns(
+    clip_x: f32,
+    clip_width: f32,
+    viewport_width: f32,
+) -> std::ops::Range<usize> {
+    let pixels = clip_width.max(0.0) as usize;
+    let start = (-clip_x).ceil().max(0.0) as usize;
+    let end = (viewport_width - clip_x).ceil().max(0.0) as usize;
+    let start = start.min(pixels);
+    let end = end.min(pixels);
+    if start < end {
+        start..end
+    } else {
+        0..0
+    }
+}
+
 impl TrackClipCanvas {
     pub(super) fn draw_impl(
         &self,
@@ -127,11 +169,8 @@ impl TrackClipCanvas {
                     let center_y = body_top + body_h / 2.0;
                     let half_h = body_h / 2.0 - 2.0;
                     let pixels = clip_w as usize;
-                    for px in 0..pixels {
+                    for px in visible_pixel_columns(clip_x, clip_w, w) {
                         let screen_x = clip_x + px as f32;
-                        if screen_x < 0.0 || screen_x > w {
-                            continue;
-                        }
                         let peak_idx = px * clip.peaks.len() / pixels.max(1);
                         if peak_idx >= clip.peaks.len() {
                             break;
@@ -217,14 +256,26 @@ impl TrackClipCanvas {
                 );
 
                 // Clip name label
-                if clip_w > 40.0 {
-                    frame.fill_text(canvas::Text {
-                        content: clip.name.clone(),
-                        position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
-                        color: theme::text(),
-                        size: iced::Pixels(11.0),
-                        ..Default::default()
-                    });
+                if let Some(title) = fit_clip_title(clip.name.as_str(), clip_w, clip.loop_enabled) {
+                    let title_width =
+                        (clip_w - if clip.loop_enabled { 18.0 } else { 0.0 }).max(0.0);
+                    frame.with_clip(
+                        Rectangle {
+                            x: clip_x,
+                            y: clip_y,
+                            width: title_width,
+                            height: CLIP_TITLE_HEIGHT,
+                        },
+                        |title_frame| {
+                            title_frame.fill_text(canvas::Text {
+                                content: title,
+                                position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
+                                color: theme::text(),
+                                size: iced::Pixels(11.0),
+                                ..Default::default()
+                            });
+                        },
+                    );
                 }
 
                 // Diagonal stripe overlay when the clip's warp is
@@ -426,14 +477,28 @@ impl TrackClipCanvas {
                 );
 
                 // Clip name label
-                if clip_w > 40.0 {
-                    frame.fill_text(canvas::Text {
-                        content: note_clip.name.clone(),
-                        position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
-                        color: theme::text(),
-                        size: iced::Pixels(11.0),
-                        ..Default::default()
-                    });
+                if let Some(title) =
+                    fit_clip_title(note_clip.name.as_str(), clip_w, note_clip.loop_enabled)
+                {
+                    let title_width =
+                        (clip_w - if note_clip.loop_enabled { 18.0 } else { 0.0 }).max(0.0);
+                    frame.with_clip(
+                        Rectangle {
+                            x: clip_x,
+                            y: clip_y,
+                            width: title_width,
+                            height: CLIP_TITLE_HEIGHT,
+                        },
+                        |title_frame| {
+                            title_frame.fill_text(canvas::Text {
+                                content: title,
+                                position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
+                                color: theme::text(),
+                                size: iced::Pixels(11.0),
+                                ..Default::default()
+                            });
+                        },
+                    );
                 }
             }
         }
@@ -541,5 +606,41 @@ impl TrackClipCanvas {
         }
 
         vec![frame.into_geometry()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fit_clip_title, visible_pixel_columns};
+
+    #[test]
+    fn clip_title_is_constrained_to_its_visible_width() {
+        assert_eq!(
+            fit_clip_title("Kick.wav", 100.0, false),
+            Some("Kick.wav".into())
+        );
+        assert_eq!(
+            fit_clip_title("OTH_128_Hub_Full.wav", 80.0, false),
+            Some("OTH_128_H..".into())
+        );
+        assert_eq!(fit_clip_title("Kick.wav", 40.0, false), None);
+    }
+
+    #[test]
+    fn loop_icon_reserves_title_space() {
+        assert_eq!(
+            fit_clip_title("OTH_128_Hub_Full.wav", 80.0, true),
+            Some("OTH_12..".into())
+        );
+    }
+
+    #[test]
+    fn waveform_iteration_is_limited_to_visible_clip_columns() {
+        assert_eq!(
+            visible_pixel_columns(-10_000.0, 20_000.0, 1_000.0),
+            10_000..11_000
+        );
+        assert_eq!(visible_pixel_columns(200.0, 400.0, 1_000.0), 0..400);
+        assert_eq!(visible_pixel_columns(1_200.0, 400.0, 1_000.0), 0..0);
     }
 }

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -50,6 +50,16 @@ fn visible_pixel_columns(
     }
 }
 
+fn visible_title_bounds(
+    clip_x: f32,
+    title_width: f32,
+    viewport_width: f32,
+) -> Option<(f32, f32, f32)> {
+    let left = clip_x.max(0.0);
+    let right = (clip_x + title_width).min(viewport_width);
+    (right > left).then(|| (left, right - left, (clip_x + 4.0).max(left + 4.0)))
+}
+
 impl TrackClipCanvas {
     pub(super) fn draw_impl(
         &self,
@@ -256,26 +266,31 @@ impl TrackClipCanvas {
                 );
 
                 // Clip name label
-                if let Some(title) = fit_clip_title(clip.name.as_str(), clip_w, clip.loop_enabled) {
-                    let title_width =
-                        (clip_w - if clip.loop_enabled { 18.0 } else { 0.0 }).max(0.0);
-                    frame.with_clip(
-                        Rectangle {
-                            x: clip_x,
-                            y: clip_y,
-                            width: title_width,
-                            height: CLIP_TITLE_HEIGHT,
-                        },
-                        |title_frame| {
-                            title_frame.fill_text(canvas::Text {
-                                content: title,
-                                position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
-                                color: theme::text(),
-                                size: iced::Pixels(11.0),
-                                ..Default::default()
-                            });
-                        },
-                    );
+                let title_width = (clip_w - if clip.loop_enabled { 18.0 } else { 0.0 }).max(0.0);
+                if let Some((title_x, visible_title_width, text_x)) =
+                    visible_title_bounds(clip_x, title_width, w)
+                {
+                    if let Some(title) =
+                        fit_clip_title(clip.name.as_str(), visible_title_width, clip.loop_enabled)
+                    {
+                        frame.with_clip(
+                            Rectangle {
+                                x: title_x,
+                                y: clip_y,
+                                width: visible_title_width,
+                                height: CLIP_TITLE_HEIGHT,
+                            },
+                            |title_frame| {
+                                title_frame.fill_text(canvas::Text {
+                                    content: title,
+                                    position: iced::Point::new(text_x, clip_y + 3.0),
+                                    color: theme::text(),
+                                    size: iced::Pixels(11.0),
+                                    ..Default::default()
+                                });
+                            },
+                        );
+                    }
                 }
 
                 // Diagonal stripe overlay when the clip's warp is
@@ -477,28 +492,34 @@ impl TrackClipCanvas {
                 );
 
                 // Clip name label
-                if let Some(title) =
-                    fit_clip_title(note_clip.name.as_str(), clip_w, note_clip.loop_enabled)
+                let title_width =
+                    (clip_w - if note_clip.loop_enabled { 18.0 } else { 0.0 }).max(0.0);
+                if let Some((title_x, visible_title_width, text_x)) =
+                    visible_title_bounds(clip_x, title_width, w)
                 {
-                    let title_width =
-                        (clip_w - if note_clip.loop_enabled { 18.0 } else { 0.0 }).max(0.0);
-                    frame.with_clip(
-                        Rectangle {
-                            x: clip_x,
-                            y: clip_y,
-                            width: title_width,
-                            height: CLIP_TITLE_HEIGHT,
-                        },
-                        |title_frame| {
-                            title_frame.fill_text(canvas::Text {
-                                content: title,
-                                position: iced::Point::new(clip_x + 4.0, clip_y + 3.0),
-                                color: theme::text(),
-                                size: iced::Pixels(11.0),
-                                ..Default::default()
-                            });
-                        },
-                    );
+                    if let Some(title) = fit_clip_title(
+                        note_clip.name.as_str(),
+                        visible_title_width,
+                        note_clip.loop_enabled,
+                    ) {
+                        frame.with_clip(
+                            Rectangle {
+                                x: title_x,
+                                y: clip_y,
+                                width: visible_title_width,
+                                height: CLIP_TITLE_HEIGHT,
+                            },
+                            |title_frame| {
+                                title_frame.fill_text(canvas::Text {
+                                    content: title,
+                                    position: iced::Point::new(text_x, clip_y + 3.0),
+                                    color: theme::text(),
+                                    size: iced::Pixels(11.0),
+                                    ..Default::default()
+                                });
+                            },
+                        );
+                    }
                 }
             }
         }
@@ -611,7 +632,7 @@ impl TrackClipCanvas {
 
 #[cfg(test)]
 mod tests {
-    use super::{fit_clip_title, visible_pixel_columns};
+    use super::{fit_clip_title, visible_pixel_columns, visible_title_bounds};
 
     #[test]
     fn clip_title_is_constrained_to_its_visible_width() {
@@ -642,5 +663,18 @@ mod tests {
         );
         assert_eq!(visible_pixel_columns(200.0, 400.0, 1_000.0), 0..400);
         assert_eq!(visible_pixel_columns(1_200.0, 400.0, 1_000.0), 0..0);
+    }
+
+    #[test]
+    fn clip_title_bounds_never_escape_the_arrangement_viewport() {
+        assert_eq!(
+            visible_title_bounds(-200.0, 400.0, 800.0),
+            Some((0.0, 200.0, 4.0))
+        );
+        assert_eq!(
+            visible_title_bounds(100.0, 200.0, 800.0),
+            Some((100.0, 200.0, 104.0))
+        );
+        assert_eq!(visible_title_bounds(900.0, 200.0, 800.0), None);
     }
 }

--- a/crates/vibez-ui/src/widgets/timeline/mod.rs
+++ b/crates/vibez-ui/src/widgets/timeline/mod.rs
@@ -1,3 +1,7 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
+
 use vibez_core::id::ClipId;
 
 // ── Lightweight data types for rendering ──
@@ -9,7 +13,7 @@ pub struct TimelineClip {
     pub duration: u64,
     pub name: String,
     /// Pre-computed waveform peaks for mini display (per pixel column).
-    pub peaks: Vec<(f32, f32)>,
+    pub peaks: Arc<Vec<(f32, f32)>>,
     pub loop_enabled: bool,
     pub loop_start: u64,
     pub loop_end: u64,
@@ -34,7 +38,44 @@ pub struct TimelineNoteClip {
 
 /// Compute waveform peaks for a clip, with loop-aware wrapping.
 /// Uses `peak_in_range` on contiguous segments for O(pixels) cost regardless of clip length.
-pub fn compute_clip_peaks(clip: &crate::state::UiClip) -> Vec<(f32, f32)> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct PeakCacheKey {
+    audio: usize,
+    source_offset: u64,
+    duration: u64,
+    loop_enabled: bool,
+    loop_start: u64,
+    loop_end: u64,
+}
+
+struct PeakCacheEntry {
+    audio: Weak<vibez_core::audio_buffer::DecodedAudio>,
+    peaks: Arc<Vec<(f32, f32)>>,
+}
+
+thread_local! {
+    static PEAK_CACHE: RefCell<HashMap<PeakCacheKey, PeakCacheEntry>> = RefCell::new(HashMap::new());
+}
+
+pub fn compute_clip_peaks(clip: &crate::state::UiClip) -> Arc<Vec<(f32, f32)>> {
+    let key = PeakCacheKey {
+        audio: Arc::as_ptr(&clip.audio) as usize,
+        source_offset: clip.source_offset,
+        duration: clip.duration,
+        loop_enabled: clip.loop_enabled,
+        loop_start: clip.loop_start,
+        loop_end: clip.loop_end,
+    };
+    if let Some(peaks) = PEAK_CACHE.with(|cache| {
+        cache.borrow().get(&key).and_then(|entry| {
+            entry.audio.upgrade().and_then(|audio| {
+                Arc::ptr_eq(&audio, &clip.audio).then(|| Arc::clone(&entry.peaks))
+            })
+        })
+    }) {
+        return peaks;
+    }
+
     let num_peaks = (clip.duration as usize / 100).clamp(1, 1000);
     let looping = clip.loop_enabled && clip.loop_end > clip.loop_start;
     let loop_start = clip.loop_start as usize;
@@ -42,7 +83,7 @@ pub fn compute_clip_peaks(clip: &crate::state::UiClip) -> Vec<(f32, f32)> {
     let loop_len = if looping { loop_end - loop_start } else { 0 };
     let channels = clip.audio.num_channels();
     if channels == 0 {
-        return vec![(0.0, 0.0); num_peaks];
+        return Arc::new(vec![(0.0, 0.0); num_peaks]);
     }
 
     let peak_for_range = |src_start: usize, src_end: usize| -> (f32, f32) {
@@ -63,43 +104,62 @@ pub fn compute_clip_peaks(clip: &crate::state::UiClip) -> Vec<(f32, f32)> {
         None
     };
 
-    (0..num_peaks)
-        .map(|i| {
-            let cf_start = i * clip.duration as usize / num_peaks;
-            let cf_end = (i + 1) * clip.duration as usize / num_peaks;
-            let span = cf_end.saturating_sub(cf_start).max(1);
+    let peaks = Arc::new(
+        (0..num_peaks)
+            .map(|i| {
+                let cf_start = i * clip.duration as usize / num_peaks;
+                let cf_end = (i + 1) * clip.duration as usize / num_peaks;
+                let span = cf_end.saturating_sub(cf_start).max(1);
 
-            if !looping {
-                let src_start = clip.source_offset as usize + cf_start;
-                let src_end = clip.source_offset as usize + cf_end;
-                peak_for_range(src_start, src_end)
-            } else if span >= loop_len {
-                full_loop_peak.unwrap()
-            } else {
-                let raw_start = clip.source_offset as usize + cf_start;
-                let raw_end = clip.source_offset as usize + cf_end;
-                let src_start = if raw_start >= loop_end {
-                    loop_start + (raw_start - loop_start) % loop_len
+                if !looping {
+                    let src_start = clip.source_offset as usize + cf_start;
+                    let src_end = clip.source_offset as usize + cf_end;
+                    peak_for_range(src_start, src_end)
+                } else if span >= loop_len {
+                    full_loop_peak.unwrap()
                 } else {
-                    raw_start
-                };
-                let src_end = if raw_end >= loop_end {
-                    loop_start + (raw_end - loop_start) % loop_len
-                } else {
-                    raw_end
-                };
+                    let raw_start = clip.source_offset as usize + cf_start;
+                    let raw_end = clip.source_offset as usize + cf_end;
+                    let src_start = if raw_start >= loop_end {
+                        loop_start + (raw_start - loop_start) % loop_len
+                    } else {
+                        raw_start
+                    };
+                    let src_end = if raw_end >= loop_end {
+                        loop_start + (raw_end - loop_start) % loop_len
+                    } else {
+                        raw_end
+                    };
 
-                if src_start <= src_end {
-                    peak_for_range(src_start, src_end.max(src_start + 1))
-                } else {
-                    // Wraps around loop boundary
-                    let (mn1, mx1) = peak_for_range(src_start, loop_end);
-                    let (mn2, mx2) = peak_for_range(loop_start, src_end.max(loop_start + 1));
-                    (mn1.min(mn2), mx1.max(mx2))
+                    if src_start <= src_end {
+                        peak_for_range(src_start, src_end.max(src_start + 1))
+                    } else {
+                        // Wraps around loop boundary
+                        let (mn1, mx1) = peak_for_range(src_start, loop_end);
+                        let (mn2, mx2) = peak_for_range(loop_start, src_end.max(loop_start + 1));
+                        (mn1.min(mn2), mx1.max(mx2))
+                    }
                 }
+            })
+            .collect(),
+    );
+    PEAK_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if cache.len() >= 256 {
+            cache.retain(|_, entry| entry.audio.strong_count() > 0);
+            if cache.len() >= 256 {
+                cache.clear();
             }
-        })
-        .collect()
+        }
+        cache.insert(
+            key,
+            PeakCacheEntry {
+                audio: Arc::downgrade(&clip.audio),
+                peaks: Arc::clone(&peaks),
+            },
+        );
+    });
+    peaks
 }
 
 // ── RulerWidget ──
@@ -120,3 +180,44 @@ mod ruler;
 pub use clips::*;
 pub use minimap::*;
 pub use ruler::*;
+
+#[cfg(test)]
+mod performance_tests {
+    use super::compute_clip_peaks;
+    use crate::state::UiClip;
+    use std::sync::Arc;
+    use vibez_core::audio_buffer::DecodedAudio;
+    use vibez_core::id::ClipId;
+
+    #[test]
+    fn duplicated_long_clips_reuse_cached_waveform_peaks() {
+        let frames = 44_100 * 30;
+        let audio = Arc::new(DecodedAudio {
+            channels: vec![vec![0.25; frames], vec![-0.25; frames]],
+            sample_rate: 44_100,
+        });
+        let clip = UiClip {
+            id: ClipId::new(),
+            name: "Long loop.wav".into(),
+            audio,
+            source: None,
+            position: 0,
+            source_offset: 0,
+            duration: frames as u64,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+            original_bpm: None,
+            warped: false,
+            warped_to_bpm: None,
+            original_audio: None,
+        };
+
+        let first = compute_clip_peaks(&clip);
+        for _ in 0..12 {
+            let duplicate_peaks = compute_clip_peaks(&clip);
+            assert_eq!(duplicate_peaks.len(), 1000);
+            assert!(Arc::ptr_eq(&first, &duplicate_peaks));
+        }
+    }
+}

--- a/crates/vibez-ui/src/widgets/timeline/ruler.rs
+++ b/crates/vibez-ui/src/widgets/timeline/ruler.rs
@@ -428,12 +428,7 @@ impl canvas::Program<Message> for RulerWidget {
                     let msg = match drag {
                         RulerDragAction::PendingSeek { beat, .. } => {
                             // Short click → seek + clear selection
-                            if self.total_beats > 0.0 {
-                                let normalized = (*beat / self.total_beats).clamp(0.0, 1.0);
-                                Some(Message::Transport(TransportMsg::Seek(normalized)))
-                            } else {
-                                None
-                            }
+                            Some(Message::Transport(TransportMsg::SeekToBeat(*beat)))
                         }
                         RulerDragAction::RegionSelect { .. } => {
                             // Completed region select


### PR DESCRIPTION
## Summary
- add copy, cut, and paste-at-playhead for full clips, multi-selections, and partial time ranges across audio and MIDI
- apply loop toggles and edge extension to all selected clips; surface clipboard, loop, Split, and Join controls in the Edit menu
- include MIDI clips in engine arrangement length bookkeeping and lock MIDI-only transport-loop retriggering down with regression coverage

## Verification
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets`
- `cargo clippy -p vibez-ui --lib -- -D warnings`
- `cargo clippy -p vibez-engine --lib -- -D warnings`
- native UI smoke check at 1400x900

## Deferred
- the intermittent MIDI clip re-loop issue needs a deterministic reproduction session; no speculative change is included here

## Note
Workspace-wide Clippy still reports pre-existing warnings in `vibez-plugin-host` examples/tests and an existing engine test helper.