### PR TITLE
Editors: musical grid sizes, triplets, snap and adaptive mode

### DIFF
--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -55,6 +55,22 @@ pub(crate) fn global_key_handler(
         return Some(Message::PianoRoll(PianoRollMsg::ToggleEditMode));
     }
 
+    if modifiers.command() {
+        if let iced::keyboard::Key::Character(ref c) = key {
+            let grid_message = match c.as_str() {
+                "1" => Some(ViewMsg::NarrowGrid),
+                "2" => Some(ViewMsg::WidenGrid),
+                "3" => Some(ViewMsg::ToggleTripletGrid),
+                "4" => Some(ViewMsg::ToggleSnapToGrid),
+                "5" => Some(ViewMsg::ToggleAdaptiveGrid),
+                _ => None,
+            };
+            if let Some(message) = grid_message {
+                return Some(Message::View(message));
+            }
+        }
+    }
+
     if !modifiers.control() {
         return None;
     }
@@ -98,5 +114,45 @@ pub(crate) fn global_key_handler(
             _ => None,
         },
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_number_shortcuts_control_the_shared_grid() {
+        use iced::keyboard::{Key, Modifiers};
+
+        let expected = [
+            ViewMsg::NarrowGrid,
+            ViewMsg::WidenGrid,
+            ViewMsg::ToggleTripletGrid,
+            ViewMsg::ToggleSnapToGrid,
+            ViewMsg::ToggleAdaptiveGrid,
+        ];
+        for (number, expected) in ["1", "2", "3", "4", "5"].into_iter().zip(expected) {
+            let message = global_key_handler(Key::Character(number.into()), Modifiers::CTRL);
+            assert!(matches!(
+                (message, expected),
+                (
+                    Some(Message::View(ViewMsg::NarrowGrid)),
+                    ViewMsg::NarrowGrid
+                ) | (Some(Message::View(ViewMsg::WidenGrid)), ViewMsg::WidenGrid)
+                    | (
+                        Some(Message::View(ViewMsg::ToggleTripletGrid)),
+                        ViewMsg::ToggleTripletGrid
+                    )
+                    | (
+                        Some(Message::View(ViewMsg::ToggleSnapToGrid)),
+                        ViewMsg::ToggleSnapToGrid
+                    )
+                    | (
+                        Some(Message::View(ViewMsg::ToggleAdaptiveGrid)),
+                        ViewMsg::ToggleAdaptiveGrid
+                    )
+            ));
+        }
     }
 }

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -125,6 +125,11 @@ mod tests {
     fn command_number_shortcuts_control_the_shared_grid() {
         use iced::keyboard::{Key, Modifiers};
 
+        #[cfg(target_os = "macos")]
+        let command = Modifiers::LOGO;
+        #[cfg(not(target_os = "macos"))]
+        let command = Modifiers::CTRL;
+
         let expected = [
             ViewMsg::NarrowGrid,
             ViewMsg::WidenGrid,
@@ -133,7 +138,7 @@ mod tests {
             ViewMsg::ToggleAdaptiveGrid,
         ];
         for (number, expected) in ["1", "2", "3", "4", "5"].into_iter().zip(expected) {
-            let message = global_key_handler(Key::Character(number.into()), Modifiers::CTRL);
+            let message = global_key_handler(Key::Character(number.into()), command);
             assert!(matches!(
                 (message, expected),
                 (

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -284,6 +284,21 @@ impl App {
         self.state.project.dirty = true;
     }
 
+    pub(super) fn active_editor_pixels_per_beat(&self) -> f32 {
+        if let Some((track_id, clip_id)) = self.state.arrangement.selected_note_clip {
+            if let Some(duration) = self.state.find_track(track_id).and_then(|track| {
+                track
+                    .note_clips
+                    .iter()
+                    .find(|clip| clip.id == clip_id)
+                    .map(|clip| clip.duration_beats)
+            }) {
+                return (self.state.view.window_width - 52.0).max(1.0) / duration.max(1.0) as f32;
+            }
+        }
+        20.0 * self.state.view.zoom_level
+    }
+
     /// Walk `next_track_number` forward past any names already in use so
     /// that `format!("{prefix} {n}")` is unique. Prevents e.g. two lanes
     /// both named "Track 2" when numbering gets out of sync after loads,

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -180,7 +180,11 @@ impl App {
             }
             Message::PianoRoll(msg) => {
                 let ctx = crate::domains::piano_roll::PianoRollCtx {
-                    snap_grid: self.state.view.snap_grid,
+                    snap_grid: self
+                        .state
+                        .view
+                        .grid_config()
+                        .effective_grid(self.active_editor_pixels_per_beat()),
                 };
                 let action = {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
@@ -893,7 +897,11 @@ impl App {
             // -- Quantize --
             Message::QuantizeAudioClip { track_id, clip_id } => {
                 self.state.view.context_menu = None;
-                let grid = self.state.view.snap_grid;
+                let grid = self
+                    .state
+                    .view
+                    .grid_config()
+                    .effective_grid(self.active_editor_pixels_per_beat());
                 return self.dispatch_audio_quantize(track_id, clip_id, grid);
             }
             Message::QuantizeAudioClipAt {

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use iced::widget::{
-    button, canvas, center, column, container, horizontal_space, row, text, text_input,
+    button, canvas, center, column, container, horizontal_space, pick_list, row, text, text_input,
 };
 use iced::{Color, Element, Length, Theme};
 
@@ -228,7 +228,7 @@ impl App {
                         clip_relative_playhead,
                         clip.duration_beats,
                         track_color,
-                        self.state.view.snap_grid,
+                        self.state.view.grid_config(),
                         self.state.piano_roll.scroll_y,
                         self.state.piano_roll.edit_mode,
                     )
@@ -404,37 +404,19 @@ impl App {
 
         let mode_row = row![select_btn, draw_btn].spacing(1);
 
-        // Snap grid selector
-        use crate::state::SnapGrid;
-        let mut snap_row = row![].spacing(2);
-        for &grid in SnapGrid::all() {
-            let is_active = self.state.view.snap_grid == grid;
-            let (bg, text_color) = if is_active {
-                (th::accent_dim(), th::accent())
-            } else {
-                (th::bg_elevated(), th::text_dim())
-            };
-            let btn = button(text(grid.label()).size(10).color(text_color))
-                .on_press(Message::View(ViewMsg::SetSnapGrid(grid)))
-                .padding([2, 6])
-                .style(move |_theme: &Theme, _status| button::Style {
-                    background: Some(bg.into()),
-                    text_color,
-                    border: iced::Border {
-                        color: if is_active {
-                            th::accent_dim()
-                        } else {
-                            th::border()
-                        },
-                        width: 1.0,
-                        radius: 3.0.into(),
-                    },
-                    ..Default::default()
-                });
-            snap_row = snap_row.push(btn);
-        }
+        let snap_picker = pick_list(
+            crate::state::SnapGrid::all(),
+            Some(
+                self.state
+                    .view
+                    .grid_config()
+                    .effective_grid(self.active_editor_pixels_per_beat()),
+            ),
+            |grid| Message::View(ViewMsg::SetSnapGrid(grid)),
+        )
+        .width(Length::Fixed(90.0));
         let snap_label = text("Snap:").size(10).color(th::text_dim());
-        let header_row = row![label, mode_row, horizontal_space(), snap_label, snap_row]
+        let header_row = row![label, mode_row, horizontal_space(), snap_label, snap_picker]
             .spacing(4)
             .align_y(iced::Alignment::Center);
 
@@ -671,10 +653,10 @@ impl App {
 
         row![
             label,
-            grid_btn(crate::state::SnapGrid::Quarter),
-            grid_btn(crate::state::SnapGrid::Eighth),
-            grid_btn(crate::state::SnapGrid::Sixteenth),
-            grid_btn(crate::state::SnapGrid::ThirtySecond),
+            grid_btn(crate::state::SnapGrid::QUARTER),
+            grid_btn(crate::state::SnapGrid::EIGHTH),
+            grid_btn(crate::state::SnapGrid::SIXTEENTH),
+            grid_btn(crate::state::SnapGrid::THIRTY_SECOND),
         ]
         .spacing(6)
         .align_y(iced::Alignment::Center)

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -3,8 +3,8 @@
 use std::collections::HashSet;
 
 use iced::widget::{
-    button, canvas, center, column, container, horizontal_space, mouse_area, row, scrollable,
-    stack, text, text_input,
+    button, canvas, center, column, container, horizontal_space, mouse_area, pick_list, row,
+    scrollable, stack, text, text_input,
 };
 use iced::{Color, Element, Length, Theme};
 
@@ -301,6 +301,7 @@ impl App {
             playhead_beats,
             bpm,
             zoom_level,
+            grid: self.state.view.grid_config(),
             scroll_offset_beats: scroll_offset,
             total_beats,
             loop_enabled: self.state.transport.loop_enabled,
@@ -434,6 +435,7 @@ impl App {
                 track,
                 playhead_beats,
                 zoom_level,
+                self.state.view.grid_config(),
                 scroll_offset,
                 total_beats,
                 sample_rate,
@@ -877,6 +879,65 @@ impl App {
 
         let bpm_label = text("BPM").size(12).color(th::text_dim());
 
+        let grid_picker = pick_list(
+            crate::state::SnapGrid::all(),
+            Some(
+                self.state
+                    .view
+                    .grid_config()
+                    .effective_grid(self.active_editor_pixels_per_beat()),
+            ),
+            |grid| Message::View(ViewMsg::SetSnapGrid(grid)),
+        )
+        .width(Length::Fixed(82.0));
+        let grid_toggle = |label: &'static str, active: bool, message: ViewMsg| {
+            let color = if active { th::accent() } else { th::text_dim() };
+            button(text(label).size(9).color(color))
+                .on_press(Message::View(message))
+                .padding([4, 6])
+                .style(move |_theme: &Theme, _status| button::Style {
+                    background: Some(
+                        if active {
+                            th::bg_elevated()
+                        } else {
+                            th::bg_surface()
+                        }
+                        .into(),
+                    ),
+                    text_color: color,
+                    border: iced::Border {
+                        color: if active {
+                            th::accent_dim()
+                        } else {
+                            th::border()
+                        },
+                        width: 1.0,
+                        radius: 3.0.into(),
+                    },
+                    ..Default::default()
+                })
+        };
+        let grid_controls = row![
+            grid_picker,
+            grid_toggle(
+                "SNAP",
+                self.state.view.snap_enabled,
+                ViewMsg::ToggleSnapToGrid,
+            ),
+            grid_toggle(
+                "T",
+                self.state.view.snap_grid.is_triplet(),
+                ViewMsg::ToggleTripletGrid,
+            ),
+            grid_toggle(
+                "AUTO",
+                self.state.view.adaptive_grid,
+                ViewMsg::ToggleAdaptiveGrid,
+            ),
+        ]
+        .spacing(3)
+        .align_y(iced::Alignment::Center);
+
         // Master VU meter
         let master_meter = VuMeterWidget {
             peak_l: self.state.peak_l,
@@ -900,6 +961,7 @@ impl App {
                 .spacing(2)
                 .align_y(iced::Alignment::Center),
             bpm_label,
+            grid_controls,
         ]
         .spacing(12)
         .padding(10)
@@ -989,7 +1051,7 @@ impl App {
                 color: track_color,
                 zoom_level: self.state.view.zoom_level,
                 scroll_offset_beats: self.state.view.scroll_offset_beats,
-                snap: self.state.view.snap_grid,
+                grid: self.state.view.grid_config(),
                 selected,
                 reference,
                 min_label,

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -889,7 +889,45 @@ impl App {
             ),
             |grid| Message::View(ViewMsg::SetSnapGrid(grid)),
         )
-        .width(Length::Fixed(82.0));
+        .width(Length::Fixed(86.0))
+        .padding([3, 8])
+        .text_size(11)
+        .style(|_theme: &Theme, status| {
+            let highlighted = matches!(
+                status,
+                pick_list::Status::Hovered | pick_list::Status::Opened
+            );
+            pick_list::Style {
+                text_color: th::text(),
+                placeholder_color: th::text_dim(),
+                handle_color: if highlighted {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                },
+                background: th::bg_surface().into(),
+                border: iced::Border {
+                    color: if highlighted {
+                        th::accent_dim()
+                    } else {
+                        th::border()
+                    },
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+            }
+        })
+        .menu_style(|_theme: &Theme| iced::widget::overlay::menu::Style {
+            background: th::bg_elevated().into(),
+            border: iced::Border {
+                color: th::border_light(),
+                width: 1.0,
+                radius: 3.0.into(),
+            },
+            text_color: th::text(),
+            selected_text_color: th::accent(),
+            selected_background: th::bg_hover().into(),
+        });
         let grid_toggle = |label: &'static str, active: bool, message: ViewMsg| {
             let color = if active { th::accent() } else { th::text_dim() };
             button(text(label).size(9).color(color))

--- a/crates/vibez-ui/src/domains/piano_roll.rs
+++ b/crates/vibez-ui/src/domains/piano_roll.rs
@@ -92,7 +92,7 @@ pub struct PianoRollCtx {
 impl Default for PianoRollCtx {
     fn default() -> Self {
         Self {
-            snap_grid: SnapGrid::Eighth,
+            snap_grid: SnapGrid::EIGHTH,
         }
     }
 }
@@ -783,7 +783,7 @@ mod tests {
             &mut engine,
             &mut tracks,
             PianoRollCtx {
-                snap_grid: SnapGrid::Quarter,
+                snap_grid: SnapGrid::QUARTER,
             },
         );
         let clip = &tracks[0].note_clips[0];

--- a/crates/vibez-ui/src/domains/view.rs
+++ b/crates/vibez-ui/src/domains/view.rs
@@ -18,6 +18,11 @@ pub enum ViewMsg {
     ZoomToFit,
     ScrollArrangement(f64),
     SetSnapGrid(SnapGrid),
+    NarrowGrid,
+    WidenGrid,
+    ToggleTripletGrid,
+    ToggleSnapToGrid,
+    ToggleAdaptiveGrid,
     CursorMoved(f32, f32),
     WindowResized(f32, f32),
     MouseReleased,
@@ -107,6 +112,31 @@ impl ViewState {
             }
             ViewMsg::SetSnapGrid(grid) => {
                 self.snap_grid = grid;
+                self.adaptive_grid = false;
+                self.adaptive_grid_bias = 0;
+            }
+            ViewMsg::NarrowGrid => {
+                if self.adaptive_grid {
+                    self.adaptive_grid_bias = (self.adaptive_grid_bias + 1).min(6);
+                } else {
+                    self.snap_grid = self.snap_grid.narrower();
+                }
+            }
+            ViewMsg::WidenGrid => {
+                if self.adaptive_grid {
+                    self.adaptive_grid_bias = (self.adaptive_grid_bias - 1).max(-6);
+                } else {
+                    self.snap_grid = self.snap_grid.wider();
+                }
+            }
+            ViewMsg::ToggleTripletGrid => {
+                self.snap_grid = self.snap_grid.toggle_triplet();
+            }
+            ViewMsg::ToggleSnapToGrid => {
+                self.snap_enabled = !self.snap_enabled;
+            }
+            ViewMsg::ToggleAdaptiveGrid => {
+                self.adaptive_grid = !self.adaptive_grid;
             }
             ViewMsg::CursorMoved(x, y) => {
                 self.cursor_x = x;
@@ -296,6 +326,39 @@ mod tests {
 
         assert_eq!(v.editing_track_name, Some(bus_id));
         assert_eq!(v.edit_name_text, "A Return");
+    }
+
+    #[test]
+    fn grid_commands_update_the_shared_editor_grid() {
+        let mut v = ViewState::default();
+        assert_eq!(v.snap_grid, SnapGrid::EIGHTH);
+        assert!(v.snap_enabled);
+        assert!(!v.adaptive_grid);
+
+        v.update(ViewMsg::NarrowGrid, &[], ViewCtx::default());
+        assert_eq!(v.snap_grid, SnapGrid::SIXTEENTH);
+        v.update(ViewMsg::WidenGrid, &[], ViewCtx::default());
+        assert_eq!(v.snap_grid, SnapGrid::EIGHTH);
+        v.update(ViewMsg::ToggleTripletGrid, &[], ViewCtx::default());
+        assert_eq!(v.snap_grid, SnapGrid::EIGHTH.triplet());
+        v.update(ViewMsg::ToggleSnapToGrid, &[], ViewCtx::default());
+        assert!(!v.snap_enabled);
+        v.update(ViewMsg::ToggleAdaptiveGrid, &[], ViewCtx::default());
+        assert!(v.adaptive_grid);
+        assert_eq!(
+            v.grid_config().effective_grid(20.0),
+            SnapGrid::QUARTER.triplet()
+        );
+        v.update(ViewMsg::NarrowGrid, &[], ViewCtx::default());
+        assert_eq!(
+            v.grid_config().effective_grid(20.0),
+            SnapGrid::EIGHTH.triplet()
+        );
+        v.update(ViewMsg::WidenGrid, &[], ViewCtx::default());
+        assert_eq!(
+            v.grid_config().effective_grid(20.0),
+            SnapGrid::QUARTER.triplet()
+        );
     }
 
     #[test]

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -19,6 +19,9 @@ pub struct ViewState {
     pub zoom_level: f32,
     pub scroll_offset_beats: f64,
     pub snap_grid: SnapGrid,
+    pub snap_enabled: bool,
+    pub adaptive_grid: bool,
+    pub adaptive_grid_bias: i8,
     pub context_menu: Option<ContextMenu>,
     pub edit_menu_open: bool,
     /// Cursor tracking (for right-click positioning from mouse_area).
@@ -40,7 +43,10 @@ impl Default for ViewState {
             detail_panel_tab: DetailPanelTab::Clip,
             zoom_level: 1.0,
             scroll_offset_beats: 0.0,
-            snap_grid: SnapGrid::Eighth,
+            snap_grid: SnapGrid::EIGHTH,
+            snap_enabled: true,
+            adaptive_grid: false,
+            adaptive_grid_bias: 0,
             context_menu: None,
             edit_menu_open: false,
             cursor_x: 0.0,
@@ -51,6 +57,17 @@ impl Default for ViewState {
             editing_clip_name: None,
             edit_name_text: String::new(),
         }
+    }
+}
+
+impl ViewState {
+    pub fn grid_config(&self) -> GridConfig {
+        GridConfig::new(
+            self.snap_grid,
+            self.snap_enabled,
+            self.adaptive_grid,
+            self.adaptive_grid_bias,
+        )
     }
 }
 

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -301,6 +301,7 @@ pub enum DetailPanelTab {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GridDivision {
+    EightBars,
     FourBars,
     TwoBars,
     Bar,
@@ -318,6 +319,7 @@ pub struct SnapGrid {
 }
 
 impl SnapGrid {
+    pub const EIGHT_BARS: Self = Self::straight(GridDivision::EightBars);
     pub const FOUR_BARS: Self = Self::straight(GridDivision::FourBars);
     pub const TWO_BARS: Self = Self::straight(GridDivision::TwoBars);
     pub const BAR: Self = Self::straight(GridDivision::Bar);
@@ -325,7 +327,8 @@ impl SnapGrid {
     pub const EIGHTH: Self = Self::straight(GridDivision::Eighth);
     pub const SIXTEENTH: Self = Self::straight(GridDivision::Sixteenth);
     pub const THIRTY_SECOND: Self = Self::straight(GridDivision::ThirtySecond);
-    const ALL: [Self; 11] = [
+    const ALL: [Self; 12] = [
+        Self::EIGHT_BARS,
         Self::FOUR_BARS,
         Self::TWO_BARS,
         Self::BAR,
@@ -349,6 +352,7 @@ impl SnapGrid {
     /// Duration of one grid unit in beats.
     pub fn beat_size(self) -> f64 {
         let straight = match self.division {
+            GridDivision::EightBars => 32.0,
             GridDivision::FourBars => 16.0,
             GridDivision::TwoBars => 8.0,
             GridDivision::Bar => 4.0,
@@ -366,6 +370,7 @@ impl SnapGrid {
 
     pub fn label(self) -> &'static str {
         match (self.division, self.triplet) {
+            (GridDivision::EightBars, false) => "8 Bars",
             (GridDivision::FourBars, false) => "4 Bars",
             (GridDivision::TwoBars, false) => "2 Bars",
             (GridDivision::Bar, false) => "1 Bar",
@@ -373,6 +378,7 @@ impl SnapGrid {
             (GridDivision::Eighth, false) => "1/8",
             (GridDivision::Sixteenth, false) => "1/16",
             (GridDivision::ThirtySecond, false) => "1/32",
+            (GridDivision::EightBars, true) => "8 Bars T",
             (GridDivision::FourBars, true) => "4 Bars T",
             (GridDivision::TwoBars, true) => "2 Bars T",
             (GridDivision::Bar, true) => "1 Bar T",
@@ -408,6 +414,7 @@ impl SnapGrid {
     pub fn narrower(self) -> Self {
         Self {
             division: match self.division {
+                GridDivision::EightBars => GridDivision::FourBars,
                 GridDivision::FourBars => GridDivision::TwoBars,
                 GridDivision::TwoBars => GridDivision::Bar,
                 GridDivision::Bar => GridDivision::Quarter,
@@ -422,7 +429,8 @@ impl SnapGrid {
     pub fn wider(self) -> Self {
         Self {
             division: match self.division {
-                GridDivision::FourBars | GridDivision::TwoBars => GridDivision::FourBars,
+                GridDivision::EightBars | GridDivision::FourBars => GridDivision::EightBars,
+                GridDivision::TwoBars => GridDivision::FourBars,
                 GridDivision::Bar => GridDivision::TwoBars,
                 GridDivision::Quarter => GridDivision::Bar,
                 GridDivision::Eighth => GridDivision::Quarter,
@@ -435,6 +443,7 @@ impl SnapGrid {
 
     pub fn adaptive(pixels_per_beat: f32, bias: i8, triplet: bool) -> Self {
         let divisions = [
+            Self::EIGHT_BARS,
             Self::FOUR_BARS,
             Self::TWO_BARS,
             Self::BAR,
@@ -520,6 +529,7 @@ mod snap_grid_tests {
 
     #[test]
     fn supports_bars_subdivisions_and_triplets() {
+        assert_eq!(SnapGrid::EIGHT_BARS.beat_size(), 32.0);
         assert_eq!(SnapGrid::FOUR_BARS.beat_size(), 16.0);
         assert_eq!(SnapGrid::BAR.beat_size(), 4.0);
         assert_eq!(SnapGrid::EIGHTH.beat_size(), 0.5);
@@ -529,6 +539,8 @@ mod snap_grid_tests {
 
     #[test]
     fn narrower_and_wider_preserve_triplet_mode() {
+        assert_eq!(SnapGrid::EIGHT_BARS.narrower(), SnapGrid::FOUR_BARS);
+        assert_eq!(SnapGrid::FOUR_BARS.wider(), SnapGrid::EIGHT_BARS);
         assert_eq!(SnapGrid::BAR.narrower(), SnapGrid::QUARTER);
         assert_eq!(SnapGrid::QUARTER.wider(), SnapGrid::BAR);
         assert_eq!(
@@ -536,11 +548,12 @@ mod snap_grid_tests {
             SnapGrid::SIXTEENTH.triplet()
         );
         assert_eq!(SnapGrid::THIRTY_SECOND.narrower(), SnapGrid::THIRTY_SECOND);
-        assert_eq!(SnapGrid::FOUR_BARS.wider(), SnapGrid::FOUR_BARS);
+        assert_eq!(SnapGrid::EIGHT_BARS.wider(), SnapGrid::EIGHT_BARS);
     }
 
     #[test]
     fn adaptive_grid_gets_narrower_as_pixels_per_beat_increase() {
+        assert_eq!(SnapGrid::adaptive(0.25, 0, false), SnapGrid::EIGHT_BARS);
         assert_eq!(SnapGrid::adaptive(5.0, 0, false), SnapGrid::BAR);
         assert_eq!(SnapGrid::adaptive(20.0, 0, false), SnapGrid::QUARTER);
         assert_eq!(SnapGrid::adaptive(80.0, 0, false), SnapGrid::SIXTEENTH);

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -299,47 +299,267 @@ pub enum DetailPanelTab {
     Devices,
 }
 
-/// Snap grid for piano roll quantization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SnapGrid {
+enum GridDivision {
+    FourBars,
+    TwoBars,
+    Bar,
     Quarter,
     Eighth,
     Sixteenth,
     ThirtySecond,
 }
 
+/// A musical grid division, optionally interpreted as a triplet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapGrid {
+    division: GridDivision,
+    triplet: bool,
+}
+
 impl SnapGrid {
+    pub const FOUR_BARS: Self = Self::straight(GridDivision::FourBars);
+    pub const TWO_BARS: Self = Self::straight(GridDivision::TwoBars);
+    pub const BAR: Self = Self::straight(GridDivision::Bar);
+    pub const QUARTER: Self = Self::straight(GridDivision::Quarter);
+    pub const EIGHTH: Self = Self::straight(GridDivision::Eighth);
+    pub const SIXTEENTH: Self = Self::straight(GridDivision::Sixteenth);
+    pub const THIRTY_SECOND: Self = Self::straight(GridDivision::ThirtySecond);
+    const ALL: [Self; 11] = [
+        Self::FOUR_BARS,
+        Self::TWO_BARS,
+        Self::BAR,
+        Self::QUARTER,
+        Self::EIGHTH,
+        Self::SIXTEENTH,
+        Self::THIRTY_SECOND,
+        Self::QUARTER.triplet(),
+        Self::EIGHTH.triplet(),
+        Self::SIXTEENTH.triplet(),
+        Self::THIRTY_SECOND.triplet(),
+    ];
+
+    const fn straight(division: GridDivision) -> Self {
+        Self {
+            division,
+            triplet: false,
+        }
+    }
+
     /// Duration of one grid unit in beats.
     pub fn beat_size(self) -> f64 {
-        match self {
-            SnapGrid::Quarter => 1.0,
-            SnapGrid::Eighth => 0.5,
-            SnapGrid::Sixteenth => 0.25,
-            SnapGrid::ThirtySecond => 0.125,
+        let straight = match self.division {
+            GridDivision::FourBars => 16.0,
+            GridDivision::TwoBars => 8.0,
+            GridDivision::Bar => 4.0,
+            GridDivision::Quarter => 1.0,
+            GridDivision::Eighth => 0.5,
+            GridDivision::Sixteenth => 0.25,
+            GridDivision::ThirtySecond => 0.125,
+        };
+        if self.triplet {
+            straight * 2.0 / 3.0
+        } else {
+            straight
         }
     }
 
     pub fn label(self) -> &'static str {
-        match self {
-            SnapGrid::Quarter => "1/4",
-            SnapGrid::Eighth => "1/8",
-            SnapGrid::Sixteenth => "1/16",
-            SnapGrid::ThirtySecond => "1/32",
+        match (self.division, self.triplet) {
+            (GridDivision::FourBars, false) => "4 Bars",
+            (GridDivision::TwoBars, false) => "2 Bars",
+            (GridDivision::Bar, false) => "1 Bar",
+            (GridDivision::Quarter, false) => "1/4",
+            (GridDivision::Eighth, false) => "1/8",
+            (GridDivision::Sixteenth, false) => "1/16",
+            (GridDivision::ThirtySecond, false) => "1/32",
+            (GridDivision::FourBars, true) => "4 Bars T",
+            (GridDivision::TwoBars, true) => "2 Bars T",
+            (GridDivision::Bar, true) => "1 Bar T",
+            (GridDivision::Quarter, true) => "1/4T",
+            (GridDivision::Eighth, true) => "1/8T",
+            (GridDivision::Sixteenth, true) => "1/16T",
+            (GridDivision::ThirtySecond, true) => "1/32T",
         }
     }
 
     pub fn all() -> &'static [SnapGrid] {
-        &[
-            SnapGrid::Quarter,
-            SnapGrid::Eighth,
-            SnapGrid::Sixteenth,
-            SnapGrid::ThirtySecond,
-        ]
+        &Self::ALL
+    }
+
+    pub const fn triplet(self) -> Self {
+        Self {
+            triplet: true,
+            ..self
+        }
+    }
+
+    pub const fn toggle_triplet(self) -> Self {
+        Self {
+            triplet: !self.triplet,
+            ..self
+        }
+    }
+
+    pub const fn is_triplet(self) -> bool {
+        self.triplet
+    }
+
+    pub fn narrower(self) -> Self {
+        Self {
+            division: match self.division {
+                GridDivision::FourBars => GridDivision::TwoBars,
+                GridDivision::TwoBars => GridDivision::Bar,
+                GridDivision::Bar => GridDivision::Quarter,
+                GridDivision::Quarter => GridDivision::Eighth,
+                GridDivision::Eighth => GridDivision::Sixteenth,
+                GridDivision::Sixteenth | GridDivision::ThirtySecond => GridDivision::ThirtySecond,
+            },
+            ..self
+        }
+    }
+
+    pub fn wider(self) -> Self {
+        Self {
+            division: match self.division {
+                GridDivision::FourBars | GridDivision::TwoBars => GridDivision::FourBars,
+                GridDivision::Bar => GridDivision::TwoBars,
+                GridDivision::Quarter => GridDivision::Bar,
+                GridDivision::Eighth => GridDivision::Quarter,
+                GridDivision::Sixteenth => GridDivision::Eighth,
+                GridDivision::ThirtySecond => GridDivision::Sixteenth,
+            },
+            ..self
+        }
+    }
+
+    pub fn adaptive(pixels_per_beat: f32, bias: i8, triplet: bool) -> Self {
+        let divisions = [
+            Self::FOUR_BARS,
+            Self::TWO_BARS,
+            Self::BAR,
+            Self::QUARTER,
+            Self::EIGHTH,
+            Self::SIXTEENTH,
+            Self::THIRTY_SECOND,
+        ];
+        let base = divisions
+            .iter()
+            .rposition(|grid| grid.beat_size() * pixels_per_beat as f64 >= 12.0)
+            .unwrap_or(0);
+        let index = (base as i8 + bias).clamp(0, divisions.len() as i8 - 1) as usize;
+        let grid = divisions[index];
+        if triplet {
+            grid.triplet()
+        } else {
+            grid
+        }
     }
 
     /// Snap a beat value to the nearest grid position.
     pub fn snap_beat(self, beat: f64) -> f64 {
         let size = self.beat_size();
         (beat / size).round() * size
+    }
+}
+
+impl std::fmt::Display for SnapGrid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Shared grid modes passed into arrangement and MIDI editor widgets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GridConfig {
+    pub selected: SnapGrid,
+    pub snap_enabled: bool,
+    pub adaptive: bool,
+    pub adaptive_bias: i8,
+}
+
+impl GridConfig {
+    pub const fn new(
+        selected: SnapGrid,
+        snap_enabled: bool,
+        adaptive: bool,
+        adaptive_bias: i8,
+    ) -> Self {
+        Self {
+            selected,
+            snap_enabled,
+            adaptive,
+            adaptive_bias,
+        }
+    }
+
+    pub fn effective_grid(self, pixels_per_beat: f32) -> SnapGrid {
+        if self.adaptive {
+            SnapGrid::adaptive(
+                pixels_per_beat,
+                self.adaptive_bias,
+                self.selected.is_triplet(),
+            )
+        } else {
+            self.selected
+        }
+    }
+
+    pub fn snap_beat(self, beat: f64, pixels_per_beat: f32) -> f64 {
+        if self.snap_enabled {
+            self.effective_grid(pixels_per_beat).snap_beat(beat)
+        } else {
+            beat
+        }
+    }
+}
+
+#[cfg(test)]
+mod snap_grid_tests {
+    use super::*;
+
+    #[test]
+    fn supports_bars_subdivisions_and_triplets() {
+        assert_eq!(SnapGrid::FOUR_BARS.beat_size(), 16.0);
+        assert_eq!(SnapGrid::BAR.beat_size(), 4.0);
+        assert_eq!(SnapGrid::EIGHTH.beat_size(), 0.5);
+        assert!((SnapGrid::EIGHTH.triplet().beat_size() - 1.0 / 3.0).abs() < 1e-9);
+        assert_eq!(SnapGrid::EIGHTH.triplet().label(), "1/8T");
+    }
+
+    #[test]
+    fn narrower_and_wider_preserve_triplet_mode() {
+        assert_eq!(SnapGrid::BAR.narrower(), SnapGrid::QUARTER);
+        assert_eq!(SnapGrid::QUARTER.wider(), SnapGrid::BAR);
+        assert_eq!(
+            SnapGrid::EIGHTH.triplet().narrower(),
+            SnapGrid::SIXTEENTH.triplet()
+        );
+        assert_eq!(SnapGrid::THIRTY_SECOND.narrower(), SnapGrid::THIRTY_SECOND);
+        assert_eq!(SnapGrid::FOUR_BARS.wider(), SnapGrid::FOUR_BARS);
+    }
+
+    #[test]
+    fn adaptive_grid_gets_narrower_as_pixels_per_beat_increase() {
+        assert_eq!(SnapGrid::adaptive(5.0, 0, false), SnapGrid::BAR);
+        assert_eq!(SnapGrid::adaptive(20.0, 0, false), SnapGrid::QUARTER);
+        assert_eq!(SnapGrid::adaptive(80.0, 0, false), SnapGrid::SIXTEENTH);
+        assert_eq!(
+            SnapGrid::adaptive(80.0, 0, true),
+            SnapGrid::SIXTEENTH.triplet()
+        );
+    }
+
+    #[test]
+    fn grid_config_resolves_adaptive_density_and_can_disable_snapping() {
+        let fixed = GridConfig::new(SnapGrid::EIGHTH, true, false, 0);
+        assert_eq!(fixed.effective_grid(80.0), SnapGrid::EIGHTH);
+        assert_eq!(fixed.snap_beat(0.31, 80.0), 0.5);
+
+        let adaptive = GridConfig::new(SnapGrid::EIGHTH.triplet(), true, true, 0);
+        assert_eq!(adaptive.effective_grid(80.0), SnapGrid::SIXTEENTH.triplet());
+
+        let free = GridConfig::new(SnapGrid::SIXTEENTH, false, false, 0);
+        assert_eq!(free.snap_beat(0.31, 80.0), 0.31);
     }
 }

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -21,7 +21,7 @@ use vibez_core::id::{LaneId, TrackId};
 
 use crate::domains::automation::AutomationMsg;
 use crate::message::Message;
-use crate::state::SnapGrid;
+use crate::state::GridConfig;
 use crate::theme as th;
 
 pub const LANE_HEIGHT: f32 = 56.0;
@@ -41,7 +41,7 @@ pub struct AutomationLaneWidget {
     pub zoom_level: f32,
     pub scroll_offset_beats: f64,
     /// Grid for beat snapping (hold shift to bypass).
-    pub snap: SnapGrid,
+    pub grid: GridConfig,
     pub selected: Option<usize>,
     /// The parameter's current un-automated value (normalized), for
     /// the dotted reference line.
@@ -85,7 +85,7 @@ impl AutomationLaneWidget {
         if state.shift {
             beat
         } else {
-            self.snap.snap_beat(beat).max(0.0)
+            self.grid.snap_beat(beat, self.pixels_per_beat()).max(0.0)
         }
     }
 

--- a/crates/vibez-ui/src/widgets/piano_roll/draw.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/draw.rs
@@ -205,8 +205,8 @@ impl PianoRollWidget {
                 .with_width(1.0),
         );
 
-        // ── Vertical beat grid lines (always 16th-note resolution) ──
-        let grid_step = 0.25_f64; // always show 16th-note grid
+        // ── Vertical musical grid lines ──
+        let grid_step = self.grid.effective_grid(grid_ppb).beat_size();
         let num_steps = (total / grid_step).ceil() as usize;
 
         for step in 0..=num_steps {

--- a/crates/vibez-ui/src/widgets/piano_roll/mod.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/mod.rs
@@ -7,7 +7,7 @@ use iced::{Color, Point, Rectangle, Renderer, Theme};
 
 use crate::domains::piano_roll::PianoRollMsg;
 use crate::message::Message;
-use crate::state::{PianoRollEditMode, SnapGrid, UiNoteClip};
+use crate::state::{GridConfig, PianoRollEditMode, SnapGrid, UiNoteClip};
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::MidiNote;
 
@@ -41,7 +41,7 @@ pub struct PianoRollWidget {
     pub playhead_beats: f64,
     pub total_beats: f64,
     pub track_color: Color,
-    pub snap_grid: SnapGrid,
+    pub grid: GridConfig,
     pub scroll_y: f32,
     pub edit_mode: PianoRollEditMode,
 }
@@ -65,7 +65,7 @@ impl PianoRollWidget {
         playhead_beats: f64,
         total_beats: f64,
         track_color: Color,
-        snap_grid: SnapGrid,
+        grid: GridConfig,
         scroll_y: f32,
         edit_mode: PianoRollEditMode,
     ) -> Self {
@@ -82,7 +82,7 @@ impl PianoRollWidget {
             playhead_beats,
             total_beats,
             track_color,
-            snap_grid,
+            grid,
             scroll_y,
             edit_mode,
         }
@@ -95,7 +95,7 @@ impl PianoRollWidget {
             playhead_beats,
             total_beats: 16.0,
             track_color,
-            snap_grid: SnapGrid::Eighth,
+            grid: GridConfig::new(SnapGrid::EIGHTH, true, false, 0),
             scroll_y: default_scroll_y(200.0),
             edit_mode: PianoRollEditMode::default(),
         }
@@ -111,6 +111,18 @@ impl PianoRollWidget {
         let grid_width = bounds.width - KEY_WIDTH;
         let total = self.total_beats.max(1.0);
         ((x - KEY_WIDTH) / grid_width) as f64 * total
+    }
+
+    fn pixels_per_beat(&self, bounds: &Rectangle) -> f32 {
+        (bounds.width - KEY_WIDTH) / self.total_beats.max(1.0) as f32
+    }
+
+    fn effective_grid(&self, bounds: &Rectangle) -> SnapGrid {
+        self.grid.effective_grid(self.pixels_per_beat(bounds))
+    }
+
+    fn snapped_beat(&self, beat: f64, bounds: &Rectangle) -> f64 {
+        self.grid.snap_beat(beat, self.pixels_per_beat(bounds))
     }
 
     fn pitch_to_y(&self, pitch: u8) -> f32 {
@@ -340,8 +352,8 @@ impl canvas::Program<Message> for PianoRollWidget {
                                 return (canvas::event::Status::Ignored, None);
                             }
 
-                            let note_duration = self.snap_grid.beat_size();
-                            let snapped_beat = self.snap_grid.snap_beat(beat).max(0.0);
+                            let note_duration = self.effective_grid(&bounds).beat_size();
+                            let snapped_beat = self.snapped_beat(beat, &bounds).max(0.0);
 
                             let max_start = self.total_beats - note_duration;
                             if max_start < 0.0 || snapped_beat > max_start {
@@ -472,8 +484,8 @@ impl canvas::Program<Message> for PianoRollWidget {
                                 return (canvas::event::Status::Ignored, None);
                             }
 
-                            let note_duration = self.snap_grid.beat_size();
-                            let snapped_beat = self.snap_grid.snap_beat(beat).max(0.0);
+                            let note_duration = self.effective_grid(&bounds).beat_size();
+                            let snapped_beat = self.snapped_beat(beat, &bounds).max(0.0);
 
                             let max_start = self.total_beats - note_duration;
                             if max_start < 0.0 || snapped_beat > max_start {
@@ -531,8 +543,8 @@ impl canvas::Program<Message> for PianoRollWidget {
                                     let beat_delta = dx as f64 * beats_per_pixel;
                                     let pitch_delta = -(dy / KEY_HEIGHT).round() as i16;
 
-                                    let anchor_new_beat =
-                                        self.snap_grid.snap_beat(original_start_beat + beat_delta);
+                                    let anchor_new_beat = self
+                                        .snapped_beat(original_start_beat + beat_delta, &bounds);
                                     let snapped_beat_delta = anchor_new_beat - original_start_beat;
 
                                     // Move anchor note for visual feedback (works for both
@@ -569,10 +581,17 @@ impl canvas::Program<Message> for PianoRollWidget {
                                 } => {
                                     let dx = local.x - start_x;
                                     let beat_delta = dx as f64 * beats_per_pixel;
-                                    let min_duration = self.snap_grid.beat_size();
-                                    let new_duration = self.snap_grid.snap_beat(
-                                        (original_duration + beat_delta).max(min_duration),
-                                    );
+                                    let min_duration = if self.grid.snap_enabled {
+                                        self.effective_grid(&bounds).beat_size()
+                                    } else {
+                                        0.01
+                                    };
+                                    let new_duration = self
+                                        .snapped_beat(
+                                            (original_duration + beat_delta).max(min_duration),
+                                            &bounds,
+                                        )
+                                        .max(min_duration);
 
                                     let idx = *note_index;
                                     if idx < clip_data.notes.len() {
@@ -598,10 +617,17 @@ impl canvas::Program<Message> for PianoRollWidget {
                                     // Extend note duration while dragging
                                     let dx = local.x - start_x;
                                     let beat_delta = dx as f64 * beats_per_pixel;
-                                    let min_duration = self.snap_grid.beat_size();
-                                    let new_duration = self.snap_grid.snap_beat(
-                                        (min_duration + beat_delta.max(0.0)).max(min_duration),
-                                    );
+                                    let min_duration = self.effective_grid(&bounds).beat_size();
+                                    let new_duration = self
+                                        .snapped_beat(
+                                            (min_duration + beat_delta.max(0.0)).max(min_duration),
+                                            &bounds,
+                                        )
+                                        .max(if self.grid.snap_enabled {
+                                            min_duration
+                                        } else {
+                                            0.01
+                                        });
 
                                     // Find the note we just added (last note at this pitch/beat)
                                     if let Some(idx) = clip_data.notes.iter().rposition(|n| {
@@ -659,8 +685,8 @@ impl canvas::Program<Message> for PianoRollWidget {
                                     let beat_delta = dx as f64 * beats_per_pixel;
                                     let pitch_delta = -(dy / KEY_HEIGHT).round() as i16;
 
-                                    let anchor_new_beat =
-                                        self.snap_grid.snap_beat(original_start_beat + beat_delta);
+                                    let anchor_new_beat = self
+                                        .snapped_beat(original_start_beat + beat_delta, &bounds);
                                     let snapped_beat_delta = anchor_new_beat - original_start_beat;
 
                                     // Compute absolute positions for all selected notes
@@ -733,7 +759,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                             Some(Message::PianoRoll(PianoRollMsg::NudgeSelectedNotes {
                                 track_id: self.track_id,
                                 clip_id: clip_data.clip_id,
-                                delta_beats: -self.snap_grid.beat_size(),
+                                delta_beats: -self.effective_grid(&bounds).beat_size(),
                                 delta_semitones: 0,
                             })),
                         );
@@ -751,7 +777,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                             Some(Message::PianoRoll(PianoRollMsg::NudgeSelectedNotes {
                                 track_id: self.track_id,
                                 clip_id: clip_data.clip_id,
-                                delta_beats: self.snap_grid.beat_size(),
+                                delta_beats: self.effective_grid(&bounds).beat_size(),
                                 delta_semitones: 0,
                             })),
                         );
@@ -822,6 +848,22 @@ impl canvas::Program<Message> for PianoRollWidget {
 /// Returns true if the given MIDI pitch is a black key.
 fn is_black_key(pitch: u8) -> bool {
     matches!(pitch % 12, 1 | 3 | 6 | 8 | 10)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn piano_roll_uses_triplet_grid_and_preserves_free_positions_when_snap_is_off() {
+        let bounds = Rectangle::new(Point::ORIGIN, iced::Size::new(852.0, 400.0));
+        let mut widget = PianoRollWidget::empty(TrackId::new(), 0.0, Color::WHITE);
+        widget.grid = GridConfig::new(SnapGrid::EIGHTH.triplet(), true, false, 0);
+        assert!((widget.snapped_beat(0.31, &bounds) - 1.0 / 3.0).abs() < 1e-9);
+
+        widget.grid = GridConfig::new(SnapGrid::SIXTEENTH, false, false, 0);
+        assert_eq!(widget.snapped_beat(0.31, &bounds), 0.31);
+    }
 }
 
 mod draw;

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -12,7 +12,7 @@ use crate::domains::browser::BrowserMsg;
 use crate::domains::transport::TransportMsg;
 use crate::domains::view::ViewMsg;
 use crate::message::Message;
-use crate::state::{ArrangementSelection, ContextMenuTarget, UiTrack};
+use crate::state::{ArrangementSelection, ContextMenuTarget, GridConfig, UiTrack};
 use vibez_core::id::{ClipId, TrackId};
 
 use super::*;
@@ -61,6 +61,7 @@ pub struct TrackClipCanvas {
     pub note_clips: Vec<TimelineNoteClip>,
     pub playhead_beats: f64,
     pub zoom_level: f32,
+    pub grid: GridConfig,
     pub scroll_offset_beats: f64,
     pub total_beats: f64,
     pub sample_rate: u32,
@@ -92,6 +93,7 @@ impl TrackClipCanvas {
         track: &UiTrack,
         playhead_beats: f64,
         zoom_level: f32,
+        grid: GridConfig,
         scroll_offset_beats: f64,
         total_beats: f64,
         sample_rate: u32,
@@ -160,6 +162,7 @@ impl TrackClipCanvas {
             note_clips,
             playhead_beats,
             zoom_level,
+            grid,
             scroll_offset_beats,
             total_beats,
             sample_rate,
@@ -189,6 +192,10 @@ impl TrackClipCanvas {
 
     pub(super) fn x_to_beat(&self, x: f32) -> f64 {
         x as f64 / self.pixels_per_beat() as f64 + self.scroll_offset_beats
+    }
+
+    fn snapped_beat(&self, beat: f64) -> f64 {
+        self.grid.snap_beat(beat, self.pixels_per_beat())
     }
 
     /// Samples per beat.
@@ -447,7 +454,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                 // `cursor.position_in(bounds)`.
                 if self.sample_drop_active {
                     if let Some(local) = cursor.position_in(bounds) {
-                        let beat = self.x_to_beat(local.x).max(0.0).round();
+                        let beat = self.snapped_beat(self.x_to_beat(local.x).max(0.0));
                         return (
                             canvas::event::Status::Ignored,
                             Some(Message::Browser(BrowserMsg::DragHoverTrack {
@@ -470,10 +477,10 @@ impl canvas::Program<Message> for TrackClipCanvas {
                             } => {
                                 let dx = (local_x - start_x).abs();
                                 if dx > 4.0 {
-                                    let anchor_snapped = anchor.round();
+                                    let anchor_snapped = self.snapped_beat(*anchor);
                                     let beat =
                                         local_x as f64 / ppb as f64 + self.scroll_offset_beats;
-                                    let current = beat.round();
+                                    let current = self.snapped_beat(beat);
                                     let start = anchor_snapped.min(current);
                                     let end = anchor_snapped.max(current);
                                     state.drag = Some(ClipDragAction::RegionSelect {
@@ -496,7 +503,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                             }
                             ClipDragAction::RegionSelect { anchor_beat } => {
                                 let beat = local_x as f64 / ppb as f64 + self.scroll_offset_beats;
-                                let current = beat.round();
+                                let current = self.snapped_beat(beat);
                                 let start = anchor_beat.min(current);
                                 let end = anchor_beat.max(current);
                                 if end > start {
@@ -524,8 +531,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 let delta_beats = delta_px as f64 / ppb as f64;
                                 let new_pos = (original_position_beats + delta_beats).max(0.0);
 
-                                // Snap to nearest beat
-                                let snapped = (new_pos * 4.0).round() / 4.0;
+                                let snapped = self.snapped_beat(new_pos);
 
                                 // Check for cross-track drag
                                 let local_y = pos.y - bounds.y;
@@ -592,9 +598,13 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 clip_start_beat,
                             } => {
                                 let current_beat = self.x_to_beat(local_x);
-                                let new_dur = (current_beat - clip_start_beat).max(0.25);
-                                // Snap to quarter beat
-                                let snapped = (new_dur * 4.0).round() / 4.0;
+                                let min_duration = if self.grid.snap_enabled {
+                                    self.grid.effective_grid(self.pixels_per_beat()).beat_size()
+                                } else {
+                                    0.01
+                                };
+                                let new_dur = (current_beat - clip_start_beat).max(min_duration);
+                                let snapped = self.snapped_beat(new_dur).max(min_duration);
 
                                 if *is_note_clip {
                                     return (
@@ -638,7 +648,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                     if let Some(pos) = cursor.position_in(bounds) {
                         // Snap the drop position to the nearest beat so it
                         // matches the indicator drawn in `draw`.
-                        let beat = self.x_to_beat(pos.x).max(0.0).round();
+                        let beat = self.snapped_beat(self.x_to_beat(pos.x).max(0.0));
                         let spb = self.spb();
                         let position_samples = if spb > 0.0 { (beat * spb) as u64 } else { 0 };
                         state.drag = None;

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -86,60 +86,36 @@ impl TrackClipCanvas {
         };
         frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), bg_color);
 
-        // Grid lines — adaptive density matching ruler
+        // Grid lines use the same effective division as interaction.
         if self.bpm > 0.0 {
             let visible = w as f64 / ppb as f64;
-            let start = self.scroll_offset_beats.floor().max(0.0) as i64;
-            let end = (self.scroll_offset_beats + visible).ceil() as i64 + 1;
+            let grid = self.grid.effective_grid(ppb);
+            let step = grid.beat_size();
+            let start = (self.scroll_offset_beats / step).floor().max(0.0) as i64;
+            let end = ((self.scroll_offset_beats + visible) / step).ceil() as i64 + 1;
 
-            for beat_i in start..end {
-                let x = self.beat_to_x(beat_i as f64);
+            for grid_i in start..end {
+                let beat = grid_i as f64 * step;
+                let x = self.beat_to_x(beat);
                 if x < -1.0 || x > w + 1.0 {
                     continue;
                 }
-                let is_bar = beat_i % 4 == 0;
-
-                if is_bar {
-                    // Bar lines always visible
-                    let vline =
-                        canvas::Path::line(iced::Point::new(x, 0.0), iced::Point::new(x, h));
-                    frame.stroke(
-                        &vline,
-                        canvas::Stroke::default()
-                            .with_color(theme::border())
-                            .with_width(1.0),
-                    );
-                } else if ppb >= 40.0 {
-                    // Beat lines only at medium+ zoom
-                    let vline =
-                        canvas::Path::line(iced::Point::new(x, 0.0), iced::Point::new(x, h));
-                    frame.stroke(
-                        &vline,
-                        canvas::Stroke::default()
-                            .with_color(theme::divider())
-                            .with_width(0.5),
-                    );
-                }
-
-                // Sub-beat lines at high zoom (≥80 ppb)
-                if ppb >= 80.0 {
-                    for sub in 1..4 {
-                        let sub_beat = beat_i as f64 + sub as f64 * 0.25;
-                        let sub_x = self.beat_to_x(sub_beat);
-                        if sub_x > 0.0 && sub_x < w {
-                            let sub_line = canvas::Path::line(
-                                iced::Point::new(sub_x, 0.0),
-                                iced::Point::new(sub_x, h),
-                            );
-                            frame.stroke(
-                                &sub_line,
-                                canvas::Stroke::default()
-                                    .with_color(theme::divider())
-                                    .with_width(0.3),
-                            );
-                        }
-                    }
-                }
+                let on_bar = (beat / 4.0 - (beat / 4.0).round()).abs() < 1e-6;
+                let on_beat = (beat - beat.round()).abs() < 1e-6;
+                let (color, width) = if on_bar {
+                    (theme::grid_bar(), 1.0)
+                } else if on_beat {
+                    (theme::grid_beat(), 0.75)
+                } else {
+                    (theme::grid_sub(), 0.5)
+                };
+                let line = canvas::Path::line(iced::Point::new(x, 0.0), iced::Point::new(x, h));
+                frame.stroke(
+                    &line,
+                    canvas::Stroke::default()
+                        .with_color(color)
+                        .with_width(width),
+                );
             }
         }
 

--- a/crates/vibez-ui/src/widgets/timeline/ruler.rs
+++ b/crates/vibez-ui/src/widgets/timeline/ruler.rs
@@ -8,7 +8,7 @@ use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::transport::TransportMsg;
 use crate::domains::view::ViewMsg;
 use crate::message::Message;
-use crate::state::ContextMenuTarget;
+use crate::state::{ContextMenuTarget, GridConfig};
 use crate::theme;
 
 /// Canvas widget that draws a beat-based ruler with bar.beat labels.
@@ -16,6 +16,7 @@ pub struct RulerWidget {
     pub playhead_beats: f64,
     pub bpm: f64,
     pub zoom_level: f32,
+    pub grid: GridConfig,
     pub scroll_offset_beats: f64,
     pub total_beats: f64,
     pub loop_enabled: bool,
@@ -51,6 +52,10 @@ impl RulerWidget {
 
     fn beat_to_x(&self, beat: f64, _width: f32) -> f32 {
         ((beat - self.scroll_offset_beats) * self.pixels_per_beat() as f64) as f32
+    }
+
+    fn snapped_beat(&self, beat: f64) -> f64 {
+        self.grid.snap_beat(beat, self.pixels_per_beat())
     }
 }
 
@@ -380,8 +385,8 @@ impl canvas::Program<Message> for RulerWidget {
                             } => {
                                 let dx = (local_x - start_x).abs();
                                 if dx > 4.0 {
-                                    let anchor = anchor.round();
-                                    let current = beat.round();
+                                    let anchor = self.snapped_beat(*anchor);
+                                    let current = self.snapped_beat(beat);
                                     let start = anchor.min(current);
                                     let end = anchor.max(current);
                                     state.drag = Some(RulerDragAction::RegionSelect {
@@ -402,7 +407,7 @@ impl canvas::Program<Message> for RulerWidget {
                                 }
                             }
                             RulerDragAction::RegionSelect { anchor_beat } => {
-                                let current = beat.round();
+                                let current = self.snapped_beat(beat);
                                 let start = anchor_beat.min(current);
                                 let end = anchor_beat.max(current);
                                 if end > start {


### PR DESCRIPTION
## What

- Adds fixed musical grids from 4 bars through 1/32, plus quarter/eighth/sixteenth/thirty-second triplets
- Adds a compact grid selector beside BPM with Snap, Triplet, and Auto toggles
- Applies the shared grid to arrangement clip move/resize, time selections, sample drops, automation points, MIDI note create/move/resize/nudge, and both editors' grid drawing
- Adaptive mode resolves independently from each editor's pixels-per-beat and reports the effective division in the selector
- Quantize uses the effective grid for arrangement audio and the active MIDI clip

## Shortcuts

- Ctrl/Cmd+1: narrower grid
- Ctrl/Cmd+2: wider grid
- Ctrl/Cmd+3: toggle triplets
- Ctrl/Cmd+4: toggle snap
- Ctrl/Cmd+5: toggle adaptive grid

## Verification

- TDD coverage for musical divisions, triplet math, adaptive density, snap-off behavior, state transitions, shortcut routing, and piano-roll snapping
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace
- Native toolbar inspected at 1400px and 900px window widths