### PR TITLE
Browser Card 07: audition local media

### DIFF
--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -227,13 +227,14 @@ pub enum EngineCommand {
         loop_end_beats: f64,
     },
 
-    // -- Preview (sample auditioning) --
-    /// Start previewing a decoded audio buffer on the hidden preview
-    /// channel. Bypasses transport, mute, and solo; one-shot; the
-    /// previous preview is cut if still playing.
-    StartPreview(Arc<DecodedAudio>),
-    /// Stop any in-progress preview.
-    StopPreview,
+    // -- Dedicated Audition Bus --
+    /// Start RAW one-shot playback after project master processing. The
+    /// previous source crossfades out while the new source fades in.
+    StartAudition(Arc<DecodedAudio>),
+    /// Stop the Audition Bus with a short click-safe fade.
+    StopAudition,
+    /// Set Audition Bus gain independently from project mixer state.
+    SetAuditionGain(f32),
 
     // -- External MIDI input --
     /// Route a live note-on from an external MIDI source (hardware

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -58,8 +58,8 @@ pub struct AudioEngine {
     /// Consumer side, parked here until the UI takes it before the
     /// engine moves to the audio thread.
     spectrum_rx: Option<Consumer<f32>>,
-    /// One-shot sample preview, bypasses transport and soloed/muted state.
-    preview: Option<PreviewVoice>,
+    /// One-shot Browser audition after project master processing.
+    audition: AuditionBus,
     sample_rate: u32,
     cmd_rx: Consumer<EngineCommand>,
     event_tx: Producer<EngineEvent>,
@@ -69,12 +69,52 @@ pub struct AudioEngine {
     split_wrap_handled: bool,
 }
 
-/// Dedicated single-voice preview channel used by the sample browser.
-/// Plays `audio` start-to-end irrespective of transport state and is
-/// interrupted whenever a new preview starts.
-struct PreviewVoice {
+/// Dedicated Browser signal path mixed after project master processing.
+struct AuditionBus {
+    active: Option<AuditionVoice>,
+    outgoing: Option<AuditionVoice>,
+    gain: f32,
+}
+
+struct AuditionVoice {
     audio: Arc<DecodedAudio>,
     position: u64,
+    fade_in_frames: usize,
+    fade_out_remaining: Option<usize>,
+}
+
+impl AuditionBus {
+    fn new() -> Self {
+        Self {
+            active: None,
+            outgoing: None,
+            gain: 1.0,
+        }
+    }
+
+    fn start(&mut self, audio: Arc<DecodedAudio>, fade_frames: usize) {
+        if let Some(mut active) = self.active.take() {
+            if active.position > 0 {
+                active.fade_out_remaining = Some(fade_frames);
+                self.outgoing = Some(active);
+            }
+        }
+        self.active = Some(AuditionVoice {
+            audio,
+            position: 0,
+            fade_in_frames: fade_frames,
+            fade_out_remaining: None,
+        });
+    }
+
+    fn stop(&mut self, fade_frames: usize) {
+        if let Some(mut active) = self.active.take() {
+            if active.position > 0 {
+                active.fade_out_remaining = Some(fade_frames);
+                self.outgoing = Some(active);
+            }
+        }
+    }
 }
 
 impl AudioEngine {
@@ -97,7 +137,7 @@ impl AudioEngine {
             spectrum_track: None,
             spectrum_tx,
             spectrum_rx: Some(spectrum_rx),
-            preview: None,
+            audition: AuditionBus::new(),
             sample_rate: 44100,
             cmd_rx,
             event_tx,
@@ -243,8 +283,8 @@ impl AudioEngine {
             push_spectrum(&mut self.spectrum_tx, output, channels);
         }
 
-        // ---- 4.5 Preview channel (bypasses transport) -------------------
-        self.process_preview(output, frames, channels);
+        // ---- 4.5 Audition Bus (post-master, outside project graph) ------
+        self.process_audition(output, frames, channels);
 
         // ---- 5. Advance transport and send events -----------------------
         let was_playing = self.transport.is_playing();
@@ -523,41 +563,27 @@ impl AudioEngine {
         }
     }
 
-    /// Render the preview voice into the output buffer on top of whatever
-    /// the main graph produced. Bypasses transport, solo, and mute; a
-    /// `StartPreview` command during playback simply overlays the preview.
-    fn process_preview(&mut self, output: &mut [f32], frames: usize, channels: usize) {
-        let Some(preview) = self.preview.as_mut() else {
-            return;
-        };
-        let audio_channels = preview.audio.num_channels();
-        let audio_frames = preview.audio.num_frames();
-        if audio_channels == 0 || audio_frames == 0 {
-            self.preview = None;
-            return;
+    fn process_audition(&mut self, output: &mut [f32], frames: usize, channels: usize) {
+        let had_voice = self.audition.active.is_some() || self.audition.outgoing.is_some();
+        let gain = self.audition.gain;
+        if self
+            .audition
+            .outgoing
+            .as_mut()
+            .is_some_and(|voice| render_audition_voice(voice, output, frames, channels, gain))
+        {
+            self.audition.outgoing = None;
         }
-
-        let start = preview.position as usize;
-        let mut consumed = 0usize;
-        for frame in 0..frames {
-            let source = start + frame;
-            if source >= audio_frames {
-                break;
-            }
-            for ch in 0..channels {
-                let sample = if ch < audio_channels {
-                    preview.audio.sample(ch, source)
-                } else {
-                    preview.audio.sample(audio_channels - 1, source)
-                };
-                output[frame * channels + ch] += sample;
-            }
-            consumed += 1;
+        if self
+            .audition
+            .active
+            .as_mut()
+            .is_some_and(|voice| render_audition_voice(voice, output, frames, channels, gain))
+        {
+            self.audition.active = None;
         }
-
-        preview.position = preview.position.saturating_add(consumed as u64);
-        if preview.position as usize >= audio_frames {
-            self.preview = None;
+        if had_voice && self.audition.active.is_none() && self.audition.outgoing.is_none() {
+            let _ = self.event_tx.push(EngineEvent::AuditionStopped);
         }
     }
 
@@ -1080,12 +1106,16 @@ impl AudioEngine {
                     }
                 }
 
-                // -- Preview --
-                EngineCommand::StartPreview(audio) => {
-                    self.preview = Some(PreviewVoice { audio, position: 0 });
+                // -- Dedicated Audition Bus --
+                EngineCommand::StartAudition(audio) => {
+                    self.audition
+                        .start(audio, audition_fade_frames(self.sample_rate));
                 }
-                EngineCommand::StopPreview => {
-                    self.preview = None;
+                EngineCommand::StopAudition => {
+                    self.audition.stop(audition_fade_frames(self.sample_rate));
+                }
+                EngineCommand::SetAuditionGain(gain) => {
+                    self.audition.gain = gain.clamp(0.0, 2.0);
                 }
 
                 // -- External MIDI input --
@@ -1291,6 +1321,61 @@ impl AudioEngine {
             self.transport.set_audio_length(None);
         }
     }
+}
+
+const AUDITION_FADE_MS: usize = 5;
+
+fn audition_fade_frames(sample_rate: u32) -> usize {
+    ((sample_rate as usize * AUDITION_FADE_MS) / 1_000).max(1)
+}
+
+/// Mix one RAW audition voice. Returns true once its source or fade is done.
+fn render_audition_voice(
+    voice: &mut AuditionVoice,
+    output: &mut [f32],
+    frames: usize,
+    channels: usize,
+    bus_gain: f32,
+) -> bool {
+    let audio_channels = voice.audio.num_channels();
+    let audio_frames = voice.audio.num_frames();
+    if audio_channels == 0 || audio_frames == 0 || channels == 0 {
+        return true;
+    }
+
+    for frame in 0..frames {
+        let source = voice.position as usize;
+        if source >= audio_frames {
+            return true;
+        }
+        let attack = if source < voice.fade_in_frames {
+            (source + 1) as f32 / voice.fade_in_frames as f32
+        } else {
+            1.0
+        };
+        let remaining_source = audio_frames.saturating_sub(source + 1);
+        let natural_release =
+            (remaining_source as f32 / voice.fade_in_frames as f32).clamp(0.0, 1.0);
+        let commanded_release = match voice.fade_out_remaining {
+            Some(remaining) => {
+                let envelope = remaining.saturating_sub(1) as f32 / voice.fade_in_frames as f32;
+                voice.fade_out_remaining = Some(remaining.saturating_sub(1));
+                envelope
+            }
+            None => 1.0,
+        };
+        let envelope = attack.min(natural_release) * commanded_release * bus_gain;
+        for ch in 0..channels {
+            let source_channel = ch.min(audio_channels - 1);
+            output[frame * channels + ch] += voice.audio.sample(source_channel, source) * envelope;
+        }
+        voice.position = voice.position.saturating_add(1);
+        if voice.fade_out_remaining == Some(0) {
+            return true;
+        }
+    }
+
+    voice.position as usize >= audio_frames
 }
 
 /// Stream a block to the UI spectrum analyser as mono samples.

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -901,70 +901,86 @@ fn resize_clip_preserves_loop_state() {
 }
 
 #[test]
-fn preview_plays_even_when_transport_stopped() {
+fn audition_plays_even_when_transport_stopped() {
     let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
-    let audio = make_constant_audio(64, 0.4);
+    let audio = make_constant_audio(4_096, 0.4);
 
-    cmd_tx.push(EngineCommand::StartPreview(audio)).unwrap();
+    cmd_tx.push(EngineCommand::StartAudition(audio)).unwrap();
 
-    // Transport is stopped: regular tracks would produce silence,
-    // but the preview voice should still render.
-    let mut buf = vec![0.0f32; 16];
+    let mut buf = vec![0.0f32; 1_024];
     engine.process(&mut buf, 2);
 
     let peak = buf.iter().map(|s| s.abs()).fold(0.0_f32, f32::max);
-    assert!(peak > 0.3, "preview should be audible: peak {peak}");
+    assert!(peak > 0.3, "audition should be audible: peak {peak}");
+    assert!(!engine.transport().is_playing());
 }
 
 #[test]
-fn stop_preview_silences_playback() {
+fn audition_stop_uses_a_short_fade_without_stopping_transport() {
     let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
-    let audio = make_constant_audio(1024, 0.5);
+    let audio = make_constant_audio(4_096, 0.5);
 
-    cmd_tx.push(EngineCommand::StartPreview(audio)).unwrap();
-    cmd_tx.push(EngineCommand::StopPreview).unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    cmd_tx.push(EngineCommand::StartAudition(audio)).unwrap();
+    let mut started = vec![0.0f32; 1_024];
+    engine.process(&mut started, 2);
+    assert!(engine.transport().is_playing());
 
-    let mut buf = vec![0.0f32; 16];
+    cmd_tx.push(EngineCommand::StopAudition).unwrap();
+    let mut buf = vec![0.0f32; 1_024];
     engine.process(&mut buf, 2);
-    assert!(buf.iter().all(|s| s.abs() < 1e-6));
+    assert!(buf[0].abs() > 0.1, "stop must begin with a fade, not a cut");
+    assert!(buf[500..].iter().all(|s| s.abs() < 1e-6));
+    assert!(engine.transport().is_playing());
 }
 
 #[test]
-fn preview_auto_completes_at_end_of_audio() {
+fn audition_auto_completes_at_end_of_audio() {
     let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
-    let audio = make_constant_audio(8, 0.6);
+    let audio = make_constant_audio(512, 0.6);
 
-    cmd_tx.push(EngineCommand::StartPreview(audio)).unwrap();
+    cmd_tx.push(EngineCommand::StartAudition(audio)).unwrap();
 
-    // First 4 frames: audible
-    let mut buf = vec![0.0f32; 8];
+    let mut buf = vec![0.0f32; 2_048];
     engine.process(&mut buf, 2);
     assert!(buf.iter().any(|s| s.abs() > 0.5));
-
-    // Next 16 frames: past end of 8-frame audio. Preview auto-clears.
-    let mut buf = vec![0.0f32; 32];
-    engine.process(&mut buf, 2);
-    // First 8 samples of buf correspond to frames 4-7 of preview (audible).
-    // The remaining should be silence.
-    let tail = &buf[16..];
+    let tail = &buf[1_024..];
     assert!(tail.iter().all(|s| s.abs() < 1e-6));
 }
 
 #[test]
-fn starting_new_preview_interrupts_previous() {
+fn newer_audition_crossfades_over_the_previous_source() {
     let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
-    let a = make_constant_audio(1024, 0.8);
-    let b = make_constant_audio(1024, 0.2);
+    let a = make_constant_audio(4_096, 0.8);
+    let b = make_constant_audio(4_096, 0.2);
 
-    cmd_tx.push(EngineCommand::StartPreview(a)).unwrap();
-    let mut buf = vec![0.0f32; 16];
+    cmd_tx.push(EngineCommand::StartAudition(a)).unwrap();
+    let mut buf = vec![0.0f32; 1_024];
     engine.process(&mut buf, 2);
-    assert!(buf[0].abs() > 0.7);
+    let before = buf[1_000];
+    assert!(before > 0.7);
 
-    cmd_tx.push(EngineCommand::StartPreview(b)).unwrap();
-    let mut buf = vec![0.0f32; 16];
+    cmd_tx.push(EngineCommand::StartAudition(b)).unwrap();
+    let mut buf = vec![0.0f32; 1_024];
     engine.process(&mut buf, 2);
-    assert!(buf[0].abs() < 0.3);
+    assert!((buf[0] - before).abs() < 0.02, "replacement must not click");
+    assert!((buf[600] - 0.2).abs() < 0.01, "new source must take over");
+}
+
+#[test]
+fn audition_gain_is_independent_and_bypasses_project_master_gain() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let audio = make_constant_audio(4_096, 0.8);
+    cmd_tx
+        .push(EngineCommand::SetTrackGain(TrackId::MASTER, 0.0))
+        .unwrap();
+    cmd_tx.push(EngineCommand::SetAuditionGain(0.25)).unwrap();
+    cmd_tx.push(EngineCommand::StartAudition(audio)).unwrap();
+
+    let mut buf = vec![0.0f32; 1_024];
+    engine.process(&mut buf, 2);
+    let peak = buf.iter().copied().fold(0.0_f32, f32::max);
+    assert!((peak - 0.2).abs() < 0.01);
 }
 
 #[test]

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -75,6 +75,9 @@ pub enum EngineEvent {
 
     /// Playback has stopped (transport entered stopped state).
     PlaybackStopped,
+
+    /// The post-master Audition Bus became silent after stop or source end.
+    AuditionStopped,
 }
 
 #[cfg(test)]
@@ -97,6 +100,7 @@ mod tests {
         };
         let _started = EngineEvent::PlaybackStarted;
         let _stopped = EngineEvent::PlaybackStopped;
+        let _audition_stopped = EngineEvent::AuditionStopped;
     }
 
     #[test]

--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -44,7 +44,9 @@ pub enum BounceMode {
 }
 
 /// Snapshot of the parts of a project needed to render offline, plus the
-/// decoded audio for every asset referenced by the snapshot.
+/// decoded audio for every asset referenced by the snapshot. The live Audition
+/// Bus is intentionally absent, so exports, stems, and resampling cannot capture
+/// Browser playback.
 pub struct BounceRequest {
     pub tracks: Vec<TrackInfo>,
     /// Master bus (gain + effect chain), applied to the summed mix
@@ -421,6 +423,33 @@ mod tests {
             automation: Vec::new(),
             sends: Vec::new(),
         }
+    }
+
+    #[test]
+    fn offline_project_render_has_no_audition_bus_input() {
+        let request = BounceRequest {
+            tracks: Vec::new(),
+            master: None,
+            buses: Vec::new(),
+            audio_clips: Vec::new(),
+            note_clips: Vec::new(),
+            clip_audio: HashMap::new(),
+            sampler_audio: HashMap::new(),
+            drum_pad_audio: HashMap::new(),
+            mode: BounceMode::Master,
+            range_samples: (0, 512),
+            bpm: 120.0,
+            sample_rate: 44_100,
+        };
+
+        let result = render_offline(&request);
+
+        assert!(result
+            .audio
+            .channels
+            .iter()
+            .flatten()
+            .all(|sample| sample.abs() < f32::EPSILON));
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -420,6 +420,12 @@ impl App {
                     EngineEvent::PlaybackStarted => {
                         self.state.transport.playing = true;
                     }
+                    EngineEvent::AuditionStopped => {
+                        self.state.browser.stop_audition_state();
+                        if self.state.status_text == "RAW Audition playing" {
+                            self.state.status_text = "Audition finished".into();
+                        }
+                    }
                     EngineEvent::TrackMeter {
                         track_id,
                         peak_l,

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -31,9 +31,9 @@ pub(crate) fn global_key_handler(
         return Some(Message::Transport(TransportMsg::TogglePlayback));
     }
 
-    // Escape: cancel editing
+    // Escape: the router stops Audition first, then falls back to cancel editing.
     if matches!(key, iced::keyboard::Key::Named(Named::Escape)) {
-        return Some(Message::View(ViewMsg::CancelEditing));
+        return Some(Message::EscapePressed);
     }
 
     // Delete/Backspace: context-resolved in update() (selected notes
@@ -189,6 +189,20 @@ mod tests {
         assert!(matches!(
             wider,
             Some(Message::Browser(BrowserMsg::NudgeDockWidth(delta))) if delta == 40.0
+        ));
+    }
+
+    #[test]
+    fn space_is_transport_and_escape_routes_through_audition_priority() {
+        use iced::keyboard::{key::Named, Key, Modifiers};
+
+        assert!(matches!(
+            global_key_handler(Key::Named(Named::Space), Modifiers::empty()),
+            Some(Message::Transport(TransportMsg::TogglePlayback))
+        ));
+        assert!(matches!(
+            global_key_handler(Key::Named(Named::Escape), Modifiers::empty()),
+            Some(Message::EscapePressed)
         ));
     }
 }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -17,6 +17,11 @@ use crate::state::{SampleBrowserEntry, UiClip, UiDrumPad, UiTrack};
 use super::*;
 
 impl App {
+    pub(super) fn stop_browser_audition(&mut self) {
+        self.send_command(EngineCommand::StopAudition);
+        self.state.browser.stop_audition_state();
+    }
+
     pub(super) fn selected_sample_browser_entry(&self) -> Option<&SampleBrowserEntry> {
         let selected = self.state.browser.selected_source.as_ref()?;
         self.state
@@ -769,7 +774,7 @@ impl App {
             None => {
                 // No active drag: treat release as a click.
                 // Select the pad AND audition its loaded sample
-                // via the engine's preview channel (bypasses
+                // via the engine's Audition Bus (bypasses
                 // transport + mute + solo; one-shot). This is
                 // the fastest way to hear what's on a pad
                 // without drawing notes into the piano roll.
@@ -786,7 +791,7 @@ impl App {
                         })
                     });
                 if let Some((audio, name)) = audition {
-                    self.send_command(EngineCommand::StartPreview(audio));
+                    self.send_command(EngineCommand::StartAudition(audio));
                     self.state.status_text = format!("Pad {}: {}", pad_index + 1, name);
                 }
                 self.update(Message::select_drum_rack_pad(track_id, pad_index))

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -174,6 +174,8 @@ impl App {
                     crate::state::BROWSER_DOCK_MIN_WIDTH,
                     crate::state::BROWSER_DOCK_MAX_WIDTH,
                 ),
+                audition_enabled: ui_settings.audition_enabled,
+                audition_gain: ui_settings.audition_gain.clamp(0.0, 2.0),
                 roots: ui_settings.sample_library_roots,
                 dropbox: dropbox_ui_state,
                 ..Default::default()
@@ -240,6 +242,9 @@ impl App {
 
         // Inform the engine of the actual sample rate
         app.send_command(EngineCommand::SetBpm(app.state.transport.bpm));
+        app.send_command(EngineCommand::SetAuditionGain(
+            app.state.browser.audition_gain,
+        ));
 
         // Console model: the master bus carries its channel EQ from
         // the first frame.

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -23,6 +23,7 @@ use super::*;
 
 impl App {
     pub(super) fn clear_project_runtime(&mut self) {
+        self.stop_browser_audition();
         self.state.transport.playing = false;
         self.state.transport.position_samples = 0;
         self.send_command(EngineCommand::Stop);
@@ -198,6 +199,8 @@ impl App {
             sample_library_roots: self.state.browser.roots.clone(),
             sample_browser_open: self.state.browser.open,
             sample_browser_width: self.state.browser.dock_width,
+            audition_enabled: self.state.browser.audition_enabled,
+            audition_gain: self.state.browser.audition_gain,
             auto_warp_on_import: self.state.auto_warp_on_import,
             warp_confidence_threshold: self.state.warp_confidence_threshold,
             preferred_midi_input: self.midi_input.as_ref().map(|h| h.port_name.clone()),

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -560,13 +560,20 @@ impl App {
                 }));
             }
             Message::ClickLocalBrowserEntry(source) => {
-                // Card 07 owns selection-driven Audition. For now click only
-                // selects and populates the truthful waveform; explicit Play
-                // remains in the persistent Audition footer.
                 let changed = self.state.browser.select_source(source.clone());
                 if changed {
-                    self.state.browser.begin_waveform_load(&source);
                     if let MediaSourceRef::LocalFile { path } = source.clone() {
+                        if self.state.browser.audition_enabled {
+                            self.state.browser.begin_audition_load(&source);
+                            self.state.status_text = "Loading RAW Audition...".to_string();
+                            return Task::perform(
+                                decode_local_for_preview_async(path),
+                                move |result| {
+                                    Message::LocalSamplePreviewReady(source.clone(), result)
+                                },
+                            );
+                        }
+                        self.state.browser.begin_waveform_load(&source);
                         return Task::perform(
                             decode_local_for_preview_async(path),
                             move |result| Message::BrowserWaveformReady(source.clone(), result),
@@ -576,17 +583,44 @@ impl App {
             }
             Message::PreviewLocalEntry(source) => {
                 self.state.browser.select_source(source.clone());
-                self.state.browser.begin_waveform_load(&source);
+                self.state.browser.begin_audition_load(&source);
                 if let MediaSourceRef::LocalFile { path } = source.clone() {
-                    self.state.status_text = "Previewing...".to_string();
+                    self.state.status_text = "Loading RAW Audition...".to_string();
                     return Task::perform(decode_local_for_preview_async(path), move |result| {
                         Message::LocalSamplePreviewReady(source.clone(), result)
                     });
                 }
             }
             Message::StopBrowserPreview => {
-                self.send_command(EngineCommand::StopPreview);
+                self.stop_browser_audition();
                 self.state.status_text = "Audition stopped".to_string();
+            }
+            Message::ToggleAuditionEnabled => {
+                let enabled = self.state.browser.toggle_audition_enabled();
+                if !enabled {
+                    self.stop_browser_audition();
+                }
+                self.persist_ui_settings();
+                self.state.status_text = if enabled {
+                    "Selection Audition enabled".into()
+                } else {
+                    "Selection Audition disabled; explicit Play remains available".into()
+                };
+            }
+            Message::SetAuditionGain(gain) => {
+                self.state.browser.set_audition_gain(gain);
+                self.send_command(EngineCommand::SetAuditionGain(
+                    self.state.browser.audition_gain,
+                ));
+                self.persist_ui_settings();
+            }
+            Message::EscapePressed => {
+                if self.state.browser.audition_playing || self.state.browser.audition_loading {
+                    self.stop_browser_audition();
+                    self.state.status_text = "Audition stopped".into();
+                } else {
+                    return self.update(Message::View(ViewMsg::CancelEditing));
+                }
             }
             // -- Drag-and-drop from sample browser --
             Message::DropSampleOnArrangement {
@@ -614,15 +648,22 @@ impl App {
                     .dispatch_drop_for_target(source, BrowserImportTarget::Sampler(track_id));
             }
             Message::LocalSamplePreviewReady(source, Ok(audio)) => {
-                self.state
+                if self
+                    .state
                     .browser
-                    .install_waveform(source, Arc::clone(&audio));
-                self.send_command(EngineCommand::StartPreview(audio));
-                self.state.status_text = "Preview playing".to_string();
+                    .install_audition(source, Arc::clone(&audio))
+                {
+                    self.send_command(EngineCommand::StartAudition(audio));
+                    self.state.status_text = "RAW Audition playing".to_string();
+                }
             }
             Message::LocalSamplePreviewReady(source, Err(err)) => {
+                let is_current = self.state.browser.selected_source.as_ref() == Some(&source);
                 self.state.browser.fail_waveform_load(&source, err.clone());
-                self.state.status_text = format!("Preview error: {err}");
+                if is_current {
+                    self.stop_browser_audition();
+                    self.state.status_text = format!("Audition error: {err}");
+                }
             }
             Message::BrowserWaveformReady(source, Ok(audio)) => {
                 self.state.browser.install_waveform(source, audio);
@@ -1133,7 +1174,7 @@ impl App {
                     rev: entry.rev.clone(),
                 };
                 self.state.browser.select_source(source.clone());
-                self.state.browser.begin_waveform_load(&source);
+                self.state.browser.begin_audition_load(&source);
                 let cache = self.dropbox_cache.clone();
                 self.state.browser.dropbox.preview_in_progress = true;
                 self.state.status_text = format!("Fetching preview: {}", entry.name);
@@ -1149,17 +1190,24 @@ impl App {
             }
             Message::DropboxPreviewReady(source, Ok(audio)) => {
                 self.state.browser.dropbox.preview_in_progress = false;
-                self.state
+                if self
+                    .state
                     .browser
-                    .install_waveform(source, Arc::clone(&audio));
-                self.send_command(EngineCommand::StartPreview(audio));
-                self.state.status_text = "Preview playing".to_string();
+                    .install_audition(source, Arc::clone(&audio))
+                {
+                    self.send_command(EngineCommand::StartAudition(audio));
+                    self.state.status_text = "RAW Audition playing".to_string();
+                }
             }
             Message::DropboxPreviewReady(source, Err(err)) => {
                 self.state.browser.dropbox.preview_in_progress = false;
+                let is_current = self.state.browser.selected_source.as_ref() == Some(&source);
                 self.state.browser.fail_waveform_load(&source, err.clone());
                 self.state.browser.dropbox.last_error = Some(err.clone());
-                self.state.status_text = format!("Preview error: {err}");
+                if is_current {
+                    self.stop_browser_audition();
+                    self.state.status_text = format!("Preview error: {err}");
+                }
             }
             Message::DropboxImportToArrangement(entry) => {
                 return self.handle_dropbox_import_to_arrangement(entry);

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use iced::widget::{
-    button, canvas, column, container, horizontal_space, mouse_area, row, scrollable, text,
+    button, canvas, column, container, horizontal_space, mouse_area, row, scrollable, slider, text,
     text_input,
 };
 use iced::{Element, Length, Theme};
@@ -464,6 +464,19 @@ impl App {
             .on_press(Message::StopBrowserPreview)
             .padding([6, 8])
             .style(browser_transport_button_style);
+        let enabled = self.state.browser.audition_enabled;
+        let follow_toggle = button(
+            text(if enabled { "ENABLED ON" } else { "ENABLED OFF" })
+                .size(9)
+                .color(if enabled {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                }),
+        )
+        .on_press(Message::ToggleAuditionEnabled)
+        .padding([2, 4])
+        .style(browser_utility_action_style);
 
         let waveform: Element<'_, Message> = container(
             canvas(crate::widgets::browser_waveform::BrowserWaveform {
@@ -486,8 +499,10 @@ impl App {
         let controls = row![
             play,
             stop,
-            text(if self.state.browser.waveform_loading {
+            text(if self.state.browser.audition_loading {
                 "LOADING"
+            } else if self.state.browser.audition_playing {
+                "PLAYING"
             } else if self.state.browser.waveform_error.is_some() {
                 "UNAVAILABLE"
             } else if self.state.browser.waveform_audio.is_some() {
@@ -501,14 +516,55 @@ impl App {
         ]
         .spacing(5)
         .align_y(iced::Alignment::Center);
+        let gain = self.state.browser.audition_gain;
+        let gain_slider = slider(0.0..=2.0, gain, Message::SetAuditionGain)
+            .step(0.01)
+            .width(Length::Fill)
+            .style(|_theme: &Theme, status| iced::widget::slider::Style {
+                rail: iced::widget::slider::Rail {
+                    backgrounds: (th::accent_dim().into(), th::divider().into()),
+                    width: 2.0,
+                    border: iced::Border::default(),
+                },
+                handle: iced::widget::slider::Handle {
+                    shape: iced::widget::slider::HandleShape::Rectangle {
+                        width: 6,
+                        border_radius: 0.0.into(),
+                    },
+                    background: if matches!(status, iced::widget::slider::Status::Dragged) {
+                        th::accent().into()
+                    } else {
+                        th::text_dim().into()
+                    },
+                    border_width: 0.0,
+                    border_color: iced::Color::TRANSPARENT,
+                },
+            });
+        let gain_row = row![
+            text("GAIN").size(9).color(th::text_muted()),
+            gain_slider,
+            text(audition_gain_label(gain))
+                .size(9)
+                .color(th::text_dim())
+                .width(Length::Fixed(48.0))
+        ]
+        .spacing(6)
+        .align_y(iced::Alignment::Center);
         let contents: Element<'_, Message> = column![
             row![
                 text("AUDITION").size(9).color(th::text_muted()),
-                horizontal_space(),
-                text(selected_label).size(10).color(th::text_dim())
+                follow_toggle,
+                text(selected_label)
+                    .size(10)
+                    .color(th::text_dim())
+                    .width(Length::Fill)
+                    .align_x(iced::alignment::Horizontal::Right)
+                    .wrapping(iced::widget::text::Wrapping::None)
             ]
+            .spacing(5)
             .align_y(iced::Alignment::Center),
-            controls
+            controls,
+            gain_row
         ]
         .spacing(5)
         .into();
@@ -1249,6 +1305,14 @@ fn browser_row_divider<'a>() -> Element<'a, Message> {
             ..Default::default()
         })
         .into()
+}
+
+fn audition_gain_label(gain: f32) -> String {
+    if gain <= 0.0001 {
+        "−∞ dB".into()
+    } else {
+        format!("{:+.1} dB", 20.0 * gain.log10())
+    }
 }
 
 fn browser_place_button_style(active: bool, status: button::Status) -> button::Style {

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -416,14 +416,28 @@ mod tests {
         let mut browser = BrowserState::default();
 
         browser.select_source(first.clone());
-        browser.begin_waveform_load(&first);
-        assert!(browser.install_waveform(first.clone(), std::sync::Arc::clone(&audio)));
+        browser.begin_audition_load(&first);
+        assert!(browser.install_audition(first.clone(), std::sync::Arc::clone(&audio)));
         assert!(browser.waveform_audio.is_some());
+        assert!(browser.audition_playing);
 
         browser.select_source(second);
         assert!(browser.waveform_audio.is_none());
-        assert!(!browser.install_waveform(first, audio));
+        assert!(!browser.install_audition(first, audio));
         assert!(browser.waveform_audio.is_none());
+    }
+
+    #[test]
+    fn audition_defaults_on_and_remembers_clamped_gain_state() {
+        let mut browser = BrowserState::default();
+        assert!(browser.audition_enabled);
+        assert_eq!(browser.audition_gain, 1.0);
+
+        assert!(!browser.toggle_audition_enabled());
+        browser.set_audition_gain(3.0);
+        assert_eq!(browser.audition_gain, 2.0);
+        browser.set_audition_gain(-1.0);
+        assert_eq!(browser.audition_gain, 0.0);
     }
 
     #[test]
@@ -437,6 +451,9 @@ mod tests {
             source: source.clone(),
             label: "kick.wav".to_string(),
         });
+        assert!(b.selected_source.is_none());
+        assert!(!b.audition_loading);
+        assert!(!b.audition_playing);
         b.update(BrowserMsg::DragHoverTrack {
             track_id: tid,
             beat: 8.0,
@@ -598,13 +615,13 @@ mod tests {
 
     #[test]
     fn affected_root_reconciliation_preserves_other_catalogs_and_updates_search() {
-        fn entry(root: &PathBuf, name: &str) -> crate::state::SampleBrowserEntry {
+        fn entry(root: &std::path::Path, name: &str) -> crate::state::SampleBrowserEntry {
             crate::state::SampleBrowserEntry {
                 source: MediaSourceRef::LocalFile {
                     path: root.join(name),
                 },
                 name: name.into(),
-                root_path: root.clone(),
+                root_path: root.to_path_buf(),
                 relative_path: PathBuf::from(name),
                 format: "WAV".into(),
                 file_size: Some(1),

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -259,11 +259,14 @@ pub enum Message {
     AddSampleLibraryRoot,
     SampleLibraryRootSelected(Option<PathBuf>),
     RescanSampleLibrary,
-    /// Click in the Local sample browser: select only, no preview.
+    /// Select a Local source; starts RAW Audition when selection-follow is on.
     ClickLocalBrowserEntry(MediaSourceRef),
-    /// Speaker-icon click on a Local browser row: audition.
+    /// Explicit Play in the persistent Audition footer.
     PreviewLocalEntry(MediaSourceRef),
     StopBrowserPreview,
+    ToggleAuditionEnabled,
+    SetAuditionGain(f32),
+    EscapePressed,
     LocalSamplePreviewReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
     BrowserWaveformReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
     DropSampleOnArrangement {

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -285,6 +285,10 @@ pub struct BrowserState {
     pub waveform_audio: Option<Arc<DecodedAudio>>,
     pub waveform_loading: bool,
     pub waveform_error: Option<String>,
+    pub audition_enabled: bool,
+    pub audition_gain: f32,
+    pub audition_loading: bool,
+    pub audition_playing: bool,
     pub scan_in_progress: bool,
     pub mode: SampleBrowserMode,
     pub dropbox: DropboxUiState,
@@ -321,6 +325,10 @@ impl Default for BrowserState {
             waveform_audio: None,
             waveform_loading: false,
             waveform_error: None,
+            audition_enabled: true,
+            audition_gain: 1.0,
+            audition_loading: false,
+            audition_playing: false,
             scan_in_progress: false,
             mode: SampleBrowserMode::default(),
             dropbox: DropboxUiState::default(),
@@ -530,6 +538,36 @@ impl BrowserState {
         if self.selected_source.as_ref() == Some(source) {
             self.waveform_loading = true;
         }
+    }
+
+    pub fn begin_audition_load(&mut self, source: &MediaSourceRef) {
+        self.begin_waveform_load(source);
+        if self.selected_source.as_ref() == Some(source) {
+            self.audition_loading = true;
+        }
+    }
+
+    pub fn install_audition(&mut self, source: MediaSourceRef, audio: Arc<DecodedAudio>) -> bool {
+        if !self.install_waveform(source, audio) {
+            return false;
+        }
+        self.audition_loading = false;
+        self.audition_playing = true;
+        true
+    }
+
+    pub fn stop_audition_state(&mut self) {
+        self.audition_loading = false;
+        self.audition_playing = false;
+    }
+
+    pub fn toggle_audition_enabled(&mut self) -> bool {
+        self.audition_enabled = !self.audition_enabled;
+        self.audition_enabled
+    }
+
+    pub fn set_audition_gain(&mut self, gain: f32) {
+        self.audition_gain = gain.clamp(0.0, 2.0);
     }
 
     pub fn install_waveform(&mut self, source: MediaSourceRef, audio: Arc<DecodedAudio>) -> bool {

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -10,6 +10,10 @@ pub struct UiSettings {
     pub sample_browser_open: bool,
     #[serde(default = "default_sample_browser_width")]
     pub sample_browser_width: f32,
+    #[serde(default = "default_audition_enabled")]
+    pub audition_enabled: bool,
+    #[serde(default = "default_audition_gain")]
+    pub audition_gain: f32,
     /// Automatically detect each dropped sample's BPM and warp it to
     /// the project tempo on import. Off by default; users opt in from
     /// Settings → Warping.
@@ -37,6 +41,8 @@ impl Default for UiSettings {
             sample_library_roots: Vec::new(),
             sample_browser_open: default_sample_browser_open(),
             sample_browser_width: default_sample_browser_width(),
+            audition_enabled: default_audition_enabled(),
+            audition_gain: default_audition_gain(),
             auto_warp_on_import: false,
             warp_confidence_threshold: default_warp_confidence_threshold(),
             preferred_midi_input: None,
@@ -79,6 +85,14 @@ fn default_sample_browser_width() -> f32 {
     crate::state::BROWSER_DOCK_DEFAULT_WIDTH
 }
 
+fn default_audition_enabled() -> bool {
+    true
+}
+
+fn default_audition_gain() -> f32 {
+    1.0
+}
+
 fn default_warp_confidence_threshold() -> f32 {
     0.6
 }
@@ -108,6 +122,26 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let loaded: UiSettings = serde_json::from_str(&json).unwrap();
         assert_eq!(loaded.sample_browser_width, 612.0);
+    }
+
+    #[test]
+    fn old_settings_enable_audition_at_unity_by_default() {
+        let loaded: UiSettings = serde_json::from_str(r#"{"sample_library_roots":[]}"#).unwrap();
+        assert!(loaded.audition_enabled);
+        assert_eq!(loaded.audition_gain, 1.0);
+    }
+
+    #[test]
+    fn audition_preferences_roundtrip() {
+        let settings = UiSettings {
+            audition_enabled: false,
+            audition_gain: 0.42,
+            ..Default::default()
+        };
+        let loaded: UiSettings =
+            serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
+        assert!(!loaded.audition_enabled);
+        assert_eq!(loaded.audition_gain, 0.42);
     }
 
     #[test]


### PR DESCRIPTION
Implements Browser Card 07 as the next chained feature PR.\n\n- replaces the hidden preview path with a dedicated post-master Audition Bus\n- adds click-safe start, replacement, and stop fades plus independent remembered gain\n- keeps Browser audition independent from transport and offline render/capture paths\n- adds the flat waveform, Enabled, Play/Stop, state, and keyboard behavior\n- stops audition on project clear and reconciles decode/completion state\n\nVerification:\n- cargo test -p vibez-engine (128 passed)\n- cargo test -p vibez-ui (142 passed)\n- cargo clippy -p vibez-engine --lib -- -D warnings\n- cargo clippy -p vibez-ui --lib -- -D warnings\n- cargo fmt --all -- --check\n- git diff --check\n- native Xvfb smoke: transport and audition coexist; Escape stops audition only; disabled selection loads waveform; explicit Play still works; gain persists\n\nNative evidence SHA-256:\n- transport + audition: 3aeedafd4894013c9ae31d21d12aea741d85d86739c4276c256ab5a418c0e4c5\n- Escape stop with transport continuing: 544158ac7f45509f995d9508fc7bcdf4fafffc5b3ca3cf7536df7b83e70ad17a\n- disabled selection waveform: 9a2b02bb12e37582e0eb95a07b84fff96b19ae8c59440b3c23e1c9bdd6e52d5a\n- disabled explicit Play: 0579f5d7d80420529d138e9e350de1a2c2381b6b0044f0c8acfef569879e23e5\n- remembered -6 dB gain: 8a6aa183cc4949b6e5388ef761f39e9957e2d2dc209c15138f218b69d75cc052