### PR TITLE
feat(project): save self-contained Project Media

### DIFF
--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -13,6 +13,19 @@ pub enum MediaSourceRef {
     LocalFile {
         path: PathBuf,
     },
+    /// Project-owned bytes copied to a staging area before the first save.
+    /// This reference must never survive in a committed project document.
+    StagedProjectMedia {
+        id: String,
+        file_name: String,
+        staging_path: PathBuf,
+        source_path: PathBuf,
+    },
+    /// Playback-critical media embedded in a Project Format V1 container.
+    ProjectMedia {
+        id: String,
+        file_name: String,
+    },
     DropboxFile {
         path_lower: String,
         display_path: String,
@@ -28,6 +41,8 @@ impl MediaSourceRef {
                 .file_name()
                 .map(|name| name.to_string_lossy().to_string())
                 .unwrap_or_else(|| path.display().to_string()),
+            MediaSourceRef::StagedProjectMedia { file_name, .. }
+            | MediaSourceRef::ProjectMedia { file_name, .. } => file_name.clone(),
             MediaSourceRef::DropboxFile { display_path, .. } => PathBuf::from(display_path)
                 .file_name()
                 .map(|name| name.to_string_lossy().to_string())

--- a/crates/vibez-project/src/bin/project-format-v1-proof.rs
+++ b/crates/vibez-project/src/bin/project-format-v1-proof.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-use vibez_project::project_format_v1_proof::{
-    abort_mid_save, hex_sha256, representative_document, ProofContainer, Provenance, StagedMedia,
+use vibez_project::project_format_v1::{
+    abort_mid_save, hex_sha256, representative_document, ProjectContainer, Provenance, StagedMedia,
 };
 
 const ASSET_BYTES: usize = 32 * 1024 * 1024;
@@ -69,7 +69,7 @@ fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
 
     let mut document = representative_document();
     let (mut container, full_save) =
-        ProofContainer::create_from_staged(&container_path, &mut document, &staged)?;
+        ProjectContainer::create_from_staged(&container_path, &mut document, &staged)?;
     assert!(!local_stage.exists() && !remote_stage.exists());
     assert_eq!(container.read_media("local-break")?, local_bytes);
     assert_eq!(container.read_media("remote-vocal")?, remote_bytes);
@@ -93,7 +93,7 @@ fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
     drop(container);
 
     let reopen_started = Instant::now();
-    let reopened = ProofContainer::open(&container_path)?;
+    let reopened = ProjectContainer::open(&container_path)?;
     let reopened_document = reopened.load_document()?;
     let reopen_elapsed = reopen_started.elapsed();
     assert_eq!(serde_json::to_vec(&reopened_document)?, committed_json);
@@ -113,7 +113,7 @@ fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
     );
 
     let recovered_started = Instant::now();
-    let recovered = ProofContainer::open(&container_path)?;
+    let recovered = ProjectContainer::open(&container_path)?;
     let recovered_document = recovered.load_document()?;
     let recovery_elapsed = recovered_started.elapsed();
     assert_eq!(serde_json::to_vec(&recovered_document)?, committed_json);
@@ -123,7 +123,7 @@ fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(recovered.read_media("local-break")?, local_bytes);
 
-    let save_as_container = ProofContainer::open(&save_as_path)?;
+    let save_as_container = ProjectContainer::open(&save_as_path)?;
     assert_eq!(
         serde_json::to_vec(&save_as_container.load_document()?)?,
         committed_json

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use vibez_core::midi::NoteClipInfo;
 use vibez_core::track::{ClipInfo, TrackInfo};
 
-pub mod project_format_v1_proof;
+pub mod project_format_v1;
 
 /// A serializable project containing tracks and clips.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/vibez-project/src/project_format_v1.rs
+++ b/crates/vibez-project/src/project_format_v1.rs
@@ -1,17 +1,18 @@
-//! Bounded Project Format V1 container proof.
+//! Production Project Format V1 SQLite container.
 //!
-//! This module deliberately does not replace [`crate::Project`]'s production
-//! JSON save/load path. It exists to measure and validate the SQLite-backed
-//! container proposed for Project Format V1 before production persistence is
-//! built on it.
+//! Project documents and playback-critical Project Media commit together.
+//! The container preserves unchanged media rows during ordinary saves and can
+//! create a self-contained Save As copy without returning to Source Storage.
 
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Transaction};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use vibez_core::track::{InstrumentStateInfo, MediaSourceRef, TrackInfo};
 
 use crate::Project;
 
@@ -91,8 +92,20 @@ pub struct SaveObservation {
     pub media_bytes_written: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectFileFormat {
+    V1,
+    LegacyJson,
+}
+
+#[derive(Debug, Clone)]
+pub struct SaveResult {
+    pub project: Project,
+    pub observation: SaveObservation,
+}
+
 #[derive(Debug)]
-pub enum ProofError {
+pub enum ProjectFormatError {
     Io(std::io::Error),
     Sql(rusqlite::Error),
     Json(serde_json::Error),
@@ -101,14 +114,14 @@ pub enum ProofError {
     ExistingDestination(PathBuf),
 }
 
-impl std::fmt::Display for ProofError {
+impl std::fmt::Display for ProjectFormatError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Io(error) => write!(f, "I/O error: {error}"),
             Self::Sql(error) => write!(f, "SQLite error: {error}"),
             Self::Json(error) => write!(f, "JSON error: {error}"),
             Self::InvalidContainer(message) => {
-                write!(f, "invalid Project Format V1 proof container: {message}")
+                write!(f, "invalid Project Format V1 container: {message}")
             }
             Self::MissingMedia(id) => write!(f, "project media {id:?} was not found"),
             Self::ExistingDestination(path) => {
@@ -118,42 +131,42 @@ impl std::fmt::Display for ProofError {
     }
 }
 
-impl std::error::Error for ProofError {}
+impl std::error::Error for ProjectFormatError {}
 
-impl From<std::io::Error> for ProofError {
+impl From<std::io::Error> for ProjectFormatError {
     fn from(value: std::io::Error) -> Self {
         Self::Io(value)
     }
 }
 
-impl From<rusqlite::Error> for ProofError {
+impl From<rusqlite::Error> for ProjectFormatError {
     fn from(value: rusqlite::Error) -> Self {
         Self::Sql(value)
     }
 }
 
-impl From<serde_json::Error> for ProofError {
+impl From<serde_json::Error> for ProjectFormatError {
     fn from(value: serde_json::Error) -> Self {
         Self::Json(value)
     }
 }
 
-pub struct ProofContainer {
+pub struct ProjectContainer {
     path: PathBuf,
     connection: Connection,
 }
 
-impl ProofContainer {
-    /// First-save proof: transactionally creates a new container and takes
+impl ProjectContainer {
+    /// First save: transactionally creates a new container and takes
     /// ownership of staged bytes. Staging files are removed only after commit.
     pub fn create_from_staged(
         path: impl AsRef<Path>,
         document: &mut ProjectDocumentV1,
         staged_media: &[StagedMedia],
-    ) -> Result<(Self, SaveObservation), ProofError> {
+    ) -> Result<(Self, SaveObservation), ProjectFormatError> {
         let path = path.as_ref();
         if path.exists() {
-            return Err(ProofError::ExistingDestination(path.to_path_buf()));
+            return Err(ProjectFormatError::ExistingDestination(path.to_path_buf()));
         }
 
         let started = Instant::now();
@@ -164,12 +177,21 @@ impl ProofContainer {
 
         let transaction = connection.transaction()?;
         let mut media_bytes_written = 0_u64;
+        let mut media_rows_written = 0_usize;
         for staged in staged_media {
             let content = fs::read(&staged.path)?;
             let entry = media_entry(staged, &content);
-            insert_media(&transaction, &entry, &content)?;
-            media_bytes_written += content.len() as u64;
-            document.project_media.push(entry);
+            if insert_media(&transaction, &entry, &content)? {
+                media_rows_written += 1;
+                media_bytes_written += content.len() as u64;
+            }
+            if !document
+                .project_media
+                .iter()
+                .any(|item| item.id == entry.id)
+            {
+                document.project_media.push(entry);
+            }
         }
         write_document(&transaction, document)?;
         transaction.commit()?;
@@ -178,13 +200,13 @@ impl ProofContainer {
         // longer needed. Cleanup failure is intentionally non-fatal because
         // losing the newly committed Project Media would be worse.
         for staged in staged_media {
-            let _ = fs::remove_file(&staged.path);
+            cleanup_staging_copy(staged);
         }
 
         let observation = SaveObservation {
             elapsed: started.elapsed(),
             container_bytes: fs::metadata(path)?.len(),
-            media_rows_written: staged_media.len(),
+            media_rows_written,
             media_bytes_written,
         };
         Ok((
@@ -196,7 +218,7 @@ impl ProofContainer {
         ))
     }
 
-    pub fn open(path: impl AsRef<Path>) -> Result<Self, ProofError> {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, ProjectFormatError> {
         let path = path.as_ref();
         let connection = Connection::open_with_flags(
             path,
@@ -210,7 +232,7 @@ impl ProofContainer {
         })
     }
 
-    pub fn load_document(&self) -> Result<ProjectDocumentV1, ProofError> {
+    pub fn load_document(&self) -> Result<ProjectDocumentV1, ProjectFormatError> {
         let json: Vec<u8> = self.connection.query_row(
             "SELECT json FROM project_document WHERE singleton = 1",
             [],
@@ -218,7 +240,7 @@ impl ProofContainer {
         )?;
         let document: ProjectDocumentV1 = serde_json::from_slice(&json)?;
         if document.format_version != FORMAT_VERSION {
-            return Err(ProofError::InvalidContainer(format!(
+            return Err(ProjectFormatError::InvalidContainer(format!(
                 "document version is {}, expected {FORMAT_VERSION}",
                 document.format_version
             )));
@@ -226,7 +248,7 @@ impl ProofContainer {
         Ok(document)
     }
 
-    pub fn read_media(&self, id: &str) -> Result<Vec<u8>, ProofError> {
+    pub fn read_media(&self, id: &str) -> Result<Vec<u8>, ProjectFormatError> {
         self.connection
             .query_row(
                 "SELECT content FROM project_media WHERE id = ?1",
@@ -234,10 +256,10 @@ impl ProofContainer {
                 |row| row.get(0),
             )
             .optional()?
-            .ok_or_else(|| ProofError::MissingMedia(id.to_owned()))
+            .ok_or_else(|| ProjectFormatError::MissingMedia(id.to_owned()))
     }
 
-    pub fn media_fingerprint(&self, id: &str) -> Result<(i64, String, u64), ProofError> {
+    pub fn media_fingerprint(&self, id: &str) -> Result<(i64, String, u64), ProjectFormatError> {
         self.connection
             .query_row(
                 "SELECT rowid, sha256, byte_len FROM project_media WHERE id = ?1",
@@ -245,7 +267,7 @@ impl ProofContainer {
                 |row| Ok((row.get(0)?, row.get(1)?, row.get::<_, i64>(2)? as u64)),
             )
             .optional()?
-            .ok_or_else(|| ProofError::MissingMedia(id.to_owned()))
+            .ok_or_else(|| ProjectFormatError::MissingMedia(id.to_owned()))
     }
 
     /// Incrementally updates only the versioned project document. The media
@@ -253,7 +275,7 @@ impl ProofContainer {
     pub fn save_document(
         &mut self,
         document: &ProjectDocumentV1,
-    ) -> Result<SaveObservation, ProofError> {
+    ) -> Result<SaveObservation, ProjectFormatError> {
         let started = Instant::now();
         let transaction = self.connection.transaction()?;
         write_document(&transaction, document)?;
@@ -266,14 +288,58 @@ impl ProofContainer {
         })
     }
 
+    /// Commits newly staged Project Media and the document in one transaction.
+    /// Existing content-addressed rows are retained without rewriting.
+    pub fn save_with_staged(
+        &mut self,
+        document: &mut ProjectDocumentV1,
+        staged_media: &[StagedMedia],
+    ) -> Result<SaveObservation, ProjectFormatError> {
+        let started = Instant::now();
+        let transaction = self.connection.transaction()?;
+        let mut media_rows_written = 0_usize;
+        let mut media_bytes_written = 0_u64;
+        for staged in staged_media {
+            let content = fs::read(&staged.path)?;
+            let entry = media_entry(staged, &content);
+            if insert_media(&transaction, &entry, &content)? {
+                media_rows_written += 1;
+                media_bytes_written += content.len() as u64;
+            }
+            if !document
+                .project_media
+                .iter()
+                .any(|item| item.id == entry.id)
+            {
+                document.project_media.push(entry);
+            }
+        }
+        write_document(&transaction, document)?;
+        transaction.commit()?;
+        for staged in staged_media {
+            cleanup_staging_copy(staged);
+        }
+        Ok(SaveObservation {
+            elapsed: started.elapsed(),
+            container_bytes: fs::metadata(&self.path)?.len(),
+            media_rows_written,
+            media_bytes_written,
+        })
+    }
+
     /// Creates a self-contained snapshot without changing the source path.
-    pub fn save_as(&self, destination: impl AsRef<Path>) -> Result<SaveObservation, ProofError> {
+    pub fn save_as(
+        &self,
+        destination: impl AsRef<Path>,
+    ) -> Result<SaveObservation, ProjectFormatError> {
         let destination = destination.as_ref();
         if destination.exists() {
-            return Err(ProofError::ExistingDestination(destination.to_path_buf()));
+            return Err(ProjectFormatError::ExistingDestination(
+                destination.to_path_buf(),
+            ));
         }
         let destination_text = destination.to_str().ok_or_else(|| {
-            ProofError::InvalidContainer("Save As destination is not valid UTF-8".into())
+            ProjectFormatError::InvalidContainer("Save As destination is not valid UTF-8".into())
         })?;
         let started = Instant::now();
         self.connection
@@ -281,7 +347,7 @@ impl ProofContainer {
         let reopened = Self::open(destination)?;
         let document = reopened.load_document()?;
         if document.format_version != FORMAT_VERSION {
-            return Err(ProofError::InvalidContainer(
+            return Err(ProjectFormatError::InvalidContainer(
                 "Save As lost format marker".into(),
             ));
         }
@@ -292,6 +358,192 @@ impl ProofContainer {
             media_bytes_written: 0,
         })
     }
+}
+
+pub fn detect_project_format(path: &Path) -> Result<ProjectFileFormat, ProjectFormatError> {
+    let mut header = [0_u8; 16];
+    let read = fs::File::open(path)?.read(&mut header)?;
+    if read == header.len() && &header == b"SQLite format 3\0" {
+        let container = ProjectContainer::open(path)?;
+        container.load_document()?;
+        Ok(ProjectFileFormat::V1)
+    } else {
+        Ok(ProjectFileFormat::LegacyJson)
+    }
+}
+
+/// Copies Local Source Storage into a Vibez-owned staging location before an
+/// unsaved project begins depending on it. The content hash is the eventual
+/// Project Media identity, so repeated imports reuse the same staged bytes.
+pub fn stage_local_file(path: &Path) -> Result<MediaSourceRef, ProjectFormatError> {
+    let content = fs::read(path)?;
+    let id = hex_sha256(&content);
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "project-media".to_string());
+    let root = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
+        .join("vibez")
+        .join("staged-project-media");
+    fs::create_dir_all(&root)?;
+    let safe_name: String = file_name
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let staging_path = root.join(format!("{id}-{safe_name}"));
+    if !staging_path.exists() {
+        let temporary = root.join(format!(".{id}.partial"));
+        fs::write(&temporary, content)?;
+        fs::rename(temporary, &staging_path)?;
+    }
+    Ok(MediaSourceRef::StagedProjectMedia {
+        id,
+        file_name,
+        staging_path,
+        source_path: path.to_path_buf(),
+    })
+}
+
+/// Saves a production Project Format V1 container. `source_container` is the
+/// currently open V1 path, when any; a different destination performs Save As
+/// by copying that self-contained container before committing the new document.
+pub fn save_project_v1(
+    destination: &Path,
+    source_container: Option<&Path>,
+    mut project: Project,
+) -> Result<SaveResult, ProjectFormatError> {
+    let same_container = source_container.is_some_and(|source| source == destination);
+    let mut staged_media = Vec::new();
+    prepare_project_media(&mut project, &mut staged_media)?;
+
+    let (mut container, mut document) = if same_container {
+        let container = ProjectContainer::open(destination)?;
+        let document = container.load_document()?;
+        (container, document)
+    } else if let Some(source) = source_container.filter(|source| source.exists()) {
+        if destination.exists() {
+            return Err(ProjectFormatError::ExistingDestination(
+                destination.to_path_buf(),
+            ));
+        }
+        let source = ProjectContainer::open(source)?;
+        source.save_as(destination)?;
+        let copied = ProjectContainer::open(destination)?;
+        let document = copied.load_document()?;
+        (copied, document)
+    } else {
+        let mut document = ProjectDocumentV1::new(project.clone());
+        let (_container, observation) =
+            ProjectContainer::create_from_staged(destination, &mut document, &staged_media)?;
+        return Ok(SaveResult {
+            project,
+            observation,
+        });
+    };
+
+    document.project = project.clone();
+    let observation = container.save_with_staged(&mut document, &staged_media)?;
+    Ok(SaveResult {
+        project,
+        observation,
+    })
+}
+
+fn prepare_project_media(
+    project: &mut Project,
+    staged_media: &mut Vec<StagedMedia>,
+) -> Result<(), ProjectFormatError> {
+    for clip in &mut project.clips {
+        if let Some(source) = &mut clip.source {
+            prepare_source(source, staged_media)?;
+            clip.file_path = None;
+        }
+    }
+    for track in &mut project.tracks {
+        prepare_track_sources(track, staged_media)?;
+    }
+    if let Some(master) = &mut project.master {
+        prepare_track_sources(master, staged_media)?;
+    }
+    for bus in &mut project.buses {
+        prepare_track_sources(bus, staged_media)?;
+    }
+    Ok(())
+}
+
+fn prepare_track_sources(
+    track: &mut TrackInfo,
+    staged_media: &mut Vec<StagedMedia>,
+) -> Result<(), ProjectFormatError> {
+    match &mut track.native_instrument {
+        Some(InstrumentStateInfo::Sampler {
+            source: Some(source),
+            ..
+        }) => prepare_source(source, staged_media)?,
+        Some(InstrumentStateInfo::DrumRack { pads }) => {
+            for pad in pads {
+                if let Some(source) = &mut pad.source {
+                    prepare_source(source, staged_media)?;
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn prepare_source(
+    source: &mut MediaSourceRef,
+    staged_media: &mut Vec<StagedMedia>,
+) -> Result<(), ProjectFormatError> {
+    let (path, file_name, provenance) = match source {
+        MediaSourceRef::LocalFile { path } => {
+            let file_name = path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "project-media".to_string());
+            (
+                path.clone(),
+                file_name,
+                Provenance::Local {
+                    source_path: path.clone(),
+                },
+            )
+        }
+        MediaSourceRef::StagedProjectMedia {
+            file_name,
+            staging_path,
+            source_path,
+            ..
+        } => (
+            staging_path.clone(),
+            file_name.clone(),
+            Provenance::Local {
+                source_path: source_path.clone(),
+            },
+        ),
+        MediaSourceRef::ProjectMedia { .. } | MediaSourceRef::DropboxFile { .. } => return Ok(()),
+    };
+    let content = fs::read(&path)?;
+    let id = hex_sha256(&content);
+    if !staged_media.iter().any(|item| item.id == id) {
+        staged_media.push(StagedMedia {
+            id: id.clone(),
+            file_name: file_name.clone(),
+            path,
+            provenance,
+        });
+    }
+    *source = MediaSourceRef::ProjectMedia { id, file_name };
+    Ok(())
 }
 
 /// Starts a real transaction, overwrites the document and a media row, then
@@ -323,12 +575,12 @@ fn configure_connection(connection: &Connection) -> Result<(), rusqlite::Error> 
     Ok(())
 }
 
-fn validate_container(connection: &Connection) -> Result<(), ProofError> {
+fn validate_container(connection: &Connection) -> Result<(), ProjectFormatError> {
     let application_id: u32 =
         connection.query_row("PRAGMA application_id", [], |row| row.get(0))?;
     let user_version: u32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     if application_id != APPLICATION_ID || user_version != FORMAT_VERSION {
-        return Err(ProofError::InvalidContainer(format!(
+        return Err(ProjectFormatError::InvalidContainer(format!(
             "application_id={application_id:#x}, user_version={user_version}"
         )));
     }
@@ -338,9 +590,9 @@ fn validate_container(connection: &Connection) -> Result<(), ProofError> {
 fn write_document(
     transaction: &Transaction<'_>,
     document: &ProjectDocumentV1,
-) -> Result<(), ProofError> {
+) -> Result<(), ProjectFormatError> {
     if document.format_version != FORMAT_VERSION {
-        return Err(ProofError::InvalidContainer(format!(
+        return Err(ProjectFormatError::InvalidContainer(format!(
             "cannot save document version {} as version {FORMAT_VERSION}",
             document.format_version
         )));
@@ -356,9 +608,9 @@ fn insert_media(
     transaction: &Transaction<'_>,
     entry: &ProjectMediaEntry,
     content: &[u8],
-) -> Result<(), ProofError> {
-    transaction.execute(
-        "INSERT INTO project_media(id, file_name, byte_len, sha256, provenance_json, content) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+) -> Result<bool, ProjectFormatError> {
+    let inserted = transaction.execute(
+        "INSERT OR IGNORE INTO project_media(id, file_name, byte_len, sha256, provenance_json, content) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
         params![
             entry.id,
             entry.file_name,
@@ -368,7 +620,17 @@ fn insert_media(
             content
         ],
     )?;
-    Ok(())
+    Ok(inserted == 1)
+}
+
+fn cleanup_staging_copy(staged: &StagedMedia) {
+    let disposable = match &staged.provenance {
+        Provenance::Local { source_path } => source_path != &staged.path,
+        Provenance::Remote { .. } => true,
+    };
+    if disposable {
+        let _ = fs::remove_file(&staged.path);
+    }
 }
 
 fn media_entry(staged: &StagedMedia, content: &[u8]) -> ProjectMediaEntry {

--- a/crates/vibez-project/tests/project_format_v1.rs
+++ b/crates/vibez-project/tests/project_format_v1.rs
@@ -2,10 +2,13 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use vibez_project::project_format_v1_proof::{
-    hex_sha256, representative_document, ProofContainer, Provenance, StagedMedia, APPLICATION_ID,
-    FORMAT_VERSION,
+use vibez_core::id::ClipId;
+use vibez_core::track::{ClipInfo, MediaSourceRef, TrackInfo};
+use vibez_project::project_format_v1::{
+    detect_project_format, hex_sha256, representative_document, save_project_v1, stage_local_file,
+    ProjectContainer, ProjectFileFormat, Provenance, StagedMedia, APPLICATION_ID, FORMAT_VERSION,
 };
+use vibez_project::Project;
 
 fn stage(path: PathBuf, id: &str, seed: u8) -> (StagedMedia, Vec<u8>) {
     let bytes: Vec<u8> = (0..2 * 1024 * 1024)
@@ -39,7 +42,7 @@ fn representative_container_roundtrips_incrementally_and_save_as() {
     let mut document = representative_document();
 
     let (mut container, full_save) =
-        ProofContainer::create_from_staged(&path, &mut document, &[staged]).unwrap();
+        ProjectContainer::create_from_staged(&path, &mut document, &[staged]).unwrap();
     assert_eq!(full_save.media_rows_written, 1);
     assert_eq!(full_save.media_bytes_written, media_bytes.len() as u64);
     assert!(
@@ -80,7 +83,7 @@ fn representative_container_roundtrips_incrementally_and_save_as() {
 
     let save_as = container.save_as(&save_as_path).unwrap();
     assert!(save_as.container_bytes > media_bytes.len() as u64);
-    let copied = ProofContainer::open(&save_as_path).unwrap();
+    let copied = ProjectContainer::open(&save_as_path).unwrap();
     assert_eq!(
         serde_json::to_vec(&copied.load_document().unwrap()).unwrap(),
         serde_json::to_vec(&document).unwrap()
@@ -93,7 +96,7 @@ fn format_markers_are_explicit_and_file_is_not_zip() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("proof.vzp");
     let mut document = representative_document();
-    let (container, _) = ProofContainer::create_from_staged(&path, &mut document, &[]).unwrap();
+    let (container, _) = ProjectContainer::create_from_staged(&path, &mut document, &[]).unwrap();
     drop(container);
 
     let bytes = fs::read(&path).unwrap();
@@ -119,7 +122,7 @@ fn process_interruption_preserves_last_committed_document_and_media() {
     let (staged, media_bytes) = stage(directory.path().join("proof.staged"), "proof-media", 83);
     let mut document = representative_document();
     let (container, _) =
-        ProofContainer::create_from_staged(&path, &mut document, &[staged]).unwrap();
+        ProjectContainer::create_from_staged(&path, &mut document, &[staged]).unwrap();
     let committed_json = serde_json::to_vec(&container.load_document().unwrap()).unwrap();
     let committed_fingerprint = container.media_fingerprint("proof-media").unwrap();
     drop(container);
@@ -132,7 +135,7 @@ fn process_interruption_preserves_last_committed_document_and_media() {
         .unwrap();
     assert_eq!(status.code(), Some(86));
 
-    let recovered = ProofContainer::open(&path).unwrap();
+    let recovered = ProjectContainer::open(&path).unwrap();
     assert_eq!(
         serde_json::to_vec(&recovered.load_document().unwrap()).unwrap(),
         committed_json
@@ -144,5 +147,101 @@ fn process_interruption_preserves_last_committed_document_and_media() {
     assert_eq!(
         hex_sha256(&recovered.read_media("proof-media").unwrap()),
         hex_sha256(&media_bytes)
+    );
+}
+
+fn project_with_source(source: MediaSourceRef) -> Project {
+    let track = TrackInfo::new("Audio");
+    Project {
+        tracks: vec![track.clone()],
+        clips: vec![ClipInfo {
+            id: ClipId::new(),
+            track_id: track.id,
+            name: source.display_name(),
+            position: 0,
+            source_offset: 0,
+            duration: 128,
+            source: Some(source),
+            file_path: None,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 128,
+            original_bpm: Some(120.0),
+            warped: false,
+            warped_to_bpm: None,
+        }],
+        ..Project::default()
+    }
+}
+
+#[test]
+fn production_save_is_self_contained_incremental_and_save_as_reuses_media() {
+    let directory = tempfile::tempdir().unwrap();
+    let source_path = directory.path().join("source.wav");
+    let path = directory.path().join("song.vzp");
+    let save_as_path = directory.path().join("song-copy.vzp");
+    let bytes = b"playback-critical-media".repeat(1024);
+    fs::write(&source_path, &bytes).unwrap();
+    let project = project_with_source(MediaSourceRef::LocalFile {
+        path: source_path.clone(),
+    });
+
+    let first = save_project_v1(&path, None, project).unwrap();
+    assert_eq!(first.observation.media_rows_written, 1);
+    assert_eq!(detect_project_format(&path).unwrap(), ProjectFileFormat::V1);
+    fs::remove_file(&source_path).unwrap();
+
+    let container = ProjectContainer::open(&path).unwrap();
+    let document = container.load_document().unwrap();
+    let MediaSourceRef::ProjectMedia { id, .. } =
+        document.project.clips[0].source.as_ref().unwrap()
+    else {
+        panic!("committed project must reference Project Media");
+    };
+    assert_eq!(container.read_media(id).unwrap(), bytes);
+    let fingerprint = container.media_fingerprint(id).unwrap();
+    drop(container);
+
+    let incremental = save_project_v1(&path, Some(&path), first.project.clone()).unwrap();
+    assert_eq!(incremental.observation.media_rows_written, 0);
+    let reopened = ProjectContainer::open(&path).unwrap();
+    assert_eq!(reopened.media_fingerprint(id).unwrap(), fingerprint);
+    drop(reopened);
+
+    let save_as = save_project_v1(&save_as_path, Some(&path), incremental.project).unwrap();
+    assert_eq!(save_as.observation.media_rows_written, 0);
+    let copied = ProjectContainer::open(save_as_path).unwrap();
+    assert_eq!(copied.read_media(id).unwrap(), bytes);
+}
+
+#[test]
+fn unsaved_project_uses_staged_copy_before_first_save() {
+    let directory = tempfile::tempdir().unwrap();
+    let source_path = directory.path().join("fragile-source.wav");
+    let path = directory.path().join("staged.vzp");
+    let bytes = b"staged-before-save".repeat(512);
+    fs::write(&source_path, &bytes).unwrap();
+    let staged_source = stage_local_file(&source_path).unwrap();
+    let MediaSourceRef::StagedProjectMedia { staging_path, .. } = &staged_source else {
+        panic!("local import must become Staged Project Media");
+    };
+    let staging_path = staging_path.clone();
+    fs::remove_file(source_path).unwrap();
+
+    let saved = save_project_v1(&path, None, project_with_source(staged_source)).unwrap();
+    assert!(
+        !staging_path.exists(),
+        "commit should consume the staging copy"
+    );
+    let MediaSourceRef::ProjectMedia { id, .. } = saved.project.clips[0].source.as_ref().unwrap()
+    else {
+        panic!("saved project must no longer reference staging");
+    };
+    assert_eq!(
+        ProjectContainer::open(path)
+            .unwrap()
+            .read_media(id)
+            .unwrap(),
+        bytes
     );
 }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -305,17 +305,66 @@ impl App {
                     .file_name()
                     .map(|s| s.to_string_lossy().to_string())
                     .unwrap_or_default();
-                let ret_source = MediaSourceRef::LocalFile { path: path.clone() };
                 self.state.status_text = format!("Dropping {name}...");
-                Task::perform(decode_file_async(path), move |result| match result {
-                    Ok(audio) => Message::BrowserSampleDecoded(
-                        target.clone(),
-                        Arc::new(audio),
-                        name.clone(),
-                        ret_source.clone(),
-                    ),
-                    Err(err) => Message::BrowserSampleDecodeError(err),
-                })
+                Task::perform(
+                    decode_and_stage_local_async(path),
+                    move |result| match result {
+                        Ok((audio, source)) => Message::BrowserSampleDecoded(
+                            target.clone(),
+                            Arc::new(audio),
+                            name.clone(),
+                            source,
+                        ),
+                        Err(err) => Message::BrowserSampleDecodeError(err),
+                    },
+                )
+            }
+            MediaSourceRef::StagedProjectMedia {
+                id,
+                file_name,
+                staging_path,
+                source_path,
+            } => {
+                let name = file_name.clone();
+                let retained_source = MediaSourceRef::StagedProjectMedia {
+                    id,
+                    file_name,
+                    staging_path: staging_path.clone(),
+                    source_path,
+                };
+                Task::perform(
+                    decode_file_async(staging_path),
+                    move |result| match result {
+                        Ok(audio) => Message::BrowserSampleDecoded(
+                            target.clone(),
+                            Arc::new(audio),
+                            name.clone(),
+                            retained_source.clone(),
+                        ),
+                        Err(err) => Message::BrowserSampleDecodeError(err),
+                    },
+                )
+            }
+            MediaSourceRef::ProjectMedia { id, file_name } => {
+                let name = file_name.clone();
+                let retained_source = MediaSourceRef::ProjectMedia { id, file_name };
+                let container_path = self.state.project.current_path.clone();
+                Task::perform(
+                    async move {
+                        hydrate_saved_source(container_path.as_ref(), None, &retained_source, &name)
+                            .await
+                            .map(|audio| (audio, retained_source, name))
+                    },
+                    move |result| match result {
+                        Ok((audio, source, name)) => Message::BrowserSampleDecoded(
+                            target.clone(),
+                            Arc::new(audio),
+                            name,
+                            source,
+                        ),
+                        Err(err) => Message::BrowserSampleDecodeError(err),
+                    },
+                )
             }
             MediaSourceRef::DropboxFile {
                 path_lower,
@@ -607,18 +656,19 @@ impl App {
                 .unwrap_or_default();
             self.state.status_text = format!("Loading {file_name}...");
             let clip_id = ClipId::new();
-            let source = MediaSourceRef::LocalFile { path: path.clone() };
-
-            return Task::perform(decode_file_async(path), move |result| match result {
-                Ok(audio) => Message::ClipAudioDecoded(
-                    track_id,
-                    clip_id,
-                    Arc::new(audio),
-                    file_name.clone(),
-                    source.clone(),
-                ),
-                Err(e) => Message::ClipDecodeError(track_id, e),
-            });
+            return Task::perform(
+                decode_and_stage_local_async(path),
+                move |result| match result {
+                    Ok((audio, source)) => Message::ClipAudioDecoded(
+                        track_id,
+                        clip_id,
+                        Arc::new(audio),
+                        file_name.clone(),
+                        source,
+                    ),
+                    Err(e) => Message::ClipDecodeError(track_id, e),
+                },
+            );
         }
         Task::none()
     }
@@ -692,18 +742,19 @@ impl App {
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_default();
             self.state.status_text = format!("Loading {file_name}...");
-            let source = MediaSourceRef::LocalFile { path: path.clone() };
-
-            return Task::perform(decode_file_async(path), move |result| match result {
-                Ok(audio) => Message::DrumRackPadSampleDecoded(
-                    track_id,
-                    pad_index,
-                    Arc::new(audio),
-                    file_name.clone(),
-                    source.clone(),
-                ),
-                Err(e) => Message::DrumRackPadDecodeError(track_id, pad_index, e),
-            });
+            return Task::perform(
+                decode_and_stage_local_async(path),
+                move |result| match result {
+                    Ok((audio, source)) => Message::DrumRackPadSampleDecoded(
+                        track_id,
+                        pad_index,
+                        Arc::new(audio),
+                        file_name.clone(),
+                        source,
+                    ),
+                    Err(e) => Message::DrumRackPadDecodeError(track_id, pad_index, e),
+                },
+            );
         }
         Task::none()
     }
@@ -804,21 +855,19 @@ impl App {
                 }),
             );
             if let MediaSourceRef::LocalFile { path } = &entry.source {
-                let source = entry.source.clone();
                 let name = entry.name.clone();
                 self.state.status_text = format!("Loading {name}...");
-                return Task::perform(
-                    decode_file_async(path.clone()),
-                    move |result| match result {
-                        Ok(audio) => Message::BrowserSampleDecoded(
+                return Task::perform(decode_and_stage_local_async(path.clone()), move |result| {
+                    match result {
+                        Ok((audio, source)) => Message::BrowserSampleDecoded(
                             target.clone(),
                             Arc::new(audio),
                             name.clone(),
-                            source.clone(),
+                            source,
                         ),
                         Err(err) => Message::BrowserSampleDecodeError(err),
-                    },
-                );
+                    }
+                });
             }
         }
         Task::none()
@@ -834,21 +883,19 @@ impl App {
             return Task::none();
         };
         if let MediaSourceRef::LocalFile { path } = &entry.source {
-            let source = entry.source.clone();
             let name = entry.name.clone();
             self.state.status_text = format!("Loading {name}...");
-            return Task::perform(
-                decode_file_async(path.clone()),
-                move |result| match result {
-                    Ok(audio) => Message::BrowserSampleDecoded(
+            return Task::perform(decode_and_stage_local_async(path.clone()), move |result| {
+                match result {
+                    Ok((audio, source)) => Message::BrowserSampleDecoded(
                         target.clone(),
                         Arc::new(audio),
                         name.clone(),
-                        source.clone(),
+                        source,
                     ),
                     Err(err) => Message::BrowserSampleDecodeError(err),
-                },
-            );
+                }
+            });
         }
         Task::none()
     }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use iced::{Subscription, Task, Theme};
@@ -24,7 +24,7 @@ use vibez_project::Project;
 use crate::icons;
 use crate::message::{
     LoadedClipData, LoadedDrumRackPadData, LoadedSamplerData, Message, ProjectLoadResult,
-    SampleLibraryScanResult,
+    ProjectSaveResult, SampleLibraryScanResult,
 };
 use crate::plugin_window::{PluginRawPtr, PluginWindowManager};
 use crate::state::AppState;
@@ -382,13 +382,52 @@ async fn decode_file_async(
     .map_err(|e| format!("decode task failed: {e}"))?
 }
 
-async fn save_project_async(path: PathBuf, project: Project) -> Result<PathBuf, String> {
+async fn decode_and_stage_local_async(
+    path: PathBuf,
+) -> Result<(vibez_core::audio_buffer::DecodedAudio, MediaSourceRef), String> {
     tokio::task::spawn_blocking(move || {
-        let save_path = path;
-        project
-            .save_to_file(&save_path)
-            .map(|_| save_path)
-            .map_err(|err| err.to_string())
+        let audio = file_io::decode_audio_file(&path).map_err(|error| error.to_string())?;
+        let source = vibez_project::project_format_v1::stage_local_file(&path)
+            .map_err(|error| error.to_string())?;
+        Ok((audio, source))
+    })
+    .await
+    .map_err(|error| format!("decode/stage task failed: {error}"))?
+}
+
+async fn save_project_async(
+    path: PathBuf,
+    source_path: Option<PathBuf>,
+    project: Project,
+) -> Result<ProjectSaveResult, String> {
+    tokio::task::spawn_blocking(move || {
+        let is_v1_destination = path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("vzp"));
+        if is_v1_destination {
+            let v1_source = source_path.as_deref().filter(|source| {
+                vibez_project::project_format_v1::detect_project_format(source).is_ok_and(
+                    |format| format == vibez_project::project_format_v1::ProjectFileFormat::V1,
+                )
+            });
+            let saved =
+                vibez_project::project_format_v1::save_project_v1(&path, v1_source, project)
+                    .map_err(|error| error.to_string())?;
+            Ok(ProjectSaveResult {
+                path,
+                project: saved.project,
+                observation: Some(saved.observation),
+            })
+        } else {
+            project
+                .save_to_file(&path)
+                .map_err(|error| error.to_string())?;
+            Ok(ProjectSaveResult {
+                path,
+                project,
+                observation: None,
+            })
+        }
     })
     .await
     .map_err(|err| format!("save task failed: {err}"))?
@@ -582,8 +621,25 @@ async fn load_project_async(
     dropbox: Option<(Arc<DropboxClient>, DropboxCache)>,
 ) -> Result<ProjectLoadResult, String> {
     let load_path = path.clone();
-    let project = tokio::task::spawn_blocking(move || {
-        Project::load_from_file(&load_path).map_err(|err| err.to_string())
+    let (project, container_path) = tokio::task::spawn_blocking(move || {
+        match vibez_project::project_format_v1::detect_project_format(&load_path)
+            .map_err(|error| error.to_string())?
+        {
+            vibez_project::project_format_v1::ProjectFileFormat::V1 => {
+                let container =
+                    vibez_project::project_format_v1::ProjectContainer::open(&load_path)
+                        .map_err(|error| error.to_string())?;
+                let document = container
+                    .load_document()
+                    .map_err(|error| error.to_string())?;
+                Ok((document.project, Some(load_path)))
+            }
+            vibez_project::project_format_v1::ProjectFileFormat::LegacyJson => {
+                Project::load_from_file(&load_path)
+                    .map(|project| (project, None))
+                    .map_err(|error| error.to_string())
+            }
+        }
     })
     .await
     .map_err(|err| format!("load task failed: {err}"))??;
@@ -595,22 +651,17 @@ async fn load_project_async(
 
     for clip in &project.clips {
         match clip.resolved_source().cloned() {
-            Some(MediaSourceRef::LocalFile { path: clip_path }) => {
-                match decode_blocking(clip_path).await {
-                    Ok(audio) => {
-                        clips.push(finish_loaded_clip(clip.clone(), Arc::new(audio)).await)
-                    }
-                    Err(err) => warnings.push(format!("Skipped clip '{}' ({})", clip.name, err)),
-                }
-            }
-            Some(source @ MediaSourceRef::DropboxFile { .. }) => {
-                match hydrate_dropbox_source(dropbox.as_ref(), &source, &clip.name).await {
-                    Ok(audio) => {
-                        clips.push(finish_loaded_clip(clip.clone(), Arc::new(audio)).await)
-                    }
-                    Err(err) => warnings.push(err),
-                }
-            }
+            Some(source) => match hydrate_saved_source(
+                container_path.as_ref(),
+                dropbox.as_ref(),
+                &source,
+                &clip.name,
+            )
+            .await
+            {
+                Ok(audio) => clips.push(finish_loaded_clip(clip.clone(), Arc::new(audio)).await),
+                Err(err) => warnings.push(format!("Skipped clip '{}' ({})", clip.name, err)),
+            },
             None => warnings.push(format!(
                 "Skipped clip '{}' (missing source reference)",
                 clip.name
@@ -624,32 +675,24 @@ async fn load_project_async(
                 InstrumentStateInfo::Sampler {
                     source: Some(source),
                     ..
-                } => match source {
-                    MediaSourceRef::LocalFile { path: sample_path } => {
-                        match decode_blocking(sample_path.clone()).await {
-                            Ok(audio) => sampler_samples.push(LoadedSamplerData {
-                                track_id: track.id,
-                                source: source.clone(),
-                                audio: Arc::new(audio),
-                                name: source.display_name(),
-                            }),
-                            Err(err) => warnings.push(format!(
-                                "Skipped sampler source on '{}' ({})",
-                                track.name, err
-                            )),
-                        }
-                    }
-                    MediaSourceRef::DropboxFile { .. } => {
-                        match hydrate_dropbox_source(dropbox.as_ref(), source, &track.name).await {
-                            Ok(audio) => sampler_samples.push(LoadedSamplerData {
-                                track_id: track.id,
-                                source: source.clone(),
-                                audio: Arc::new(audio),
-                                name: source.display_name(),
-                            }),
-                            Err(err) => warnings.push(err),
-                        }
-                    }
+                } => match hydrate_saved_source(
+                    container_path.as_ref(),
+                    dropbox.as_ref(),
+                    source,
+                    &track.name,
+                )
+                .await
+                {
+                    Ok(audio) => sampler_samples.push(LoadedSamplerData {
+                        track_id: track.id,
+                        source: source.clone(),
+                        audio: Arc::new(audio),
+                        name: source.display_name(),
+                    }),
+                    Err(err) => warnings.push(format!(
+                        "Skipped sampler source on '{}' ({})",
+                        track.name, err
+                    )),
                 },
                 InstrumentStateInfo::DrumRack { pads } => {
                     for (pad_index, pad) in pads.iter().enumerate() {
@@ -657,38 +700,23 @@ async fn load_project_async(
                             continue;
                         };
                         let label = format!("drum pad {} on '{}'", pad_index + 1, track.name);
-                        match source {
-                            MediaSourceRef::LocalFile { path: sample_path } => {
-                                match decode_blocking(sample_path.clone()).await {
-                                    Ok(audio) => {
-                                        drum_rack_pad_samples.push(LoadedDrumRackPadData {
-                                            track_id: track.id,
-                                            pad_index,
-                                            source: source.clone(),
-                                            audio: Arc::new(audio),
-                                            name: source.display_name(),
-                                            state: pad.clone(),
-                                        })
-                                    }
-                                    Err(err) => warnings.push(format!("Skipped {label} ({err})")),
-                                }
-                            }
-                            MediaSourceRef::DropboxFile { .. } => {
-                                match hydrate_dropbox_source(dropbox.as_ref(), source, &label).await
-                                {
-                                    Ok(audio) => {
-                                        drum_rack_pad_samples.push(LoadedDrumRackPadData {
-                                            track_id: track.id,
-                                            pad_index,
-                                            source: source.clone(),
-                                            audio: Arc::new(audio),
-                                            name: source.display_name(),
-                                            state: pad.clone(),
-                                        })
-                                    }
-                                    Err(err) => warnings.push(err),
-                                }
-                            }
+                        match hydrate_saved_source(
+                            container_path.as_ref(),
+                            dropbox.as_ref(),
+                            source,
+                            &label,
+                        )
+                        .await
+                        {
+                            Ok(audio) => drum_rack_pad_samples.push(LoadedDrumRackPadData {
+                                track_id: track.id,
+                                pad_index,
+                                source: source.clone(),
+                                audio: Arc::new(audio),
+                                name: source.display_name(),
+                                state: pad.clone(),
+                            }),
+                            Err(err) => warnings.push(format!("Skipped {label} ({err})")),
                         }
                     }
                 }
@@ -705,6 +733,45 @@ async fn load_project_async(
         drum_rack_pad_samples,
         warnings,
     })
+}
+
+async fn hydrate_saved_source(
+    container_path: Option<&PathBuf>,
+    dropbox: Option<&(Arc<DropboxClient>, DropboxCache)>,
+    source: &MediaSourceRef,
+    label: &str,
+) -> Result<vibez_core::audio_buffer::DecodedAudio, String> {
+    match source {
+        MediaSourceRef::LocalFile { path }
+        | MediaSourceRef::StagedProjectMedia {
+            staging_path: path, ..
+        } => decode_blocking(path.clone()).await,
+        MediaSourceRef::ProjectMedia { id, file_name } => {
+            let container_path = container_path
+                .cloned()
+                .ok_or_else(|| format!("{label} has Project Media without a V1 container"))?;
+            let id = id.clone();
+            let extension = Path::new(file_name)
+                .extension()
+                .map(|value| value.to_string_lossy().into_owned());
+            tokio::task::spawn_blocking(move || {
+                let container =
+                    vibez_project::project_format_v1::ProjectContainer::open(container_path)
+                        .map_err(|error| error.to_string())?;
+                let bytes = container
+                    .read_media(&id)
+                    .map_err(|error| error.to_string())?;
+                vibez_audio_io::file_io::decode_audio_cursor(
+                    std::io::Cursor::new(bytes),
+                    extension.as_deref(),
+                )
+                .map_err(|error| error.to_string())
+            })
+            .await
+            .map_err(|error| format!("Project Media decode task failed: {error}"))?
+        }
+        MediaSourceRef::DropboxFile { .. } => hydrate_dropbox_source(dropbox, source, label).await,
+    }
 }
 
 async fn decode_blocking(path: PathBuf) -> Result<vibez_core::audio_buffer::DecodedAudio, String> {
@@ -779,4 +846,58 @@ async fn scan_sample_library_async(roots: Vec<PathBuf>) -> Result<SampleLibraryS
     })
     .await
     .map_err(|err| format!("scan task failed: {err}"))?
+}
+
+#[cfg(test)]
+mod project_format_v1_tests {
+    use super::*;
+    use vibez_core::audio_buffer::DecodedAudio;
+    use vibez_core::id::ClipId;
+    use vibez_core::track::TrackInfo;
+
+    #[tokio::test]
+    async fn v1_reopen_decodes_embedded_audio_after_source_removal() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("source.wav");
+        let project_path = directory.path().join("self-contained.vzp");
+        let audio = DecodedAudio {
+            channels: vec![vec![0.0, 0.25, -0.5, 0.75, -1.0]],
+            sample_rate: 44_100,
+        };
+        vibez_audio_io::file_io::write_wav_file(&source_path, &audio).unwrap();
+        let track = TrackInfo::new("Audio");
+        let project = Project {
+            tracks: vec![track.clone()],
+            clips: vec![ClipInfo {
+                id: ClipId::new(),
+                track_id: track.id,
+                name: "source.wav".into(),
+                position: 0,
+                source_offset: 0,
+                duration: audio.num_frames() as u64,
+                source: Some(MediaSourceRef::LocalFile {
+                    path: source_path.clone(),
+                }),
+                file_path: Some(source_path.clone()),
+                loop_enabled: false,
+                loop_start: 0,
+                loop_end: audio.num_frames() as u64,
+                original_bpm: None,
+                warped: false,
+                warped_to_bpm: None,
+            }],
+            ..Project::default()
+        };
+        vibez_project::project_format_v1::save_project_v1(&project_path, None, project).unwrap();
+        std::fs::remove_file(source_path).unwrap();
+
+        let loaded = load_project_async(project_path, None).await.unwrap();
+        assert_eq!(loaded.clips.len(), 1);
+        assert_eq!(loaded.clips[0].audio.num_frames(), audio.num_frames());
+        assert!(matches!(
+            loaded.project.clips[0].source,
+            Some(MediaSourceRef::ProjectMedia { .. })
+        ));
+        assert_eq!(loaded.project.tracks[0].id, track.id);
+    }
 }

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -307,7 +307,9 @@ impl App {
                     source: clip.source.clone(),
                     file_path: clip.source.as_ref().and_then(|source| match source {
                         MediaSourceRef::LocalFile { path } => Some(path.clone()),
-                        MediaSourceRef::DropboxFile { .. } => None,
+                        MediaSourceRef::StagedProjectMedia { .. }
+                        | MediaSourceRef::ProjectMedia { .. }
+                        | MediaSourceRef::DropboxFile { .. } => None,
                     }),
                     loop_enabled: clip.loop_enabled,
                     loop_start: clip.loop_start,
@@ -364,6 +366,32 @@ impl App {
                 .iter()
                 .map(|bus| self.track_info_from_ui(bus))
                 .collect(),
+        }
+    }
+
+    pub(super) fn apply_saved_project_sources(&mut self, project: &Project) {
+        for saved_clip in &project.clips {
+            if let Some(track) = self.state.find_track_mut(saved_clip.track_id) {
+                if let Some(clip) = track.clips.iter_mut().find(|clip| clip.id == saved_clip.id) {
+                    clip.source = saved_clip.source.clone();
+                }
+            }
+        }
+        for saved_track in &project.tracks {
+            let Some(track) = self.state.find_track_mut(saved_track.id) else {
+                continue;
+            };
+            match &saved_track.native_instrument {
+                Some(InstrumentStateInfo::Sampler { source, .. }) => {
+                    track.sample_source = source.clone();
+                }
+                Some(InstrumentStateInfo::DrumRack { pads }) => {
+                    for (slot, saved_pad) in track.drum_rack_pads.iter_mut().zip(pads) {
+                        slot.source = saved_pad.source.clone();
+                    }
+                }
+                _ => {}
+            }
         }
     }
 

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -331,16 +331,16 @@ impl App {
                         .map(|n| n.to_string_lossy().to_string())
                         .unwrap_or_default();
                     self.state.status_text = format!("Loading {file_name}...");
-                    let source = MediaSourceRef::LocalFile { path: path.clone() };
-
-                    return Task::perform(decode_file_async(path), move |result| match result {
-                        Ok(audio) => Message::SamplerSampleDecoded(
-                            track_id,
-                            Arc::new(audio),
-                            file_name.clone(),
-                            source.clone(),
-                        ),
-                        Err(e) => Message::SamplerDecodeError(track_id, e),
+                    return Task::perform(decode_and_stage_local_async(path), move |result| {
+                        match result {
+                            Ok((audio, source)) => Message::SamplerSampleDecoded(
+                                track_id,
+                                Arc::new(audio),
+                                file_name.clone(),
+                                source,
+                            ),
+                            Err(e) => Message::SamplerDecodeError(track_id, e),
+                        }
                     });
                 }
             }
@@ -634,7 +634,10 @@ impl App {
                 self.state.project.file_menu_open = false;
                 let project = self.project_from_state();
                 if let Some(path) = self.state.project.current_path.clone() {
-                    return Task::perform(save_project_async(path, project), Message::ProjectSaved);
+                    return Task::perform(
+                        save_project_async(path.clone(), Some(path), project),
+                        |result| Message::ProjectSaved(Box::new(result)),
+                    );
                 }
                 return self.update(Message::SaveProjectAs);
             }
@@ -645,7 +648,7 @@ impl App {
                         let handle = rfd::AsyncFileDialog::new()
                             .set_title("Save Vibez Project")
                             .set_file_name("Untitled.vzp")
-                            .add_filter("Vibez Project", &["vzp", "vibez"])
+                            .add_filter("Vibez Project Format V1", &["vzp"])
                             .save_file()
                             .await;
                         handle.map(|file| file.path().to_path_buf())
@@ -667,11 +670,17 @@ impl App {
             }
             Message::ProjectSavePathSelected(path) => {
                 if let Some(mut path) = path {
-                    if path.extension().is_none() {
+                    if !path
+                        .extension()
+                        .is_some_and(|extension| extension.eq_ignore_ascii_case("vzp"))
+                    {
                         path.set_extension("vzp");
                     }
                     let project = self.project_from_state();
-                    return Task::perform(save_project_async(path, project), Message::ProjectSaved);
+                    return Task::perform(
+                        save_project_async(path, self.state.project.current_path.clone(), project),
+                        |result| Message::ProjectSaved(Box::new(result)),
+                    );
                 }
             }
             Message::ProjectLoaded(result) => match *result {
@@ -682,11 +691,12 @@ impl App {
                     self.state.status_text = format!("Project load error: {err}");
                 }
             },
-            Message::ProjectSaved(result) => match result {
-                Ok(path) => {
-                    self.state.project.current_path = Some(path.clone());
+            Message::ProjectSaved(result) => match *result {
+                Ok(saved) => {
+                    self.apply_saved_project_sources(&saved.project);
+                    self.state.project.current_path = Some(saved.path.clone());
                     self.state.project.dirty = false;
-                    self.state.status_text = format!("Saved {}", path.display());
+                    self.state.status_text = format!("Saved {}", saved.path.display());
                 }
                 Err(err) => {
                     self.state.status_text = format!("Project save error: {err}");

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -9,6 +9,7 @@ use vibez_core::track::{ClipInfo, DrumPadState, MediaSourceRef};
 use vibez_dropbox::{AccountInfo, DropboxEntry, Tokens as DropboxTokens};
 use vibez_plugin_host::gui::PluginGuiKey;
 use vibez_plugin_host::PluginId;
+use vibez_project::project_format_v1::SaveObservation;
 use vibez_project::Project;
 
 use crate::state::{SampleBrowserEntry, SettingsTab};
@@ -145,6 +146,13 @@ pub struct ProjectLoadResult {
 }
 
 #[derive(Debug, Clone)]
+pub struct ProjectSaveResult {
+    pub path: PathBuf,
+    pub project: Project,
+    pub observation: Option<SaveObservation>,
+}
+
+#[derive(Debug, Clone)]
 pub enum Message {
     /// Transport domain (playback, tempo, arrangement loop).
     Transport(crate::domains::transport::TransportMsg),
@@ -222,7 +230,7 @@ pub enum Message {
     ProjectOpenPathSelected(Option<PathBuf>),
     ProjectSavePathSelected(Option<PathBuf>),
     ProjectLoaded(Box<Result<ProjectLoadResult, String>>),
-    ProjectSaved(Result<PathBuf, String>),
+    ProjectSaved(Box<Result<ProjectSaveResult, String>>),
     /// Settings: toggle auto-warp-on-import.
     ToggleAutoWarpOnImport,
     /// Settings: set warp detection confidence threshold.


### PR DESCRIPTION
## Demo outcome

A new Project Format V1 `.vzp` owns playback-critical imported audio. The source file can be removed or the project moved, and reopen still restores decoded audio plus the current project document state.

Stacked on #51. This PR contains Card 03 only and is independent of the Card 02 visual gate.

## Included

- promotes the accepted SQLite proof into the production `project_format_v1` API
- explicit V1 detection through SQLite application/user version markers
- content-addressed Project Media with Local provenance and no credential/cache/plugin-binary tables
- Vibez-owned staging copies for unsaved Local imports; first save consumes staging only after commit
- atomic document + new-media transactions, content deduplication, document-only incremental saves, and self-contained Save As
- `StagedProjectMedia` and `ProjectMedia` references carried through clips, Sampler, and Drum Rack state
- UI Save/Save As routing to `.vzp`, source-reference refresh after commit, and embedded-byte decode on reopen
- legacy JSON conversion and Remote materialization intentionally deferred

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p vibez-project --all-targets -- -D warnings`
- `cargo clippy -p vibez-ui --lib -- -D warnings`
- `cargo test -p vibez-project` — 19 passed
- `cargo test -p vibez-ui` — 111 passed
- production round trip removes the source after save, then reads identical embedded bytes
- UI load regression removes a WAV source after save, then reopens and decodes the embedded audio
- incremental save writes zero media rows and preserves the media fingerprint
- Save As reuses the embedded row; interrupted transaction preserves the last committed document and media

## Non-goals

- Legacy JSON conversion/relink UI (Card 04)
- complete autosave or unused-media cleanup
- Remote materialization