### PR TITLE
Browser Card 06: watch local roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,6 +1479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2247,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,6 +2383,26 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
 
 [[package]]
 name = "kurbo"
@@ -2649,6 +2698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2733,6 +2783,33 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -5128,6 +5205,7 @@ dependencies = [
  "base64",
  "dirs 5.0.1",
  "iced",
+ "notify",
  "rfd",
  "rtrb",
  "serde",
@@ -5763,6 +5841,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5809,11 +5896,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5835,6 +5939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5851,6 +5961,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5871,10 +5987,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5895,6 +6023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5911,6 +6045,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5931,6 +6071,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5947,6 +6093,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ iced = { version = "0.13", features = ["canvas", "tokio"] }
 serde = { version = "1", features = ["derive"] }
 base64 = "0.22"
 serde_json = "1"
+notify = "8.2"
 
 [package]
 name = "vibez"

--- a/crates/vibez-ui/Cargo.toml
+++ b/crates/vibez-ui/Cargo.toml
@@ -18,6 +18,7 @@ rtrb = { workspace = true }
 serde = { workspace = true }
 base64 = { workspace = true }
 serde_json = { workspace = true }
+notify = { workspace = true }
 rfd = "0.15"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync"] }
 x11rb = "0.13"

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -120,6 +120,33 @@ impl App {
         if action.expand_dropbox_root && self.dropbox_client.is_some() {
             return self.update(Message::DropboxExpandFolder(String::new()));
         }
+        if !action.debounce_root_scans.is_empty() {
+            return Task::batch(
+                action
+                    .debounce_root_scans
+                    .into_iter()
+                    .map(|(root, revision)| {
+                        Task::perform(
+                            async move {
+                                tokio::time::sleep(std::time::Duration::from_millis(180)).await;
+                                (root, revision)
+                            },
+                            |(root, revision)| {
+                                Message::Browser(BrowserMsg::ReconcileLocalRoot { root, revision })
+                            },
+                        )
+                    }),
+            );
+        }
+        if let Some((root, revision)) = action.scan_root {
+            return Task::perform(scan_sample_root_async(root.clone()), move |result| {
+                Message::Browser(BrowserMsg::LocalRootCatalogReconciled {
+                    root: root.clone(),
+                    revision,
+                    result,
+                })
+            });
+        }
         if let Some((track_id, beat, source)) = action.drop_on_arrangement {
             let position_samples = self.state.beats_to_samples(beat);
             return self.dispatch_drop_on_arrangement(track_id, position_samples, source);

--- a/crates/vibez-ui/src/app/audio_tasks.rs
+++ b/crates/vibez-ui/src/app/audio_tasks.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use vibez_core::id::ClipId;
 use vibez_core::track::MediaSourceRef;
 
+use crate::message::SampleLibraryScanResult;
 use crate::state::{SampleBrowserEntry, SampleBrowserFolder};
 
 pub(crate) struct AutoWarpInput {
@@ -192,6 +193,13 @@ pub(crate) fn scan_root_into(
             }
         };
         let path = item.path();
+        if path
+            .strip_prefix(root)
+            .ok()
+            .is_some_and(path_contains_hidden_component)
+        {
+            continue;
+        }
         let file_type = match item.file_type() {
             Ok(file_type) => file_type,
             Err(err) => {
@@ -265,6 +273,37 @@ pub(crate) fn scan_root_into(
             search_text,
         });
     }
+}
+
+pub(crate) fn scan_sample_root(root: &PathBuf) -> Result<SampleLibraryScanResult, String> {
+    if !root.is_dir() {
+        return Err(format!("Root is unavailable: {}", root.display()));
+    }
+    let mut entries = Vec::new();
+    let mut folders = Vec::new();
+    let mut warnings = Vec::new();
+    scan_root_into(root, root, &mut entries, &mut folders, &mut warnings);
+    entries.sort_by(|a, b| {
+        a.relative_path
+            .cmp(&b.relative_path)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    folders.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    Ok(SampleLibraryScanResult {
+        entries,
+        folders,
+        warnings,
+    })
+}
+
+pub(crate) fn path_contains_hidden_component(path: &std::path::Path) -> bool {
+    path.components().any(|component| {
+        let std::path::Component::Normal(name) = component else {
+            return false;
+        };
+        name.to_str()
+            .is_some_and(|name| name.starts_with('.') && name != "." && name != "..")
+    })
 }
 
 pub(crate) fn is_supported_audio_file(path: &std::path::Path) -> bool {
@@ -364,5 +403,44 @@ mod local_catalog_tests {
             "2,000-entry scan took {:?}",
             started.elapsed()
         );
+    }
+
+    #[test]
+    fn local_catalog_ignores_hidden_entries() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("Samples");
+        fs::create_dir_all(root.join(".cache")).unwrap();
+        fs::create_dir_all(root.join("Visible")).unwrap();
+        fs::write(root.join(".hidden.wav"), []).unwrap();
+        fs::write(root.join(".cache/inside.wav"), []).unwrap();
+        fs::write(root.join("Visible/keep.wav"), []).unwrap();
+
+        let catalog = scan_sample_root(&root).unwrap();
+
+        assert_eq!(catalog.entries.len(), 1);
+        assert_eq!(catalog.entries[0].name, "keep.wav");
+        assert_eq!(catalog.folders.len(), 1);
+        assert_eq!(catalog.folders[0].name, "Visible");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn local_catalog_does_not_follow_symlinks_outside_the_root() {
+        use std::os::unix::fs::symlink;
+
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("Samples");
+        let outside = temporary.path().join("Outside");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("escape.wav"), []).unwrap();
+        symlink(&outside, root.join("linked-outside")).unwrap();
+
+        let catalog = scan_sample_root(&root).unwrap();
+
+        assert!(catalog.entries.is_empty());
+        assert!(catalog.folders.is_empty());
+        assert_eq!(catalog.warnings.len(), 1);
+        assert!(catalog.warnings[0].contains("Skipped symbolic link"));
     }
 }

--- a/crates/vibez-ui/src/app/local_watcher.rs
+++ b/crates/vibez-ui/src/app/local_watcher.rs
@@ -1,0 +1,281 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use iced::futures::SinkExt;
+use iced::{stream, Subscription};
+use notify::{RecursiveMode, Watcher};
+
+use crate::domains::browser::BrowserMsg;
+use crate::message::{LocalRootWatchEvent, Message};
+
+pub(super) fn subscription(roots: Vec<PathBuf>) -> Subscription<Message> {
+    if roots.is_empty() {
+        return Subscription::none();
+    }
+
+    let identity = ("local-root-watcher", roots.clone());
+    let events = stream::channel(128, move |mut output| async move {
+        let (sender, mut receiver) =
+            tokio::sync::mpsc::unbounded_channel::<notify::Result<notify::Event>>();
+        let mut watcher = match notify::recommended_watcher(move |event| {
+            let _ = sender.send(event);
+        }) {
+            Ok(watcher) => watcher,
+            Err(error) => {
+                let _ = output
+                    .send(Message::Browser(BrowserMsg::LocalRootWatchEvent(
+                        LocalRootWatchEvent::Failed {
+                            roots,
+                            message: error.to_string(),
+                        },
+                    )))
+                    .await;
+                std::future::pending::<()>().await;
+                return;
+            }
+        };
+
+        let mut watched_parents = HashSet::new();
+        for parent in roots.iter().filter_map(|root| root.parent()) {
+            if watched_parents.insert(parent.to_path_buf()) {
+                if let Err(error) = watcher.watch(parent, RecursiveMode::NonRecursive) {
+                    let affected = roots
+                        .iter()
+                        .filter(|root| root.parent() == Some(parent))
+                        .cloned()
+                        .collect();
+                    let _ = output
+                        .send(Message::Browser(BrowserMsg::LocalRootWatchEvent(
+                            LocalRootWatchEvent::Failed {
+                                roots: affected,
+                                message: error.to_string(),
+                            },
+                        )))
+                        .await;
+                }
+            }
+        }
+
+        let mut watched_roots = HashSet::new();
+        attach_available_roots(&roots, &mut watched_roots, &mut watcher, &mut output).await;
+
+        while let Some(event) = receiver.recv().await {
+            match event {
+                Ok(event) => {
+                    if !is_catalog_event(&event.kind) {
+                        continue;
+                    }
+                    let affected = affected_roots(&roots, &event.paths);
+                    refresh_root_watches(&roots, &mut watched_roots, &mut watcher, &mut output)
+                        .await;
+                    if !affected.is_empty() {
+                        let _ = output
+                            .send(Message::Browser(BrowserMsg::LocalRootWatchEvent(
+                                LocalRootWatchEvent::Changed(affected),
+                            )))
+                            .await;
+                    }
+                }
+                Err(error) => {
+                    let affected = if error.paths.is_empty() {
+                        roots.clone()
+                    } else {
+                        affected_roots(&roots, &error.paths)
+                    };
+                    if !affected.is_empty() {
+                        let _ = output
+                            .send(Message::Browser(BrowserMsg::LocalRootWatchEvent(
+                                LocalRootWatchEvent::Failed {
+                                    roots: affected,
+                                    message: error.to_string(),
+                                },
+                            )))
+                            .await;
+                    }
+                }
+            }
+        }
+    });
+
+    Subscription::run_with_id(identity, events)
+}
+
+fn is_catalog_event(kind: &notify::EventKind) -> bool {
+    use notify::event::ModifyKind;
+    use notify::EventKind;
+
+    matches!(
+        kind,
+        EventKind::Any
+            | EventKind::Create(_)
+            | EventKind::Remove(_)
+            | EventKind::Modify(ModifyKind::Any | ModifyKind::Data(_) | ModifyKind::Name(_))
+    )
+}
+
+async fn attach_available_roots(
+    roots: &[PathBuf],
+    watched_roots: &mut HashSet<PathBuf>,
+    watcher: &mut notify::RecommendedWatcher,
+    output: &mut iced::futures::channel::mpsc::Sender<Message>,
+) {
+    let mut watching = Vec::new();
+    for root in roots {
+        if !root.is_dir() || watched_roots.contains(root) {
+            continue;
+        }
+        match watcher.watch(root, RecursiveMode::Recursive) {
+            Ok(()) => {
+                watched_roots.insert(root.clone());
+                watching.push(root.clone());
+            }
+            Err(error) => {
+                let _ = output
+                    .send(Message::Browser(BrowserMsg::LocalRootWatchEvent(
+                        LocalRootWatchEvent::Failed {
+                            roots: vec![root.clone()],
+                            message: error.to_string(),
+                        },
+                    )))
+                    .await;
+            }
+        }
+    }
+    if !watching.is_empty() {
+        let _ = output
+            .send(Message::Browser(BrowserMsg::LocalRootWatchEvent(
+                LocalRootWatchEvent::Watching(watching),
+            )))
+            .await;
+    }
+}
+
+async fn refresh_root_watches(
+    roots: &[PathBuf],
+    watched_roots: &mut HashSet<PathBuf>,
+    watcher: &mut notify::RecommendedWatcher,
+    output: &mut iced::futures::channel::mpsc::Sender<Message>,
+) {
+    let unavailable: Vec<_> = watched_roots
+        .iter()
+        .filter(|root| !root.is_dir())
+        .cloned()
+        .collect();
+    for root in unavailable {
+        let _ = watcher.unwatch(&root);
+        watched_roots.remove(&root);
+    }
+    attach_available_roots(roots, watched_roots, watcher, output).await;
+}
+
+pub(crate) fn affected_roots(roots: &[PathBuf], paths: &[PathBuf]) -> Vec<PathBuf> {
+    roots
+        .iter()
+        .filter(|root| {
+            paths.is_empty()
+                || paths.iter().any(|path| {
+                    path_affects_root(root, path) && !is_hidden_beneath_root(root, path)
+                })
+        })
+        .cloned()
+        .collect()
+}
+
+fn path_affects_root(root: &Path, path: &Path) -> bool {
+    path.starts_with(root) || root.starts_with(path)
+}
+
+fn is_hidden_beneath_root(root: &Path, path: &Path) -> bool {
+    path.strip_prefix(root)
+        .ok()
+        .is_some_and(super::audio_tasks::path_contains_hidden_component)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn affected_roots_ignore_hidden_paths_and_unrelated_siblings() {
+        let roots = vec![PathBuf::from("/samples"), PathBuf::from("/other")];
+        assert_eq!(
+            affected_roots(&roots, &[PathBuf::from("/samples/drums/kick.wav")]),
+            vec![PathBuf::from("/samples")]
+        );
+        assert!(affected_roots(&roots, &[PathBuf::from("/samples/.cache/a.wav")]).is_empty());
+        assert!(affected_roots(&roots, &[PathBuf::from("/sibling/a.wav")]).is_empty());
+    }
+
+    #[test]
+    fn watcher_ignores_access_and_metadata_noise_from_catalog_reads() {
+        use notify::event::{AccessKind, AccessMode, MetadataKind, ModifyKind};
+
+        assert!(!is_catalog_event(&notify::EventKind::Access(
+            AccessKind::Open(AccessMode::Read)
+        )));
+        assert!(!is_catalog_event(&notify::EventKind::Modify(
+            ModifyKind::Metadata(MetadataKind::AccessTime)
+        )));
+        assert!(is_catalog_event(&notify::EventKind::Create(
+            notify::event::CreateKind::File
+        )));
+        assert!(is_catalog_event(&notify::EventKind::Modify(
+            ModifyKind::Name(notify::event::RenameMode::Both)
+        )));
+    }
+
+    #[test]
+    fn recursive_watcher_observes_create_rename_move_delete_and_bursts() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("Samples");
+        let drums = root.join("Drums");
+        let bass = root.join("Bass");
+        fs::create_dir_all(&drums).unwrap();
+        fs::create_dir_all(&bass).unwrap();
+        let (sender, receiver) = mpsc::channel();
+        let mut watcher = notify::recommended_watcher(sender).unwrap();
+        watcher.watch(&root, RecursiveMode::Recursive).unwrap();
+
+        let created = drums.join("kick.wav");
+        fs::write(&created, b"kick").unwrap();
+        wait_for_path(&receiver, &created);
+
+        let renamed = drums.join("kick-02.wav");
+        fs::rename(&created, &renamed).unwrap();
+        wait_for_path(&receiver, &renamed);
+
+        let moved = bass.join("kick-02.wav");
+        fs::rename(&renamed, &moved).unwrap();
+        wait_for_path(&receiver, &moved);
+
+        for index in 0..20 {
+            fs::write(bass.join(format!("burst-{index}.wav")), []).unwrap();
+        }
+        wait_for_path(&receiver, &bass.join("burst-19.wav"));
+
+        fs::remove_file(&moved).unwrap();
+        wait_for_path(&receiver, &moved);
+
+        let final_catalog = super::super::audio_tasks::scan_sample_root(&root).unwrap();
+        assert_eq!(final_catalog.entries.len(), 20);
+        assert!(final_catalog
+            .entries
+            .iter()
+            .all(|entry| entry.name.starts_with("burst-")));
+    }
+
+    fn wait_for_path(receiver: &mpsc::Receiver<notify::Result<notify::Event>>, expected: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let event = receiver.recv_timeout(remaining).unwrap().unwrap();
+            if event.paths.iter().any(|path| path == expected) {
+                return;
+            }
+        }
+        panic!("watcher did not report {}", expected.display());
+    }
+}

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -108,6 +108,7 @@ mod actions;
 mod audio_tasks;
 mod bounce;
 mod keyboard;
+mod local_watcher;
 
 pub(crate) use audio_tasks::*;
 pub(crate) use keyboard::*;
@@ -244,15 +245,17 @@ impl App {
         // the first frame.
         app.ensure_master_eq();
 
-        let startup_task = if app.state.browser.roots.is_empty() {
-            Task::none()
-        } else {
-            app.state.browser.scan_in_progress = true;
-            Task::perform(
-                scan_sample_library_async(app.state.browser.roots.clone()),
-                |r| Message::Browser(BrowserMsg::SampleLibraryScanned(r)),
-            )
-        };
+        let roots = app.state.browser.roots.clone();
+        let startup_task = Task::batch(roots.into_iter().map(|root| {
+            let revision = app.state.browser.begin_root_scan(&root, false);
+            Task::perform(scan_sample_root_async(root.clone()), move |result| {
+                Message::Browser(BrowserMsg::LocalRootCatalogReconciled {
+                    root: root.clone(),
+                    revision,
+                    result,
+                })
+            })
+        }));
 
         // `vibez <project.vzp>` opens a project straight from the
         // command line (also how file-manager associations launch
@@ -353,6 +356,7 @@ impl App {
     fn subscription(&self) -> Subscription<Message> {
         Subscription::batch([
             iced::time::every(std::time::Duration::from_millis(UI_TICK_MS)).map(|_| Message::Tick),
+            local_watcher::subscription(self.state.browser.roots.clone()),
             iced::keyboard::on_key_press(global_key_handler),
             iced::event::listen_with(|event, _status, _id| match event {
                 iced::Event::Mouse(iced::mouse::Event::CursorMoved { position }) => {
@@ -761,37 +765,8 @@ async fn hydrate_dropbox_source(
         .map_err(|e| format!("Skipped '{label}' ({e})"))
 }
 
-async fn scan_sample_library_async(roots: Vec<PathBuf>) -> Result<SampleLibraryScanResult, String> {
-    tokio::task::spawn_blocking(move || {
-        let mut entries = Vec::new();
-        let mut folders = Vec::new();
-        let mut warnings = Vec::new();
-
-        for root in roots {
-            if !root.is_dir() {
-                warnings.push(format!("Missing root: {}", root.display()));
-                continue;
-            }
-            scan_root_into(&root, &root, &mut entries, &mut folders, &mut warnings);
-        }
-
-        entries.sort_by(|a, b| {
-            a.relative_path
-                .cmp(&b.relative_path)
-                .then_with(|| a.name.cmp(&b.name))
-        });
-        folders.sort_by(|a, b| {
-            a.root_path
-                .cmp(&b.root_path)
-                .then_with(|| a.relative_path.cmp(&b.relative_path))
-        });
-
-        Ok(SampleLibraryScanResult {
-            entries,
-            folders,
-            warnings,
-        })
-    })
-    .await
-    .map_err(|err| format!("scan task failed: {err}"))?
+async fn scan_sample_root_async(root: PathBuf) -> Result<SampleLibraryScanResult, String> {
+    tokio::task::spawn_blocking(move || scan_sample_root(&root))
+        .await
+        .map_err(|err| format!("scan task failed: {err}"))?
 }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -534,25 +534,30 @@ impl App {
                         self.persist_ui_settings();
                     }
                     self.state.browser.select_local_folder(Some(path.clone()));
-                    self.state.browser.scan_in_progress = true;
-                    self.state.browser.scan_error = None;
-                    self.state.browser.scan_warnings.clear();
+                    let revision = self.state.browser.begin_root_scan(&path, false);
                     self.state.status_text = format!("Scanning {}...", path.display());
-                    return Task::perform(
-                        scan_sample_library_async(self.state.browser.roots.clone()),
-                        |r| Message::Browser(BrowserMsg::SampleLibraryScanned(r)),
-                    );
+                    return Task::perform(scan_sample_root_async(path.clone()), move |result| {
+                        Message::Browser(BrowserMsg::LocalRootCatalogReconciled {
+                            root: path.clone(),
+                            revision,
+                            result,
+                        })
+                    });
                 }
             }
             Message::RescanSampleLibrary => {
-                self.state.browser.scan_in_progress = true;
-                self.state.browser.scan_error = None;
-                self.state.browser.scan_warnings.clear();
                 self.state.status_text = "Rescanning sample library...".to_string();
-                return Task::perform(
-                    scan_sample_library_async(self.state.browser.roots.clone()),
-                    |r| Message::Browser(BrowserMsg::SampleLibraryScanned(r)),
-                );
+                let roots = self.state.browser.roots.clone();
+                return Task::batch(roots.into_iter().map(|root| {
+                    let revision = self.state.browser.begin_root_scan(&root, false);
+                    Task::perform(scan_sample_root_async(root.clone()), move |result| {
+                        Message::Browser(BrowserMsg::LocalRootCatalogReconciled {
+                            root: root.clone(),
+                            revision,
+                            result,
+                        })
+                    })
+                }));
             }
             Message::ClickLocalBrowserEntry(source) => {
                 // Card 07 owns selection-driven Audition. For now click only

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -264,8 +264,21 @@ impl App {
                 )))
                 .padding([4, 2])
                 .style(browser_utility_action_style);
+            let root_state = self.state.browser.root_catalog_label(root);
+            let state_marker = text(match root_state {
+                "INDEXING" | "UPDATING" => "↻",
+                "STALE" | "WATCH ERR" => "!",
+                "WARN" => "!",
+                _ => "·",
+            })
+            .size(9)
+            .color(if matches!(root_state, "STALE" | "WATCH ERR" | "WARN") {
+                th::danger()
+            } else {
+                th::text_muted()
+            });
             local_tree_rows.push(
-                row![toggle, root_button, remove]
+                row![toggle, root_button, state_marker, remove]
                     .spacing(1)
                     .align_y(iced::Alignment::Center)
                     .into(),
@@ -657,27 +670,40 @@ impl App {
         let mut remaining = visible_results;
         let mut entries_col = column![].spacing(1);
 
-        if let Some(error) = &self.state.browser.scan_error {
+        let notice = self
+            .state
+            .browser
+            .current_local_root()
+            .and_then(|root| {
+                self.state
+                    .browser
+                    .root_catalog_message(root)
+                    .map(|message| (root, message))
+            })
+            .or_else(|| {
+                self.state.browser.roots.iter().find_map(|root| {
+                    self.state
+                        .browser
+                        .root_catalog_message(root)
+                        .map(|message| (root, message))
+                })
+            });
+        if let Some((root, message)) = &notice {
             entries_col = entries_col.push(
                 container(
-                    text(format!("INDEX ERROR · {error}"))
+                    text(format!("{} · {message}", browser_root_name(root)))
                         .size(9)
-                        .color(th::danger())
+                        .color(
+                            if matches!(
+                                self.state.browser.root_catalog_label(root),
+                                "STALE" | "WATCH ERR" | "WARN"
+                            ) {
+                                th::danger()
+                            } else {
+                                th::text_dim()
+                            },
+                        )
                         .wrapping(iced::widget::text::Wrapping::None),
-                )
-                .padding([6, 8]),
-            );
-        } else if let Some(first_warning) = self.state.browser.scan_warnings.first() {
-            entries_col = entries_col.push(
-                container(
-                    text(format!(
-                        "WARN {} · {}",
-                        self.state.browser.scan_warnings.len(),
-                        first_warning
-                    ))
-                    .size(9)
-                    .color(th::danger())
-                    .wrapping(iced::widget::text::Wrapping::None),
                 )
                 .padding([6, 8]),
             );
@@ -688,7 +714,7 @@ impl App {
                 .push(self.view_local_folder_result(
                     browser_root_name(root),
                     format!("LOCAL ROOT · {}", root.display()),
-                    "ROOT",
+                    self.state.browser.root_catalog_label(root).to_string(),
                     root.clone(),
                     wide_columns,
                 ))
@@ -705,7 +731,7 @@ impl App {
                         "FOLDER",
                         None,
                     ),
-                    "FOLDER",
+                    "FOLDER".into(),
                     folder.path.clone(),
                     wide_columns,
                 ))
@@ -798,7 +824,7 @@ impl App {
             entries_col = entries_col.push(flat_row).push(browser_row_divider());
         }
 
-        if total_results == 0 && self.state.browser.scan_error.is_none() {
+        if total_results == 0 && notice.is_none() {
             entries_col = entries_col.push(
                 container(
                     text(if searching {
@@ -834,7 +860,7 @@ impl App {
         let count = if self.state.browser.scan_in_progress {
             format!("INDEXING… · {}", self.state.browser.entries.len())
         } else if self.state.browser.scan_error.is_some() {
-            "INDEX ERROR".into()
+            "STALE".into()
         } else if self.state.browser.scan_warnings.is_empty() {
             format!("{visible_results} / {total_results}")
         } else {
@@ -880,7 +906,7 @@ impl App {
         &self,
         name: String,
         context: String,
-        status: &'static str,
+        status: String,
         destination: std::path::PathBuf,
         wide_columns: bool,
     ) -> Element<'_, Message> {

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -11,8 +11,8 @@ use vibez_core::id::TrackId;
 use vibez_core::track::MediaSourceRef;
 use vibez_dropbox::DropboxEntry;
 
-use crate::message::SampleLibraryScanResult;
-use crate::state::{BrowserState, SampleBrowserMode};
+use crate::message::{LocalRootWatchEvent, SampleLibraryScanResult};
+use crate::state::{BrowserState, LocalRootCatalogState, SampleBrowserMode};
 
 /// Messages the browser domain handles (sync tranche).
 #[derive(Debug, Clone)]
@@ -40,7 +40,16 @@ pub enum BrowserMsg {
         beat: f64,
     },
     EndDragSample,
-    SampleLibraryScanned(Result<SampleLibraryScanResult, String>),
+    LocalRootWatchEvent(LocalRootWatchEvent),
+    ReconcileLocalRoot {
+        root: PathBuf,
+        revision: u64,
+    },
+    LocalRootCatalogReconciled {
+        root: PathBuf,
+        revision: u64,
+        result: Result<SampleLibraryScanResult, String>,
+    },
     RemoveSampleLibraryRoot(PathBuf),
     DropboxCollapseFolder(String),
     DropboxSelectEntry(DropboxEntry),
@@ -64,6 +73,10 @@ pub struct BrowserAction {
     /// Decode a Local selection for the truthful Audition waveform without
     /// starting playback.
     pub load_waveform: Option<MediaSourceRef>,
+    /// Debounce filesystem activity before asking the domain to reconcile.
+    pub debounce_root_scans: Vec<(PathBuf, u64)>,
+    /// The newest debounce token for this root matured and may be scanned.
+    pub scan_root: Option<(PathBuf, u64)>,
 }
 
 impl BrowserState {
@@ -155,20 +168,74 @@ impl BrowserState {
                     action.status = Some("Drag cancelled".to_string());
                 }
             }
-            BrowserMsg::SampleLibraryScanned(result) => {
-                self.scan_in_progress = false;
+            BrowserMsg::LocalRootWatchEvent(event) => match event {
+                LocalRootWatchEvent::Changed(roots) => {
+                    for root in roots {
+                        if self.roots.iter().any(|configured| configured == &root) {
+                            let revision = self.begin_root_scan(&root, true);
+                            action.debounce_root_scans.push((root, revision));
+                        }
+                    }
+                }
+                LocalRootWatchEvent::Watching(roots) => {
+                    for root in roots {
+                        self.root_watch_errors.remove(&root);
+                    }
+                    self.refresh_scan_diagnostics();
+                }
+                LocalRootWatchEvent::Failed { roots, message } => {
+                    for root in roots {
+                        if self.roots.iter().any(|configured| configured == &root) {
+                            self.root_watch_errors.insert(root, message.clone());
+                        }
+                    }
+                    self.refresh_scan_diagnostics();
+                    action.status = Some(format!("Local watch error: {message}"));
+                }
+            },
+            BrowserMsg::ReconcileLocalRoot { root, revision } => {
+                if self.root_refresh_is_current(&root, revision) {
+                    action.scan_root = Some((root, revision));
+                }
+            }
+            BrowserMsg::LocalRootCatalogReconciled {
+                root,
+                revision,
+                result,
+            } => {
+                if !self.root_refresh_is_current(&root, revision) {
+                    return action;
+                }
                 match result {
                     Ok(scan) => {
-                        self.entries = scan.entries;
-                        self.folders = scan.folders;
-                        self.scan_warnings = scan.warnings;
-                        self.scan_error = None;
+                        self.entries.retain(|entry| entry.root_path != root);
+                        self.entries.extend(scan.entries);
+                        self.entries.sort_by(|a, b| {
+                            a.root_path
+                                .cmp(&b.root_path)
+                                .then_with(|| a.relative_path.cmp(&b.relative_path))
+                        });
+                        self.folders.retain(|folder| folder.root_path != root);
+                        self.folders.extend(scan.folders);
+                        self.folders.sort_by(|a, b| {
+                            a.root_path
+                                .cmp(&b.root_path)
+                                .then_with(|| a.relative_path.cmp(&b.relative_path))
+                        });
+                        let warning_count = scan.warnings.len();
+                        self.root_catalog_states.insert(
+                            root.clone(),
+                            LocalRootCatalogState::Ready {
+                                warnings: scan.warnings,
+                            },
+                        );
+                        self.reset_results_window();
                         let current_exists = self.current_folder.as_ref().is_none_or(|current| {
                             self.roots.iter().any(|root| root == current)
                                 || self.folders.iter().any(|folder| &folder.path == current)
                         });
                         if !current_exists {
-                            self.select_local_folder(None);
+                            self.select_local_folder(Some(root.clone()));
                         }
                         if self
                             .selected_source
@@ -180,19 +247,33 @@ impl BrowserState {
                         {
                             self.clear_selection();
                         }
-                        action.status = Some(if self.scan_warnings.is_empty() {
-                            format!("Indexed {} samples", self.entries.len())
+                        self.refresh_scan_diagnostics();
+                        let root_count = self
+                            .entries
+                            .iter()
+                            .filter(|entry| entry.root_path == root)
+                            .count();
+                        action.status = Some(if warning_count == 0 {
+                            format!("Indexed {root_count} samples in {}", root.display())
                         } else {
                             format!(
-                                "Indexed {} samples with {} warning(s)",
-                                self.entries.len(),
-                                self.scan_warnings.len()
+                                "Indexed {root_count} samples in {} with {warning_count} warning(s)",
+                                root.display()
                             )
                         });
                     }
-                    Err(err) => {
-                        self.scan_error = Some(err.clone());
-                        action.status = Some(format!("Sample scan error: {err}"));
+                    Err(error) => {
+                        self.root_catalog_states.insert(
+                            root.clone(),
+                            LocalRootCatalogState::Stale {
+                                error: error.clone(),
+                            },
+                        );
+                        self.refresh_scan_diagnostics();
+                        action.status = Some(format!(
+                            "Local root unavailable; kept stale catalog for {} ({error})",
+                            root.display()
+                        ));
                     }
                 }
             }
@@ -209,8 +290,12 @@ impl BrowserState {
                 self.folders.retain(|folder| folder.root_path != path);
                 self.expanded_local_folders
                     .retain(|folder| !folder.starts_with(&path));
+                self.root_catalog_states.remove(&path);
+                self.root_refresh_revisions.remove(&path);
+                self.root_watch_errors.remove(&path);
                 self.scan_warnings.clear();
                 self.scan_error = None;
+                self.refresh_scan_diagnostics();
                 if self
                     .selected_source
                     .as_ref()
@@ -420,36 +505,189 @@ mod tests {
 
     #[test]
     fn scan_completion_and_failure_remain_visible_in_browser_state() {
+        let root = PathBuf::from("/samples");
         let mut browser = BrowserState {
-            scan_in_progress: true,
+            roots: vec![root.clone()],
             ..BrowserState::default()
         };
+        let revision = browser.begin_root_scan(&root, false);
         let folder = crate::state::SampleBrowserFolder {
             path: PathBuf::from("/samples/drums"),
-            root_path: PathBuf::from("/samples"),
+            root_path: root.clone(),
             relative_path: PathBuf::from("drums"),
             name: "drums".into(),
             search_text: "drums".into(),
         };
 
-        browser.update(BrowserMsg::SampleLibraryScanned(Ok(
-            crate::message::SampleLibraryScanResult {
+        browser.update(BrowserMsg::LocalRootCatalogReconciled {
+            root: root.clone(),
+            revision,
+            result: Ok(crate::message::SampleLibraryScanResult {
                 entries: Vec::new(),
                 folders: vec![folder.clone()],
                 warnings: vec!["Unreadable folder".into()],
-            },
-        )));
+            }),
+        });
         assert!(!browser.scan_in_progress);
         assert_eq!(browser.folders, vec![folder]);
         assert_eq!(browser.scan_warnings, vec!["Unreadable folder"]);
         assert!(browser.scan_error.is_none());
 
-        browser.scan_in_progress = true;
-        browser.update(BrowserMsg::SampleLibraryScanned(Err(
-            "catalog failed".into()
-        )));
+        let revision = browser.begin_root_scan(&root, false);
+        browser.update(BrowserMsg::LocalRootCatalogReconciled {
+            root,
+            revision,
+            result: Err("catalog failed".into()),
+        });
         assert!(!browser.scan_in_progress);
         assert_eq!(browser.scan_error.as_deref(), Some("catalog failed"));
+        assert_eq!(browser.folders.len(), 1, "stale catalog must be retained");
+    }
+
+    #[test]
+    fn watcher_bursts_only_reconcile_the_latest_root_revision() {
+        let root = PathBuf::from("/samples");
+        let mut browser = BrowserState {
+            roots: vec![root.clone()],
+            ..BrowserState::default()
+        };
+
+        let first = browser.update(BrowserMsg::LocalRootWatchEvent(
+            crate::message::LocalRootWatchEvent::Changed(vec![root.clone()]),
+        ));
+        let second = browser.update(BrowserMsg::LocalRootWatchEvent(
+            crate::message::LocalRootWatchEvent::Changed(vec![root.clone()]),
+        ));
+        let first_revision = first.debounce_root_scans[0].1;
+        let second_revision = second.debounce_root_scans[0].1;
+        assert!(second_revision > first_revision);
+
+        let stale = browser.update(BrowserMsg::ReconcileLocalRoot {
+            root: root.clone(),
+            revision: first_revision,
+        });
+        assert!(stale.scan_root.is_none());
+        let current = browser.update(BrowserMsg::ReconcileLocalRoot {
+            root: root.clone(),
+            revision: second_revision,
+        });
+        assert_eq!(current.scan_root, Some((root, second_revision)));
+    }
+
+    #[test]
+    fn watcher_failures_are_scoped_to_the_affected_root() {
+        let samples = PathBuf::from("/samples");
+        let other = PathBuf::from("/other");
+        let mut browser = BrowserState {
+            roots: vec![samples.clone(), other.clone()],
+            ..BrowserState::default()
+        };
+
+        browser.update(BrowserMsg::LocalRootWatchEvent(
+            crate::message::LocalRootWatchEvent::Failed {
+                roots: vec![samples.clone()],
+                message: "watch limit reached".into(),
+            },
+        ));
+
+        assert_eq!(browser.root_catalog_label(&samples), "WATCH ERR");
+        assert_eq!(browser.root_catalog_label(&other), "PENDING");
+        assert!(browser.root_catalog_message(&samples).is_some());
+        assert!(browser.root_catalog_message(&other).is_none());
+    }
+
+    #[test]
+    fn affected_root_reconciliation_preserves_other_catalogs_and_updates_search() {
+        fn entry(root: &PathBuf, name: &str) -> crate::state::SampleBrowserEntry {
+            crate::state::SampleBrowserEntry {
+                source: MediaSourceRef::LocalFile {
+                    path: root.join(name),
+                },
+                name: name.into(),
+                root_path: root.clone(),
+                relative_path: PathBuf::from(name),
+                format: "WAV".into(),
+                file_size: Some(1),
+                modified: None,
+                search_text: name.to_lowercase(),
+            }
+        }
+
+        let samples = PathBuf::from("/samples");
+        let other = PathBuf::from("/other");
+        let mut browser = BrowserState {
+            roots: vec![samples.clone(), other.clone()],
+            entries: vec![entry(&samples, "old.wav"), entry(&other, "keep.wav")],
+            ..BrowserState::default()
+        };
+        let revision = browser.begin_root_scan(&samples, true);
+
+        browser.update(BrowserMsg::LocalRootCatalogReconciled {
+            root: samples.clone(),
+            revision,
+            result: Ok(crate::message::SampleLibraryScanResult {
+                entries: vec![entry(&samples, "new.wav")],
+                folders: Vec::new(),
+                warnings: Vec::new(),
+            }),
+        });
+
+        assert!(browser.entries.iter().any(|entry| entry.name == "new.wav"));
+        assert!(browser.entries.iter().any(|entry| entry.name == "keep.wav"));
+        assert!(!browser.entries.iter().any(|entry| entry.name == "old.wav"));
+        browser.select_local_folder(Some(samples));
+        assert!(browser.local_entry_is_result(
+            browser
+                .entries
+                .iter()
+                .find(|entry| entry.name == "new.wav")
+                .unwrap(),
+            "new"
+        ));
+    }
+
+    #[test]
+    fn manual_rescan_repairs_a_stale_root_without_discarding_old_data_first() {
+        let root = PathBuf::from("/samples");
+        let mut browser = BrowserState {
+            roots: vec![root.clone()],
+            entries: vec![crate::state::SampleBrowserEntry {
+                source: MediaSourceRef::LocalFile {
+                    path: root.join("old.wav"),
+                },
+                name: "old.wav".into(),
+                root_path: root.clone(),
+                relative_path: PathBuf::from("old.wav"),
+                format: "WAV".into(),
+                file_size: Some(1),
+                modified: None,
+                search_text: "old.wav".into(),
+            }],
+            ..BrowserState::default()
+        };
+        let revision = browser.begin_root_scan(&root, true);
+        browser.update(BrowserMsg::LocalRootCatalogReconciled {
+            root: root.clone(),
+            revision,
+            result: Err("offline".into()),
+        });
+        assert_eq!(browser.root_catalog_label(&root), "STALE");
+        assert_eq!(browser.entries.len(), 1);
+
+        let revision = browser.begin_root_scan(&root, false);
+        browser.update(BrowserMsg::LocalRootCatalogReconciled {
+            root: root.clone(),
+            revision,
+            result: Ok(crate::message::SampleLibraryScanResult {
+                entries: Vec::new(),
+                folders: Vec::new(),
+                warnings: Vec::new(),
+            }),
+        });
+
+        assert_eq!(browser.root_catalog_label(&root), "READY");
+        assert!(browser.entries.is_empty());
+        assert!(browser.scan_error.is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -60,6 +60,16 @@ pub struct SampleLibraryScanResult {
 }
 
 #[derive(Debug, Clone)]
+pub enum LocalRootWatchEvent {
+    Changed(Vec<PathBuf>),
+    Watching(Vec<PathBuf>),
+    Failed {
+        roots: Vec<PathBuf>,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone)]
 pub struct BounceOutcome {
     pub audio: Arc<DecodedAudio>,
     pub source: MediaSourceRef,

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 mod ui_types;
@@ -230,6 +230,30 @@ pub enum BrowserSearchScope {
     Everywhere,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalRootCatalogState {
+    Indexing,
+    Updating,
+    Ready { warnings: Vec<String> },
+    Stale { error: String },
+}
+
+impl LocalRootCatalogState {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Indexing => "INDEXING",
+            Self::Updating => "UPDATING",
+            Self::Ready { warnings } if warnings.is_empty() => "READY",
+            Self::Ready { .. } => "WARN",
+            Self::Stale { .. } => "STALE",
+        }
+    }
+
+    pub fn is_busy(&self) -> bool {
+        matches!(self, Self::Indexing | Self::Updating)
+    }
+}
+
 /// Browser domain slice: sample library, Dropbox browsing, and
 /// drag-and-drop from the browser into the arrangement.
 #[derive(Debug, Clone)]
@@ -249,6 +273,9 @@ pub struct BrowserState {
     pub expanded_local_folders: HashSet<PathBuf>,
     pub search_scope: BrowserSearchScope,
     pub results_visible_limit: usize,
+    pub root_catalog_states: HashMap<PathBuf, LocalRootCatalogState>,
+    pub root_refresh_revisions: HashMap<PathBuf, u64>,
+    pub root_watch_errors: HashMap<PathBuf, String>,
     pub scan_warnings: Vec<String>,
     pub scan_error: Option<String>,
     pub selected_source: Option<MediaSourceRef>,
@@ -284,6 +311,9 @@ impl Default for BrowserState {
             expanded_local_folders: HashSet::new(),
             search_scope: BrowserSearchScope::default(),
             results_visible_limit: BROWSER_RESULTS_PAGE_SIZE,
+            root_catalog_states: HashMap::new(),
+            root_refresh_revisions: HashMap::new(),
+            root_watch_errors: HashMap::new(),
             scan_warnings: Vec::new(),
             scan_error: None,
             selected_source: None,
@@ -303,6 +333,81 @@ impl Default for BrowserState {
 }
 
 impl BrowserState {
+    pub fn begin_root_scan(&mut self, root: &Path, from_watcher: bool) -> u64 {
+        let revision = *self
+            .root_refresh_revisions
+            .entry(root.to_path_buf())
+            .and_modify(|revision| *revision = revision.saturating_add(1))
+            .or_insert(1);
+        self.root_catalog_states.insert(
+            root.to_path_buf(),
+            if from_watcher {
+                LocalRootCatalogState::Updating
+            } else {
+                LocalRootCatalogState::Indexing
+            },
+        );
+        self.refresh_scan_diagnostics();
+        revision
+    }
+
+    pub fn root_refresh_is_current(&self, root: &Path, revision: u64) -> bool {
+        self.roots.iter().any(|configured| configured == root)
+            && self.root_refresh_revisions.get(root).copied() == Some(revision)
+    }
+
+    pub fn root_catalog_label(&self, root: &Path) -> &'static str {
+        if self.root_watch_errors.contains_key(root) {
+            "WATCH ERR"
+        } else {
+            self.root_catalog_states
+                .get(root)
+                .map(LocalRootCatalogState::label)
+                .unwrap_or("PENDING")
+        }
+    }
+
+    pub fn root_catalog_message(&self, root: &Path) -> Option<String> {
+        if let Some(error) = self.root_watch_errors.get(root) {
+            return Some(format!("WATCH ERROR · {error}"));
+        }
+        match self.root_catalog_states.get(root) {
+            Some(LocalRootCatalogState::Indexing) => Some("INDEXING LOCAL ROOT…".into()),
+            Some(LocalRootCatalogState::Updating) => Some("UPDATING LOCAL ROOT…".into()),
+            Some(LocalRootCatalogState::Ready { warnings }) if !warnings.is_empty() => {
+                Some(format!("WARN {} · {}", warnings.len(), warnings[0]))
+            }
+            Some(LocalRootCatalogState::Stale { error }) => {
+                Some(format!("STALE · {error} · RESCAN TO REPAIR"))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn refresh_scan_diagnostics(&mut self) {
+        self.scan_in_progress = self
+            .root_catalog_states
+            .values()
+            .any(LocalRootCatalogState::is_busy);
+        self.scan_warnings = self
+            .root_catalog_states
+            .values()
+            .filter_map(|state| match state {
+                LocalRootCatalogState::Ready { warnings } => Some(warnings.as_slice()),
+                _ => None,
+            })
+            .flatten()
+            .cloned()
+            .collect();
+        self.scan_error = self
+            .root_catalog_states
+            .values()
+            .find_map(|state| match state {
+                LocalRootCatalogState::Stale { error } => Some(error.clone()),
+                _ => None,
+            });
+    }
+
     pub fn reset_results_window(&mut self) {
         self.results_visible_limit = BROWSER_RESULTS_PAGE_SIZE;
     }


### PR DESCRIPTION
## Demo outcome
Creating, renaming, moving, or deleting supported media beneath a configured Local Root updates the Browser automatically without pressing Rescan.

## Non-goals
- Advanced exclusion patterns or hidden-file preferences
- Remote Catalog refresh
- Source Storage mutation by Vibez

## Implementation
- Recursive `notify` watcher per available root plus parent recovery watches
- 180 ms revision debounce; only the newest event burst scans the affected root
- Per-root INDEXING/UPDATING/READY/WARN/STALE/WATCH ERR state
- Stale catalogs remain browsable while an unavailable root is repaired or restored
- Hidden entries and symlink escapes are excluded
- Manual Rescan remains an explicit per-root repair path

## Verification
- `cargo test -p vibez-ui` — 138 passed
- `cargo clippy -p vibez-ui --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Real temporary-directory watcher integration covers create, rename, move, delete, and a 20-file burst
- State coverage proves burst convergence, affected-root-only merging, search refresh, stale retention, scoped failures, and manual repair
- Native smoke covers automatic burst update with hidden-file exclusion, offline stale retention, and automatic recovery

## Evidence
Screenshot hashes and the complete manual sequence are recorded in the private Card 06 Delivery record.

Depends on #55.