### PR TITLE
feat(browser): add responsive themed Browser Dock

### DIFF
--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -124,6 +124,14 @@ impl App {
             let position_samples = self.state.beats_to_samples(beat);
             return self.dispatch_drop_on_arrangement(track_id, position_samples, source);
         }
+        if let Some(source) = action.load_waveform {
+            self.state.browser.begin_waveform_load(&source);
+            if let MediaSourceRef::LocalFile { path } = source.clone() {
+                return Task::perform(decode_local_for_preview_async(path), move |result| {
+                    Message::BrowserWaveformReady(source.clone(), result)
+                });
+            }
+        }
         Task::none()
     }
 

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -3,6 +3,7 @@
 //! Split out of app.rs; inherent methods on [`super::App`].
 
 use crate::domains::arrangement::ArrangementMsg;
+use crate::domains::browser::BrowserMsg;
 use crate::domains::piano_roll::PianoRollMsg;
 use crate::domains::project::ProjectMsg;
 use crate::domains::transport::TransportMsg;
@@ -53,6 +54,19 @@ pub(crate) fn global_key_handler(
         && matches!(key, iced::keyboard::Key::Character(ref c) if c.as_str() == "b")
     {
         return Some(Message::PianoRoll(PianoRollMsg::ToggleEditMode));
+    }
+
+    // Alt+Left / Alt+Right: resize the Browser without permanent header chrome.
+    if modifiers.alt() && !modifiers.control() && !modifiers.shift() && !modifiers.logo() {
+        match key {
+            iced::keyboard::Key::Named(Named::ArrowLeft) => {
+                return Some(Message::Browser(BrowserMsg::NudgeDockWidth(-40.0)));
+            }
+            iced::keyboard::Key::Named(Named::ArrowRight) => {
+                return Some(Message::Browser(BrowserMsg::NudgeDockWidth(40.0)));
+            }
+            _ => {}
+        }
     }
 
     if modifiers.command() {
@@ -159,5 +173,22 @@ mod tests {
                     )
             ));
         }
+    }
+
+    #[test]
+    fn alt_arrows_resize_the_browser_without_header_buttons() {
+        use iced::keyboard::{key::Named, Key, Modifiers};
+
+        let narrower = global_key_handler(Key::Named(Named::ArrowLeft), Modifiers::ALT);
+        let wider = global_key_handler(Key::Named(Named::ArrowRight), Modifiers::ALT);
+
+        assert!(matches!(
+            narrower,
+            Some(Message::Browser(BrowserMsg::NudgeDockWidth(delta))) if delta == -40.0
+        ));
+        assert!(matches!(
+            wider,
+            Some(Message::Browser(BrowserMsg::NudgeDockWidth(delta))) if delta == 40.0
+        ));
     }
 }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -87,6 +87,7 @@ pub fn run() -> iced::Result {
             #[allow(unused_mut)]
             let mut settings = iced::window::Settings {
                 icon,
+                min_size: Some(iced::Size::new(900.0, 600.0)),
                 ..Default::default()
             };
             // WM_CLASS / app_id: lets docks and taskbars match the
@@ -168,6 +169,10 @@ impl App {
             warp_confidence_threshold: ui_settings.warp_confidence_threshold,
             browser: crate::state::BrowserState {
                 open: ui_settings.sample_browser_open,
+                dock_width: ui_settings.sample_browser_width.clamp(
+                    crate::state::BROWSER_DOCK_MIN_WIDTH,
+                    crate::state::BROWSER_DOCK_MAX_WIDTH,
+                ),
                 roots: ui_settings.sample_library_roots,
                 dropbox: dropbox_ui_state,
                 ..Default::default()

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -197,6 +197,7 @@ impl App {
         let settings = UiSettings {
             sample_library_roots: self.state.browser.roots.clone(),
             sample_browser_open: self.state.browser.open,
+            sample_browser_width: self.state.browser.dock_width,
             auto_warp_on_import: self.state.auto_warp_on_import,
             warp_confidence_threshold: self.state.warp_confidence_threshold,
             preferred_midi_input: self.midi_input.as_ref().map(|h| h.port_name.clone()),

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -553,16 +553,25 @@ impl App {
                 // Previously auto-previewed on click; now click only
                 // selects. Preview fires via the speaker icon (see
                 // `Message::PreviewLocalEntry`).
-                self.state.browser.selected_source = Some(source);
+                let changed = self.state.browser.select_source(source.clone());
+                if changed {
+                    self.state.browser.begin_waveform_load(&source);
+                    if let MediaSourceRef::LocalFile { path } = source.clone() {
+                        return Task::perform(
+                            decode_local_for_preview_async(path),
+                            move |result| Message::BrowserWaveformReady(source.clone(), result),
+                        );
+                    }
+                }
             }
             Message::PreviewLocalEntry(source) => {
-                self.state.browser.selected_source = Some(source.clone());
-                if let MediaSourceRef::LocalFile { path } = source {
+                self.state.browser.select_source(source.clone());
+                self.state.browser.begin_waveform_load(&source);
+                if let MediaSourceRef::LocalFile { path } = source.clone() {
                     self.state.status_text = "Previewing...".to_string();
-                    return Task::perform(
-                        decode_local_for_preview_async(path),
-                        Message::LocalSamplePreviewReady,
-                    );
+                    return Task::perform(decode_local_for_preview_async(path), move |result| {
+                        Message::LocalSamplePreviewReady(source.clone(), result)
+                    });
                 }
             }
             Message::StopBrowserPreview => {
@@ -594,12 +603,22 @@ impl App {
                 return self
                     .dispatch_drop_for_target(source, BrowserImportTarget::Sampler(track_id));
             }
-            Message::LocalSamplePreviewReady(Ok(audio)) => {
+            Message::LocalSamplePreviewReady(source, Ok(audio)) => {
+                self.state
+                    .browser
+                    .install_waveform(source, Arc::clone(&audio));
                 self.send_command(EngineCommand::StartPreview(audio));
                 self.state.status_text = "Preview playing".to_string();
             }
-            Message::LocalSamplePreviewReady(Err(err)) => {
+            Message::LocalSamplePreviewReady(source, Err(err)) => {
+                self.state.browser.fail_waveform_load(&source, err.clone());
                 self.state.status_text = format!("Preview error: {err}");
+            }
+            Message::BrowserWaveformReady(source, Ok(audio)) => {
+                self.state.browser.install_waveform(source, audio);
+            }
+            Message::BrowserWaveformReady(source, Err(err)) => {
+                self.state.browser.fail_waveform_load(&source, err);
             }
             Message::ImportSelectedBrowserSampleToArrangement => {
                 return self.handle_import_selected_browser_sample_to_arrangement();
@@ -1098,20 +1117,37 @@ impl App {
                     self.state.browser.dropbox.last_error = Some("Not connected to Dropbox".into());
                     return Task::none();
                 };
+                let source = MediaSourceRef::DropboxFile {
+                    path_lower: entry.path_lower.clone(),
+                    display_path: entry.path_display.clone(),
+                    rev: entry.rev.clone(),
+                };
+                self.state.browser.select_source(source.clone());
+                self.state.browser.begin_waveform_load(&source);
                 let cache = self.dropbox_cache.clone();
                 self.state.browser.dropbox.preview_in_progress = true;
                 self.state.status_text = format!("Fetching preview: {}", entry.name);
-                return Task::perform(fetch_dropbox_sample_async(client, cache, entry), |result| {
-                    Message::DropboxPreviewReady(result.map(|(audio, _, _)| audio))
-                });
+                return Task::perform(
+                    fetch_dropbox_sample_async(client, cache, entry),
+                    move |result| {
+                        Message::DropboxPreviewReady(
+                            source.clone(),
+                            result.map(|(audio, _, _)| audio),
+                        )
+                    },
+                );
             }
-            Message::DropboxPreviewReady(Ok(audio)) => {
+            Message::DropboxPreviewReady(source, Ok(audio)) => {
                 self.state.browser.dropbox.preview_in_progress = false;
+                self.state
+                    .browser
+                    .install_waveform(source, Arc::clone(&audio));
                 self.send_command(EngineCommand::StartPreview(audio));
                 self.state.status_text = "Preview playing".to_string();
             }
-            Message::DropboxPreviewReady(Err(err)) => {
+            Message::DropboxPreviewReady(source, Err(err)) => {
                 self.state.browser.dropbox.preview_in_progress = false;
+                self.state.browser.fail_waveform_load(&source, err.clone());
                 self.state.browser.dropbox.last_error = Some(err.clone());
                 self.state.status_text = format!("Preview error: {err}");
             }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -220,6 +220,21 @@ impl App {
                 if matches!(&msg, ViewMsg::ToggleEditMenu) {
                     self.state.project.file_menu_open = false;
                 }
+                let browser_resize = match &msg {
+                    ViewMsg::CursorMoved(x, _) if self.state.browser.dock_resize_active => {
+                        Some(BrowserMsg::ResizeDock(*x))
+                    }
+                    ViewMsg::MouseReleased if self.state.browser.dock_resize_active => {
+                        Some(BrowserMsg::EndDockResize)
+                    }
+                    _ => None,
+                };
+                if let Some(browser_msg) = browser_resize {
+                    let action = self.state.browser.update(browser_msg);
+                    if action.persist_settings {
+                        self.persist_ui_settings();
+                    }
+                }
                 let ctx = crate::domains::view::ViewCtx {
                     total_beats: self.state.total_beats(),
                 };
@@ -549,6 +564,10 @@ impl App {
                         Message::LocalSamplePreviewReady,
                     );
                 }
+            }
+            Message::StopBrowserPreview => {
+                self.send_command(EngineCommand::StopPreview);
+                self.state.status_text = "Audition stopped".to_string();
             }
             // -- Drag-and-drop from sample browser --
             Message::DropSampleOnArrangement {

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -1,7 +1,8 @@
 //! Split out of app.rs; inherent methods on [`super::App`].
 
 use iced::widget::{
-    button, column, container, horizontal_space, mouse_area, row, scrollable, text, text_input,
+    button, canvas, column, container, horizontal_space, mouse_area, row, scrollable, text,
+    text_input,
 };
 use iced::{Element, Length, Theme};
 
@@ -57,7 +58,19 @@ impl App {
             .on_input(|value| Message::Browser(BrowserMsg::SampleBrowserSearchChanged(value)))
             .size(12)
             .padding([7, 9])
-            .width(Length::Fill);
+            .width(Length::Fill)
+            .style(|_theme: &Theme, _status| iced::widget::text_input::Style {
+                background: th::bg_dark().into(),
+                border: iced::Border {
+                    color: th::border(),
+                    width: 1.0,
+                    radius: 0.0.into(),
+                },
+                icon: th::text_dim(),
+                placeholder: th::text_dim(),
+                value: th::text(),
+                selection: th::accent(),
+            });
 
         let body: Element<'_, Message> = match self.state.browser.mode {
             SampleBrowserMode::Local => self.view_local_sample_browser(),
@@ -303,23 +316,38 @@ impl App {
             .padding([6, 8])
             .style(browser_transport_button_style);
 
-        let waveform = container(text("▁▂▄▇▅▂▃▆▄▁▃▇▆▂▁").size(13).color(th::waveform()))
-            .padding([5, 7])
+        let waveform: Element<'_, Message> = container(
+            canvas(crate::widgets::browser_waveform::BrowserWaveform {
+                audio: self.state.browser.waveform_audio.clone(),
+            })
             .width(Length::Fill)
-            .style(|_theme: &Theme| container::Style {
-                background: Some(th::display_bg().into()),
-                border: iced::Border {
-                    color: th::divider(),
-                    width: 1.0,
-                    radius: 3.0.into(),
-                },
-                ..Default::default()
-            });
+            .height(Length::Fixed(26.0)),
+        )
+        .width(Length::Fill)
+        .style(|_theme: &Theme| container::Style {
+            border: iced::Border {
+                color: th::divider(),
+                width: 1.0,
+                radius: 0.0.into(),
+            },
+            ..Default::default()
+        })
+        .into();
 
         let controls = row![
             play,
             stop,
-            text("RAW").size(9).color(th::text_dim()),
+            text(if self.state.browser.waveform_loading {
+                "LOADING"
+            } else if self.state.browser.waveform_error.is_some() {
+                "UNAVAILABLE"
+            } else if self.state.browser.waveform_audio.is_some() {
+                "RAW"
+            } else {
+                "SELECT"
+            })
+            .size(9)
+            .color(th::text_dim()),
             waveform
         ]
         .spacing(5)
@@ -440,36 +468,16 @@ impl App {
             // plain container as the click target instead.
             let entry_body = container(
                 column![
-                    text(entry.name.as_str()).size(12).color(if selected {
-                        th::accent()
-                    } else {
-                        th::text()
-                    }),
+                    text(entry.name.as_str()).size(12).color(th::text()),
                     text(entry.relative_path.display().to_string())
                         .size(10)
-                        .color(th::text_dim())
+                        .color(if selected { th::text() } else { th::text_dim() })
                 ]
                 .spacing(2)
                 .width(Length::Fill),
             )
             .padding([6, 8])
-            .width(Length::Fill)
-            .style(move |_theme: &Theme| container::Style {
-                background: Some(
-                    if selected {
-                        th::accent_dim()
-                    } else {
-                        th::bg_elevated()
-                    }
-                    .into(),
-                ),
-                border: iced::Border {
-                    color: th::border(),
-                    width: 1.0,
-                    radius: 4.0.into(),
-                },
-                ..Default::default()
-            });
+            .width(Length::Fill);
             let entry_dragger: Element<'_, Message> = mouse_area(entry_body)
                 .on_press(Message::Browser(BrowserMsg::StartDragSample {
                     source: entry.source.clone(),
@@ -480,12 +488,25 @@ impl App {
             let preview_btn = button(icons::icon(icons::PLAY).size(11).color(th::text_dim()))
                 .on_press(Message::PreviewLocalEntry(entry.source.clone()))
                 .padding([6, 8])
-                .style(browser_transport_button_style);
-            entries_col = entries_col.push(
-                row![entry_dragger, preview_btn]
-                    .spacing(4)
+                .style(browser_row_action_style);
+            let selection_marker = container(text(""))
+                .width(Length::Fixed(2.0))
+                .height(Length::Fixed(43.0))
+                .style(move |_theme: &Theme| container::Style {
+                    background: selected.then(|| th::accent().into()),
+                    ..Default::default()
+                });
+            let flat_row = container(
+                row![selection_marker, entry_dragger, preview_btn]
+                    .spacing(0)
                     .align_y(iced::Alignment::Center),
-            );
+            )
+            .width(Length::Fill)
+            .style(move |_theme: &Theme| container::Style {
+                background: selected.then(|| th::accent_dim().into()),
+                ..Default::default()
+            });
+            entries_col = entries_col.push(flat_row).push(browser_row_divider());
         }
 
         if filtered_entries.is_empty() {
@@ -518,9 +539,18 @@ impl App {
                     text(count).size(9).color(th::text_dim())
                 ]
                 .align_y(iced::Alignment::Center),
-                scrollable(entries_col).height(Length::Fill).direction(
-                    scrollable::Direction::Vertical(scrollable::Scrollbar::default())
+                scrollable(
+                    container(entries_col)
+                        .width(Length::Fill)
+                        .padding(iced::Padding {
+                            right: 12.0,
+                            ..Default::default()
+                        })
                 )
+                .height(Length::Fill)
+                .direction(scrollable::Direction::Vertical(
+                    scrollable::Scrollbar::default()
+                ))
             ]
             .spacing(6)
             .padding(8)
@@ -595,9 +625,18 @@ impl App {
                     status
                 ]
                 .align_y(iced::Alignment::Center),
-                scrollable(entries_col).height(Length::Fill).direction(
-                    scrollable::Direction::Vertical(scrollable::Scrollbar::default())
+                scrollable(
+                    container(entries_col)
+                        .width(Length::Fill)
+                        .padding(iced::Padding {
+                            right: 12.0,
+                            ..Default::default()
+                        })
                 )
+                .height(Length::Fill)
+                .direction(scrollable::Direction::Vertical(
+                    scrollable::Scrollbar::default()
+                ))
             ]
             .spacing(6)
             .padding(8)
@@ -661,19 +700,7 @@ impl App {
                 let text_color = if selected { th::accent() } else { th::text() };
                 let row_body = container(text(label).size(11).color(text_color))
                     .padding([3, 6])
-                    .width(Length::Fill)
-                    .style(move |_theme: &Theme| container::Style {
-                        background: Some(
-                            if selected {
-                                th::accent_dim()
-                            } else {
-                                th::bg_elevated()
-                            }
-                            .into(),
-                        ),
-                        border: iced::Border::default(),
-                        ..Default::default()
-                    });
+                    .width(Length::Fill);
                 let source = MediaSourceRef::DropboxFile {
                     path_lower: entry.path_lower.clone(),
                     display_path: entry.path_display.clone(),
@@ -689,25 +716,26 @@ impl App {
                 let speaker = button(icons::icon(icons::VOLUME_2).size(11).color(th::accent()))
                     .on_press(Message::DropboxPreview(entry.clone()))
                     .padding([3, 6])
-                    .style(|_theme: &Theme, status| {
-                        let bg = match status {
-                            button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::bg_hover().into())
-                            }
-                            _ => None,
-                        };
-                        button::Style {
-                            background: bg,
-                            text_color: th::accent(),
-                            border: iced::Border::default(),
-                            ..Default::default()
-                        }
+                    .style(browser_row_action_style);
+                let selection_marker = container(text(""))
+                    .width(Length::Fixed(2.0))
+                    .height(Length::Fixed(25.0))
+                    .style(move |_theme: &Theme| container::Style {
+                        background: selected.then(|| th::accent().into()),
+                        ..Default::default()
                     });
                 rows.push(
-                    row![dragger, speaker]
-                        .spacing(2)
-                        .align_y(iced::Alignment::Center)
-                        .into(),
+                    container(
+                        row![selection_marker, dragger, speaker]
+                            .spacing(2)
+                            .align_y(iced::Alignment::Center),
+                    )
+                    .width(Length::Fill)
+                    .style(move |_theme: &Theme| container::Style {
+                        background: selected.then(|| th::accent_dim().into()),
+                        ..Default::default()
+                    })
+                    .into(),
                 );
             } else {
                 // Folders + non-audio entries keep the button path since they
@@ -730,18 +758,23 @@ impl App {
                             button::Status::Hovered | button::Status::Pressed => {
                                 Some(th::bg_hover().into())
                             }
-                            _ => Some(th::bg_elevated().into()),
+                            _ => None,
                         }
                     };
                     button::Style {
                         background: bg,
                         text_color: if selected { th::accent() } else { th::text() },
-                        border: iced::Border::default(),
+                        border: iced::Border {
+                            radius: 0.0.into(),
+                            ..Default::default()
+                        },
                         ..Default::default()
                     }
                 });
                 rows.push(btn.into());
             }
+
+            rows.push(browser_row_divider());
 
             if entry.is_folder && expanded {
                 self.render_dropbox_tree(entry.path_lower.clone(), depth + 1, rows);
@@ -765,10 +798,34 @@ fn browser_icon_button_style(_theme: &Theme, status: button::Status) -> button::
                 th::border()
             },
             width: 1.0,
-            radius: 3.0.into(),
+            radius: 0.0.into(),
         },
         ..Default::default()
     }
+}
+
+fn browser_row_action_style(_theme: &Theme, status: button::Status) -> button::Style {
+    button::Style {
+        background: matches!(status, button::Status::Hovered | button::Status::Pressed)
+            .then(|| th::bg_hover().into()),
+        text_color: th::text_dim(),
+        border: iced::Border {
+            radius: 0.0.into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn browser_row_divider<'a>() -> Element<'a, Message> {
+    container(text(""))
+        .width(Length::Fill)
+        .height(Length::Fixed(1.0))
+        .style(|_theme: &Theme| container::Style {
+            background: Some(th::divider().into()),
+            ..Default::default()
+        })
+        .into()
 }
 
 fn browser_location_button_style(_theme: &Theme, status: button::Status) -> button::Style {
@@ -789,7 +846,7 @@ fn browser_location_button_style(_theme: &Theme, status: button::Status) -> butt
                 th::divider()
             },
             width: 1.0,
-            radius: 3.0.into(),
+            radius: 0.0.into(),
         },
         ..Default::default()
     }
@@ -815,7 +872,7 @@ fn browser_place_button_style(active: bool, status: button::Status) -> button::S
                 iced::Color::TRANSPARENT
             },
             width: if active { 1.0 } else { 0.0 },
-            radius: 3.0.into(),
+            radius: 0.0.into(),
         },
         ..Default::default()
     }
@@ -839,7 +896,7 @@ fn browser_transport_button_style(_theme: &Theme, status: button::Status) -> but
                 th::border()
             },
             width: 1.0,
-            radius: 3.0.into(),
+            radius: 0.0.into(),
         },
         ..Default::default()
     }

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -1,7 +1,5 @@
 //! Split out of app.rs; inherent methods on [`super::App`].
 
-use std::path::PathBuf;
-
 use iced::widget::{
     button, column, container, horizontal_space, mouse_area, row, scrollable, text, text_input,
 };
@@ -12,74 +10,114 @@ use vibez_core::track::MediaSourceRef;
 use vibez_dropbox::DropboxEntry;
 
 use crate::icons;
-use crate::message::{BrowserImportTarget, Message};
-use crate::state::SampleBrowserEntry;
+use crate::message::Message;
+use crate::state::{BrowserDockLayout, SampleBrowserEntry, SampleBrowserMode};
 use crate::theme as th;
 
 use super::*;
 
 impl App {
     pub(super) fn view_sample_browser_panel(&self) -> Element<'_, Message> {
-        let tab_bar = {
-            let local_active = matches!(
-                self.state.browser.mode,
-                crate::state::SampleBrowserMode::Local
-            );
-            let dropbox_active = !local_active;
-            let tab_btn = |label: &'static str, active: bool, mode| {
-                button(text(label).size(11).color(if active {
-                    th::accent()
-                } else {
-                    th::text_dim()
-                }))
-                .on_press(Message::Browser(BrowserMsg::SetSampleBrowserMode(mode)))
-                .padding([4, 12])
-                .style(move |_theme: &Theme, status| {
-                    let bg = if active {
-                        Some(th::accent_dim().into())
-                    } else {
-                        match status {
-                            button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::bg_hover().into())
-                            }
-                            _ => None,
-                        }
-                    };
-                    button::Style {
-                        background: bg,
-                        text_color: if active { th::accent() } else { th::text_dim() },
-                        border: iced::Border::default(),
-                        ..Default::default()
-                    }
-                })
-            };
-            row![
-                tab_btn(
-                    "Local",
-                    local_active,
-                    crate::state::SampleBrowserMode::Local
-                ),
-                tab_btn(
-                    "Dropbox",
-                    dropbox_active,
-                    crate::state::SampleBrowserMode::Dropbox,
-                ),
-            ]
-            .spacing(0)
+        let width = self
+            .state
+            .browser
+            .effective_dock_width(self.state.view.window_width);
+        let layout = self.state.browser.dock_layout(self.state.view.window_width);
+        let layout_label = match layout {
+            BrowserDockLayout::Narrow => "NARROW",
+            BrowserDockLayout::Standard => "STANDARD",
+            BrowserDockLayout::Wide => "WIDE",
         };
 
+        let width_down = button(text("−").size(14).color(th::text_dim()))
+            .on_press(Message::Browser(BrowserMsg::NudgeDockWidth(-40.0)))
+            .padding([2, 7])
+            .style(browser_icon_button_style);
+        let width_up = button(text("+").size(13).color(th::text_dim()))
+            .on_press(Message::Browser(BrowserMsg::NudgeDockWidth(40.0)))
+            .padding([2, 7])
+            .style(browser_icon_button_style);
+        let close = button(icons::icon(icons::X).size(11).color(th::text_dim()))
+            .on_press(Message::Browser(BrowserMsg::ToggleSampleBrowser))
+            .padding([3, 6])
+            .style(browser_icon_button_style);
+
+        let title_row = row![
+            text("BROWSER").size(12).color(th::text()),
+            text(layout_label).size(9).color(th::text_muted()),
+            horizontal_space(),
+            width_down,
+            width_up,
+            close
+        ]
+        .spacing(5)
+        .align_y(iced::Alignment::Center);
+
+        let search = text_input("Search this location…", &self.state.browser.search)
+            .on_input(|value| Message::Browser(BrowserMsg::SampleBrowserSearchChanged(value)))
+            .size(12)
+            .padding([7, 9])
+            .width(Length::Fill);
+
         let body: Element<'_, Message> = match self.state.browser.mode {
-            crate::state::SampleBrowserMode::Local => self.view_local_sample_browser(),
-            crate::state::SampleBrowserMode::Dropbox => self.view_dropbox_browser(),
+            SampleBrowserMode::Local => self.view_local_sample_browser(),
+            SampleBrowserMode::Dropbox => self.view_dropbox_browser(),
+        };
+
+        let content: Element<'_, Message> = if layout == BrowserDockLayout::Wide {
+            row![
+                container(self.view_browser_places())
+                    .width(Length::Fixed(158.0))
+                    .height(Length::Fill)
+                    .style(browser_places_style),
+                body
+            ]
+            .height(Length::Fill)
+            .into()
+        } else {
+            let place_name = match self.state.browser.mode {
+                SampleBrowserMode::Local => "Local  /  All Roots",
+                SampleBrowserMode::Dropbox => "Remote  /  Alex's Dropbox",
+            };
+            let disclosure = if self.state.browser.places_drawer_open {
+                icons::CHEVRON_UP
+            } else {
+                icons::CHEVRON_DOWN
+            };
+            let location = button(
+                row![
+                    text(place_name).size(11).color(th::text()),
+                    horizontal_space(),
+                    icons::icon(disclosure).size(10).color(th::text_dim())
+                ]
+                .align_y(iced::Alignment::Center),
+            )
+            .on_press(Message::Browser(BrowserMsg::TogglePlacesDrawer))
+            .padding([6, 9])
+            .width(Length::Fill)
+            .style(browser_location_button_style);
+            let mut stack = column![location].spacing(4).height(Length::Fill);
+            if self.state.browser.places_drawer_open {
+                stack = stack.push(
+                    container(self.view_browser_places())
+                        .width(Length::Fill)
+                        .style(browser_places_style),
+                );
+            }
+            stack.push(body).into()
         };
 
         container(
-            column![tab_bar, body]
-                .spacing(4)
-                .padding([4, 0])
-                .height(Length::Fill),
+            column![
+                container(column![title_row, search].spacing(7))
+                    .padding([8, 10])
+                    .style(browser_header_style),
+                content,
+                self.view_browser_audition_footer(layout)
+            ]
+            .height(Length::Fill),
         )
-        .width(Length::Fixed(320.0))
+        .width(Length::Fixed(width))
         .height(Length::Fill)
         .style(|_theme: &Theme| container::Style {
             background: Some(th::bg_surface().into()),
@@ -93,196 +131,288 @@ impl App {
         .into()
     }
 
-    pub(super) fn view_local_sample_browser(&self) -> Element<'_, Message> {
-        let title = text("Sample Browser").size(14).color(th::accent());
-        let mut add_root_btn = button(text("Add Root").size(11).color(th::text()))
-            .padding([4, 10])
-            .style(|_theme: &Theme, status| {
-                let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::bg_hover().into())
-                    }
-                    _ => Some(th::bg_elevated().into()),
-                };
-                button::Style {
-                    background: bg,
-                    text_color: th::text(),
-                    border: iced::Border {
-                        color: th::border(),
-                        width: 1.0,
-                        radius: 4.0.into(),
-                    },
-                    ..Default::default()
-                }
-            });
-        add_root_btn = add_root_btn.on_press(Message::AddSampleLibraryRoot);
-
-        let mut rescan_btn = button(text("Rescan").size(11).color(th::text()))
-            .padding([4, 10])
-            .style(|_theme: &Theme, status| {
-                let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::bg_hover().into())
-                    }
-                    _ => Some(th::bg_elevated().into()),
-                };
-                button::Style {
-                    background: bg,
-                    text_color: th::text(),
-                    border: iced::Border {
-                        color: th::border(),
-                        width: 1.0,
-                        radius: 4.0.into(),
-                    },
-                    ..Default::default()
-                }
-            });
-        if !self.state.browser.roots.is_empty() && !self.state.browser.scan_in_progress {
-            rescan_btn = rescan_btn.on_press(Message::RescanSampleLibrary);
-        }
-
-        let header = row![title, horizontal_space(), add_root_btn, rescan_btn]
-            .spacing(6)
-            .align_y(iced::Alignment::Center);
-
-        if self.state.browser.roots.is_empty() {
-            let empty = column![
-                header,
-                text("Add a root folder to index your sample library.")
-                    .size(12)
-                    .color(th::text_dim())
-            ]
-            .spacing(10)
-            .padding(10);
-            return container(empty)
-                .width(Length::Fixed(320.0))
+    pub(super) fn view_browser_splitter(&self) -> Element<'_, Message> {
+        mouse_area(
+            container(text(""))
+                .width(Length::Fixed(7.0))
                 .height(Length::Fill)
                 .style(|_theme: &Theme| container::Style {
-                    background: Some(th::bg_surface().into()),
-                    border: iced::Border {
-                        color: th::border(),
-                        width: 1.0,
-                        radius: 0.0.into(),
-                    },
+                    background: Some(if self.state.browser.dock_resize_active {
+                        th::accent_dim().into()
+                    } else {
+                        th::divider().into()
+                    }),
                     ..Default::default()
-                })
-                .into();
-        }
+                }),
+        )
+        .on_press(Message::Browser(BrowserMsg::BeginDockResize))
+        .interaction(iced::mouse::Interaction::ResizingHorizontally)
+        .into()
+    }
 
-        let root_label = |path: &PathBuf| {
-            path.file_name()
-                .map(|name| name.to_string_lossy().to_string())
-                .unwrap_or_else(|| path.display().to_string())
+    fn view_browser_places(&self) -> Element<'_, Message> {
+        let local_active = self.state.browser.mode == SampleBrowserMode::Local;
+        let remote_active = self.state.browser.mode == SampleBrowserMode::Dropbox;
+        let place_button = |label: &'static str, active: bool, mode| {
+            button(
+                row![
+                    text(if active { "●" } else { "○" })
+                        .size(9)
+                        .color(if active {
+                            th::accent()
+                        } else {
+                            th::text_muted()
+                        }),
+                    text(label)
+                        .size(11)
+                        .color(if active { th::text() } else { th::text_dim() })
+                ]
+                .spacing(7)
+                .align_y(iced::Alignment::Center),
+            )
+            .on_press(Message::Browser(BrowserMsg::SetSampleBrowserMode(mode)))
+            .padding([6, 7])
+            .width(Length::Fill)
+            .style(move |_theme: &Theme, status| browser_place_button_style(active, status))
         };
 
-        let mut roots_col = column![].spacing(4);
-        let all_active = self.state.browser.root_filter.is_none();
-        let mut all_btn = button(text("All Roots").size(11).color(if all_active {
+        let mut places = column![
+            text("PLACES").size(9).color(th::text_muted()),
+            place_button("Local", local_active, SampleBrowserMode::Local),
+        ]
+        .spacing(3);
+
+        let all_active = local_active && self.state.browser.root_filter.is_none();
+        let all_roots = button(text("All Roots").size(10).color(if all_active {
             th::accent()
         } else {
             th::text_dim()
         }))
+        .on_press(Message::Browser(BrowserMsg::SelectSampleBrowserRoot(None)))
         .padding([4, 8])
-        .style(move |_theme: &Theme, status| {
-            let bg = if all_active {
-                Some(th::accent_dim().into())
-            } else {
-                match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::bg_hover().into())
-                    }
-                    _ => Some(th::bg_elevated().into()),
-                }
-            };
-            button::Style {
-                background: bg,
-                text_color: if all_active {
-                    th::accent()
-                } else {
-                    th::text_dim()
-                },
-                border: iced::Border {
-                    color: th::border(),
-                    width: 1.0,
-                    radius: 4.0.into(),
-                },
-                ..Default::default()
-            }
-        });
-        all_btn = all_btn.on_press(Message::Browser(BrowserMsg::SelectSampleBrowserRoot(None)));
-        roots_col = roots_col.push(all_btn);
+        .width(Length::Fill)
+        .style(move |_theme: &Theme, status| browser_place_button_style(all_active, status));
+        places = places.push(row![
+            horizontal_space().width(Length::Fixed(14.0)),
+            all_roots
+        ]);
 
         for root in &self.state.browser.roots {
-            let active = self
-                .state
-                .browser
-                .root_filter
-                .as_ref()
-                .is_some_and(|selected| selected == root);
-            let mut filter_btn = button(text(root_label(root)).size(11).color(if active {
+            let active = local_active
+                && self
+                    .state
+                    .browser
+                    .root_filter
+                    .as_ref()
+                    .is_some_and(|selected| selected == root);
+            let label = root
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| root.display().to_string());
+            let root_button = button(text(label).size(10).color(if active {
                 th::accent()
             } else {
-                th::text()
+                th::text_dim()
             }))
+            .on_press(Message::Browser(BrowserMsg::SelectSampleBrowserRoot(Some(
+                root.clone(),
+            ))))
             .padding([4, 8])
             .width(Length::Fill)
-            .style(move |_theme: &Theme, status| {
-                let bg = if active {
-                    Some(th::accent_dim().into())
-                } else {
-                    match status {
-                        button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::bg_hover().into())
-                        }
-                        _ => Some(th::bg_elevated().into()),
-                    }
-                };
-                button::Style {
-                    background: bg,
-                    text_color: if active { th::accent() } else { th::text() },
-                    border: iced::Border {
-                        color: th::border(),
-                        width: 1.0,
-                        radius: 4.0.into(),
-                    },
-                    ..Default::default()
-                }
-            });
-            filter_btn = filter_btn.on_press(Message::Browser(
-                BrowserMsg::SelectSampleBrowserRoot(Some(root.clone())),
-            ));
-
-            let remove_btn = button(icons::icon(icons::X).size(10).color(th::danger()))
-                .on_press(Message::Browser(BrowserMsg::RemoveSampleLibraryRoot(
-                    root.clone(),
-                )))
-                .padding([3, 6])
-                .style(|_theme: &Theme, status| {
-                    let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::bg_hover().into())
-                        }
-                        _ => None,
-                    };
-                    button::Style {
-                        background: bg,
-                        text_color: th::danger(),
-                        border: iced::Border::default(),
-                        ..Default::default()
-                    }
-                });
-
-            roots_col = roots_col.push(
-                row![filter_btn, remove_btn]
-                    .spacing(4)
-                    .align_y(iced::Alignment::Center),
-            );
+            .style(move |_theme: &Theme, status| browser_place_button_style(active, status));
+            places = places.push(row![
+                horizontal_space().width(Length::Fixed(14.0)),
+                root_button
+            ]);
         }
 
-        let search = text_input("Search samples...", &self.state.browser.search)
-            .on_input(|s| Message::Browser(BrowserMsg::SampleBrowserSearchChanged(s)))
-            .size(12)
-            .width(Length::Fill);
+        places = places.push(place_button(
+            "Remote",
+            remote_active,
+            SampleBrowserMode::Dropbox,
+        ));
+        let connection_color = if self.state.browser.dropbox.connected {
+            th::text_dim()
+        } else {
+            th::text_muted()
+        };
+        places = places.push(row![
+            horizontal_space().width(Length::Fixed(22.0)),
+            container(
+                text(if self.state.browser.dropbox.connected {
+                    "Alex's Dropbox"
+                } else {
+                    "Dropbox · disconnected"
+                })
+                .size(10)
+                .color(connection_color),
+            )
+            .padding([3, 0]),
+        ]);
+
+        let add = button(text("+ Root").size(10).color(th::text_dim()))
+            .on_press(Message::AddSampleLibraryRoot)
+            .padding([4, 7])
+            .style(browser_icon_button_style);
+        let mut rescan = button(text("Rescan").size(10).color(th::text_dim()))
+            .padding([4, 7])
+            .style(browser_icon_button_style);
+        if !self.state.browser.roots.is_empty() && !self.state.browser.scan_in_progress {
+            rescan = rescan.on_press(Message::RescanSampleLibrary);
+        }
+        places = places.push(
+            row![add, rescan]
+                .spacing(4)
+                .padding([8, 0])
+                .align_y(iced::Alignment::Center),
+        );
+
+        container(places.padding(9)).width(Length::Fill).into()
+    }
+
+    fn view_browser_audition_footer(&self, layout: BrowserDockLayout) -> Element<'_, Message> {
+        let selected_local = self.selected_sample_browser_entry();
+        let selected_dropbox = self.selected_dropbox_entry();
+        let selected_label = match self.state.browser.mode {
+            SampleBrowserMode::Local => selected_local
+                .map(|entry| entry.name.clone())
+                .unwrap_or_else(|| "No source selected".into()),
+            SampleBrowserMode::Dropbox => selected_dropbox
+                .as_ref()
+                .map(|entry| entry.name.clone())
+                .unwrap_or_else(|| "No source selected".into()),
+        };
+
+        let preview_message = match self.state.browser.mode {
+            SampleBrowserMode::Local => {
+                selected_local.map(|entry| Message::PreviewLocalEntry(entry.source.clone()))
+            }
+            SampleBrowserMode::Dropbox => selected_dropbox
+                .as_ref()
+                .filter(|entry| entry.is_supported_audio())
+                .map(|entry| Message::DropboxPreview(entry.clone())),
+        };
+        let mut play = button(icons::icon(icons::PLAY).size(12).color(th::text_dim()))
+            .padding([6, 8])
+            .style(browser_transport_button_style);
+        if let Some(message) = preview_message {
+            play = play.on_press(message);
+        }
+        let stop = button(icons::icon(icons::STOP).size(11).color(th::text_dim()))
+            .on_press(Message::StopBrowserPreview)
+            .padding([6, 8])
+            .style(browser_transport_button_style);
+
+        let waveform = container(text("▁▂▄▇▅▂▃▆▄▁▃▇▆▂▁").size(13).color(th::waveform()))
+            .padding([5, 7])
+            .width(Length::Fill)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::display_bg().into()),
+                border: iced::Border {
+                    color: th::divider(),
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                ..Default::default()
+            });
+
+        let controls = row![
+            play,
+            stop,
+            text("RAW").size(9).color(th::text_dim()),
+            waveform
+        ]
+        .spacing(5)
+        .align_y(iced::Alignment::Center);
+        let import_message = match self.state.browser.mode {
+            SampleBrowserMode::Local => {
+                selected_local.map(|_| Message::ImportSelectedBrowserSampleToArrangement)
+            }
+            SampleBrowserMode::Dropbox => selected_dropbox
+                .as_ref()
+                .filter(|entry| entry.is_supported_audio())
+                .map(|entry| Message::DropboxImportToArrangement(entry.clone())),
+        };
+        let device_message = match self.state.browser.mode {
+            SampleBrowserMode::Local => (selected_local.is_some()
+                && self.selected_browser_device_target().is_some())
+            .then_some(Message::LoadSelectedBrowserSampleToDevice),
+            SampleBrowserMode::Dropbox => selected_dropbox
+                .as_ref()
+                .filter(|entry| entry.is_supported_audio())
+                .filter(|_| self.selected_browser_device_target().is_some())
+                .map(|entry| Message::DropboxImportToDevice(entry.clone())),
+        };
+        let mut arrange = button(text("Add to Arrange").size(10).color(th::text_dim()))
+            .padding([4, 7])
+            .style(browser_transport_button_style);
+        if let Some(message) = import_message {
+            arrange = arrange.on_press(message);
+        }
+        let mut device = button(text("Load Device").size(10).color(th::text_dim()))
+            .padding([4, 7])
+            .style(browser_transport_button_style);
+        if let Some(message) = device_message {
+            device = device.on_press(message);
+        }
+        let import_controls = row![arrange, device].spacing(5);
+        let contents: Element<'_, Message> = if layout == BrowserDockLayout::Narrow {
+            column![
+                row![
+                    text("AUDITION").size(9).color(th::text_muted()),
+                    horizontal_space(),
+                    text(selected_label).size(10).color(th::text_dim())
+                ]
+                .align_y(iced::Alignment::Center),
+                controls
+            ]
+            .spacing(5)
+            .into()
+        } else {
+            column![
+                row![
+                    text("AUDITION").size(9).color(th::text_muted()),
+                    text(selected_label).size(11).color(th::text()),
+                ]
+                .spacing(8)
+                .align_y(iced::Alignment::Center),
+                controls,
+                import_controls
+            ]
+            .spacing(5)
+            .into()
+        };
+
+        container(contents)
+            .padding([7, 9])
+            .width(Length::Fill)
+            .style(browser_footer_style)
+            .into()
+    }
+
+    pub(super) fn view_local_sample_browser(&self) -> Element<'_, Message> {
+        if self.state.browser.roots.is_empty() {
+            let add = button(text("Add Local Root").size(11).color(th::text()))
+                .on_press(Message::AddSampleLibraryRoot)
+                .padding([6, 10])
+                .style(browser_transport_button_style);
+            return container(
+                column![
+                    text("RESULTS").size(9).color(th::text_muted()),
+                    text("Your Local Place is empty").size(13).color(th::text()),
+                    text("Choose a folder to begin indexing supported audio.")
+                        .size(11)
+                        .color(th::text_dim()),
+                    add
+                ]
+                .spacing(8)
+                .padding(12),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .style(browser_results_style)
+            .into();
+        }
 
         let search_lower = self.state.browser.search.to_lowercase();
         let mut filtered_entries: Vec<&SampleBrowserEntry> = self
@@ -302,10 +432,7 @@ impl App {
         filtered_entries.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
 
         let selected_source = self.state.browser.selected_source.as_ref();
-        let selected_entry = self.selected_sample_browser_entry();
-        let selected_target = self.selected_browser_device_target();
-
-        let mut entries_col = column![].spacing(2);
+        let mut entries_col = column![].spacing(1);
         for entry in filtered_entries.iter().take(400) {
             let selected = selected_source.is_some_and(|source| &entry.source == source);
             // mouse_area returns early if its child captures the event, so
@@ -350,27 +477,10 @@ impl App {
                 }))
                 .on_release(Message::ClickLocalBrowserEntry(entry.source.clone()))
                 .into();
-            let preview_btn = button(icons::icon(icons::VOLUME_2).size(12).color(th::text_dim()))
+            let preview_btn = button(icons::icon(icons::PLAY).size(11).color(th::text_dim()))
                 .on_press(Message::PreviewLocalEntry(entry.source.clone()))
                 .padding([6, 8])
-                .style(|_theme: &Theme, status| {
-                    let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::bg_hover().into())
-                        }
-                        _ => Some(th::bg_elevated().into()),
-                    };
-                    button::Style {
-                        background: bg,
-                        text_color: th::accent(),
-                        border: iced::Border {
-                            color: th::border(),
-                            width: 1.0,
-                            radius: 4.0.into(),
-                        },
-                        ..Default::default()
-                    }
-                });
+                .style(browser_transport_button_style);
             entries_col = entries_col.push(
                 row![entry_dragger, preview_btn]
                     .spacing(4)
@@ -389,7 +499,7 @@ impl App {
             );
         }
 
-        let count_label = text(format!(
+        let count = format!(
             "{} shown / {} indexed{}",
             filtered_entries.len().min(400),
             self.state.browser.entries.len(),
@@ -398,127 +508,53 @@ impl App {
             } else {
                 ""
             }
-        ))
-        .size(10)
-        .color(th::text_dim());
+        );
 
-        let selected_text = selected_entry
-            .map(|entry| entry.relative_path.display().to_string())
-            .unwrap_or_else(|| "Select a sample".to_string());
-        let selected_hint = match selected_target {
-            Some(BrowserImportTarget::Sampler(track_id)) => self
-                .state
-                .find_track(track_id)
-                .map(|track| format!("Load to {}", track.name))
-                .unwrap_or_else(|| "Load to sampler".to_string()),
-            Some(BrowserImportTarget::DrumRackPad {
-                track_id,
-                pad_index,
-            }) => self
-                .state
-                .find_track(track_id)
-                .map(|track| format!("Load to {} pad {}", track.name, pad_index + 1))
-                .unwrap_or_else(|| "Load to drum rack".to_string()),
-            _ => "No sampler or drum rack selected".to_string(),
-        };
-
-        let mut add_clip_btn = button(text("Add Clip").size(11).color(th::text()))
-            .padding([6, 10])
-            .style(|_theme: &Theme, status| {
-                let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::bg_hover().into())
-                    }
-                    _ => Some(th::bg_elevated().into()),
-                };
-                button::Style {
-                    background: bg,
-                    text_color: th::text(),
-                    border: iced::Border {
-                        color: th::border(),
-                        width: 1.0,
-                        radius: 4.0.into(),
-                    },
-                    ..Default::default()
-                }
-            });
-        if selected_entry.is_some() {
-            add_clip_btn = add_clip_btn.on_press(Message::ImportSelectedBrowserSampleToArrangement);
-        }
-
-        let mut load_device_btn = button(text("Load Device").size(11).color(th::text()))
-            .padding([6, 10])
-            .style(|_theme: &Theme, status| {
-                let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::bg_hover().into())
-                    }
-                    _ => Some(th::bg_elevated().into()),
-                };
-                button::Style {
-                    background: bg,
-                    text_color: th::text(),
-                    border: iced::Border {
-                        color: th::border(),
-                        width: 1.0,
-                        radius: 4.0.into(),
-                    },
-                    ..Default::default()
-                }
-            });
-        if selected_entry.is_some() && selected_target.is_some() {
-            load_device_btn = load_device_btn.on_press(Message::LoadSelectedBrowserSampleToDevice);
-        }
-
-        let footer = column![
-            text(selected_text).size(11).color(th::text()),
-            text(selected_hint).size(10).color(th::text_dim()),
-            row![add_clip_btn, load_device_btn]
-                .spacing(6)
-                .align_y(iced::Alignment::Center)
-        ]
-        .spacing(6);
-
-        column![
-            header,
-            roots_col,
-            search,
-            count_label,
-            scrollable(entries_col).height(Length::Fill).direction(
-                scrollable::Direction::Vertical(scrollable::Scrollbar::default())
-            ),
-            footer
-        ]
-        .spacing(8)
-        .padding(10)
+        container(
+            column![
+                row![
+                    text("RESULTS").size(9).color(th::text_muted()),
+                    horizontal_space(),
+                    text(count).size(9).color(th::text_dim())
+                ]
+                .align_y(iced::Alignment::Center),
+                scrollable(entries_col).height(Length::Fill).direction(
+                    scrollable::Direction::Vertical(scrollable::Scrollbar::default())
+                )
+            ]
+            .spacing(6)
+            .padding(8)
+            .height(Length::Fill),
+        )
+        .width(Length::Fill)
         .height(Length::Fill)
+        .style(browser_results_style)
         .into()
     }
 
     pub(super) fn view_dropbox_browser(&self) -> Element<'_, Message> {
-        let title = text("Dropbox").size(14).color(th::accent());
-
         if !self.state.browser.dropbox.connected {
             let hint = if self.state.browser.dropbox.auth_in_progress {
                 "Waiting for browser authorisation..."
             } else {
                 "Connect in Settings > Dropbox to browse your library."
             };
-            return column![title, text(hint).size(12).color(th::text_dim())]
-                .spacing(10)
-                .padding(10)
-                .height(Length::Fill)
-                .into();
+            return container(
+                column![
+                    text("RESULTS").size(9).color(th::text_muted()),
+                    text("Remote Connection unavailable")
+                        .size(13)
+                        .color(th::text()),
+                    text(hint).size(11).color(th::text_dim())
+                ]
+                .spacing(8)
+                .padding(12),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .style(browser_results_style)
+            .into();
         }
-
-        let account = self
-            .state
-            .browser
-            .dropbox
-            .account_email
-            .clone()
-            .unwrap_or_default();
-        let header = column![title, text(account).size(11).color(th::text_dim()),].spacing(2);
 
         let mut rows: Vec<Element<'_, Message>> = Vec::new();
         self.render_dropbox_tree(String::new(), 0, &mut rows);
@@ -534,97 +570,42 @@ impl App {
         for row in rows {
             entries_col = entries_col.push(row);
         }
-
-        let selected_entry = self.selected_dropbox_entry();
-        let selected_label = selected_entry
-            .as_ref()
-            .map(|e| e.path_display.clone())
-            .unwrap_or_else(|| "Select a file".to_string());
-
-        // Preview is triggered by click-to-audition on the tree row itself;
-        // no dedicated button here.
-
-        let add_clip_btn: Element<'_, Message> = {
-            let mut btn = button(text("Add Clip").size(11).color(th::text()))
-                .padding([6, 10])
-                .style(|_theme: &Theme, status| {
-                    let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::bg_hover().into())
-                        }
-                        _ => Some(th::bg_elevated().into()),
-                    };
-                    button::Style {
-                        background: bg,
-                        text_color: th::text(),
-                        border: iced::Border {
-                            color: th::border(),
-                            width: 1.0,
-                            radius: 4.0.into(),
-                        },
-                        ..Default::default()
-                    }
-                });
-            if let Some(entry) = selected_entry.as_ref().filter(|e| e.is_supported_audio()) {
-                btn = btn.on_press(Message::DropboxImportToArrangement(entry.clone()));
-            }
-            btn.into()
-        };
-
-        let load_device_btn: Element<'_, Message> = {
-            let mut btn = button(text("Load Device").size(11).color(th::text()))
-                .padding([6, 10])
-                .style(|_theme: &Theme, status| {
-                    let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::bg_hover().into())
-                        }
-                        _ => Some(th::bg_elevated().into()),
-                    };
-                    button::Style {
-                        background: bg,
-                        text_color: th::text(),
-                        border: iced::Border {
-                            color: th::border(),
-                            width: 1.0,
-                            radius: 4.0.into(),
-                        },
-                        ..Default::default()
-                    }
-                });
-            if let (Some(entry), Some(_)) = (
-                selected_entry.as_ref().filter(|e| e.is_supported_audio()),
-                self.selected_browser_device_target(),
-            ) {
-                btn = btn.on_press(Message::DropboxImportToDevice(entry.clone()));
-            }
-            btn.into()
-        };
-
-        let error_line: Element<'_, Message> =
-            if let Some(err) = self.state.browser.dropbox.last_error.clone() {
-                text(err).size(10).color(th::danger()).into()
+        let status: Element<'_, Message> =
+            if let Some(error) = self.state.browser.dropbox.last_error.clone() {
+                text(format!("Error · {error}"))
+                    .size(9)
+                    .color(th::danger())
+                    .into()
             } else {
-                horizontal_space().width(Length::Shrink).into()
+                let account = self
+                    .state
+                    .browser
+                    .dropbox
+                    .account_email
+                    .clone()
+                    .unwrap_or_else(|| "Connected".into());
+                text(account).size(9).color(th::text_dim()).into()
             };
 
-        let footer = column![
-            text(selected_label).size(11).color(th::text()),
-            row![add_clip_btn, load_device_btn].spacing(6),
-            error_line,
-        ]
-        .spacing(6);
-
-        column![
-            header,
-            scrollable(entries_col).height(Length::Fill).direction(
-                scrollable::Direction::Vertical(scrollable::Scrollbar::default())
-            ),
-            footer,
-        ]
-        .spacing(8)
-        .padding(10)
+        container(
+            column![
+                row![
+                    text("RESULTS").size(9).color(th::text_muted()),
+                    horizontal_space(),
+                    status
+                ]
+                .align_y(iced::Alignment::Center),
+                scrollable(entries_col).height(Length::Fill).direction(
+                    scrollable::Direction::Vertical(scrollable::Scrollbar::default())
+                )
+            ]
+            .spacing(6)
+            .padding(8)
+            .height(Length::Fill),
+        )
+        .width(Length::Fill)
         .height(Length::Fill)
+        .style(browser_results_style)
         .into()
     }
 
@@ -766,5 +747,148 @@ impl App {
                 self.render_dropbox_tree(entry.path_lower.clone(), depth + 1, rows);
             }
         }
+    }
+}
+
+fn browser_icon_button_style(_theme: &Theme, status: button::Status) -> button::Style {
+    let background = match status {
+        button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
+        _ => None,
+    };
+    button::Style {
+        background,
+        text_color: th::text_dim(),
+        border: iced::Border {
+            color: if matches!(status, button::Status::Pressed) {
+                th::accent()
+            } else {
+                th::border()
+            },
+            width: 1.0,
+            radius: 3.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
+fn browser_location_button_style(_theme: &Theme, status: button::Status) -> button::Style {
+    button::Style {
+        background: Some(
+            if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                th::bg_hover()
+            } else {
+                th::bg_elevated()
+            }
+            .into(),
+        ),
+        text_color: th::text(),
+        border: iced::Border {
+            color: if matches!(status, button::Status::Pressed) {
+                th::accent()
+            } else {
+                th::divider()
+            },
+            width: 1.0,
+            radius: 3.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
+fn browser_place_button_style(active: bool, status: button::Status) -> button::Style {
+    button::Style {
+        background: Some(
+            if active {
+                th::accent_dim()
+            } else if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                th::bg_hover()
+            } else {
+                iced::Color::TRANSPARENT
+            }
+            .into(),
+        ),
+        text_color: if active { th::text() } else { th::text_dim() },
+        border: iced::Border {
+            color: if active {
+                th::accent()
+            } else {
+                iced::Color::TRANSPARENT
+            },
+            width: if active { 1.0 } else { 0.0 },
+            radius: 3.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
+fn browser_transport_button_style(_theme: &Theme, status: button::Status) -> button::Style {
+    button::Style {
+        background: Some(
+            if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                th::bg_hover()
+            } else {
+                th::bg_elevated()
+            }
+            .into(),
+        ),
+        text_color: th::text_dim(),
+        border: iced::Border {
+            color: if matches!(status, button::Status::Pressed) {
+                th::accent()
+            } else {
+                th::border()
+            },
+            width: 1.0,
+            radius: 3.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
+fn browser_header_style(_theme: &Theme) -> container::Style {
+    container::Style {
+        background: Some(th::bg_surface().into()),
+        border: iced::Border {
+            color: th::divider(),
+            width: 1.0,
+            radius: 0.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
+fn browser_places_style(_theme: &Theme) -> container::Style {
+    container::Style {
+        background: Some(th::bg_dark().into()),
+        border: iced::Border {
+            color: th::divider(),
+            width: 1.0,
+            radius: 0.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
+fn browser_results_style(_theme: &Theme) -> container::Style {
+    container::Style {
+        background: Some(th::bg_surface().into()),
+        border: iced::Border {
+            color: th::divider(),
+            width: 1.0,
+            radius: 0.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
+fn browser_footer_style(_theme: &Theme) -> container::Style {
+    container::Style {
+        background: Some(th::bg_surface().into()),
+        border: iced::Border {
+            color: th::divider(),
+            width: 1.0,
+            radius: 0.0.into(),
+        },
+        ..Default::default()
     }
 }

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -12,7 +12,7 @@ use vibez_dropbox::DropboxEntry;
 
 use crate::icons;
 use crate::message::Message;
-use crate::state::{BrowserDockLayout, SampleBrowserEntry, SampleBrowserMode};
+use crate::state::{SampleBrowserEntry, SampleBrowserMode};
 use crate::theme as th;
 
 use super::*;
@@ -23,21 +23,11 @@ impl App {
             .state
             .browser
             .effective_dock_width(self.state.view.window_width);
-        let layout = self.state.browser.dock_layout(self.state.view.window_width);
-        let layout_label = match layout {
-            BrowserDockLayout::Narrow => "NARROW",
-            BrowserDockLayout::Standard => "STANDARD",
-            BrowserDockLayout::Wide => "WIDE",
-        };
+        let places_width = self
+            .state
+            .browser
+            .places_pane_width(self.state.view.window_width);
 
-        let width_down = button(text("−").size(14).color(th::text_dim()))
-            .on_press(Message::Browser(BrowserMsg::NudgeDockWidth(-40.0)))
-            .padding([2, 7])
-            .style(browser_icon_button_style);
-        let width_up = button(text("+").size(13).color(th::text_dim()))
-            .on_press(Message::Browser(BrowserMsg::NudgeDockWidth(40.0)))
-            .padding([2, 7])
-            .style(browser_icon_button_style);
         let close = button(icons::icon(icons::X).size(11).color(th::text_dim()))
             .on_press(Message::Browser(BrowserMsg::ToggleSampleBrowser))
             .padding([3, 6])
@@ -45,10 +35,7 @@ impl App {
 
         let title_row = row![
             text("BROWSER").size(12).color(th::text()),
-            text(layout_label).size(9).color(th::text_muted()),
             horizontal_space(),
-            width_down,
-            width_up,
             close
         ]
         .spacing(5)
@@ -77,48 +64,15 @@ impl App {
             SampleBrowserMode::Dropbox => self.view_dropbox_browser(),
         };
 
-        let content: Element<'_, Message> = if layout == BrowserDockLayout::Wide {
-            row![
-                container(self.view_browser_places())
-                    .width(Length::Fixed(158.0))
-                    .height(Length::Fill)
-                    .style(browser_places_style),
-                body
-            ]
-            .height(Length::Fill)
-            .into()
-        } else {
-            let place_name = match self.state.browser.mode {
-                SampleBrowserMode::Local => "Local  /  All Roots",
-                SampleBrowserMode::Dropbox => "Remote  /  Alex's Dropbox",
-            };
-            let disclosure = if self.state.browser.places_drawer_open {
-                icons::CHEVRON_UP
-            } else {
-                icons::CHEVRON_DOWN
-            };
-            let location = button(
-                row![
-                    text(place_name).size(11).color(th::text()),
-                    horizontal_space(),
-                    icons::icon(disclosure).size(10).color(th::text_dim())
-                ]
-                .align_y(iced::Alignment::Center),
-            )
-            .on_press(Message::Browser(BrowserMsg::TogglePlacesDrawer))
-            .padding([6, 9])
-            .width(Length::Fill)
-            .style(browser_location_button_style);
-            let mut stack = column![location].spacing(4).height(Length::Fill);
-            if self.state.browser.places_drawer_open {
-                stack = stack.push(
-                    container(self.view_browser_places())
-                        .width(Length::Fill)
-                        .style(browser_places_style),
-                );
-            }
-            stack.push(body).into()
-        };
+        let content: Element<'_, Message> = row![
+            container(self.view_browser_places())
+                .width(Length::Fixed(places_width))
+                .height(Length::Fill)
+                .style(browser_places_style),
+            body
+        ]
+        .height(Length::Fill)
+        .into();
 
         container(
             column![
@@ -126,7 +80,7 @@ impl App {
                     .padding([8, 10])
                     .style(browser_header_style),
                 content,
-                self.view_browser_audition_footer(layout)
+                self.view_browser_audition_footer()
             ]
             .height(Length::Fill),
         )
@@ -255,7 +209,7 @@ impl App {
                 text(if self.state.browser.dropbox.connected {
                     "Alex's Dropbox"
                 } else {
-                    "Dropbox · disconnected"
+                    "Disconnected"
                 })
                 .size(10)
                 .color(connection_color),
@@ -263,27 +217,43 @@ impl App {
             .padding([3, 0]),
         ]);
 
-        let add = button(text("+ Root").size(10).color(th::text_dim()))
-            .on_press(Message::AddSampleLibraryRoot)
-            .padding([4, 7])
-            .style(browser_icon_button_style);
-        let mut rescan = button(text("Rescan").size(10).color(th::text_dim()))
-            .padding([4, 7])
-            .style(browser_icon_button_style);
+        let add = button(
+            row![
+                icons::icon(icons::PLUS).size(10).color(th::text_muted()),
+                text("ADD ROOT").size(9).color(th::text_dim())
+            ]
+            .spacing(5)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::AddSampleLibraryRoot)
+        .padding([4, 5])
+        .width(Length::Fill)
+        .style(browser_utility_action_style);
+        let mut rescan = button(
+            row![
+                icons::icon(icons::REPEAT).size(10).color(th::text_muted()),
+                text("RESCAN").size(9).color(th::text_dim())
+            ]
+            .spacing(5)
+            .align_y(iced::Alignment::Center),
+        )
+        .padding([4, 5])
+        .width(Length::Fill)
+        .style(browser_utility_action_style);
         if !self.state.browser.roots.is_empty() && !self.state.browser.scan_in_progress {
             rescan = rescan.on_press(Message::RescanSampleLibrary);
         }
         places = places.push(
-            row![add, rescan]
+            column![add, rescan]
                 .spacing(4)
                 .padding([8, 0])
-                .align_y(iced::Alignment::Center),
+                .align_x(iced::Alignment::Start),
         );
 
         container(places.padding(9)).width(Length::Fill).into()
     }
 
-    fn view_browser_audition_footer(&self, layout: BrowserDockLayout) -> Element<'_, Message> {
+    fn view_browser_audition_footer(&self) -> Element<'_, Message> {
         let selected_local = self.selected_sample_browser_entry();
         let selected_dropbox = self.selected_dropbox_entry();
         let selected_label = match self.state.browser.mode {
@@ -352,64 +322,17 @@ impl App {
         ]
         .spacing(5)
         .align_y(iced::Alignment::Center);
-        let import_message = match self.state.browser.mode {
-            SampleBrowserMode::Local => {
-                selected_local.map(|_| Message::ImportSelectedBrowserSampleToArrangement)
-            }
-            SampleBrowserMode::Dropbox => selected_dropbox
-                .as_ref()
-                .filter(|entry| entry.is_supported_audio())
-                .map(|entry| Message::DropboxImportToArrangement(entry.clone())),
-        };
-        let device_message = match self.state.browser.mode {
-            SampleBrowserMode::Local => (selected_local.is_some()
-                && self.selected_browser_device_target().is_some())
-            .then_some(Message::LoadSelectedBrowserSampleToDevice),
-            SampleBrowserMode::Dropbox => selected_dropbox
-                .as_ref()
-                .filter(|entry| entry.is_supported_audio())
-                .filter(|_| self.selected_browser_device_target().is_some())
-                .map(|entry| Message::DropboxImportToDevice(entry.clone())),
-        };
-        let mut arrange = button(text("Add to Arrange").size(10).color(th::text_dim()))
-            .padding([4, 7])
-            .style(browser_transport_button_style);
-        if let Some(message) = import_message {
-            arrange = arrange.on_press(message);
-        }
-        let mut device = button(text("Load Device").size(10).color(th::text_dim()))
-            .padding([4, 7])
-            .style(browser_transport_button_style);
-        if let Some(message) = device_message {
-            device = device.on_press(message);
-        }
-        let import_controls = row![arrange, device].spacing(5);
-        let contents: Element<'_, Message> = if layout == BrowserDockLayout::Narrow {
-            column![
-                row![
-                    text("AUDITION").size(9).color(th::text_muted()),
-                    horizontal_space(),
-                    text(selected_label).size(10).color(th::text_dim())
-                ]
-                .align_y(iced::Alignment::Center),
-                controls
+        let contents: Element<'_, Message> = column![
+            row![
+                text("AUDITION").size(9).color(th::text_muted()),
+                horizontal_space(),
+                text(selected_label).size(10).color(th::text_dim())
             ]
-            .spacing(5)
-            .into()
-        } else {
-            column![
-                row![
-                    text("AUDITION").size(9).color(th::text_muted()),
-                    text(selected_label).size(11).color(th::text()),
-                ]
-                .spacing(8)
-                .align_y(iced::Alignment::Center),
-                controls,
-                import_controls
-            ]
-            .spacing(5)
-            .into()
-        };
+            .align_y(iced::Alignment::Center),
+            controls
+        ]
+        .spacing(5)
+        .into();
 
         container(contents)
             .padding([7, 9])
@@ -521,11 +444,11 @@ impl App {
         }
 
         let count = format!(
-            "{} shown / {} indexed{}",
+            "{} / {}{}",
             filtered_entries.len().min(400),
             self.state.browser.entries.len(),
             if self.state.browser.scan_in_progress {
-                " (scanning...)"
+                " …"
             } else {
                 ""
             }
@@ -828,30 +751,6 @@ fn browser_row_divider<'a>() -> Element<'a, Message> {
         .into()
 }
 
-fn browser_location_button_style(_theme: &Theme, status: button::Status) -> button::Style {
-    button::Style {
-        background: Some(
-            if matches!(status, button::Status::Hovered | button::Status::Pressed) {
-                th::bg_hover()
-            } else {
-                th::bg_elevated()
-            }
-            .into(),
-        ),
-        text_color: th::text(),
-        border: iced::Border {
-            color: if matches!(status, button::Status::Pressed) {
-                th::accent()
-            } else {
-                th::divider()
-            },
-            width: 1.0,
-            radius: 0.0.into(),
-        },
-        ..Default::default()
-    }
-}
-
 fn browser_place_button_style(active: bool, status: button::Status) -> button::Style {
     button::Style {
         background: Some(
@@ -872,6 +771,24 @@ fn browser_place_button_style(active: bool, status: button::Status) -> button::S
                 iced::Color::TRANSPARENT
             },
             width: if active { 1.0 } else { 0.0 },
+            radius: 0.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
+fn browser_utility_action_style(_theme: &Theme, status: button::Status) -> button::Style {
+    button::Style {
+        background: matches!(status, button::Status::Hovered | button::Status::Pressed)
+            .then(|| th::bg_hover().into()),
+        text_color: if matches!(status, button::Status::Pressed) {
+            th::accent()
+        } else {
+            th::text_dim()
+        },
+        border: iced::Border {
+            color: iced::Color::TRANSPARENT,
+            width: 0.0,
             radius: 0.0.into(),
         },
         ..Default::default()

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -383,24 +383,122 @@ impl App {
         filtered_entries.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
 
         let selected_source = self.state.browser.selected_source.as_ref();
+        let wide_columns = self
+            .state
+            .browser
+            .results_use_wide_columns(self.state.view.window_width);
+        let table_header: Element<'_, Message> = if wide_columns {
+            container(
+                row![
+                    text("NAME")
+                        .size(9)
+                        .color(th::text_muted())
+                        .width(Length::Fill),
+                    text("BPM")
+                        .size(9)
+                        .color(th::text_muted())
+                        .width(Length::Fixed(36.0)),
+                    text("LENGTH")
+                        .size(9)
+                        .color(th::text_muted())
+                        .width(Length::Fixed(50.0)),
+                    text("STATUS")
+                        .size(9)
+                        .color(th::text_muted())
+                        .width(Length::Fixed(48.0))
+                ]
+                .spacing(4)
+                .align_y(iced::Alignment::Center),
+            )
+            .padding(iced::Padding {
+                top: 5.0,
+                right: 12.0,
+                bottom: 5.0,
+                left: 10.0,
+            })
+            .width(Length::Fill)
+            .style(browser_table_header_style)
+            .into()
+        } else {
+            container(
+                row![
+                    text("NAME")
+                        .size(9)
+                        .color(th::text_muted())
+                        .width(Length::Fill),
+                    text("STATUS")
+                        .size(9)
+                        .color(th::text_muted())
+                        .width(Length::Fixed(42.0))
+                ]
+                .spacing(0)
+                .align_y(iced::Alignment::Center),
+            )
+            .padding(iced::Padding {
+                top: 5.0,
+                right: 12.0,
+                bottom: 5.0,
+                left: 10.0,
+            })
+            .width(Length::Fill)
+            .style(browser_table_header_style)
+            .into()
+        };
         let mut entries_col = column![].spacing(1);
         for entry in filtered_entries.iter().take(400) {
             let selected = selected_source.is_some_and(|source| &entry.source == source);
+            let cell_color = browser_result_cell_color(selected);
             // mouse_area returns early if its child captures the event, so
             // iced Button underneath would swallow press events. Use a
             // plain container as the click target instead.
-            let entry_body = container(
-                column![
-                    text(entry.name.as_str()).size(12).color(th::text()),
-                    text(entry.relative_path.display().to_string())
-                        .size(10)
-                        .color(if selected { th::text() } else { th::text_dim() })
-                ]
-                .spacing(2)
-                .width(Length::Fill),
-            )
-            .padding([6, 8])
+            let name_cell = column![
+                text(entry.name.as_str())
+                    .size(12)
+                    .color(th::text())
+                    .width(Length::Fill)
+                    .height(Length::Fixed(14.0))
+                    .wrapping(iced::widget::text::Wrapping::None),
+                text(entry.relative_path.display().to_string())
+                    .size(9)
+                    .color(cell_color)
+                    .width(Length::Fill)
+                    .height(Length::Fixed(11.0))
+                    .wrapping(iced::widget::text::Wrapping::None)
+            ]
+            .spacing(2)
             .width(Length::Fill);
+            let table_cells: Element<'_, Message> = if wide_columns {
+                row![
+                    name_cell,
+                    text("—")
+                        .size(10)
+                        .color(cell_color)
+                        .width(Length::Fixed(36.0)),
+                    text("—")
+                        .size(10)
+                        .color(cell_color)
+                        .width(Length::Fixed(50.0)),
+                    text("LOCAL")
+                        .size(9)
+                        .color(cell_color)
+                        .width(Length::Fixed(48.0))
+                ]
+                .spacing(4)
+                .align_y(iced::Alignment::Center)
+                .into()
+            } else {
+                row![
+                    name_cell,
+                    text("LOCAL")
+                        .size(9)
+                        .color(cell_color)
+                        .width(Length::Fixed(42.0))
+                ]
+                .spacing(0)
+                .align_y(iced::Alignment::Center)
+                .into()
+            };
+            let entry_body = container(table_cells).padding([6, 8]).width(Length::Fill);
             let entry_dragger: Element<'_, Message> = mouse_area(entry_body)
                 .on_press(Message::Browser(BrowserMsg::StartDragSample {
                     source: entry.source.clone(),
@@ -408,10 +506,6 @@ impl App {
                 }))
                 .on_release(Message::ClickLocalBrowserEntry(entry.source.clone()))
                 .into();
-            let preview_btn = button(icons::icon(icons::PLAY).size(11).color(th::text_dim()))
-                .on_press(Message::PreviewLocalEntry(entry.source.clone()))
-                .padding([6, 8])
-                .style(browser_row_action_style);
             let selection_marker = container(text(""))
                 .width(Length::Fixed(2.0))
                 .height(Length::Fixed(43.0))
@@ -420,7 +514,7 @@ impl App {
                     ..Default::default()
                 });
             let flat_row = container(
-                row![selection_marker, entry_dragger, preview_btn]
+                row![selection_marker, entry_dragger]
                     .spacing(0)
                     .align_y(iced::Alignment::Center),
             )
@@ -462,6 +556,7 @@ impl App {
                     text(count).size(9).color(th::text_dim())
                 ]
                 .align_y(iced::Alignment::Center),
+                table_header,
                 scrollable(
                     container(entries_col)
                         .width(Length::Fill)
@@ -475,7 +570,7 @@ impl App {
                     scrollable::Scrollbar::default()
                 ))
             ]
-            .spacing(6)
+            .spacing(0)
             .padding(8)
             .height(Length::Fill),
         )
@@ -636,10 +731,6 @@ impl App {
                     }))
                     .on_release(msg)
                     .into();
-                let speaker = button(icons::icon(icons::VOLUME_2).size(11).color(th::accent()))
-                    .on_press(Message::DropboxPreview(entry.clone()))
-                    .padding([3, 6])
-                    .style(browser_row_action_style);
                 let selection_marker = container(text(""))
                     .width(Length::Fixed(2.0))
                     .height(Length::Fixed(25.0))
@@ -649,7 +740,7 @@ impl App {
                     });
                 rows.push(
                     container(
-                        row![selection_marker, dragger, speaker]
+                        row![selection_marker, dragger]
                             .spacing(2)
                             .align_y(iced::Alignment::Center),
                     )
@@ -722,19 +813,6 @@ fn browser_icon_button_style(_theme: &Theme, status: button::Status) -> button::
             },
             width: 1.0,
             radius: 0.0.into(),
-        },
-        ..Default::default()
-    }
-}
-
-fn browser_row_action_style(_theme: &Theme, status: button::Status) -> button::Style {
-    button::Style {
-        background: matches!(status, button::Status::Hovered | button::Status::Pressed)
-            .then(|| th::bg_hover().into()),
-        text_color: th::text_dim(),
-        border: iced::Border {
-            radius: 0.0.into(),
-            ..Default::default()
         },
         ..Default::default()
     }
@@ -855,6 +933,21 @@ fn browser_results_style(_theme: &Theme) -> container::Style {
     }
 }
 
+fn browser_table_header_style(_theme: &Theme) -> container::Style {
+    container::Style {
+        background: Some(th::bg_dark().into()),
+        ..Default::default()
+    }
+}
+
+fn browser_result_cell_color(selected: bool) -> iced::Color {
+    if selected {
+        th::text()
+    } else {
+        th::text_dim()
+    }
+}
+
 fn browser_footer_style(_theme: &Theme) -> container::Style {
     container::Style {
         background: Some(th::bg_surface().into()),
@@ -864,5 +957,16 @@ fn browser_footer_style(_theme: &Theme) -> container::Style {
             radius: 0.0.into(),
         },
         ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod browser_table_tests {
+    use super::*;
+
+    #[test]
+    fn selected_result_metadata_uses_the_selected_foreground() {
+        assert_eq!(browser_result_cell_color(true), th::text());
+        assert_eq!(browser_result_cell_color(false), th::text_dim());
     }
 }

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -37,9 +37,13 @@ impl App {
         };
         let content: Element<'_, Message> =
             if self.state.view.workspace == Workspace::Arrange && self.state.browser.open {
-                row![self.view_sample_browser_panel(), workspace_content]
-                    .height(Length::FillPortion(5))
-                    .into()
+                row![
+                    self.view_sample_browser_panel(),
+                    self.view_browser_splitter(),
+                    workspace_content
+                ]
+                .height(Length::FillPortion(5))
+                .into()
             } else {
                 workspace_content
             };

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -18,6 +18,11 @@ use crate::state::{BrowserState, SampleBrowserMode};
 #[derive(Debug, Clone)]
 pub enum BrowserMsg {
     ToggleSampleBrowser,
+    BeginDockResize,
+    ResizeDock(f32),
+    EndDockResize,
+    NudgeDockWidth(f32),
+    TogglePlacesDrawer,
     SampleBrowserSearchChanged(String),
     SelectSampleBrowserRoot(Option<PathBuf>),
     SelectSampleBrowserEntry(MediaSourceRef),
@@ -64,17 +69,40 @@ impl BrowserState {
                 self.open = !self.open;
                 action.persist_settings = true;
             }
+            BrowserMsg::BeginDockResize => {
+                self.dock_resize_active = true;
+            }
+            BrowserMsg::ResizeDock(width) => {
+                if self.dock_resize_active {
+                    self.set_dock_width(width);
+                }
+            }
+            BrowserMsg::EndDockResize => {
+                if self.dock_resize_active {
+                    self.dock_resize_active = false;
+                    action.persist_settings = true;
+                }
+            }
+            BrowserMsg::NudgeDockWidth(delta) => {
+                self.set_dock_width(self.dock_width + delta);
+                action.persist_settings = true;
+            }
+            BrowserMsg::TogglePlacesDrawer => {
+                self.places_drawer_open = !self.places_drawer_open;
+            }
             BrowserMsg::SampleBrowserSearchChanged(query) => {
                 self.search = query;
             }
             BrowserMsg::SelectSampleBrowserRoot(root) => {
                 self.root_filter = root;
+                self.places_drawer_open = false;
             }
             BrowserMsg::SelectSampleBrowserEntry(source) => {
                 self.selected_source = Some(source);
             }
             BrowserMsg::SetSampleBrowserMode(mode) => {
                 self.mode = mode;
+                self.places_drawer_open = false;
                 if mode == crate::state::SampleBrowserMode::Dropbox
                     && !self.dropbox.folders.contains_key("")
                     && !self.dropbox.listing_in_progress.contains("")
@@ -190,6 +218,69 @@ mod tests {
         let action = b.update(BrowserMsg::ToggleSampleBrowser);
         assert!(!b.open);
         assert!(action.persist_settings);
+    }
+
+    #[test]
+    fn dock_width_clamps_and_persists_only_when_committed() {
+        let mut browser = BrowserState::default();
+        assert_eq!(
+            browser.dock_layout(1400.0),
+            crate::state::BrowserDockLayout::Standard
+        );
+
+        let action = browser.update(BrowserMsg::BeginDockResize);
+        assert!(!action.persist_settings);
+        browser.update(BrowserMsg::ResizeDock(900.0));
+        assert_eq!(browser.dock_width, crate::state::BROWSER_DOCK_MAX_WIDTH);
+        let action = browser.update(BrowserMsg::EndDockResize);
+        assert!(action.persist_settings);
+
+        let action = browser.update(BrowserMsg::NudgeDockWidth(-1_000.0));
+        assert_eq!(browser.dock_width, crate::state::BROWSER_DOCK_MIN_WIDTH);
+        assert!(action.persist_settings);
+    }
+
+    #[test]
+    fn dock_yields_to_arrange_without_forgetting_preference() {
+        let mut browser = BrowserState::default();
+        browser.set_dock_width(620.0);
+        assert_eq!(browser.effective_dock_width(1_500.0), 620.0);
+        assert_eq!(browser.effective_dock_width(900.0), 340.0);
+        assert_eq!(browser.dock_width, 620.0);
+        assert_eq!(
+            browser.dock_layout(900.0),
+            crate::state::BrowserDockLayout::Narrow
+        );
+    }
+
+    #[test]
+    fn layout_transitions_do_not_change_browser_context() {
+        let mut browser = BrowserState {
+            search: "break".into(),
+            root_filter: Some(PathBuf::from("/samples")),
+            selected_source: Some(MediaSourceRef::LocalFile {
+                path: PathBuf::from("/samples/break.wav"),
+            }),
+            ..BrowserState::default()
+        };
+        browser.set_dock_width(350.0);
+        assert_eq!(
+            browser.dock_layout(1_400.0),
+            crate::state::BrowserDockLayout::Narrow
+        );
+        browser.set_dock_width(460.0);
+        assert_eq!(
+            browser.dock_layout(1_400.0),
+            crate::state::BrowserDockLayout::Standard
+        );
+        browser.set_dock_width(580.0);
+        assert_eq!(
+            browser.dock_layout(1_400.0),
+            crate::state::BrowserDockLayout::Wide
+        );
+        assert_eq!(browser.search, "break");
+        assert_eq!(browser.root_filter, Some(PathBuf::from("/samples")));
+        assert!(browser.selected_source.is_some());
     }
 
     #[test]

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -22,7 +22,6 @@ pub enum BrowserMsg {
     ResizeDock(f32),
     EndDockResize,
     NudgeDockWidth(f32),
-    TogglePlacesDrawer,
     SampleBrowserSearchChanged(String),
     SelectSampleBrowserRoot(Option<PathBuf>),
     SelectSampleBrowserEntry(MediaSourceRef),
@@ -90,15 +89,11 @@ impl BrowserState {
                 self.set_dock_width(self.dock_width + delta);
                 action.persist_settings = true;
             }
-            BrowserMsg::TogglePlacesDrawer => {
-                self.places_drawer_open = !self.places_drawer_open;
-            }
             BrowserMsg::SampleBrowserSearchChanged(query) => {
                 self.search = query;
             }
             BrowserMsg::SelectSampleBrowserRoot(root) => {
                 self.root_filter = root;
-                self.places_drawer_open = false;
             }
             BrowserMsg::SelectSampleBrowserEntry(source) => {
                 if self.select_source(source.clone()) {
@@ -107,7 +102,6 @@ impl BrowserState {
             }
             BrowserMsg::SetSampleBrowserMode(mode) => {
                 self.mode = mode;
-                self.places_drawer_open = false;
                 if mode == crate::state::SampleBrowserMode::Dropbox
                     && !self.dropbox.folders.contains_key("")
                     && !self.dropbox.listing_in_progress.contains("")
@@ -234,10 +228,6 @@ mod tests {
     #[test]
     fn dock_width_clamps_and_persists_only_when_committed() {
         let mut browser = BrowserState::default();
-        assert_eq!(
-            browser.dock_layout(1400.0),
-            crate::state::BrowserDockLayout::Standard
-        );
 
         let action = browser.update(BrowserMsg::BeginDockResize);
         assert!(!action.persist_settings);
@@ -258,14 +248,11 @@ mod tests {
         assert_eq!(browser.effective_dock_width(1_500.0), 620.0);
         assert_eq!(browser.effective_dock_width(900.0), 340.0);
         assert_eq!(browser.dock_width, 620.0);
-        assert_eq!(
-            browser.dock_layout(900.0),
-            crate::state::BrowserDockLayout::Narrow
-        );
+        assert!((browser.places_pane_width(900.0) - 124.0).abs() < f32::EPSILON * 100.0);
     }
 
     #[test]
-    fn layout_transitions_do_not_change_browser_context() {
+    fn resizing_keeps_one_places_and_results_shell_without_changing_context() {
         let mut browser = BrowserState {
             search: "break".into(),
             root_filter: Some(PathBuf::from("/samples")),
@@ -275,20 +262,11 @@ mod tests {
             ..BrowserState::default()
         };
         browser.set_dock_width(350.0);
-        assert_eq!(
-            browser.dock_layout(1_400.0),
-            crate::state::BrowserDockLayout::Narrow
-        );
+        assert!((browser.places_pane_width(1_400.0) - 126.0).abs() < f32::EPSILON * 100.0);
         browser.set_dock_width(460.0);
-        assert_eq!(
-            browser.dock_layout(1_400.0),
-            crate::state::BrowserDockLayout::Standard
-        );
+        assert!((browser.places_pane_width(1_400.0) - 165.6).abs() < f32::EPSILON * 100.0);
         browser.set_dock_width(580.0);
-        assert_eq!(
-            browser.dock_layout(1_400.0),
-            crate::state::BrowserDockLayout::Wide
-        );
+        assert!((browser.places_pane_width(1_400.0) - 176.0).abs() < f32::EPSILON * 100.0);
         assert_eq!(browser.search, "break");
         assert_eq!(browser.root_filter, Some(PathBuf::from("/samples")));
         assert!(browser.selected_source.is_some());

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -273,6 +273,20 @@ mod tests {
     }
 
     #[test]
+    fn results_table_promotes_metadata_to_columns_only_when_space_allows() {
+        let mut browser = BrowserState::default();
+
+        browser.set_dock_width(crate::state::BROWSER_DOCK_MIN_WIDTH);
+        assert!(!browser.results_use_wide_columns(1_400.0));
+
+        browser.set_dock_width(crate::state::BROWSER_DOCK_DEFAULT_WIDTH);
+        assert!(!browser.results_use_wide_columns(1_400.0));
+
+        browser.set_dock_width(crate::state::BROWSER_DOCK_MAX_WIDTH);
+        assert!(browser.results_use_wide_columns(1_400.0));
+    }
+
+    #[test]
     fn changing_selection_clears_waveform_and_rejects_stale_decode() {
         let first = MediaSourceRef::LocalFile {
             path: PathBuf::from("/samples/first.wav"),

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -59,6 +59,9 @@ pub struct BrowserAction {
     /// A drag was released over a lane: import `source` onto this
     /// track at this beat.
     pub drop_on_arrangement: Option<(TrackId, f64, MediaSourceRef)>,
+    /// Decode a Local selection for the truthful Audition waveform without
+    /// starting playback.
+    pub load_waveform: Option<MediaSourceRef>,
 }
 
 impl BrowserState {
@@ -98,7 +101,9 @@ impl BrowserState {
                 self.places_drawer_open = false;
             }
             BrowserMsg::SelectSampleBrowserEntry(source) => {
-                self.selected_source = Some(source);
+                if self.select_source(source.clone()) {
+                    action.load_waveform = Some(source);
+                }
             }
             BrowserMsg::SetSampleBrowserMode(mode) => {
                 self.mode = mode;
@@ -152,8 +157,14 @@ impl BrowserState {
                             })
                             .is_none()
                         {
-                            self.selected_source =
-                                self.entries.first().map(|entry| entry.source.clone());
+                            if let Some(source) =
+                                self.entries.first().map(|entry| entry.source.clone())
+                            {
+                                self.select_source(source.clone());
+                                action.load_waveform = Some(source);
+                            } else {
+                                self.clear_selection();
+                            }
                         }
                         action.status = Some(if scan.warnings.is_empty() {
                             format!("Indexed {} samples", self.entries.len())
@@ -184,7 +195,7 @@ impl BrowserState {
                     })
                     .is_none()
                 {
-                    self.selected_source = None;
+                    self.clear_selection();
                 }
                 action.persist_settings = true;
                 action.status = Some("Removed sample root".to_string());
@@ -194,7 +205,7 @@ impl BrowserState {
             }
             BrowserMsg::DropboxSelectEntry(entry) => {
                 self.dropbox.selected_path = Some(entry.path_lower.clone());
-                self.selected_source = Some(MediaSourceRef::DropboxFile {
+                self.select_source(MediaSourceRef::DropboxFile {
                     path_lower: entry.path_lower,
                     display_path: entry.path_display,
                     rev: entry.rev,
@@ -281,6 +292,31 @@ mod tests {
         assert_eq!(browser.search, "break");
         assert_eq!(browser.root_filter, Some(PathBuf::from("/samples")));
         assert!(browser.selected_source.is_some());
+    }
+
+    #[test]
+    fn changing_selection_clears_waveform_and_rejects_stale_decode() {
+        let first = MediaSourceRef::LocalFile {
+            path: PathBuf::from("/samples/first.wav"),
+        };
+        let second = MediaSourceRef::LocalFile {
+            path: PathBuf::from("/samples/second.wav"),
+        };
+        let audio = std::sync::Arc::new(vibez_core::audio_buffer::DecodedAudio {
+            channels: vec![vec![0.0, 0.8, -0.4]],
+            sample_rate: 44_100,
+        });
+        let mut browser = BrowserState::default();
+
+        browser.select_source(first.clone());
+        browser.begin_waveform_load(&first);
+        assert!(browser.install_waveform(first.clone(), std::sync::Arc::clone(&audio)));
+        assert!(browser.waveform_audio.is_some());
+
+        browser.select_source(second);
+        assert!(browser.waveform_audio.is_none());
+        assert!(!browser.install_waveform(first, audio));
+        assert!(browser.waveform_audio.is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -253,7 +253,8 @@ pub enum Message {
     /// Speaker-icon click on a Local browser row: audition.
     PreviewLocalEntry(MediaSourceRef),
     StopBrowserPreview,
-    LocalSamplePreviewReady(Result<Arc<DecodedAudio>, String>),
+    LocalSamplePreviewReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
+    BrowserWaveformReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
     DropSampleOnArrangement {
         track_id: TrackId,
         position_samples: u64,
@@ -383,7 +384,7 @@ pub enum Message {
         result: Result<Vec<DropboxEntry>, String>,
     },
     DropboxPreview(DropboxEntry),
-    DropboxPreviewReady(Result<Arc<DecodedAudio>, String>),
+    DropboxPreviewReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
     DropboxImportToArrangement(DropboxEntry),
     DropboxImportToDevice(DropboxEntry),
 }

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -252,6 +252,7 @@ pub enum Message {
     ClickLocalBrowserEntry(MediaSourceRef),
     /// Speaker-icon click on a Local browser row: audition.
     PreviewLocalEntry(MediaSourceRef),
+    StopBrowserPreview,
     LocalSamplePreviewReady(Result<Arc<DecodedAudio>, String>),
     DropSampleOnArrangement {
         track_id: TrackId,

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -339,6 +339,15 @@ impl BrowserState {
         (self.effective_dock_width(window_width) * 0.36)
             .clamp(BROWSER_PLACES_MIN_WIDTH, BROWSER_PLACES_MAX_WIDTH)
     }
+
+    /// The single Results table keeps Name and Status visible throughout the
+    /// resize range, then promotes BPM and Length into dedicated columns once
+    /// the Results pane has enough room to keep every column readable.
+    pub fn results_use_wide_columns(&self, window_width: f32) -> bool {
+        let results_width =
+            self.effective_dock_width(window_width) - self.places_pane_width(window_width);
+        results_width >= 400.0
+    }
 }
 
 /// UI-side state for the Dropbox browser and Settings tab.

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -1,9 +1,11 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 mod ui_types;
 pub use ui_types::*;
 
+use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::constants::DEFAULT_BPM;
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::track::MediaSourceRef;
@@ -251,6 +253,12 @@ pub struct BrowserState {
     pub entries: Vec<SampleBrowserEntry>,
     pub root_filter: Option<PathBuf>,
     pub selected_source: Option<MediaSourceRef>,
+    /// Decoded audio used only for the selected Browser source's visual
+    /// waveform. Audition still travels through the existing engine path.
+    pub waveform_source: Option<MediaSourceRef>,
+    pub waveform_audio: Option<Arc<DecodedAudio>>,
+    pub waveform_loading: bool,
+    pub waveform_error: Option<String>,
     pub scan_in_progress: bool,
     pub mode: SampleBrowserMode,
     pub dropbox: DropboxUiState,
@@ -275,6 +283,10 @@ impl Default for BrowserState {
             entries: Vec::new(),
             root_filter: None,
             selected_source: None,
+            waveform_source: None,
+            waveform_audio: None,
+            waveform_loading: false,
+            waveform_error: None,
             scan_in_progress: false,
             mode: SampleBrowserMode::default(),
             dropbox: DropboxUiState::default(),
@@ -287,6 +299,51 @@ impl Default for BrowserState {
 }
 
 impl BrowserState {
+    pub fn select_source(&mut self, source: MediaSourceRef) -> bool {
+        let changed = self.selected_source.as_ref() != Some(&source);
+        self.selected_source = Some(source);
+        if changed {
+            self.clear_waveform();
+        }
+        changed
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.selected_source = None;
+        self.clear_waveform();
+    }
+
+    pub fn begin_waveform_load(&mut self, source: &MediaSourceRef) {
+        if self.selected_source.as_ref() == Some(source) {
+            self.waveform_loading = true;
+        }
+    }
+
+    pub fn install_waveform(&mut self, source: MediaSourceRef, audio: Arc<DecodedAudio>) -> bool {
+        if self.selected_source.as_ref() != Some(&source) {
+            return false;
+        }
+        self.waveform_source = Some(source);
+        self.waveform_audio = Some(audio);
+        self.waveform_loading = false;
+        self.waveform_error = None;
+        true
+    }
+
+    pub fn fail_waveform_load(&mut self, source: &MediaSourceRef, error: String) {
+        if self.selected_source.as_ref() == Some(source) {
+            self.waveform_loading = false;
+            self.waveform_error = Some(error);
+        }
+    }
+
+    fn clear_waveform(&mut self) {
+        self.waveform_source = None;
+        self.waveform_audio = None;
+        self.waveform_loading = false;
+        self.waveform_error = None;
+    }
+
     pub fn set_dock_width(&mut self, width: f32) {
         self.dock_width = width.clamp(BROWSER_DOCK_MIN_WIDTH, BROWSER_DOCK_MAX_WIDTH);
     }

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -212,11 +212,40 @@ pub enum SampleBrowserMode {
     Dropbox,
 }
 
+pub const BROWSER_DOCK_MIN_WIDTH: f32 = 300.0;
+pub const BROWSER_DOCK_DEFAULT_WIDTH: f32 = 410.0;
+pub const BROWSER_DOCK_MAX_WIDTH: f32 = 650.0;
+pub const ARRANGE_MIN_WIDTH_WITH_BROWSER: f32 = 560.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowserDockLayout {
+    Narrow,
+    Standard,
+    Wide,
+}
+
+impl BrowserDockLayout {
+    pub fn for_width(width: f32) -> Self {
+        if width < 400.0 {
+            Self::Narrow
+        } else if width < 520.0 {
+            Self::Standard
+        } else {
+            Self::Wide
+        }
+    }
+}
+
 /// Browser domain slice: sample library, Dropbox browsing, and
 /// drag-and-drop from the browser into the arrangement.
 #[derive(Debug, Clone)]
 pub struct BrowserState {
     pub open: bool,
+    /// Remembered user width. The rendered width may temporarily yield to a
+    /// narrow window without overwriting this preference.
+    pub dock_width: f32,
+    pub dock_resize_active: bool,
+    pub places_drawer_open: bool,
     pub search: String,
     pub roots: Vec<PathBuf>,
     pub entries: Vec<SampleBrowserEntry>,
@@ -238,6 +267,9 @@ impl Default for BrowserState {
     fn default() -> Self {
         Self {
             open: true,
+            dock_width: BROWSER_DOCK_DEFAULT_WIDTH,
+            dock_resize_active: false,
+            places_drawer_open: false,
             search: String::new(),
             roots: Vec::new(),
             entries: Vec::new(),
@@ -251,6 +283,22 @@ impl Default for BrowserState {
             drag_hover_track: None,
             drag_hover_beat: 0.0,
         }
+    }
+}
+
+impl BrowserState {
+    pub fn set_dock_width(&mut self, width: f32) {
+        self.dock_width = width.clamp(BROWSER_DOCK_MIN_WIDTH, BROWSER_DOCK_MAX_WIDTH);
+    }
+
+    pub fn effective_dock_width(&self, window_width: f32) -> f32 {
+        let available = (window_width - ARRANGE_MIN_WIDTH_WITH_BROWSER)
+            .clamp(BROWSER_DOCK_MIN_WIDTH, BROWSER_DOCK_MAX_WIDTH);
+        self.dock_width.min(available).max(BROWSER_DOCK_MIN_WIDTH)
+    }
+
+    pub fn dock_layout(&self, window_width: f32) -> BrowserDockLayout {
+        BrowserDockLayout::for_width(self.effective_dock_width(window_width))
     }
 }
 

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -218,25 +218,8 @@ pub const BROWSER_DOCK_MIN_WIDTH: f32 = 300.0;
 pub const BROWSER_DOCK_DEFAULT_WIDTH: f32 = 410.0;
 pub const BROWSER_DOCK_MAX_WIDTH: f32 = 650.0;
 pub const ARRANGE_MIN_WIDTH_WITH_BROWSER: f32 = 560.0;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BrowserDockLayout {
-    Narrow,
-    Standard,
-    Wide,
-}
-
-impl BrowserDockLayout {
-    pub fn for_width(width: f32) -> Self {
-        if width < 400.0 {
-            Self::Narrow
-        } else if width < 520.0 {
-            Self::Standard
-        } else {
-            Self::Wide
-        }
-    }
-}
+pub const BROWSER_PLACES_MIN_WIDTH: f32 = 124.0;
+pub const BROWSER_PLACES_MAX_WIDTH: f32 = 176.0;
 
 /// Browser domain slice: sample library, Dropbox browsing, and
 /// drag-and-drop from the browser into the arrangement.
@@ -247,7 +230,6 @@ pub struct BrowserState {
     /// narrow window without overwriting this preference.
     pub dock_width: f32,
     pub dock_resize_active: bool,
-    pub places_drawer_open: bool,
     pub search: String,
     pub roots: Vec<PathBuf>,
     pub entries: Vec<SampleBrowserEntry>,
@@ -277,7 +259,6 @@ impl Default for BrowserState {
             open: true,
             dock_width: BROWSER_DOCK_DEFAULT_WIDTH,
             dock_resize_active: false,
-            places_drawer_open: false,
             search: String::new(),
             roots: Vec::new(),
             entries: Vec::new(),
@@ -354,8 +335,9 @@ impl BrowserState {
         self.dock_width.min(available).max(BROWSER_DOCK_MIN_WIDTH)
     }
 
-    pub fn dock_layout(&self, window_width: f32) -> BrowserDockLayout {
-        BrowserDockLayout::for_width(self.effective_dock_width(window_width))
+    pub fn places_pane_width(&self, window_width: f32) -> f32 {
+        (self.effective_dock_width(window_width) * 0.36)
+            .clamp(BROWSER_PLACES_MIN_WIDTH, BROWSER_PLACES_MAX_WIDTH)
     }
 }
 

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -8,6 +8,8 @@ pub struct UiSettings {
     pub sample_library_roots: Vec<PathBuf>,
     #[serde(default = "default_sample_browser_open")]
     pub sample_browser_open: bool,
+    #[serde(default = "default_sample_browser_width")]
+    pub sample_browser_width: f32,
     /// Automatically detect each dropped sample's BPM and warp it to
     /// the project tempo on import. Off by default; users opt in from
     /// Settings → Warping.
@@ -34,6 +36,7 @@ impl Default for UiSettings {
         Self {
             sample_library_roots: Vec::new(),
             sample_browser_open: default_sample_browser_open(),
+            sample_browser_width: default_sample_browser_width(),
             auto_warp_on_import: false,
             warp_confidence_threshold: default_warp_confidence_threshold(),
             preferred_midi_input: None,
@@ -72,6 +75,38 @@ fn default_sample_browser_open() -> bool {
     true
 }
 
+fn default_sample_browser_width() -> f32 {
+    crate::state::BROWSER_DOCK_DEFAULT_WIDTH
+}
+
 fn default_warp_confidence_threshold() -> f32 {
     0.6
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn old_settings_receive_the_browser_width_default() {
+        let loaded: UiSettings =
+            serde_json::from_str(r#"{"sample_library_roots":[],"sample_browser_open":false}"#)
+                .unwrap();
+        assert!(!loaded.sample_browser_open);
+        assert_eq!(
+            loaded.sample_browser_width,
+            crate::state::BROWSER_DOCK_DEFAULT_WIDTH
+        );
+    }
+
+    #[test]
+    fn browser_width_roundtrips() {
+        let settings = UiSettings {
+            sample_browser_width: 612.0,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let loaded: UiSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.sample_browser_width, 612.0);
+    }
 }

--- a/crates/vibez-ui/src/widgets/browser_waveform.rs
+++ b/crates/vibez-ui/src/widgets/browser_waveform.rs
@@ -1,0 +1,139 @@
+//! Truthful, non-interactive waveform for the Browser Audition footer.
+
+use std::cell::Cell;
+use std::sync::Arc;
+
+use iced::mouse;
+use iced::widget::canvas;
+use iced::{Rectangle, Renderer, Theme};
+use vibez_core::audio_buffer::DecodedAudio;
+
+use crate::message::Message;
+use crate::theme;
+
+pub struct BrowserWaveform {
+    pub audio: Option<Arc<DecodedAudio>>,
+}
+
+pub struct BrowserWaveformState {
+    cache: canvas::Cache,
+    fingerprint: Cell<u64>,
+}
+
+impl Default for BrowserWaveformState {
+    fn default() -> Self {
+        Self {
+            cache: canvas::Cache::new(),
+            fingerprint: Cell::new(u64::MAX),
+        }
+    }
+}
+
+impl canvas::Program<Message> for BrowserWaveform {
+    type State = BrowserWaveformState;
+
+    fn draw(
+        &self,
+        state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let fingerprint = self
+            .audio
+            .as_ref()
+            .map(|audio| Arc::as_ptr(audio) as u64)
+            .unwrap_or(0);
+        if state.fingerprint.get() != fingerprint {
+            state.cache.clear();
+            state.fingerprint.set(fingerprint);
+        }
+
+        let geometry = state.cache.draw(renderer, bounds.size(), |frame| {
+            let width = frame.width();
+            let height = frame.height();
+            frame.fill_rectangle(
+                iced::Point::ORIGIN,
+                iced::Size::new(width, height),
+                theme::display_bg(),
+            );
+
+            let middle = height / 2.0;
+            let center_line = canvas::Path::line(
+                iced::Point::new(0.0, middle),
+                iced::Point::new(width, middle),
+            );
+            frame.stroke(
+                &center_line,
+                canvas::Stroke::default()
+                    .with_color(theme::border())
+                    .with_width(1.0),
+            );
+
+            let Some(audio) = &self.audio else {
+                return;
+            };
+            let peaks = summarize_waveform(audio, width.max(1.0) as usize);
+            let amplitude = (height / 2.0 - 2.0).max(1.0);
+            for (x, (min, max)) in peaks.into_iter().enumerate() {
+                let top = middle - max.clamp(-1.0, 1.0) * amplitude;
+                let bottom = middle - min.clamp(-1.0, 1.0) * amplitude;
+                frame.fill_rectangle(
+                    iced::Point::new(x as f32, top.min(bottom)),
+                    iced::Size::new(1.0, (bottom - top).abs().max(1.0)),
+                    theme::waveform(),
+                );
+            }
+        });
+
+        vec![geometry]
+    }
+}
+
+pub(crate) fn summarize_waveform(audio: &DecodedAudio, columns: usize) -> Vec<(f32, f32)> {
+    let columns = columns.max(1);
+    let frames = audio.num_frames();
+    if frames == 0 || audio.num_channels() == 0 {
+        return vec![(0.0, 0.0); columns];
+    }
+
+    (0..columns)
+        .map(|column| {
+            let start = column * frames / columns;
+            let end = ((column + 1) * frames / columns).max(start + 1);
+            let mut min = 0.0;
+            let mut max = 0.0;
+            for channel in 0..audio.num_channels() {
+                let (channel_min, channel_max) = audio.peak_in_range(channel, start, end);
+                min += channel_min;
+                max += channel_max;
+            }
+            let channels = audio.num_channels() as f32;
+            (min / channels, max / channels)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn waveform_summary_reflects_the_selected_audio() {
+        let quiet = DecodedAudio {
+            channels: vec![vec![0.1, -0.1, 0.1, -0.1]],
+            sample_rate: 44_100,
+        };
+        let transient = DecodedAudio {
+            channels: vec![vec![0.0, 1.0, 0.0, -0.8]],
+            sample_rate: 44_100,
+        };
+
+        assert_ne!(
+            summarize_waveform(&quiet, 4),
+            summarize_waveform(&transient, 4)
+        );
+        assert_eq!(summarize_waveform(&transient, 4)[1], (1.0, 1.0));
+    }
+}

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -1,5 +1,6 @@
 pub mod audio_clip_detail;
 pub mod automation_lane;
+pub mod browser_waveform;
 pub mod effect_knob;
 pub mod effect_slot;
 pub mod eq_display;


### PR DESCRIPTION
## Demo outcome

The existing Local index now lives in a polished, continuously resizable Browser Dock. It resizes from 300–650 px, remembers width/open state, yields to keep Arrange usable, and keeps Places + Results visible in one invariant shell across the full range.

Stacked on #51. This PR contains Card 02 only.

## Included

- persistent dock width, visible drag splitter, and tested `Alt+Left` / `Alt+Right` resizing without redundant header controls
- Places + Results side by side at every width, using continuous pane proportions and stable single-line default-width navigation labels
- flat, square Results rows with a reserved scrollbar gutter
- flat Add Root / Rescan utility rows rather than boxed controls
- Audition-only footer; premature Add to Arrange / Load Device buttons are removed pending the deliberate Enter + Media Drag flow in Card 09
- truthful cached waveform driven by selected decoded audio; unsupported sources show unavailable rather than a fabricated waveform
- ThemePalette-only Browser styling across dark, light, and custom `.vzt` palettes
- resize-policy, keyboard shortcut, waveform selection/summary, and settings compatibility tests

## Non-goals

- folder-tree or catalogue redesign
- new Remote behaviour
- WARP, Sync, Loop, or a new Audition signal path
- Card 09 import interaction redesign

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p vibez-ui --lib -- -D warnings`
- `cargo test -p vibez-ui` — 118 passed
- native final matrix at the 300 px minimum, 410 px default, and 650 px maximum
- native keyboard check reached and persisted both extrema with `Alt+Left` / `Alt+Right`
- two distinct WAV selections render distinct waveforms; row-end actions remain clear of the scrollbar

## Human gate

Delivery remains awaiting screenshot approval. The corrected minimum, default, and maximum native screenshots will be presented for approval before Card 02 is marked delivered.