### PR TITLE
Browser Card 05: navigate local roots

### DIFF
--- a/crates/vibez-ui/src/app/audio_tasks.rs
+++ b/crates/vibez-ui/src/app/audio_tasks.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use vibez_core::id::ClipId;
 use vibez_core::track::MediaSourceRef;
 
-use crate::state::SampleBrowserEntry;
+use crate::state::{SampleBrowserEntry, SampleBrowserFolder};
 
 pub(crate) struct AutoWarpInput {
     pub(crate) audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
@@ -169,6 +169,7 @@ pub(crate) fn scan_root_into(
     root: &PathBuf,
     dir: &PathBuf,
     entries: &mut Vec<SampleBrowserEntry>,
+    folders: &mut Vec<SampleBrowserFolder>,
     warnings: &mut Vec<String>,
 ) {
     let read_dir = match std::fs::read_dir(dir) {
@@ -180,15 +181,53 @@ pub(crate) fn scan_root_into(
     };
 
     for item in read_dir {
-        let Ok(item) = item else {
-            continue;
+        let item = match item {
+            Ok(item) => item,
+            Err(err) => {
+                warnings.push(format!(
+                    "Failed to read an item in {} ({err})",
+                    dir.display()
+                ));
+                continue;
+            }
         };
         let path = item.path();
-        if path.is_dir() {
-            scan_root_into(root, &path, entries, warnings);
+        let file_type = match item.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) => {
+                warnings.push(format!("Failed to inspect {} ({err})", path.display()));
+                continue;
+            }
+        };
+        if file_type.is_symlink() {
+            warnings.push(format!("Skipped symbolic link: {}", path.display()));
             continue;
         }
-        if !is_supported_audio_file(&path) {
+        if file_type.is_dir() {
+            let relative_path = path
+                .strip_prefix(root)
+                .map(|relative| relative.to_path_buf())
+                .unwrap_or_else(|_| path.clone());
+            let name = path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.display().to_string());
+            folders.push(SampleBrowserFolder {
+                path: path.clone(),
+                root_path: root.clone(),
+                search_text: format!(
+                    "{} {} {}",
+                    name.to_lowercase(),
+                    relative_path.display().to_string().to_lowercase(),
+                    root.display().to_string().to_lowercase()
+                ),
+                relative_path,
+                name,
+            });
+            scan_root_into(root, &path, entries, folders, warnings);
+            continue;
+        }
+        if !file_type.is_file() || !is_supported_audio_file(&path) {
             continue;
         }
         let relative_path = path
@@ -200,16 +239,29 @@ pub(crate) fn scan_root_into(
             .map(|name| name.to_string_lossy().to_string())
             .unwrap_or_else(|| path.display().to_string());
         let search_text = format!(
-            "{} {} {}",
+            "{} {} {} {}",
             name.to_lowercase(),
             relative_path.display().to_string().to_lowercase(),
-            root.display().to_string().to_lowercase()
+            root.display().to_string().to_lowercase(),
+            path.extension()
+                .and_then(|extension| extension.to_str())
+                .unwrap_or_default()
+                .to_lowercase()
         );
+        let metadata = item.metadata().ok();
         entries.push(SampleBrowserEntry {
             source: MediaSourceRef::LocalFile { path },
             name,
             root_path: root.clone(),
             relative_path,
+            format: item
+                .path()
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .unwrap_or("AUDIO")
+                .to_ascii_uppercase(),
+            file_size: metadata.as_ref().map(std::fs::Metadata::len),
+            modified: metadata.and_then(|metadata| metadata.modified().ok()),
             search_text,
         });
     }
@@ -225,4 +277,92 @@ pub(crate) fn is_supported_audio_file(path: &std::path::Path) -> bool {
             )
         })
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod local_catalog_tests {
+    use super::*;
+    use std::fs;
+    use std::time::{Duration, Instant};
+
+    fn snapshot_tree(root: &std::path::Path) -> Vec<(PathBuf, Option<Vec<u8>>)> {
+        fn visit(
+            root: &std::path::Path,
+            directory: &std::path::Path,
+            snapshot: &mut Vec<(PathBuf, Option<Vec<u8>>)>,
+        ) {
+            let mut children: Vec<_> = fs::read_dir(directory)
+                .unwrap()
+                .map(|entry| entry.unwrap().path())
+                .collect();
+            children.sort();
+            for path in children {
+                let relative = path.strip_prefix(root).unwrap().to_path_buf();
+                if path.is_dir() {
+                    snapshot.push((relative, None));
+                    visit(root, &path, snapshot);
+                } else {
+                    snapshot.push((relative, Some(fs::read(path).unwrap())));
+                }
+            }
+        }
+
+        let mut snapshot = Vec::new();
+        visit(root, root, &mut snapshot);
+        snapshot
+    }
+
+    #[test]
+    fn local_catalog_is_read_only_media_only_and_preserves_source_identity() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("Samples");
+        let drums = root.join("Drums");
+        let nested = drums.join("One Shots");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(drums.join("kick.wav"), b"same bytes").unwrap();
+        fs::write(nested.join("kick-copy.wav"), b"same bytes").unwrap();
+        fs::write(drums.join("notes.pdf"), b"not media").unwrap();
+        fs::write(root.join("cover.png"), b"not media").unwrap();
+        let before = snapshot_tree(&root);
+
+        let mut entries = Vec::new();
+        let mut folders = Vec::new();
+        let mut warnings = Vec::new();
+        scan_root_into(&root, &root, &mut entries, &mut folders, &mut warnings);
+
+        assert_eq!(snapshot_tree(&root), before);
+        assert!(warnings.is_empty());
+        assert_eq!(entries.len(), 2);
+        assert_eq!(folders.len(), 2);
+        assert!(entries.iter().all(|entry| entry.format == "WAV"));
+        assert!(entries.iter().all(|entry| entry.file_size == Some(10)));
+        assert_ne!(entries[0].source, entries[1].source);
+        assert!(entries
+            .iter()
+            .all(|entry| !entry.name.ends_with(".pdf") && !entry.name.ends_with(".png")));
+    }
+
+    #[test]
+    fn large_synthetic_catalog_scan_remains_bounded_in_wall_time() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("Large Samples");
+        fs::create_dir_all(&root).unwrap();
+        for index in 0..2_000 {
+            fs::write(root.join(format!("sample-{index:04}.wav")), []).unwrap();
+        }
+
+        let mut entries = Vec::new();
+        let mut folders = Vec::new();
+        let mut warnings = Vec::new();
+        let started = Instant::now();
+        scan_root_into(&root, &root, &mut entries, &mut folders, &mut warnings);
+
+        assert_eq!(entries.len(), 2_000);
+        assert!(warnings.is_empty());
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "2,000-entry scan took {:?}",
+            started.elapsed()
+        );
+    }
 }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -764,14 +764,15 @@ async fn hydrate_dropbox_source(
 async fn scan_sample_library_async(roots: Vec<PathBuf>) -> Result<SampleLibraryScanResult, String> {
     tokio::task::spawn_blocking(move || {
         let mut entries = Vec::new();
+        let mut folders = Vec::new();
         let mut warnings = Vec::new();
 
         for root in roots {
-            if !root.exists() {
+            if !root.is_dir() {
                 warnings.push(format!("Missing root: {}", root.display()));
                 continue;
             }
-            scan_root_into(&root, &root, &mut entries, &mut warnings);
+            scan_root_into(&root, &root, &mut entries, &mut folders, &mut warnings);
         }
 
         entries.sort_by(|a, b| {
@@ -779,8 +780,17 @@ async fn scan_sample_library_async(roots: Vec<PathBuf>) -> Result<SampleLibraryS
                 .cmp(&b.relative_path)
                 .then_with(|| a.name.cmp(&b.name))
         });
+        folders.sort_by(|a, b| {
+            a.root_path
+                .cmp(&b.root_path)
+                .then_with(|| a.relative_path.cmp(&b.relative_path))
+        });
 
-        Ok(SampleLibraryScanResult { entries, warnings })
+        Ok(SampleLibraryScanResult {
+            entries,
+            folders,
+            warnings,
+        })
     })
     .await
     .map_err(|err| format!("scan task failed: {err}"))?

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -533,7 +533,10 @@ impl App {
                         self.state.browser.roots.sort();
                         self.persist_ui_settings();
                     }
+                    self.state.browser.select_local_folder(Some(path.clone()));
                     self.state.browser.scan_in_progress = true;
+                    self.state.browser.scan_error = None;
+                    self.state.browser.scan_warnings.clear();
                     self.state.status_text = format!("Scanning {}...", path.display());
                     return Task::perform(
                         scan_sample_library_async(self.state.browser.roots.clone()),
@@ -543,6 +546,8 @@ impl App {
             }
             Message::RescanSampleLibrary => {
                 self.state.browser.scan_in_progress = true;
+                self.state.browser.scan_error = None;
+                self.state.browser.scan_warnings.clear();
                 self.state.status_text = "Rescanning sample library...".to_string();
                 return Task::perform(
                     scan_sample_library_async(self.state.browser.roots.clone()),
@@ -550,9 +555,9 @@ impl App {
                 );
             }
             Message::ClickLocalBrowserEntry(source) => {
-                // Previously auto-previewed on click; now click only
-                // selects. Preview fires via the speaker icon (see
-                // `Message::PreviewLocalEntry`).
+                // Card 07 owns selection-driven Audition. For now click only
+                // selects and populates the truthful waveform; explicit Play
+                // remains in the persistent Audition footer.
                 let changed = self.state.browser.select_source(source.clone());
                 if changed {
                     self.state.browser.begin_waveform_load(&source);

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -1,5 +1,7 @@
 //! Split out of app.rs; inherent methods on [`super::App`].
 
+use std::path::Path;
+
 use iced::widget::{
     button, canvas, column, container, horizontal_space, mouse_area, row, scrollable, text,
     text_input,
@@ -59,6 +61,49 @@ impl App {
                 selection: th::accent(),
             });
 
+        let search_context: Element<'_, Message> = match self.state.browser.mode {
+            SampleBrowserMode::Local => {
+                let scope = button(
+                    row![
+                        text("SCOPE").size(9).color(th::text_muted()),
+                        text(self.state.browser.search_scope_label())
+                            .size(9)
+                            .color(th::text())
+                    ]
+                    .spacing(5)
+                    .align_y(iced::Alignment::Center),
+                )
+                .on_press(Message::Browser(BrowserMsg::CycleSearchScope))
+                .padding([3, 0])
+                .style(browser_utility_action_style);
+                let location = self
+                    .state
+                    .browser
+                    .current_folder
+                    .as_ref()
+                    .and_then(|folder| folder.file_name())
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "All Roots".into());
+                row![
+                    scope,
+                    horizontal_space(),
+                    text(location)
+                        .size(9)
+                        .color(th::text_dim())
+                        .wrapping(iced::widget::text::Wrapping::None)
+                ]
+                .align_y(iced::Alignment::Center)
+                .into()
+            }
+            SampleBrowserMode::Dropbox => row![
+                text("SCOPE").size(9).color(th::text_muted()),
+                text("REMOTE CATALOG").size(9).color(th::text_dim())
+            ]
+            .spacing(5)
+            .align_y(iced::Alignment::Center)
+            .into(),
+        };
+
         let body: Element<'_, Message> = match self.state.browser.mode {
             SampleBrowserMode::Local => self.view_local_sample_browser(),
             SampleBrowserMode::Dropbox => self.view_dropbox_browser(),
@@ -76,7 +121,7 @@ impl App {
 
         container(
             column![
-                container(column![title_row, search].spacing(7))
+                container(column![title_row, search, search_context].spacing(6))
                     .padding([8, 10])
                     .style(browser_header_style),
                 content,
@@ -149,13 +194,13 @@ impl App {
         ]
         .spacing(3);
 
-        let all_active = local_active && self.state.browser.root_filter.is_none();
+        let all_active = local_active && self.state.browser.current_folder.is_none();
         let all_roots = button(text("All Roots").size(10).color(if all_active {
             th::accent()
         } else {
             th::text_dim()
         }))
-        .on_press(Message::Browser(BrowserMsg::SelectSampleBrowserRoot(None)))
+        .on_press(Message::Browser(BrowserMsg::SelectLocalFolder(None)))
         .padding([4, 8])
         .width(Length::Fill)
         .style(move |_theme: &Theme, status| browser_place_button_style(all_active, status));
@@ -164,33 +209,73 @@ impl App {
             all_roots
         ]);
 
+        let mut local_tree_rows = Vec::new();
         for root in &self.state.browser.roots {
             let active = local_active
                 && self
                     .state
                     .browser
-                    .root_filter
+                    .current_folder
                     .as_ref()
                     .is_some_and(|selected| selected == root);
+            let expanded = self.state.browser.expanded_local_folders.contains(root);
+            let has_children = self
+                .state
+                .browser
+                .folders
+                .iter()
+                .any(|folder| folder.root_path == *root && folder.path.parent() == Some(root));
             let label = root
                 .file_name()
                 .map(|name| name.to_string_lossy().into_owned())
                 .unwrap_or_else(|| root.display().to_string());
-            let root_button = button(text(label).size(10).color(if active {
-                th::accent()
+            let toggle: Element<'_, Message> = if has_children {
+                button(
+                    text(if expanded { "▾" } else { "▸" })
+                        .size(10)
+                        .color(th::text_muted()),
+                )
+                .on_press(Message::Browser(BrowserMsg::ToggleLocalFolder(
+                    root.clone(),
+                )))
+                .padding([4, 2])
+                .style(browser_utility_action_style)
+                .into()
             } else {
-                th::text_dim()
-            }))
-            .on_press(Message::Browser(BrowserMsg::SelectSampleBrowserRoot(Some(
+                container(text("·").size(9).color(th::text_muted()))
+                    .padding([4, 3])
+                    .into()
+            };
+            let root_button = button(
+                text(label)
+                    .size(10)
+                    .color(if active { th::accent() } else { th::text_dim() })
+                    .wrapping(iced::widget::text::Wrapping::None),
+            )
+            .on_press(Message::Browser(BrowserMsg::SelectLocalFolder(Some(
                 root.clone(),
             ))))
-            .padding([4, 8])
+            .padding([4, 2])
             .width(Length::Fill)
             .style(move |_theme: &Theme, status| browser_place_button_style(active, status));
-            places = places.push(row![
-                horizontal_space().width(Length::Fixed(14.0)),
-                root_button
-            ]);
+            let remove = button(icons::icon(icons::X).size(8).color(th::text_muted()))
+                .on_press(Message::Browser(BrowserMsg::RemoveSampleLibraryRoot(
+                    root.clone(),
+                )))
+                .padding([4, 2])
+                .style(browser_utility_action_style);
+            local_tree_rows.push(
+                row![toggle, root_button, remove]
+                    .spacing(1)
+                    .align_y(iced::Alignment::Center)
+                    .into(),
+            );
+            if expanded {
+                self.render_local_places_tree(root, root, 1, &mut local_tree_rows);
+            }
+        }
+        for local_row in local_tree_rows {
+            places = places.push(local_row);
         }
 
         places = places.push(place_button(
@@ -250,7 +335,88 @@ impl App {
                 .align_x(iced::Alignment::Start),
         );
 
-        container(places.padding(9)).width(Length::Fill).into()
+        container(
+            scrollable(container(places.padding(9)).width(Length::Fill)).direction(
+                scrollable::Direction::Vertical(scrollable::Scrollbar::default()),
+            ),
+        )
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into()
+    }
+
+    fn render_local_places_tree<'a>(
+        &'a self,
+        root: &Path,
+        parent: &Path,
+        depth: usize,
+        rows: &mut Vec<Element<'a, Message>>,
+    ) {
+        let mut children: Vec<_> = self
+            .state
+            .browser
+            .folders
+            .iter()
+            .filter(|folder| folder.root_path == root && folder.path.parent() == Some(parent))
+            .collect();
+        children.sort_by_key(|folder| folder.name.to_lowercase());
+
+        for folder in children {
+            let expanded = self
+                .state
+                .browser
+                .expanded_local_folders
+                .contains(&folder.path);
+            let active = self.state.browser.mode == SampleBrowserMode::Local
+                && self.state.browser.current_folder.as_ref() == Some(&folder.path);
+            let has_children =
+                self.state.browser.folders.iter().any(|child| {
+                    child.root_path == root && child.path.parent() == Some(&folder.path)
+                });
+            let toggle: Element<'a, Message> = if has_children {
+                button(
+                    text(if expanded { "▾" } else { "▸" })
+                        .size(10)
+                        .color(th::text_muted()),
+                )
+                .on_press(Message::Browser(BrowserMsg::ToggleLocalFolder(
+                    folder.path.clone(),
+                )))
+                .padding([3, 2])
+                .style(browser_utility_action_style)
+                .into()
+            } else {
+                container(text("·").size(9).color(th::text_muted()))
+                    .padding([3, 3])
+                    .into()
+            };
+            let select = button(
+                text(folder.name.clone())
+                    .size(9)
+                    .color(if active { th::accent() } else { th::text_dim() })
+                    .height(Length::Fixed(12.0))
+                    .wrapping(iced::widget::text::Wrapping::None),
+            )
+            .on_press(Message::Browser(BrowserMsg::SelectLocalFolder(Some(
+                folder.path.clone(),
+            ))))
+            .padding([3, 1])
+            .width(Length::Fill)
+            .style(move |_theme: &Theme, status| browser_place_button_style(active, status));
+            rows.push(
+                row![
+                    horizontal_space().width(Length::Fixed((depth as f32 * 8.0).min(40.0))),
+                    toggle,
+                    select
+                ]
+                .spacing(1)
+                .align_y(iced::Alignment::Center)
+                .into(),
+            );
+            if expanded {
+                self.render_local_places_tree(root, &folder.path, depth + 1, rows);
+            }
+        }
     }
 
     fn view_browser_audition_footer(&self) -> Element<'_, Message> {
@@ -365,7 +531,47 @@ impl App {
             .into();
         }
 
-        let search_lower = self.state.browser.search.to_lowercase();
+        let search_lower = self.state.browser.search.trim().to_lowercase();
+        let searching = !search_lower.is_empty();
+        let current_folder = self.state.browser.current_folder.as_deref();
+
+        let mut root_results: Vec<&std::path::PathBuf> = if !searching && current_folder.is_none() {
+            self.state.browser.roots.iter().collect()
+        } else if searching && self.state.browser.search_scope_path().is_none() {
+            self.state
+                .browser
+                .roots
+                .iter()
+                .filter(|root| {
+                    root.display()
+                        .to_string()
+                        .to_lowercase()
+                        .contains(&search_lower)
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+        root_results.sort_by_key(|root| browser_root_name(root).to_lowercase());
+
+        let mut folder_results: Vec<_> = self
+            .state
+            .browser
+            .folders
+            .iter()
+            .filter(|folder| {
+                self.state
+                    .browser
+                    .local_folder_is_result(folder, &search_lower)
+            })
+            .collect();
+        folder_results.sort_by(|a, b| {
+            a.name
+                .to_lowercase()
+                .cmp(&b.name.to_lowercase())
+                .then_with(|| a.path.cmp(&b.path))
+        });
+
         let mut filtered_entries: Vec<&SampleBrowserEntry> = self
             .state
             .browser
@@ -374,13 +580,15 @@ impl App {
             .filter(|entry| {
                 self.state
                     .browser
-                    .root_filter
-                    .as_ref()
-                    .is_none_or(|root| &entry.root_path == root)
+                    .local_entry_is_result(entry, &search_lower)
             })
-            .filter(|entry| search_lower.is_empty() || entry.search_text.contains(&search_lower))
             .collect();
-        filtered_entries.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+        filtered_entries.sort_by(|a, b| {
+            a.name
+                .to_lowercase()
+                .cmp(&b.name.to_lowercase())
+                .then_with(|| a.relative_path.cmp(&b.relative_path))
+        });
 
         let selected_source = self.state.browser.selected_source.as_ref();
         let wide_columns = self
@@ -444,8 +652,67 @@ impl App {
             .style(browser_table_header_style)
             .into()
         };
+        let total_results = root_results.len() + folder_results.len() + filtered_entries.len();
+        let visible_results = self.state.browser.visible_result_count(total_results);
+        let mut remaining = visible_results;
         let mut entries_col = column![].spacing(1);
-        for entry in filtered_entries.iter().take(400) {
+
+        if let Some(error) = &self.state.browser.scan_error {
+            entries_col = entries_col.push(
+                container(
+                    text(format!("INDEX ERROR · {error}"))
+                        .size(9)
+                        .color(th::danger())
+                        .wrapping(iced::widget::text::Wrapping::None),
+                )
+                .padding([6, 8]),
+            );
+        } else if let Some(first_warning) = self.state.browser.scan_warnings.first() {
+            entries_col = entries_col.push(
+                container(
+                    text(format!(
+                        "WARN {} · {}",
+                        self.state.browser.scan_warnings.len(),
+                        first_warning
+                    ))
+                    .size(9)
+                    .color(th::danger())
+                    .wrapping(iced::widget::text::Wrapping::None),
+                )
+                .padding([6, 8]),
+            );
+        }
+
+        for root in root_results.into_iter().take(remaining) {
+            entries_col = entries_col
+                .push(self.view_local_folder_result(
+                    browser_root_name(root),
+                    format!("LOCAL ROOT · {}", root.display()),
+                    "ROOT",
+                    root.clone(),
+                    wide_columns,
+                ))
+                .push(browser_row_divider());
+            remaining = remaining.saturating_sub(1);
+        }
+        for folder in folder_results.into_iter().take(remaining) {
+            entries_col = entries_col
+                .push(self.view_local_folder_result(
+                    folder.name.clone(),
+                    browser_folder_context(
+                        &folder.root_path,
+                        &folder.relative_path,
+                        "FOLDER",
+                        None,
+                    ),
+                    "FOLDER",
+                    folder.path.clone(),
+                    wide_columns,
+                ))
+                .push(browser_row_divider());
+            remaining = remaining.saturating_sub(1);
+        }
+        for entry in filtered_entries.into_iter().take(remaining) {
             let selected = selected_source.is_some_and(|source| &entry.source == source);
             let cell_color = browser_result_cell_color(selected);
             // mouse_area returns early if its child captures the event, so
@@ -458,12 +725,17 @@ impl App {
                     .width(Length::Fill)
                     .height(Length::Fixed(14.0))
                     .wrapping(iced::widget::text::Wrapping::None),
-                text(entry.relative_path.display().to_string())
-                    .size(9)
-                    .color(cell_color)
-                    .width(Length::Fill)
-                    .height(Length::Fixed(11.0))
-                    .wrapping(iced::widget::text::Wrapping::None)
+                text(browser_folder_context(
+                    &entry.root_path,
+                    &entry.relative_path,
+                    &entry.format,
+                    entry.file_size,
+                ))
+                .size(9)
+                .color(cell_color)
+                .width(Length::Fill)
+                .height(Length::Fixed(11.0))
+                .wrapping(iced::widget::text::Wrapping::None)
             ]
             .spacing(2)
             .width(Length::Fill);
@@ -526,27 +798,51 @@ impl App {
             entries_col = entries_col.push(flat_row).push(browser_row_divider());
         }
 
-        if filtered_entries.is_empty() {
+        if total_results == 0 && self.state.browser.scan_error.is_none() {
             entries_col = entries_col.push(
                 container(
-                    text("No samples match the current filters")
-                        .size(11)
-                        .color(th::text_dim()),
+                    text(if searching {
+                        "No media or folders match this scope"
+                    } else {
+                        "This location has no child folders or supported media"
+                    })
+                    .size(11)
+                    .color(th::text_dim()),
                 )
                 .padding([8, 4]),
             );
         }
 
-        let count = format!(
-            "{} / {}{}",
-            filtered_entries.len().min(400),
-            self.state.browser.entries.len(),
-            if self.state.browser.scan_in_progress {
-                " …"
-            } else {
-                ""
-            }
-        );
+        if self.state.browser.has_more_results(total_results) {
+            let hidden = total_results.saturating_sub(visible_results);
+            entries_col = entries_col.push(browser_row_divider()).push(
+                button(
+                    text(format!(
+                        "SHOW {} MORE",
+                        hidden.min(crate::state::BROWSER_RESULTS_PAGE_SIZE)
+                    ))
+                    .size(9)
+                    .color(th::text_dim()),
+                )
+                .on_press(Message::Browser(BrowserMsg::ShowMoreLocalResults))
+                .padding([7, 8])
+                .width(Length::Fill)
+                .style(browser_utility_action_style),
+            );
+        }
+
+        let count = if self.state.browser.scan_in_progress {
+            format!("INDEXING… · {}", self.state.browser.entries.len())
+        } else if self.state.browser.scan_error.is_some() {
+            "INDEX ERROR".into()
+        } else if self.state.browser.scan_warnings.is_empty() {
+            format!("{visible_results} / {total_results}")
+        } else {
+            format!(
+                "{visible_results} / {total_results} · WARN {}",
+                self.state.browser.scan_warnings.len()
+            )
+        };
 
         container(
             column![
@@ -578,6 +874,71 @@ impl App {
         .height(Length::Fill)
         .style(browser_results_style)
         .into()
+    }
+
+    fn view_local_folder_result(
+        &self,
+        name: String,
+        context: String,
+        status: &'static str,
+        destination: std::path::PathBuf,
+        wide_columns: bool,
+    ) -> Element<'_, Message> {
+        let name_cell = column![
+            text(format!("› {name}"))
+                .size(12)
+                .color(th::text())
+                .width(Length::Fill)
+                .height(Length::Fixed(14.0))
+                .wrapping(iced::widget::text::Wrapping::None),
+            text(context)
+                .size(9)
+                .color(th::text_dim())
+                .width(Length::Fill)
+                .height(Length::Fixed(11.0))
+                .wrapping(iced::widget::text::Wrapping::None)
+        ]
+        .spacing(2)
+        .width(Length::Fill);
+        let cells: Element<'_, Message> = if wide_columns {
+            row![
+                name_cell,
+                text("—")
+                    .size(10)
+                    .color(th::text_dim())
+                    .width(Length::Fixed(36.0)),
+                text("—")
+                    .size(10)
+                    .color(th::text_dim())
+                    .width(Length::Fixed(50.0)),
+                text(status)
+                    .size(9)
+                    .color(th::text_dim())
+                    .width(Length::Fixed(48.0))
+            ]
+            .spacing(4)
+            .align_y(iced::Alignment::Center)
+            .into()
+        } else {
+            row![
+                name_cell,
+                text(status)
+                    .size(9)
+                    .color(th::text_dim())
+                    .width(Length::Fixed(42.0))
+            ]
+            .align_y(iced::Alignment::Center)
+            .into()
+        };
+
+        button(container(cells).padding([6, 8]).width(Length::Fill))
+            .on_press(Message::Browser(BrowserMsg::SelectLocalFolder(Some(
+                destination,
+            ))))
+            .padding(0)
+            .width(Length::Fill)
+            .style(browser_utility_action_style)
+            .into()
     }
 
     pub(super) fn view_dropbox_browser(&self) -> Element<'_, Message> {
@@ -794,6 +1155,41 @@ impl App {
                 self.render_dropbox_tree(entry.path_lower.clone(), depth + 1, rows);
             }
         }
+    }
+}
+
+fn browser_root_name(root: &Path) -> String {
+    root.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| root.display().to_string())
+}
+
+fn browser_folder_context(
+    root: &Path,
+    relative_path: &Path,
+    detail: &str,
+    file_size: Option<u64>,
+) -> String {
+    let size = file_size
+        .map(format_browser_file_size)
+        .map(|size| format!(" · {size}"))
+        .unwrap_or_default();
+    format!(
+        "{detail}{size} · {}/{}",
+        browser_root_name(root),
+        relative_path.display()
+    )
+}
+
+fn format_browser_file_size(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    if bytes < 1024 {
+        format!("{bytes} B")
+    } else if (bytes as f64) < MIB {
+        format!("{:.1} KB", bytes as f64 / KIB)
+    } else {
+        format!("{:.1} MB", bytes as f64 / MIB)
     }
 }
 

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -23,7 +23,10 @@ pub enum BrowserMsg {
     EndDockResize,
     NudgeDockWidth(f32),
     SampleBrowserSearchChanged(String),
-    SelectSampleBrowserRoot(Option<PathBuf>),
+    SelectLocalFolder(Option<PathBuf>),
+    ToggleLocalFolder(PathBuf),
+    CycleSearchScope,
+    ShowMoreLocalResults,
     SelectSampleBrowserEntry(MediaSourceRef),
     SetSampleBrowserMode(SampleBrowserMode),
     StartDragSample {
@@ -91,9 +94,23 @@ impl BrowserState {
             }
             BrowserMsg::SampleBrowserSearchChanged(query) => {
                 self.search = query;
+                self.reset_results_window();
             }
-            BrowserMsg::SelectSampleBrowserRoot(root) => {
-                self.root_filter = root;
+            BrowserMsg::SelectLocalFolder(folder) => {
+                self.select_local_folder(folder);
+            }
+            BrowserMsg::ToggleLocalFolder(folder) => {
+                if !self.expanded_local_folders.remove(&folder) {
+                    self.expanded_local_folders.insert(folder);
+                }
+            }
+            BrowserMsg::CycleSearchScope => {
+                self.cycle_search_scope();
+            }
+            BrowserMsg::ShowMoreLocalResults => {
+                self.results_visible_limit = self
+                    .results_visible_limit
+                    .saturating_add(crate::state::BROWSER_RESULTS_PAGE_SIZE);
             }
             BrowserMsg::SelectSampleBrowserEntry(source) => {
                 if self.select_source(source.clone()) {
@@ -143,6 +160,16 @@ impl BrowserState {
                 match result {
                     Ok(scan) => {
                         self.entries = scan.entries;
+                        self.folders = scan.folders;
+                        self.scan_warnings = scan.warnings;
+                        self.scan_error = None;
+                        let current_exists = self.current_folder.as_ref().is_none_or(|current| {
+                            self.roots.iter().any(|root| root == current)
+                                || self.folders.iter().any(|folder| &folder.path == current)
+                        });
+                        if !current_exists {
+                            self.select_local_folder(None);
+                        }
                         if self
                             .selected_source
                             .as_ref()
@@ -151,36 +178,39 @@ impl BrowserState {
                             })
                             .is_none()
                         {
-                            if let Some(source) =
-                                self.entries.first().map(|entry| entry.source.clone())
-                            {
-                                self.select_source(source.clone());
-                                action.load_waveform = Some(source);
-                            } else {
-                                self.clear_selection();
-                            }
+                            self.clear_selection();
                         }
-                        action.status = Some(if scan.warnings.is_empty() {
+                        action.status = Some(if self.scan_warnings.is_empty() {
                             format!("Indexed {} samples", self.entries.len())
                         } else {
                             format!(
                                 "Indexed {} samples with {} warning(s)",
                                 self.entries.len(),
-                                scan.warnings.len()
+                                self.scan_warnings.len()
                             )
                         });
                     }
                     Err(err) => {
+                        self.scan_error = Some(err.clone());
                         action.status = Some(format!("Sample scan error: {err}"));
                     }
                 }
             }
             BrowserMsg::RemoveSampleLibraryRoot(path) => {
                 self.roots.retain(|root| root != &path);
-                if self.root_filter.as_ref().is_some_and(|root| root == &path) {
-                    self.root_filter = None;
+                if self
+                    .current_folder
+                    .as_ref()
+                    .is_some_and(|folder| folder.starts_with(&path))
+                {
+                    self.select_local_folder(None);
                 }
                 self.entries.retain(|entry| entry.root_path != path);
+                self.folders.retain(|folder| folder.root_path != path);
+                self.expanded_local_folders
+                    .retain(|folder| !folder.starts_with(&path));
+                self.scan_warnings.clear();
+                self.scan_error = None;
                 if self
                     .selected_source
                     .as_ref()
@@ -255,7 +285,7 @@ mod tests {
     fn resizing_keeps_one_places_and_results_shell_without_changing_context() {
         let mut browser = BrowserState {
             search: "break".into(),
-            root_filter: Some(PathBuf::from("/samples")),
+            current_folder: Some(PathBuf::from("/samples")),
             selected_source: Some(MediaSourceRef::LocalFile {
                 path: PathBuf::from("/samples/break.wav"),
             }),
@@ -268,7 +298,7 @@ mod tests {
         browser.set_dock_width(580.0);
         assert!((browser.places_pane_width(1_400.0) - 176.0).abs() < f32::EPSILON * 100.0);
         assert_eq!(browser.search, "break");
-        assert_eq!(browser.root_filter, Some(PathBuf::from("/samples")));
+        assert_eq!(browser.current_folder, Some(PathBuf::from("/samples")));
         assert!(browser.selected_source.is_some());
     }
 
@@ -361,11 +391,174 @@ mod tests {
         let mut b = BrowserState::default();
         let root = PathBuf::from("/samples");
         b.roots.push(root.clone());
-        b.root_filter = Some(root.clone());
+        b.current_folder = Some(root.clone());
         let action = b.update(BrowserMsg::RemoveSampleLibraryRoot(root));
         assert!(b.roots.is_empty());
-        assert_eq!(b.root_filter, None);
+        assert_eq!(b.current_folder, None);
         assert!(action.persist_settings);
         assert_eq!(action.status.as_deref(), Some("Removed sample root"));
+    }
+
+    #[test]
+    fn removing_a_root_never_mutates_source_storage() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("Source Storage");
+        std::fs::create_dir_all(&root).unwrap();
+        let source = root.join("kick.wav");
+        std::fs::write(&source, b"source bytes").unwrap();
+        let mut browser = BrowserState {
+            roots: vec![root.clone()],
+            current_folder: Some(root.clone()),
+            ..BrowserState::default()
+        };
+
+        browser.update(BrowserMsg::RemoveSampleLibraryRoot(root));
+
+        assert_eq!(std::fs::read(source).unwrap(), b"source bytes");
+        assert!(browser.roots.is_empty());
+    }
+
+    #[test]
+    fn scan_completion_and_failure_remain_visible_in_browser_state() {
+        let mut browser = BrowserState {
+            scan_in_progress: true,
+            ..BrowserState::default()
+        };
+        let folder = crate::state::SampleBrowserFolder {
+            path: PathBuf::from("/samples/drums"),
+            root_path: PathBuf::from("/samples"),
+            relative_path: PathBuf::from("drums"),
+            name: "drums".into(),
+            search_text: "drums".into(),
+        };
+
+        browser.update(BrowserMsg::SampleLibraryScanned(Ok(
+            crate::message::SampleLibraryScanResult {
+                entries: Vec::new(),
+                folders: vec![folder.clone()],
+                warnings: vec!["Unreadable folder".into()],
+            },
+        )));
+        assert!(!browser.scan_in_progress);
+        assert_eq!(browser.folders, vec![folder]);
+        assert_eq!(browser.scan_warnings, vec!["Unreadable folder"]);
+        assert!(browser.scan_error.is_none());
+
+        browser.scan_in_progress = true;
+        browser.update(BrowserMsg::SampleLibraryScanned(Err(
+            "catalog failed".into()
+        )));
+        assert!(!browser.scan_in_progress);
+        assert_eq!(browser.scan_error.as_deref(), Some("catalog failed"));
+    }
+
+    #[test]
+    fn local_search_scope_widens_from_folder_to_root_to_everywhere() {
+        let mut browser = BrowserState {
+            roots: vec![PathBuf::from("/samples"), PathBuf::from("/other")],
+            ..BrowserState::default()
+        };
+        browser.select_local_folder(Some(PathBuf::from("/samples/drums")));
+
+        assert_eq!(browser.search_scope_label(), "THIS FOLDER");
+        assert!(browser.path_is_in_search_scope(std::path::Path::new("/samples/drums/kick.wav")));
+        assert!(!browser.path_is_in_search_scope(std::path::Path::new("/samples/bass/sub.wav")));
+
+        browser.update(BrowserMsg::CycleSearchScope);
+        assert_eq!(browser.search_scope_label(), "THIS ROOT");
+        assert!(browser.path_is_in_search_scope(std::path::Path::new("/samples/bass/sub.wav")));
+        assert!(!browser.path_is_in_search_scope(std::path::Path::new("/other/kick.wav")));
+
+        browser.update(BrowserMsg::CycleSearchScope);
+        assert_eq!(browser.search_scope_label(), "EVERYWHERE");
+        assert!(browser.path_is_in_search_scope(std::path::Path::new("/other/kick.wav")));
+    }
+
+    #[test]
+    fn local_filtering_uses_immediate_children_for_navigation_and_subtrees_for_search() {
+        fn entry(root: &str, relative: &str) -> crate::state::SampleBrowserEntry {
+            let root_path = PathBuf::from(root);
+            let relative_path = PathBuf::from(relative);
+            let path = root_path.join(&relative_path);
+            crate::state::SampleBrowserEntry {
+                source: MediaSourceRef::LocalFile { path },
+                name: relative_path
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned(),
+                root_path,
+                relative_path: relative_path.clone(),
+                format: "WAV".into(),
+                file_size: Some(4),
+                modified: None,
+                search_text: relative_path.display().to_string().to_lowercase(),
+            }
+        }
+
+        let mut browser = BrowserState {
+            roots: vec![PathBuf::from("/samples"), PathBuf::from("/other")],
+            ..BrowserState::default()
+        };
+        browser.select_local_folder(Some(PathBuf::from("/samples/drums")));
+        let immediate = entry("/samples", "drums/kick.wav");
+        let nested = entry("/samples", "drums/one-shots/kick-deep.wav");
+        let sibling = entry("/samples", "bass/kick-bass.wav");
+        let other_root = entry("/other", "kick-other.wav");
+
+        assert!(browser.local_entry_is_result(&immediate, ""));
+        assert!(!browser.local_entry_is_result(&nested, ""));
+        assert!(browser.local_entry_is_result(&immediate, "kick"));
+        assert!(browser.local_entry_is_result(&nested, "kick"));
+        assert!(!browser.local_entry_is_result(&sibling, "kick"));
+
+        browser.cycle_search_scope();
+        assert!(browser.local_entry_is_result(&sibling, "kick"));
+        assert!(!browser.local_entry_is_result(&other_root, "kick"));
+
+        browser.cycle_search_scope();
+        assert!(browser.local_entry_is_result(&other_root, "kick"));
+    }
+
+    #[test]
+    fn selecting_a_folder_expands_it_and_resets_the_result_window() {
+        let mut browser = BrowserState {
+            results_visible_limit: 800,
+            search_scope: crate::state::BrowserSearchScope::Everywhere,
+            ..BrowserState::default()
+        };
+        let folder = PathBuf::from("/samples/drums");
+
+        browser.update(BrowserMsg::SelectLocalFolder(Some(folder.clone())));
+
+        assert_eq!(browser.current_folder, Some(folder.clone()));
+        assert!(browser.expanded_local_folders.contains(&folder));
+        assert_eq!(
+            browser.search_scope,
+            crate::state::BrowserSearchScope::SelectedFolder
+        );
+        assert_eq!(
+            browser.results_visible_limit,
+            crate::state::BROWSER_RESULTS_PAGE_SIZE
+        );
+    }
+
+    #[test]
+    fn large_results_are_rendered_in_bounded_windows_without_losing_total() {
+        let mut browser = BrowserState::default();
+        let total = 25_000;
+
+        assert_eq!(
+            browser.visible_result_count(total),
+            crate::state::BROWSER_RESULTS_PAGE_SIZE
+        );
+        assert!(browser.has_more_results(total));
+
+        browser.update(BrowserMsg::ShowMoreLocalResults);
+        assert_eq!(
+            browser.visible_result_count(total),
+            crate::state::BROWSER_RESULTS_PAGE_SIZE * 2
+        );
+        assert!(browser.has_more_results(total));
     }
 }

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -11,7 +11,7 @@ use vibez_plugin_host::gui::PluginGuiKey;
 use vibez_plugin_host::PluginId;
 use vibez_project::Project;
 
-use crate::state::{SampleBrowserEntry, SettingsTab};
+use crate::state::{SampleBrowserEntry, SampleBrowserFolder, SettingsTab};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DrumPadParam {
@@ -55,6 +55,7 @@ pub struct LoadedDrumRackPadData {
 #[derive(Debug, Clone)]
 pub struct SampleLibraryScanResult {
     pub entries: Vec<SampleBrowserEntry>,
+    pub folders: Vec<SampleBrowserFolder>,
     pub warnings: Vec<String>,
 }
 

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -220,6 +220,15 @@ pub const BROWSER_DOCK_MAX_WIDTH: f32 = 650.0;
 pub const ARRANGE_MIN_WIDTH_WITH_BROWSER: f32 = 560.0;
 pub const BROWSER_PLACES_MIN_WIDTH: f32 = 124.0;
 pub const BROWSER_PLACES_MAX_WIDTH: f32 = 176.0;
+pub const BROWSER_RESULTS_PAGE_SIZE: usize = 200;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BrowserSearchScope {
+    #[default]
+    SelectedFolder,
+    Root,
+    Everywhere,
+}
 
 /// Browser domain slice: sample library, Dropbox browsing, and
 /// drag-and-drop from the browser into the arrangement.
@@ -233,7 +242,15 @@ pub struct BrowserState {
     pub search: String,
     pub roots: Vec<PathBuf>,
     pub entries: Vec<SampleBrowserEntry>,
-    pub root_filter: Option<PathBuf>,
+    pub folders: Vec<SampleBrowserFolder>,
+    /// Absolute Local Source Storage folder currently shown in Results. `None`
+    /// is the All Roots location.
+    pub current_folder: Option<PathBuf>,
+    pub expanded_local_folders: HashSet<PathBuf>,
+    pub search_scope: BrowserSearchScope,
+    pub results_visible_limit: usize,
+    pub scan_warnings: Vec<String>,
+    pub scan_error: Option<String>,
     pub selected_source: Option<MediaSourceRef>,
     /// Decoded audio used only for the selected Browser source's visual
     /// waveform. Audition still travels through the existing engine path.
@@ -262,7 +279,13 @@ impl Default for BrowserState {
             search: String::new(),
             roots: Vec::new(),
             entries: Vec::new(),
-            root_filter: None,
+            folders: Vec::new(),
+            current_folder: None,
+            expanded_local_folders: HashSet::new(),
+            search_scope: BrowserSearchScope::default(),
+            results_visible_limit: BROWSER_RESULTS_PAGE_SIZE,
+            scan_warnings: Vec::new(),
+            scan_error: None,
             selected_source: None,
             waveform_source: None,
             waveform_audio: None,
@@ -280,6 +303,110 @@ impl Default for BrowserState {
 }
 
 impl BrowserState {
+    pub fn reset_results_window(&mut self) {
+        self.results_visible_limit = BROWSER_RESULTS_PAGE_SIZE;
+    }
+
+    pub fn select_local_folder(&mut self, folder: Option<PathBuf>) {
+        self.current_folder = folder;
+        if let Some(folder) = &self.current_folder {
+            self.expanded_local_folders.insert(folder.clone());
+        }
+        self.search_scope = BrowserSearchScope::SelectedFolder;
+        self.reset_results_window();
+    }
+
+    pub fn current_local_root(&self) -> Option<&PathBuf> {
+        let current = self.current_folder.as_ref()?;
+        self.roots
+            .iter()
+            .filter(|root| current.starts_with(root))
+            .max_by_key(|root| root.components().count())
+    }
+
+    pub fn search_scope_path(&self) -> Option<&std::path::Path> {
+        match self.search_scope {
+            BrowserSearchScope::SelectedFolder => self.current_folder.as_deref(),
+            BrowserSearchScope::Root => self.current_local_root().map(PathBuf::as_path),
+            BrowserSearchScope::Everywhere => None,
+        }
+    }
+
+    pub fn search_scope_label(&self) -> &'static str {
+        match self.search_scope {
+            BrowserSearchScope::SelectedFolder if self.current_folder.is_none() => "EVERYWHERE",
+            BrowserSearchScope::SelectedFolder
+                if self.current_folder.as_ref() == self.current_local_root() =>
+            {
+                "THIS ROOT"
+            }
+            BrowserSearchScope::SelectedFolder => "THIS FOLDER",
+            BrowserSearchScope::Root => "THIS ROOT",
+            BrowserSearchScope::Everywhere => "EVERYWHERE",
+        }
+    }
+
+    pub fn cycle_search_scope(&mut self) {
+        self.search_scope = match self.search_scope {
+            BrowserSearchScope::SelectedFolder
+                if self.current_folder.is_some()
+                    && self.current_folder.as_ref() != self.current_local_root() =>
+            {
+                BrowserSearchScope::Root
+            }
+            BrowserSearchScope::SelectedFolder | BrowserSearchScope::Root => {
+                BrowserSearchScope::Everywhere
+            }
+            BrowserSearchScope::Everywhere if self.current_folder.is_some() => {
+                BrowserSearchScope::SelectedFolder
+            }
+            BrowserSearchScope::Everywhere => BrowserSearchScope::Everywhere,
+        };
+        self.reset_results_window();
+    }
+
+    pub fn path_is_in_search_scope(&self, path: &std::path::Path) -> bool {
+        self.search_scope_path()
+            .is_none_or(|scope| path.starts_with(scope))
+    }
+
+    pub fn local_folder_is_result(
+        &self,
+        folder: &SampleBrowserFolder,
+        normalized_query: &str,
+    ) -> bool {
+        if normalized_query.is_empty() {
+            return self
+                .current_folder
+                .as_deref()
+                .is_some_and(|current| folder.path.parent() == Some(current));
+        }
+        self.path_is_in_search_scope(&folder.path) && folder.search_text.contains(normalized_query)
+    }
+
+    pub fn local_entry_is_result(
+        &self,
+        entry: &SampleBrowserEntry,
+        normalized_query: &str,
+    ) -> bool {
+        let path = entry.root_path.join(&entry.relative_path);
+        if normalized_query.is_empty() {
+            return self
+                .current_folder
+                .as_deref()
+                .is_some_and(|current| path.parent() == Some(current));
+        }
+        self.path_is_in_search_scope(&path) && entry.search_text.contains(normalized_query)
+    }
+
+    pub fn visible_result_count(&self, total: usize) -> usize {
+        total.min(self.results_visible_limit)
+    }
+
+    pub fn has_more_results(&self, total: usize) -> bool {
+        self.results_visible_limit < total
+    }
+
     pub fn select_source(&mut self, source: MediaSourceRef) -> bool {
         let changed = self.selected_source.as_ref() != Some(&source);
         self.selected_source = Some(source);

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -4,6 +4,7 @@ use super::default_drum_rack_pads;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::effect::{EffectType, ParamDescriptor};
@@ -117,6 +118,20 @@ pub struct SampleBrowserEntry {
     pub name: String,
     pub root_path: PathBuf,
     pub relative_path: PathBuf,
+    pub format: String,
+    pub file_size: Option<u64>,
+    pub modified: Option<SystemTime>,
+    pub search_text: String,
+}
+
+/// A read-only folder record in the Local Catalog. Roots remain configuration;
+/// these records only describe Source Storage for navigation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SampleBrowserFolder {
+    pub path: PathBuf,
+    pub root_path: PathBuf,
+    pub relative_path: PathBuf,
+    pub name: String,
     pub search_text: String,
 }
 

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -109,4 +109,21 @@ mod tests {
         let loaded: UiSettings = serde_json::from_str(&json).unwrap();
         assert_eq!(loaded.sample_browser_width, 612.0);
     }
+
+    #[test]
+    fn multiple_local_roots_roundtrip_in_ui_configuration() {
+        let roots = vec![
+            PathBuf::from("/samples/drums"),
+            PathBuf::from("/samples/field-recordings"),
+        ];
+        let settings = UiSettings {
+            sample_library_roots: roots.clone(),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&settings).unwrap();
+        let loaded: UiSettings = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(loaded.sample_library_roots, roots);
+    }
 }


### PR DESCRIPTION
## Demo outcome
Users can add and remove local roots, navigate their folder hierarchy through Places, inspect only child folders and supported media in Results, and search the selected subtree with an explicit widening path to the root or everywhere.

## Non-goals
- Filesystem watchers or incremental refresh
- Renaming, moving, or deleting source files
- Favorites, Recents, Crates, or archive browsing

## Verification
- `cargo test -p vibez-ui` — 129 passed
- `cargo clippy -p vibez-ui --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Read-only fixture proves unrelated files are excluded and equal bytes at different paths remain distinct Source Locations
- 2,000-file synthetic scan and bounded 200-row result windows
- Native QA at 300, 410, and 650 px browser widths; folder navigation and subtree search manually exercised

## Evidence
Screenshots and hashes are recorded in the private Card 05 Delivery record.

Depends on #52.