### PR TITLE
feat(project): prove Project Format V1 SQLite container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +1789,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "hassle-rs"
@@ -2406,6 +2427,17 @@ dependencies = [
  "bitflags 2.11.0",
  "libc",
  "redox_syscall 0.7.1",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3829,6 +3861,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4960,6 +5006,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5061,8 +5113,10 @@ dependencies = [
 name = "vibez-project"
 version = "0.1.0"
 dependencies = [
+ "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "vibez-core",
 ]

--- a/crates/vibez-project/Cargo.toml
+++ b/crates/vibez-project/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 vibez-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+rusqlite = { version = "0.32", features = ["bundled"] }
+sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/vibez-project/src/bin/project-format-v1-proof.rs
+++ b/crates/vibez-project/src/bin/project-format-v1-proof.rs
@@ -1,0 +1,197 @@
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use vibez_project::project_format_v1_proof::{
+    abort_mid_save, hex_sha256, representative_document, ProofContainer, Provenance, StagedMedia,
+};
+
+const ASSET_BYTES: usize = 32 * 1024 * 1024;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let arguments: Vec<String> = std::env::args().collect();
+    if arguments.get(1).map(String::as_str) == Some("interrupt") {
+        abort_mid_save(
+            arguments
+                .get(2)
+                .expect("interrupt requires a container path"),
+        );
+    }
+
+    let output_dir = arguments
+        .get(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(default_output_dir);
+    run_measurement(&output_dir)
+}
+
+fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
+    fs::create_dir_all(output_dir)?;
+    let container_path = output_dir.join("project-format-v1-proof.vzp");
+    let save_as_path = output_dir.join("project-format-v1-proof-save-as.vzp");
+    for path in [&container_path, &save_as_path] {
+        if path.exists() {
+            fs::remove_file(path)?;
+        }
+    }
+
+    let local_bytes = pcm_wav_bytes(0x31);
+    let remote_bytes = pcm_wav_bytes(0xa7);
+    let local_stage = output_dir.join("local.staged");
+    let remote_stage = output_dir.join("remote.staged");
+    fs::write(&local_stage, &local_bytes)?;
+    fs::write(&remote_stage, &remote_bytes)?;
+
+    let staged = vec![
+        StagedMedia {
+            id: "local-break".into(),
+            file_name: "local-break.wav".into(),
+            path: local_stage.clone(),
+            provenance: Provenance::Local {
+                source_path: PathBuf::from("/library/Breaks/local-break.wav"),
+            },
+        },
+        StagedMedia {
+            id: "remote-vocal".into(),
+            file_name: "remote-vocal.wav".into(),
+            path: remote_stage.clone(),
+            provenance: Provenance::Remote {
+                provider: "dropbox".into(),
+                connection_id: "alex-dropbox".into(),
+                source_id: "id:proof-remote-vocal".into(),
+                source_path: "/Megalodon/Vocals/remote-vocal.wav".into(),
+                revision: Some("proof-rev-1".into()),
+            },
+        },
+    ];
+
+    let mut document = representative_document();
+    let (mut container, full_save) =
+        ProofContainer::create_from_staged(&container_path, &mut document, &staged)?;
+    assert!(!local_stage.exists() && !remote_stage.exists());
+    assert_eq!(container.read_media("local-break")?, local_bytes);
+    assert_eq!(container.read_media("remote-vocal")?, remote_bytes);
+    let document_json = serde_json::to_vec(&document)?;
+    assert_eq!(
+        serde_json::to_vec(&container.load_document()?)?,
+        document_json
+    );
+
+    let original_size = fs::metadata(&container_path)?.len();
+    let fingerprint_before = container.media_fingerprint("local-break")?;
+    document.project.name = "Document-only incremental change".into();
+    document.project.bpm = 127.0;
+    let committed_json = serde_json::to_vec(&document)?;
+    let incremental = container.save_document(&document)?;
+    let fingerprint_after = container.media_fingerprint("local-break")?;
+    assert_eq!(fingerprint_after, fingerprint_before);
+    assert_eq!(incremental.media_rows_written, 0);
+
+    let save_as = container.save_as(&save_as_path)?;
+    drop(container);
+
+    let reopen_started = Instant::now();
+    let reopened = ProofContainer::open(&container_path)?;
+    let reopened_document = reopened.load_document()?;
+    let reopen_elapsed = reopen_started.elapsed();
+    assert_eq!(serde_json::to_vec(&reopened_document)?, committed_json);
+    assert_eq!(
+        hex_sha256(&reopened.read_media("local-break")?),
+        fingerprint_before.1
+    );
+    drop(reopened);
+
+    let child = Command::new(std::env::current_exe()?)
+        .arg("interrupt")
+        .arg(&container_path)
+        .status()?;
+    assert!(
+        !child.success(),
+        "the interrupted child must terminate before commit"
+    );
+
+    let recovered_started = Instant::now();
+    let recovered = ProofContainer::open(&container_path)?;
+    let recovered_document = recovered.load_document()?;
+    let recovery_elapsed = recovered_started.elapsed();
+    assert_eq!(serde_json::to_vec(&recovered_document)?, committed_json);
+    assert_eq!(
+        recovered.media_fingerprint("local-break")?,
+        fingerprint_before
+    );
+    assert_eq!(recovered.read_media("local-break")?, local_bytes);
+
+    let save_as_container = ProofContainer::open(&save_as_path)?;
+    assert_eq!(
+        serde_json::to_vec(&save_as_container.load_document()?)?,
+        committed_json
+    );
+    assert_eq!(save_as_container.read_media("remote-vocal")?, remote_bytes);
+
+    let final_size = fs::metadata(&container_path)?.len();
+    println!("# Project Format V1 SQLite proof measurement");
+    println!("fixture_media_bytes={}", ASSET_BYTES * 2);
+    println!(
+        "full_save_ms={:.3}",
+        full_save.elapsed.as_secs_f64() * 1000.0
+    );
+    println!(
+        "incremental_save_ms={:.3}",
+        incremental.elapsed.as_secs_f64() * 1000.0
+    );
+    println!("reopen_ms={:.3}", reopen_elapsed.as_secs_f64() * 1000.0);
+    println!("save_as_ms={:.3}", save_as.elapsed.as_secs_f64() * 1000.0);
+    println!(
+        "recovery_reopen_ms={:.3}",
+        recovery_elapsed.as_secs_f64() * 1000.0
+    );
+    println!("container_bytes_after_full_save={original_size}");
+    println!("container_bytes_after_incremental_and_recovery={final_size}");
+    println!(
+        "incremental_media_rows_written={}",
+        incremental.media_rows_written
+    );
+    println!(
+        "incremental_media_bytes_written={}",
+        incremental.media_bytes_written
+    );
+    println!("media_rowid_before={}", fingerprint_before.0);
+    println!("media_rowid_after={}", fingerprint_after.0);
+    println!("media_sha256_before={}", fingerprint_before.1);
+    println!("media_sha256_after={}", fingerprint_after.1);
+    println!("interrupted_child_status={child}");
+    println!("artifacts={}", output_dir.display());
+    Ok(())
+}
+
+fn pcm_wav_bytes(seed: u8) -> Vec<u8> {
+    let mut bytes = vec![0; ASSET_BYTES];
+    let data_bytes = (ASSET_BYTES - 44) as u32;
+    bytes[0..4].copy_from_slice(b"RIFF");
+    bytes[4..8].copy_from_slice(&((ASSET_BYTES as u32) - 8).to_le_bytes());
+    bytes[8..12].copy_from_slice(b"WAVE");
+    bytes[12..16].copy_from_slice(b"fmt ");
+    bytes[16..20].copy_from_slice(&16_u32.to_le_bytes());
+    bytes[20..22].copy_from_slice(&1_u16.to_le_bytes());
+    bytes[22..24].copy_from_slice(&2_u16.to_le_bytes());
+    bytes[24..28].copy_from_slice(&48_000_u32.to_le_bytes());
+    bytes[28..32].copy_from_slice(&(48_000_u32 * 4).to_le_bytes());
+    bytes[32..34].copy_from_slice(&4_u16.to_le_bytes());
+    bytes[34..36].copy_from_slice(&16_u16.to_le_bytes());
+    bytes[36..40].copy_from_slice(b"data");
+    bytes[40..44].copy_from_slice(&data_bytes.to_le_bytes());
+    for (index, byte) in bytes[44..].iter_mut().enumerate() {
+        *byte = seed.wrapping_add((index % 251) as u8);
+    }
+    bytes
+}
+
+fn default_output_dir() -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after Unix epoch")
+        .as_millis();
+    std::env::temp_dir().join(format!("vibez-project-format-v1-proof-{timestamp}"))
+}

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use vibez_core::midi::NoteClipInfo;
 use vibez_core::track::{ClipInfo, TrackInfo};
 
+pub mod project_format_v1_proof;
+
 /// A serializable project containing tracks and clips.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Project {

--- a/crates/vibez-project/src/project_format_v1_proof.rs
+++ b/crates/vibez-project/src/project_format_v1_proof.rs
@@ -1,0 +1,469 @@
+//! Bounded Project Format V1 container proof.
+//!
+//! This module deliberately does not replace [`crate::Project`]'s production
+//! JSON save/load path. It exists to measure and validate the SQLite-backed
+//! container proposed for Project Format V1 before production persistence is
+//! built on it.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Transaction};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::Project;
+
+pub const FORMAT_VERSION: u32 = 1;
+/// ASCII `VZP1`, stored in SQLite's application-id header field.
+pub const APPLICATION_ID: u32 = 0x565a_5031;
+
+const SCHEMA: &str = r#"
+CREATE TABLE project_document (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    json BLOB NOT NULL
+);
+CREATE TABLE project_media (
+    id TEXT PRIMARY KEY,
+    file_name TEXT NOT NULL,
+    byte_len INTEGER NOT NULL,
+    sha256 TEXT NOT NULL,
+    provenance_json BLOB NOT NULL,
+    content BLOB NOT NULL
+);
+"#;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Provenance {
+    Local {
+        source_path: PathBuf,
+    },
+    Remote {
+        provider: String,
+        connection_id: String,
+        source_id: String,
+        source_path: String,
+        revision: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectMediaEntry {
+    pub id: String,
+    pub file_name: String,
+    pub byte_len: u64,
+    pub sha256: String,
+    pub provenance: Provenance,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectDocumentV1 {
+    pub format_version: u32,
+    pub project: Project,
+    pub project_media: Vec<ProjectMediaEntry>,
+}
+
+impl ProjectDocumentV1 {
+    pub fn new(project: Project) -> Self {
+        Self {
+            format_version: FORMAT_VERSION,
+            project,
+            project_media: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StagedMedia {
+    pub id: String,
+    pub file_name: String,
+    pub path: PathBuf,
+    pub provenance: Provenance,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SaveObservation {
+    pub elapsed: Duration,
+    pub container_bytes: u64,
+    pub media_rows_written: usize,
+    pub media_bytes_written: u64,
+}
+
+#[derive(Debug)]
+pub enum ProofError {
+    Io(std::io::Error),
+    Sql(rusqlite::Error),
+    Json(serde_json::Error),
+    InvalidContainer(String),
+    MissingMedia(String),
+    ExistingDestination(PathBuf),
+}
+
+impl std::fmt::Display for ProofError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "I/O error: {error}"),
+            Self::Sql(error) => write!(f, "SQLite error: {error}"),
+            Self::Json(error) => write!(f, "JSON error: {error}"),
+            Self::InvalidContainer(message) => {
+                write!(f, "invalid Project Format V1 proof container: {message}")
+            }
+            Self::MissingMedia(id) => write!(f, "project media {id:?} was not found"),
+            Self::ExistingDestination(path) => {
+                write!(f, "Save As destination already exists: {}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProofError {}
+
+impl From<std::io::Error> for ProofError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<rusqlite::Error> for ProofError {
+    fn from(value: rusqlite::Error) -> Self {
+        Self::Sql(value)
+    }
+}
+
+impl From<serde_json::Error> for ProofError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Json(value)
+    }
+}
+
+pub struct ProofContainer {
+    path: PathBuf,
+    connection: Connection,
+}
+
+impl ProofContainer {
+    /// First-save proof: transactionally creates a new container and takes
+    /// ownership of staged bytes. Staging files are removed only after commit.
+    pub fn create_from_staged(
+        path: impl AsRef<Path>,
+        document: &mut ProjectDocumentV1,
+        staged_media: &[StagedMedia],
+    ) -> Result<(Self, SaveObservation), ProofError> {
+        let path = path.as_ref();
+        if path.exists() {
+            return Err(ProofError::ExistingDestination(path.to_path_buf()));
+        }
+
+        let started = Instant::now();
+        let mut connection = Connection::open(path)?;
+        configure_connection(&connection)?;
+        initialize_schema_markers(&connection)?;
+        connection.execute_batch(SCHEMA)?;
+
+        let transaction = connection.transaction()?;
+        let mut media_bytes_written = 0_u64;
+        for staged in staged_media {
+            let content = fs::read(&staged.path)?;
+            let entry = media_entry(staged, &content);
+            insert_media(&transaction, &entry, &content)?;
+            media_bytes_written += content.len() as u64;
+            document.project_media.push(entry);
+        }
+        write_document(&transaction, document)?;
+        transaction.commit()?;
+
+        // A committed container owns the media; stale staging copies are no
+        // longer needed. Cleanup failure is intentionally non-fatal because
+        // losing the newly committed Project Media would be worse.
+        for staged in staged_media {
+            let _ = fs::remove_file(&staged.path);
+        }
+
+        let observation = SaveObservation {
+            elapsed: started.elapsed(),
+            container_bytes: fs::metadata(path)?.len(),
+            media_rows_written: staged_media.len(),
+            media_bytes_written,
+        };
+        Ok((
+            Self {
+                path: path.to_path_buf(),
+                connection,
+            },
+            observation,
+        ))
+    }
+
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, ProofError> {
+        let path = path.as_ref();
+        let connection = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        validate_container(&connection)?;
+        configure_connection(&connection)?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            connection,
+        })
+    }
+
+    pub fn load_document(&self) -> Result<ProjectDocumentV1, ProofError> {
+        let json: Vec<u8> = self.connection.query_row(
+            "SELECT json FROM project_document WHERE singleton = 1",
+            [],
+            |row| row.get(0),
+        )?;
+        let document: ProjectDocumentV1 = serde_json::from_slice(&json)?;
+        if document.format_version != FORMAT_VERSION {
+            return Err(ProofError::InvalidContainer(format!(
+                "document version is {}, expected {FORMAT_VERSION}",
+                document.format_version
+            )));
+        }
+        Ok(document)
+    }
+
+    pub fn read_media(&self, id: &str) -> Result<Vec<u8>, ProofError> {
+        self.connection
+            .query_row(
+                "SELECT content FROM project_media WHERE id = ?1",
+                [id],
+                |row| row.get(0),
+            )
+            .optional()?
+            .ok_or_else(|| ProofError::MissingMedia(id.to_owned()))
+    }
+
+    pub fn media_fingerprint(&self, id: &str) -> Result<(i64, String, u64), ProofError> {
+        self.connection
+            .query_row(
+                "SELECT rowid, sha256, byte_len FROM project_media WHERE id = ?1",
+                [id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get::<_, i64>(2)? as u64)),
+            )
+            .optional()?
+            .ok_or_else(|| ProofError::MissingMedia(id.to_owned()))
+    }
+
+    /// Incrementally updates only the versioned project document. The media
+    /// table is not touched; the observation makes that explicit.
+    pub fn save_document(
+        &mut self,
+        document: &ProjectDocumentV1,
+    ) -> Result<SaveObservation, ProofError> {
+        let started = Instant::now();
+        let transaction = self.connection.transaction()?;
+        write_document(&transaction, document)?;
+        transaction.commit()?;
+        Ok(SaveObservation {
+            elapsed: started.elapsed(),
+            container_bytes: fs::metadata(&self.path)?.len(),
+            media_rows_written: 0,
+            media_bytes_written: 0,
+        })
+    }
+
+    /// Creates a self-contained snapshot without changing the source path.
+    pub fn save_as(&self, destination: impl AsRef<Path>) -> Result<SaveObservation, ProofError> {
+        let destination = destination.as_ref();
+        if destination.exists() {
+            return Err(ProofError::ExistingDestination(destination.to_path_buf()));
+        }
+        let destination_text = destination.to_str().ok_or_else(|| {
+            ProofError::InvalidContainer("Save As destination is not valid UTF-8".into())
+        })?;
+        let started = Instant::now();
+        self.connection
+            .execute("VACUUM INTO ?1", [destination_text])?;
+        let reopened = Self::open(destination)?;
+        let document = reopened.load_document()?;
+        if document.format_version != FORMAT_VERSION {
+            return Err(ProofError::InvalidContainer(
+                "Save As lost format marker".into(),
+            ));
+        }
+        Ok(SaveObservation {
+            elapsed: started.elapsed(),
+            container_bytes: fs::metadata(destination)?.len(),
+            media_rows_written: 0,
+            media_bytes_written: 0,
+        })
+    }
+}
+
+/// Starts a real transaction, overwrites the document and a media row, then
+/// terminates the process without running destructors or committing. This is
+/// only for the proof's child-process interruption test.
+pub fn abort_mid_save(path: impl AsRef<Path>) -> ! {
+    let mut connection = Connection::open(path).expect("open proof container before abort");
+    configure_connection(&connection).expect("configure proof container before abort");
+    let transaction = connection
+        .transaction()
+        .expect("start interrupted transaction");
+    transaction
+        .execute(
+            "UPDATE project_document SET json = ?1 WHERE singleton = 1",
+            [br#"{"interrupted":true}"#.as_slice()],
+        )
+        .expect("overwrite document inside interrupted transaction");
+    transaction
+        .execute(
+            "UPDATE project_media SET content = zeroblob(byte_len), sha256 = 'interrupted' WHERE rowid = (SELECT MIN(rowid) FROM project_media)",
+            [],
+        )
+        .expect("overwrite media inside interrupted transaction");
+    std::process::exit(86)
+}
+
+fn configure_connection(connection: &Connection) -> Result<(), rusqlite::Error> {
+    connection.execute_batch("PRAGMA journal_mode = DELETE; PRAGMA synchronous = FULL;")?;
+    Ok(())
+}
+
+fn validate_container(connection: &Connection) -> Result<(), ProofError> {
+    let application_id: u32 =
+        connection.query_row("PRAGMA application_id", [], |row| row.get(0))?;
+    let user_version: u32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if application_id != APPLICATION_ID || user_version != FORMAT_VERSION {
+        return Err(ProofError::InvalidContainer(format!(
+            "application_id={application_id:#x}, user_version={user_version}"
+        )));
+    }
+    Ok(())
+}
+
+fn write_document(
+    transaction: &Transaction<'_>,
+    document: &ProjectDocumentV1,
+) -> Result<(), ProofError> {
+    if document.format_version != FORMAT_VERSION {
+        return Err(ProofError::InvalidContainer(format!(
+            "cannot save document version {} as version {FORMAT_VERSION}",
+            document.format_version
+        )));
+    }
+    transaction.execute(
+        "INSERT INTO project_document(singleton, json) VALUES (1, ?1) ON CONFLICT(singleton) DO UPDATE SET json = excluded.json",
+        [serde_json::to_vec(document)?],
+    )?;
+    Ok(())
+}
+
+fn insert_media(
+    transaction: &Transaction<'_>,
+    entry: &ProjectMediaEntry,
+    content: &[u8],
+) -> Result<(), ProofError> {
+    transaction.execute(
+        "INSERT INTO project_media(id, file_name, byte_len, sha256, provenance_json, content) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            entry.id,
+            entry.file_name,
+            entry.byte_len as i64,
+            entry.sha256,
+            serde_json::to_vec(&entry.provenance)?,
+            content
+        ],
+    )?;
+    Ok(())
+}
+
+fn media_entry(staged: &StagedMedia, content: &[u8]) -> ProjectMediaEntry {
+    ProjectMediaEntry {
+        id: staged.id.clone(),
+        file_name: staged.file_name.clone(),
+        byte_len: content.len() as u64,
+        sha256: hex_sha256(content),
+        provenance: staged.provenance.clone(),
+    }
+}
+
+pub fn hex_sha256(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+/// Representative non-media document used by the repeatable proof and its
+/// tests. It includes MIDI, automation, native-device state and opaque
+/// third-party plugin state.
+pub fn representative_document() -> ProjectDocumentV1 {
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+    use vibez_core::effect::{EffectInfo, EffectType, PluginDeviceInfo};
+    use vibez_core::id::{ClipId, EffectId};
+    use vibez_core::midi::{MidiNote, NoteClipInfo};
+    use vibez_core::track::{InstrumentStateInfo, TrackInfo};
+
+    let mut track = TrackInfo::new("Proof instrument");
+    track.native_instrument = Some(InstrumentStateInfo::SubtractiveSynth {
+        params: vec![0.05, 0.2, 0.8, 0.4],
+    });
+    track.effects.push(EffectInfo {
+        id: EffectId::new(),
+        effect_type: EffectType::Gain,
+        bypass: false,
+        params: vec![1.0],
+        plugin: Some(PluginDeviceInfo {
+            format: "clap".into(),
+            uid: "org.vibez.proof-plugin".into(),
+            path: PathBuf::from("/plugins/proof.clap"),
+            name: "Opaque Proof Plugin".into(),
+            state_b64: Some("AAECA/7/UGx1Z2luU3RhdGU=".into()),
+        }),
+    });
+    let mut automation = AutomationLane::new(AutomationTarget::TrackGain);
+    automation.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 0.25,
+        curve: 0.0,
+    });
+    automation.insert_point(AutomationPoint {
+        beat: 16.0,
+        value: 0.9,
+        curve: 0.35,
+    });
+    track.automation.push(automation);
+
+    let track_id = track.id;
+    let project = Project {
+        name: "Project Format V1 proof".into(),
+        bpm: 126.0,
+        sample_rate: 48_000,
+        tracks: vec![track],
+        clips: Vec::new(),
+        note_clips: vec![NoteClipInfo {
+            id: ClipId::new(),
+            track_id,
+            name: "Proof pattern".into(),
+            position_beats: 0.0,
+            duration_beats: 4.0,
+            notes: vec![
+                MidiNote {
+                    pitch: 36,
+                    velocity: 112,
+                    start_beat: 0.0,
+                    duration_beats: 0.25,
+                },
+                MidiNote {
+                    pitch: 42,
+                    velocity: 96,
+                    start_beat: 0.5,
+                    duration_beats: 0.125,
+                },
+            ],
+            loop_enabled: true,
+            loop_start_beats: 0.0,
+            loop_end_beats: 4.0,
+        }],
+        master: Some(TrackInfo::new("Master")),
+        buses: vec![TrackInfo::new("Return A")],
+    };
+    ProjectDocumentV1::new(project)
+}
+
+pub fn initialize_schema_markers(connection: &Connection) -> Result<(), rusqlite::Error> {
+    connection.pragma_update(None, "application_id", i64::from(APPLICATION_ID))?;
+    connection.pragma_update(None, "user_version", i64::from(FORMAT_VERSION))?;
+    Ok(())
+}

--- a/crates/vibez-project/tests/project_format_v1_proof.rs
+++ b/crates/vibez-project/tests/project_format_v1_proof.rs
@@ -1,0 +1,148 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use vibez_project::project_format_v1_proof::{
+    hex_sha256, representative_document, ProofContainer, Provenance, StagedMedia, APPLICATION_ID,
+    FORMAT_VERSION,
+};
+
+fn stage(path: PathBuf, id: &str, seed: u8) -> (StagedMedia, Vec<u8>) {
+    let bytes: Vec<u8> = (0..2 * 1024 * 1024)
+        .map(|index| seed.wrapping_add((index % 251) as u8))
+        .collect();
+    fs::write(&path, &bytes).unwrap();
+    (
+        StagedMedia {
+            id: id.into(),
+            file_name: format!("{id}.wav"),
+            path,
+            provenance: Provenance::Remote {
+                provider: "dropbox".into(),
+                connection_id: "proof-connection".into(),
+                source_id: format!("id:{id}"),
+                source_path: format!("/Megalodon/{id}.wav"),
+                revision: Some("proof-rev".into()),
+            },
+        },
+        bytes,
+    )
+}
+
+#[test]
+fn representative_container_roundtrips_incrementally_and_save_as() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("proof.vzp");
+    let save_as_path = directory.path().join("proof-copy.vzp");
+    let (staged, media_bytes) = stage(directory.path().join("proof.staged"), "proof-media", 17);
+    let staging_path = staged.path.clone();
+    let mut document = representative_document();
+
+    let (mut container, full_save) =
+        ProofContainer::create_from_staged(&path, &mut document, &[staged]).unwrap();
+    assert_eq!(full_save.media_rows_written, 1);
+    assert_eq!(full_save.media_bytes_written, media_bytes.len() as u64);
+    assert!(
+        !staging_path.exists(),
+        "first save should consume Staged Media"
+    );
+
+    let loaded = container.load_document().unwrap();
+    assert_eq!(
+        serde_json::to_vec(&loaded).unwrap(),
+        serde_json::to_vec(&document).unwrap()
+    );
+    assert_eq!(container.read_media("proof-media").unwrap(), media_bytes);
+    assert_eq!(loaded.project.note_clips[0].notes.len(), 2);
+    assert_eq!(loaded.project.tracks[0].automation[0].points.len(), 2);
+    assert!(loaded.project.tracks[0].native_instrument.is_some());
+    assert!(loaded.project.tracks[0].effects[0]
+        .plugin
+        .as_ref()
+        .unwrap()
+        .state_b64
+        .is_some());
+    assert!(matches!(
+        loaded.project_media[0].provenance,
+        Provenance::Remote { .. }
+    ));
+
+    let file_size_before = fs::metadata(&path).unwrap().len();
+    let media_before = container.media_fingerprint("proof-media").unwrap();
+    document.project.bpm = 131.0;
+    document.project.name = "Incremental document edit".into();
+    let incremental = container.save_document(&document).unwrap();
+    let media_after = container.media_fingerprint("proof-media").unwrap();
+    assert_eq!(incremental.media_rows_written, 0);
+    assert_eq!(incremental.media_bytes_written, 0);
+    assert_eq!(media_before, media_after);
+    assert!(fs::metadata(&path).unwrap().len() - file_size_before < 128 * 1024);
+
+    let save_as = container.save_as(&save_as_path).unwrap();
+    assert!(save_as.container_bytes > media_bytes.len() as u64);
+    let copied = ProofContainer::open(&save_as_path).unwrap();
+    assert_eq!(
+        serde_json::to_vec(&copied.load_document().unwrap()).unwrap(),
+        serde_json::to_vec(&document).unwrap()
+    );
+    assert_eq!(copied.read_media("proof-media").unwrap(), media_bytes);
+}
+
+#[test]
+fn format_markers_are_explicit_and_file_is_not_zip() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("proof.vzp");
+    let mut document = representative_document();
+    let (container, _) = ProofContainer::create_from_staged(&path, &mut document, &[]).unwrap();
+    drop(container);
+
+    let bytes = fs::read(&path).unwrap();
+    assert_eq!(&bytes[..16], b"SQLite format 3\0");
+    assert_ne!(&bytes[..2], b"PK");
+    assert_eq!(document.format_version, FORMAT_VERSION);
+
+    let connection = rusqlite::Connection::open(&path).unwrap();
+    let application_id: u32 = connection
+        .query_row("PRAGMA application_id", [], |row| row.get(0))
+        .unwrap();
+    let user_version: u32 = connection
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(application_id, APPLICATION_ID);
+    assert_eq!(user_version, FORMAT_VERSION);
+}
+
+#[test]
+fn process_interruption_preserves_last_committed_document_and_media() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("proof.vzp");
+    let (staged, media_bytes) = stage(directory.path().join("proof.staged"), "proof-media", 83);
+    let mut document = representative_document();
+    let (container, _) =
+        ProofContainer::create_from_staged(&path, &mut document, &[staged]).unwrap();
+    let committed_json = serde_json::to_vec(&container.load_document().unwrap()).unwrap();
+    let committed_fingerprint = container.media_fingerprint("proof-media").unwrap();
+    drop(container);
+
+    let binary = env!("CARGO_BIN_EXE_project-format-v1-proof");
+    let status = Command::new(binary)
+        .arg("interrupt")
+        .arg(&path)
+        .status()
+        .unwrap();
+    assert_eq!(status.code(), Some(86));
+
+    let recovered = ProofContainer::open(&path).unwrap();
+    assert_eq!(
+        serde_json::to_vec(&recovered.load_document().unwrap()).unwrap(),
+        committed_json
+    );
+    assert_eq!(
+        recovered.media_fingerprint("proof-media").unwrap(),
+        committed_fingerprint
+    );
+    assert_eq!(
+        hex_sha256(&recovered.read_media("proof-media").unwrap()),
+        hex_sha256(&media_bytes)
+    );
+}

--- a/docs/PROJECT_FORMAT_V1_PROOF.md
+++ b/docs/PROJECT_FORMAT_V1_PROOF.md
@@ -1,0 +1,116 @@
+# Project Format V1 SQLite container proof
+
+Date: 2026-07-13  
+Scope: Browser Card 01 technical proof only
+
+## Result
+
+Proceed with a SQLite-backed `.vzp` Project Container, with changes before it
+becomes the production persistence path. The proof preserved representative
+project state and 64 MiB of Project Media, performed a document-only save
+without touching media rows, produced an independent Save As container, and
+recovered the last committed document and media after a child process exited
+mid-transaction.
+
+The existing JSON production save/load path remains unchanged.
+
+## Repeatable fixture
+
+Run:
+
+```sh
+cargo run --release -p vibez-project --bin project-format-v1-proof -- /tmp/vibez-card-01-measurement
+```
+
+The deterministic fixture contains:
+
+- two valid 32 MiB stereo 48 kHz/16-bit PCM WAV assets, one with Local
+  provenance and one with Dropbox Remote provenance;
+- a versioned project document with MIDI notes and loop state;
+- track automation;
+- native-device parameter state;
+- opaque third-party plugin state;
+- master and return channel state; and
+- a Project Media manifest linking owned bytes to provenance.
+
+First save ingests the two Staged Media files transactionally and removes the
+staging copies only after commit. Save As uses SQLite `VACUUM INTO` to make an
+independent, compact container. The interruption case launches the same proof
+executable as a child, updates the document and media inside a transaction,
+and exits with code 86 without commit or Rust destructor cleanup.
+
+## Measurements
+
+Measured on Linux 6.8.0-134-generic, ext4 on NVMe, an Intel i5-11400H, and
+Rust 1.96.1. Timings are one local observation, not a performance budget.
+
+| Observation | Result |
+|---|---:|
+| Fixture media | 67,108,864 bytes |
+| Full save | 214.218 ms |
+| Document-only incremental save | 6.140 ms |
+| Normal reopen and document read | 0.091 ms |
+| Save As | 76.931 ms |
+| Reopen after interrupted transaction | 7.325 ms |
+| Container after full save | 67,190,784 bytes |
+| Container after incremental save and recovery | 67,190,784 bytes |
+| Media rows written by incremental save | 0 |
+| Media bytes written by incremental save | 0 |
+
+The unchanged media row retained rowid `1`, byte length, and SHA-256
+`f734805f2f179ae439a9f1e28d0be4ae498e930b24db7ae1f111cc38a7f9983a`
+before and after the document-only save. The container size did not grow.
+
+Both original and Save As files were recognized as SQLite 3 databases with
+application id `0x565a5031` (`VZP1`) and user version `1`. Their first 16 bytes
+are `SQLite format 3\0`, not ZIP's `PK` signature. No SQLite journal or other
+sidecar remained after commit or recovery.
+
+## Automated evidence
+
+`cargo test -p vibez-project` passes 17 tests: 14 existing JSON-path tests and
+3 proof integration tests. The proof tests cover:
+
+- complete document, media, and provenance round-trip;
+- Staged Media ownership on first save;
+- zero media-row/media-byte writes on a document-only save;
+- stable media rowid, byte length, and SHA-256 across that save;
+- Save As independence;
+- explicit SQLite application/document version markers and non-ZIP signature;
+  and
+- child-process interruption followed by unchanged committed document and
+  media recovery.
+
+## Failure modes and trade-offs
+
+- The proof reads each staged asset into memory before inserting it. Production
+  implementation should use SQLite incremental BLOB I/O (or an equivalently
+  bounded streaming path) and expose progress/cancellation for multi-gigabyte
+  media.
+- SQLite's rollback-journal mode creates a transient sidecar while a write is
+  active. The `.vzp` is the sole durable artifact after commit/recovery, but
+  production must define same-directory filesystem requirements and test
+  power loss, disk-full, and filesystems with weaker durability semantics.
+- Staging cleanup is best-effort after commit. Production needs a persisted
+  cleanup queue so committed Project Media is never removed while abandoned
+  staging copies are eventually reclaimed.
+- A failed first-save proof can leave an incomplete destination file.
+  Production should create under a private temporary name and atomically
+  publish the first committed container.
+- SHA-256 is recorded and tested, but reads do not automatically verify it.
+  Production should define when integrity verification runs and how corruption
+  is reported/recovered.
+- `VACUUM INTO` is safe and compact but copies all bytes, so Save As cost scales
+  with total Project Media. That is acceptable semantics, but UI progress and
+  disk-space preflight are required.
+- The benchmark uses deterministic PCM WAV fixtures without decoding them and
+  does not establish cross-platform latency or maximum supported project size.
+
+## Recommendation
+
+Proceed with SQLite as the Project Format V1 container foundation. Before Card
+03 turns the proof into production persistence, change media ingestion to a
+bounded streaming implementation and specify first-save publication, staging
+cleanup, integrity checks, disk-full behavior, and cross-platform crash/power-
+loss validation. Preserve the proof's explicit `VZP1` application id, format
+version, transactional document/media update, and independent Save As model.


### PR DESCRIPTION
## Summary

- Add a bounded SQLite-backed Project Format V1 `.vzp` container proof without replacing the production JSON persistence path
- Round-trip versioned project state, MIDI, automation, native and opaque plugin state, Project Media, and Local/Remote provenance
- Exercise transactional first-save Staged Media ingestion, document-only incremental saving, and independent Save As
- Verify child-process interruption preserves the last committed document and media
- Add a repeatable 64 MiB PCM WAV measurement runner and written findings
- Record a proceed-with-changes recommendation: production adoption still needs streaming BLOB ingestion, atomic first-save publication, durable staging cleanup, integrity policy, and disk-full/power-loss validation

## Measured proof

- Full save: 214.218 ms
- Document-only incremental save: 6.140 ms
- Reopen: 0.091 ms
- Save As: 76.931 ms
- Interrupted-transaction recovery reopen: 7.325 ms
- Incremental media rows/bytes written: 0 / 0
- Container growth after incremental save: 0 bytes

## Test plan

- [x] `cargo test --workspace` (489 passed, 0 failed; 2 ignored doctests)
- [x] `cargo test -p vibez-project` (17 passed, 0 failed)
- [x] `cargo clippy -p vibez-project --all-targets -- -D warnings`
- [x] Run the release-mode 64 MiB measurement fixture
- [x] Confirm source and Save As artifacts carry SQLite application id `VZP1`, user/document version `1`, and are not ZIP files
- [x] Terminate a child process mid-transaction and confirm exact committed document/media recovery

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)