### PR TITLE
Browser Card 04: import legacy JSON projects non-destructively

### DIFF
--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -21,6 +21,17 @@ pub enum MediaSourceRef {
         staging_path: PathBuf,
         source_path: PathBuf,
     },
+    /// Remote bytes materialized into Vibez-owned staging during Legacy Import.
+    StagedRemoteProjectMedia {
+        id: String,
+        file_name: String,
+        staging_path: PathBuf,
+        provider: String,
+        connection_id: String,
+        source_id: String,
+        source_path: String,
+        rev: Option<String>,
+    },
     /// Playback-critical media embedded in a Project Format V1 container.
     ProjectMedia {
         id: String,
@@ -42,6 +53,7 @@ impl MediaSourceRef {
                 .map(|name| name.to_string_lossy().to_string())
                 .unwrap_or_else(|| path.display().to_string()),
             MediaSourceRef::StagedProjectMedia { file_name, .. }
+            | MediaSourceRef::StagedRemoteProjectMedia { file_name, .. }
             | MediaSourceRef::ProjectMedia { file_name, .. } => file_name.clone(),
             MediaSourceRef::DropboxFile { display_path, .. } => PathBuf::from(display_path)
                 .file_name()

--- a/crates/vibez-project/src/project_format_v1.rs
+++ b/crates/vibez-project/src/project_format_v1.rs
@@ -104,6 +104,18 @@ pub struct SaveResult {
     pub observation: SaveObservation,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LegacyRelinkItem {
+    pub source: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct LegacyImportResult {
+    pub saved: SaveResult,
+    pub relink: Vec<LegacyRelinkItem>,
+}
+
 #[derive(Debug)]
 pub enum ProjectFormatError {
     Io(std::io::Error),
@@ -412,6 +424,40 @@ pub fn stage_local_file(path: &Path) -> Result<MediaSourceRef, ProjectFormatErro
     })
 }
 
+pub fn stage_remote_file(
+    materialized_path: &Path,
+    file_name: String,
+    connection_id: String,
+    source_id: String,
+    source_path: String,
+    rev: Option<String>,
+) -> Result<MediaSourceRef, ProjectFormatError> {
+    let content = fs::read(materialized_path)?;
+    let id = hex_sha256(&content);
+    let root = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
+        .join("vibez")
+        .join("staged-project-media");
+    fs::create_dir_all(&root)?;
+    let staging_path = root.join(format!("{id}-remote"));
+    if !staging_path.exists() {
+        let temporary = root.join(format!(".{id}.remote.partial"));
+        fs::write(&temporary, content)?;
+        fs::rename(temporary, &staging_path)?;
+    }
+    Ok(MediaSourceRef::StagedRemoteProjectMedia {
+        id,
+        file_name,
+        staging_path,
+        provider: "dropbox".into(),
+        connection_id,
+        source_id,
+        source_path,
+        rev,
+    })
+}
+
 /// Saves a production Project Format V1 container. `source_container` is the
 /// currently open V1 path, when any; a different destination performs Save As
 /// by copying that self-contained container before committing the new document.
@@ -457,24 +503,84 @@ pub fn save_project_v1(
     })
 }
 
+/// Converts an already-parsed legacy project into a separate V1 destination.
+/// Resolvable references become Project Media; unavailable references remain
+/// in the document and are returned as an explicit relink report.
+pub fn import_legacy_project_v1(
+    destination: &Path,
+    mut project: Project,
+) -> Result<LegacyImportResult, ProjectFormatError> {
+    if destination.exists() {
+        return Err(ProjectFormatError::ExistingDestination(
+            destination.to_path_buf(),
+        ));
+    }
+    let mut staged_media = Vec::new();
+    let mut relink = Vec::new();
+    prepare_project_media_inner(&mut project, &mut staged_media, Some(&mut relink))?;
+    let mut document = ProjectDocumentV1::new(project.clone());
+    let (_container, observation) =
+        ProjectContainer::create_from_staged(destination, &mut document, &staged_media)?;
+    Ok(LegacyImportResult {
+        saved: SaveResult {
+            project,
+            observation,
+        },
+        relink,
+    })
+}
+
+pub fn import_legacy_json_file(
+    source: &Path,
+    destination: &Path,
+) -> Result<LegacyImportResult, ProjectFormatError> {
+    if source == destination {
+        return Err(ProjectFormatError::InvalidContainer(
+            "Legacy Import destination must be separate from its source".into(),
+        ));
+    }
+    if detect_project_format(source)? != ProjectFileFormat::LegacyJson {
+        return Err(ProjectFormatError::InvalidContainer(
+            "Legacy Import requires a JSON source".into(),
+        ));
+    }
+    let original = fs::read(source)?;
+    let project: Project = serde_json::from_slice(&original)?;
+    let imported = import_legacy_project_v1(destination, project)?;
+    if fs::read(source)? != original {
+        return Err(ProjectFormatError::InvalidContainer(
+            "Legacy Import modified its source".into(),
+        ));
+    }
+    Ok(imported)
+}
+
 fn prepare_project_media(
     project: &mut Project,
     staged_media: &mut Vec<StagedMedia>,
 ) -> Result<(), ProjectFormatError> {
+    prepare_project_media_inner(project, staged_media, None)
+}
+
+fn prepare_project_media_inner(
+    project: &mut Project,
+    staged_media: &mut Vec<StagedMedia>,
+    mut relink: Option<&mut Vec<LegacyRelinkItem>>,
+) -> Result<(), ProjectFormatError> {
     for clip in &mut project.clips {
         if let Some(source) = &mut clip.source {
-            prepare_source(source, staged_media)?;
+            prepare_source(source, staged_media, relink.as_deref_mut())?;
             clip.file_path = None;
         }
     }
     for track in &mut project.tracks {
-        prepare_track_sources(track, staged_media)?;
+        prepare_track_sources(track, staged_media, relink.as_deref_mut())?;
     }
     if let Some(master) = &mut project.master {
-        prepare_track_sources(master, staged_media)?;
+        prepare_track_sources(master, staged_media, relink.as_deref_mut())?;
     }
     for bus in &mut project.buses {
-        prepare_track_sources(bus, staged_media)?;
+        prepare_track_sources(bus, staged_media, relink.as_deref_mut())?;
     }
     Ok(())
 }
@@ -482,16 +588,17 @@ fn prepare_project_media(
 fn prepare_track_sources(
     track: &mut TrackInfo,
     staged_media: &mut Vec<StagedMedia>,
+    mut relink: Option<&mut Vec<LegacyRelinkItem>>,
 ) -> Result<(), ProjectFormatError> {
     match &mut track.native_instrument {
         Some(InstrumentStateInfo::Sampler {
             source: Some(source),
             ..
-        }) => prepare_source(source, staged_media)?,
+        }) => prepare_source(source, staged_media, relink.as_deref_mut())?,
         Some(InstrumentStateInfo::DrumRack { pads }) => {
             for pad in pads {
                 if let Some(source) = &mut pad.source {
-                    prepare_source(source, staged_media)?;
+                    prepare_source(source, staged_media, relink.as_deref_mut())?;
                 }
             }
         }
@@ -503,6 +610,7 @@ fn prepare_track_sources(
 fn prepare_source(
     source: &mut MediaSourceRef,
     staged_media: &mut Vec<StagedMedia>,
+    mut relink: Option<&mut Vec<LegacyRelinkItem>>,
 ) -> Result<(), ProjectFormatError> {
     let (path, file_name, provenance) = match source {
         MediaSourceRef::LocalFile { path } => {
@@ -530,9 +638,50 @@ fn prepare_source(
                 source_path: source_path.clone(),
             },
         ),
-        MediaSourceRef::ProjectMedia { .. } | MediaSourceRef::DropboxFile { .. } => return Ok(()),
+        MediaSourceRef::StagedRemoteProjectMedia {
+            file_name,
+            staging_path,
+            provider,
+            connection_id,
+            source_id,
+            source_path,
+            rev,
+            ..
+        } => (
+            staging_path.clone(),
+            file_name.clone(),
+            Provenance::Remote {
+                provider: provider.clone(),
+                connection_id: connection_id.clone(),
+                source_id: source_id.clone(),
+                source_path: source_path.clone(),
+                revision: rev.clone(),
+            },
+        ),
+        MediaSourceRef::ProjectMedia { .. } => return Ok(()),
+        MediaSourceRef::DropboxFile { display_path, .. } => {
+            if let Some(relink) = relink.as_deref_mut() {
+                relink.push(LegacyRelinkItem {
+                    source: display_path.clone(),
+                    reason: "Remote source was not available during Legacy Import".into(),
+                });
+            }
+            return Ok(());
+        }
     };
-    let content = fs::read(&path)?;
+    let content = match fs::read(&path) {
+        Ok(content) => content,
+        Err(error) => {
+            if let Some(relink) = relink {
+                relink.push(LegacyRelinkItem {
+                    source: source.display_name(),
+                    reason: error.to_string(),
+                });
+                return Ok(());
+            }
+            return Err(error.into());
+        }
+    };
     let id = hex_sha256(&content);
     if !staged_media.iter().any(|item| item.id == id) {
         staged_media.push(StagedMedia {

--- a/crates/vibez-project/tests/project_format_v1.rs
+++ b/crates/vibez-project/tests/project_format_v1.rs
@@ -5,8 +5,9 @@ use std::process::Command;
 use vibez_core::id::ClipId;
 use vibez_core::track::{ClipInfo, MediaSourceRef, TrackInfo};
 use vibez_project::project_format_v1::{
-    detect_project_format, hex_sha256, representative_document, save_project_v1, stage_local_file,
-    ProjectContainer, ProjectFileFormat, Provenance, StagedMedia, APPLICATION_ID, FORMAT_VERSION,
+    detect_project_format, hex_sha256, import_legacy_json_file, import_legacy_project_v1,
+    representative_document, save_project_v1, stage_local_file, ProjectContainer,
+    ProjectFileFormat, Provenance, StagedMedia, APPLICATION_ID, FORMAT_VERSION,
 };
 use vibez_project::Project;
 
@@ -244,4 +245,85 @@ fn unsaved_project_uses_staged_copy_before_first_save() {
             .unwrap(),
         bytes
     );
+}
+
+#[test]
+fn legacy_json_import_is_separate_self_contained_and_reports_missing_media() {
+    let directory = tempfile::tempdir().unwrap();
+    let source_media = directory.path().join("present.wav");
+    let missing_media = directory.path().join("missing.wav");
+    let legacy_path = directory.path().join("legacy.vzp");
+    let imported_path = directory.path().join("legacy-imported.vzp");
+    let bytes = b"legacy-local-media".repeat(256);
+    fs::write(&source_media, &bytes).unwrap();
+    let mut project = project_with_source(MediaSourceRef::LocalFile { path: source_media });
+    let mut missing_clip = project.clips[0].clone();
+    missing_clip.id = ClipId::new();
+    missing_clip.name = "missing.wav".into();
+    missing_clip.source = Some(MediaSourceRef::LocalFile {
+        path: missing_media,
+    });
+    project.clips.push(missing_clip);
+    project.save_to_file(&legacy_path).unwrap();
+    let original = fs::read(&legacy_path).unwrap();
+
+    let imported = import_legacy_json_file(&legacy_path, &imported_path).unwrap();
+    assert_eq!(fs::read(&legacy_path).unwrap(), original);
+    assert_eq!(imported.relink.len(), 1);
+    assert!(imported.relink[0].source.contains("missing.wav"));
+    assert_eq!(
+        detect_project_format(&imported_path).unwrap(),
+        ProjectFileFormat::V1
+    );
+    let container = ProjectContainer::open(imported_path).unwrap();
+    let document = container.load_document().unwrap();
+    let MediaSourceRef::ProjectMedia { id, .. } =
+        document.project.clips[0].source.as_ref().unwrap()
+    else {
+        panic!("resolvable legacy media must become Project Media");
+    };
+    assert_eq!(container.read_media(id).unwrap(), bytes);
+}
+
+#[test]
+fn malformed_legacy_import_never_creates_or_changes_a_destination() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("malformed.vzp");
+    let destination = directory.path().join("should-not-exist.vzp");
+    let bytes = b"{ definitely not valid project JSON";
+    fs::write(&source, bytes).unwrap();
+
+    assert!(import_legacy_json_file(&source, &destination).is_err());
+    assert_eq!(fs::read(source).unwrap(), bytes);
+    assert!(!destination.exists());
+}
+
+#[test]
+fn materialized_legacy_remote_reference_keeps_remote_provenance() {
+    let directory = tempfile::tempdir().unwrap();
+    let staged_path = directory.path().join("remote.staged");
+    let destination = directory.path().join("remote-import.vzp");
+    let bytes = b"remote-materialized-media".repeat(128);
+    fs::write(&staged_path, &bytes).unwrap();
+    let source = MediaSourceRef::StagedRemoteProjectMedia {
+        id: hex_sha256(&bytes),
+        file_name: "remote.wav".into(),
+        staging_path: staged_path,
+        provider: "dropbox".into(),
+        connection_id: "legacy-connection".into(),
+        source_id: "id:remote".into(),
+        source_path: "/Samples/remote.wav".into(),
+        rev: Some("rev-1".into()),
+    };
+
+    let imported = import_legacy_project_v1(&destination, project_with_source(source)).unwrap();
+    assert!(imported.relink.is_empty());
+    let document = ProjectContainer::open(destination)
+        .unwrap()
+        .load_document()
+        .unwrap();
+    assert!(matches!(
+        document.project_media[0].provenance,
+        Provenance::Remote { .. }
+    ));
 }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -345,6 +345,25 @@ impl App {
                     },
                 )
             }
+            staged @ MediaSourceRef::StagedRemoteProjectMedia { .. } => {
+                let name = staged.display_name();
+                let MediaSourceRef::StagedRemoteProjectMedia { staging_path, .. } = &staged else {
+                    unreachable!();
+                };
+                let staging_path = staging_path.clone();
+                Task::perform(
+                    decode_file_async(staging_path),
+                    move |result| match result {
+                        Ok(audio) => Message::BrowserSampleDecoded(
+                            target.clone(),
+                            Arc::new(audio),
+                            name.clone(),
+                            staged.clone(),
+                        ),
+                        Err(err) => Message::BrowserSampleDecodeError(err),
+                    },
+                )
+            }
             MediaSourceRef::ProjectMedia { id, file_name } => {
                 let name = file_name.clone();
                 let retained_source = MediaSourceRef::ProjectMedia { id, file_name };

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -395,6 +395,153 @@ async fn decode_and_stage_local_async(
     .map_err(|error| format!("decode/stage task failed: {error}"))?
 }
 
+async fn detect_project_format_async(
+    path: PathBuf,
+) -> Result<vibez_project::project_format_v1::ProjectFileFormat, String> {
+    tokio::task::spawn_blocking(move || {
+        vibez_project::project_format_v1::detect_project_format(&path)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("format detection task failed: {error}"))?
+}
+
+async fn import_legacy_and_load_async(
+    source: PathBuf,
+    destination: PathBuf,
+    dropbox: Option<(Arc<DropboxClient>, DropboxCache)>,
+) -> Result<ProjectLoadResult, String> {
+    if source == destination {
+        return Err("Legacy Import destination must be separate from the source".into());
+    }
+    let original =
+        std::fs::read(&source).map_err(|error| format!("read legacy source: {error}"))?;
+    let legacy_path = source.clone();
+    let mut project = tokio::task::spawn_blocking(move || {
+        Project::load_from_file(&legacy_path).map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("legacy parse task failed: {error}"))??;
+
+    let remote_sources = collect_remote_sources(&project);
+    if let Some((client, cache)) = dropbox.as_ref() {
+        for remote in remote_sources {
+            let MediaSourceRef::DropboxFile {
+                path_lower,
+                display_path,
+                rev,
+            } = &remote
+            else {
+                continue;
+            };
+            let file_name = Path::new(display_path)
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| display_path.clone());
+            let entry = DropboxEntry {
+                path_lower: path_lower.clone(),
+                path_display: display_path.clone(),
+                name: file_name.clone(),
+                is_folder: false,
+                rev: rev.clone(),
+                size: None,
+            };
+            if let Ok(materialized) = client.download_to_cache(&entry, cache).await {
+                let staged = vibez_project::project_format_v1::stage_remote_file(
+                    &materialized,
+                    file_name,
+                    "dropbox-default".into(),
+                    path_lower.clone(),
+                    display_path.clone(),
+                    rev.clone(),
+                )
+                .map_err(|error| error.to_string())?;
+                replace_project_source(&mut project, &remote, staged);
+            }
+        }
+    }
+
+    let import_destination = destination.clone();
+    let imported = tokio::task::spawn_blocking(move || {
+        vibez_project::project_format_v1::import_legacy_project_v1(&import_destination, project)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("Legacy Import task failed: {error}"))??;
+    let after =
+        std::fs::read(&source).map_err(|error| format!("re-read legacy source: {error}"))?;
+    if after != original {
+        return Err("Legacy Import modified its source; converted project was rejected".into());
+    }
+
+    let mut loaded = load_project_async(destination, dropbox).await?;
+    loaded.warnings.extend(
+        imported
+            .relink
+            .into_iter()
+            .map(|item| format!("Relink required: {} ({})", item.source, item.reason)),
+    );
+    Ok(loaded)
+}
+
+fn collect_remote_sources(project: &Project) -> Vec<MediaSourceRef> {
+    let mut sources = Vec::new();
+    let mut collect = |source: &Option<MediaSourceRef>| {
+        if let Some(source @ MediaSourceRef::DropboxFile { .. }) = source {
+            if !sources.contains(source) {
+                sources.push(source.clone());
+            }
+        }
+    };
+    for clip in &project.clips {
+        collect(&clip.source);
+    }
+    for track in project
+        .tracks
+        .iter()
+        .chain(project.master.iter())
+        .chain(project.buses.iter())
+    {
+        match &track.native_instrument {
+            Some(InstrumentStateInfo::Sampler { source, .. }) => collect(source),
+            Some(InstrumentStateInfo::DrumRack { pads }) => {
+                for pad in pads {
+                    collect(&pad.source);
+                }
+            }
+            _ => {}
+        }
+    }
+    sources
+}
+
+fn replace_project_source(project: &mut Project, from: &MediaSourceRef, to: MediaSourceRef) {
+    let replace = |source: &mut Option<MediaSourceRef>| {
+        if source.as_ref() == Some(from) {
+            *source = Some(to.clone());
+        }
+    };
+    for clip in &mut project.clips {
+        replace(&mut clip.source);
+    }
+    for track in project
+        .tracks
+        .iter_mut()
+        .chain(project.master.iter_mut())
+        .chain(project.buses.iter_mut())
+    {
+        match &mut track.native_instrument {
+            Some(InstrumentStateInfo::Sampler { source, .. }) => replace(source),
+            Some(InstrumentStateInfo::DrumRack { pads }) => {
+                for pad in pads {
+                    replace(&mut pad.source);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 async fn save_project_async(
     path: PathBuf,
     source_path: Option<PathBuf>,
@@ -744,6 +891,9 @@ async fn hydrate_saved_source(
     match source {
         MediaSourceRef::LocalFile { path }
         | MediaSourceRef::StagedProjectMedia {
+            staging_path: path, ..
+        }
+        | MediaSourceRef::StagedRemoteProjectMedia {
             staging_path: path, ..
         } => decode_blocking(path.clone()).await,
         MediaSourceRef::ProjectMedia { id, file_name } => {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -308,6 +308,7 @@ impl App {
                     file_path: clip.source.as_ref().and_then(|source| match source {
                         MediaSourceRef::LocalFile { path } => Some(path.clone()),
                         MediaSourceRef::StagedProjectMedia { .. }
+                        | MediaSourceRef::StagedRemoteProjectMedia { .. }
                         | MediaSourceRef::ProjectMedia { .. }
                         | MediaSourceRef::DropboxFile { .. } => None,
                     }),
@@ -781,9 +782,10 @@ impl App {
             format!("Opened {}", loaded.path.display())
         } else {
             format!(
-                "Opened {} with {} warning(s)",
+                "Opened {} with {} warning(s): {}",
                 loaded.path.display(),
-                loaded.warnings.len()
+                loaded.warnings.len(),
+                loaded.warnings[0]
             )
         };
 

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -73,6 +73,8 @@ impl App {
                     | Message::Project(ProjectMsg::ToggleFileMenu)
                     | Message::Project(ProjectMsg::DismissFileMenu)
                     | Message::ProjectOpenPathSelected(_)
+                    | Message::ProjectFormatDetected(..)
+                    | Message::LegacyImportDestinationSelected { .. }
                     | Message::ProjectSavePathSelected(_)
                     | Message::ProjectLoaded(_)
                     | Message::ProjectSaved(_)
@@ -658,6 +660,15 @@ impl App {
             }
             Message::ProjectOpenPathSelected(path) => {
                 if let Some(path) = path {
+                    self.state.status_text = format!("Inspecting {}...", path.display());
+                    let inspected = path.clone();
+                    return Task::perform(detect_project_format_async(path), move |result| {
+                        Message::ProjectFormatDetected(inspected.clone(), result)
+                    });
+                }
+            }
+            Message::ProjectFormatDetected(path, result) => match result {
+                Ok(vibez_project::project_format_v1::ProjectFileFormat::V1) => {
                     self.state.status_text = format!("Opening {}...", path.display());
                     let dropbox = self
                         .dropbox_client
@@ -667,6 +678,58 @@ impl App {
                         Message::ProjectLoaded(Box::new(result))
                     });
                 }
+                Ok(vibez_project::project_format_v1::ProjectFileFormat::LegacyJson) => {
+                    let source = path.clone();
+                    let suggested = path
+                        .file_stem()
+                        .map(|stem| format!("{}-imported.vzp", stem.to_string_lossy()))
+                        .unwrap_or_else(|| "Imported-project.vzp".into());
+                    self.state.status_text =
+                        "Legacy JSON detected — choose a separate V1 destination".into();
+                    return Task::perform(
+                        async move {
+                            let handle = rfd::AsyncFileDialog::new()
+                                .set_title("Import Legacy Project as V1")
+                                .set_file_name(&suggested)
+                                .add_filter("Vibez Project Format V1", &["vzp"])
+                                .save_file()
+                                .await;
+                            handle.map(|file| file.path().to_path_buf())
+                        },
+                        move |destination| Message::LegacyImportDestinationSelected {
+                            source: source.clone(),
+                            destination,
+                        },
+                    );
+                }
+                Err(error) => {
+                    self.state.status_text = format!("Project format error: {error}");
+                }
+            },
+            Message::LegacyImportDestinationSelected {
+                source,
+                destination,
+            } => {
+                let Some(mut destination) = destination else {
+                    self.state.status_text =
+                        "Legacy Import cancelled; original project was not modified".into();
+                    return Task::none();
+                };
+                if !destination
+                    .extension()
+                    .is_some_and(|extension| extension.eq_ignore_ascii_case("vzp"))
+                {
+                    destination.set_extension("vzp");
+                }
+                self.state.status_text = format!("Importing {}...", source.display());
+                let dropbox = self
+                    .dropbox_client
+                    .clone()
+                    .map(|client| (client, self.dropbox_cache.clone()));
+                return Task::perform(
+                    import_legacy_and_load_async(source, destination, dropbox),
+                    |result| Message::ProjectLoaded(Box::new(result)),
+                );
             }
             Message::ProjectSavePathSelected(path) => {
                 if let Some(mut path) = path {

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -9,6 +9,7 @@ use vibez_core::track::{ClipInfo, DrumPadState, MediaSourceRef};
 use vibez_dropbox::{AccountInfo, DropboxEntry, Tokens as DropboxTokens};
 use vibez_plugin_host::gui::PluginGuiKey;
 use vibez_plugin_host::PluginId;
+use vibez_project::project_format_v1::ProjectFileFormat;
 use vibez_project::project_format_v1::SaveObservation;
 use vibez_project::Project;
 
@@ -228,6 +229,11 @@ pub enum Message {
     SaveProject,
     SaveProjectAs,
     ProjectOpenPathSelected(Option<PathBuf>),
+    ProjectFormatDetected(PathBuf, Result<ProjectFileFormat, String>),
+    LegacyImportDestinationSelected {
+        source: PathBuf,
+        destination: Option<PathBuf>,
+    },
     ProjectSavePathSelected(Option<PathBuf>),
     ProjectLoaded(Box<Result<ProjectLoadResult, String>>),
     ProjectSaved(Box<Result<ProjectSaveResult, String>>),


### PR DESCRIPTION
## Browser Card 04

Imports pre-V1 JSON projects into a separate Project Format V1 container without modifying the legacy source.

### Demo outcome

- Detects V1 versus legacy JSON by file content.
- Requires a separate V1 destination for legacy projects.
- Embeds resolvable local and materialized remote media with provenance.
- Reports unavailable media as actionable relink warnings.
- Reopens the converted project through the normal V1 load path.
- Never enters a permanent legacy editing/save mode.

### Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vibez-project` — 22 passed
- `cargo test -p vibez-ui` — 111 passed
- `cargo clippy -p vibez-project --all-targets -- -D warnings`
- `cargo clippy -p vibez-ui --lib -- -D warnings`
- Native smoke: `assets/demo.vibez` detected as legacy JSON, imported into a separate SQLite V1 file, source SHA-256 remained `6bfb9b3715c311f0d5ae522fe276dc6297b97f996c90dfe6cb290944b9eb7e02`, and the converted project rebuilt all four tracks at 124 BPM.

### Stack

Depends on #53 (Card 03). This is a feature PR, not a release PR.
