### PR TITLE
Browser Card 08: WARP, sync, and loop audition

### DIFF
--- a/crates/vibez-dsp/src/time_stretch.rs
+++ b/crates/vibez-dsp/src/time_stretch.rs
@@ -32,14 +32,6 @@ const WSOLA_SEARCH: isize = 256;
 
 // Ratio router.
 const RATIO_PASSTHROUGH_EPS: f64 = 0.005;
-/// Stretch ratios this close to unity use plain resampling instead of
-/// a phase vocoder: the resulting pitch shift is under one semitone
-/// (inaudible on drums, barely audible on melodic material) and the
-/// time domain stays bit-exact, so transients cannot smear. This is
-/// the classic tempo-match case (e.g. a 135 BPM loop into a 138 BPM
-/// project) that produced audible artifacts under WSOLA.
-const RESAMPLE_BAND_MIN: f64 = 0.94;
-const RESAMPLE_BAND_MAX: f64 = 1.06;
 /// Signalsmith Stretch stays musical over a far wider range than the
 /// old hand-rolled WSOLA did.
 const RATIO_MIN: f64 = 0.25;
@@ -84,11 +76,6 @@ pub fn pitch_preserving_stretch(audio: &DecodedAudio, target_frames: usize) -> D
 
     if (ratio - 1.0).abs() < RATIO_PASSTHROUGH_EPS {
         return resize_clone(audio, target_frames);
-    }
-
-    // Near-unity ratios: plain resample beats any stretcher.
-    if (RESAMPLE_BAND_MIN..=RESAMPLE_BAND_MAX).contains(&ratio) {
-        return stretch_to(audio, target_frames);
     }
 
     if !(RATIO_MIN..=RATIO_MAX).contains(&ratio) || src_frames < WSOLA_FRAME * 2 {
@@ -662,9 +649,8 @@ mod stretch_quality_tests {
     }
 
     #[test]
-    fn near_unity_ratio_uses_exact_length_resample() {
-        // 2.2% stretch (the 135->138 BPM dogfood case) must resample:
-        // output length exact and content dense (no silent tail).
+    fn near_unity_warp_preserves_pitch_and_exact_length() {
+        // Even a subtle 135->138 tempo match is WARP, not REPITCH.
         let audio = sine(440.0, 1.0, 44_100);
         let target = (44_100.0 * 1.022) as usize;
         let out = pitch_preserving_stretch(&audio, target);
@@ -673,6 +659,11 @@ mod stretch_quality_tests {
         assert!(
             tail.iter().any(|s| s.abs() > 0.1),
             "tail must contain signal"
+        );
+        let measured = zero_crossings(&out.channels[0]) as f32 / (target as f32 / 44_100.0);
+        assert!(
+            (measured - 440.0).abs() < 4.0,
+            "near-unity WARP detuned to {measured} Hz"
         );
     }
 

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -7,6 +7,14 @@ use vibez_core::track::DrumPadState;
 use vibez_dsp::effect::AudioEffect;
 use vibez_instruments::Instrument;
 
+/// Quantization policy for the next Browser Audition start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditionSync {
+    Off,
+    Beat,
+    Bar,
+}
+
 /// Commands sent from the UI thread to the audio engine (via rtrb).
 ///
 /// These are pushed into an `rtrb::Producer<EngineCommand>` on the UI side
@@ -228,13 +236,19 @@ pub enum EngineCommand {
     },
 
     // -- Dedicated Audition Bus --
-    /// Start RAW one-shot playback after project master processing. The
-    /// previous source crossfades out while the new source fades in.
-    StartAudition(Arc<DecodedAudio>),
+    /// Request Browser Audition playback after project master processing.
+    /// Beat/Bar quantization applies only while transport is already running.
+    StartAudition {
+        audio: Arc<DecodedAudio>,
+        sync: AuditionSync,
+        looped: bool,
+    },
     /// Stop the Audition Bus with a short click-safe fade.
     StopAudition,
     /// Set Audition Bus gain independently from project mixer state.
     SetAuditionGain(f32),
+    /// Change looping for the active or queued Browser Audition.
+    SetAuditionLoop(bool),
 
     // -- External MIDI input --
     /// Route a live note-on from an external MIDI source (hardware

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -9,7 +9,7 @@ use vibez_core::time::TempoMap;
 use vibez_dsp::factory::create_effect;
 use vibez_instruments::create_instrument;
 
-use crate::commands::EngineCommand;
+use crate::commands::{AuditionSync, EngineCommand};
 use crate::events::EngineEvent;
 use crate::metering;
 use crate::mixer::{
@@ -73,6 +73,7 @@ pub struct AudioEngine {
 struct AuditionBus {
     active: Option<AuditionVoice>,
     outgoing: Option<AuditionVoice>,
+    queued: Option<QueuedAudition>,
     gain: f32,
 }
 
@@ -81,6 +82,13 @@ struct AuditionVoice {
     position: u64,
     fade_in_frames: usize,
     fade_out_remaining: Option<usize>,
+    looped: bool,
+}
+
+struct QueuedAudition {
+    audio: Arc<DecodedAudio>,
+    target_position: u64,
+    looped: bool,
 }
 
 impl AuditionBus {
@@ -88,11 +96,13 @@ impl AuditionBus {
         Self {
             active: None,
             outgoing: None,
+            queued: None,
             gain: 1.0,
         }
     }
 
-    fn start(&mut self, audio: Arc<DecodedAudio>, fade_frames: usize) {
+    fn start(&mut self, audio: Arc<DecodedAudio>, fade_frames: usize, looped: bool) {
+        self.queued = None;
         if let Some(mut active) = self.active.take() {
             if active.position > 0 {
                 active.fade_out_remaining = Some(fade_frames);
@@ -104,15 +114,45 @@ impl AuditionBus {
             position: 0,
             fade_in_frames: fade_frames,
             fade_out_remaining: None,
+            looped,
+        });
+    }
+
+    fn queue(
+        &mut self,
+        audio: Arc<DecodedAudio>,
+        target_position: u64,
+        fade_frames: usize,
+        looped: bool,
+    ) {
+        self.stop_active(fade_frames);
+        self.queued = Some(QueuedAudition {
+            audio,
+            target_position,
+            looped,
         });
     }
 
     fn stop(&mut self, fade_frames: usize) {
+        self.queued = None;
+        self.stop_active(fade_frames);
+    }
+
+    fn stop_active(&mut self, fade_frames: usize) {
         if let Some(mut active) = self.active.take() {
             if active.position > 0 {
                 active.fade_out_remaining = Some(fade_frames);
                 self.outgoing = Some(active);
             }
+        }
+    }
+
+    fn set_looped(&mut self, looped: bool) {
+        if let Some(active) = self.active.as_mut() {
+            active.looped = looped;
+        }
+        if let Some(queued) = self.queued.as_mut() {
+            queued.looped = looped;
         }
     }
 }
@@ -564,25 +604,50 @@ impl AudioEngine {
     }
 
     fn process_audition(&mut self, output: &mut [f32], frames: usize, channels: usize) {
-        let had_voice = self.audition.active.is_some() || self.audition.outgoing.is_some();
+        let mut had_voice = self.audition.active.is_some() || self.audition.outgoing.is_some();
+        let mut start_offset = 0;
+        let queued_ready = self.audition.queued.as_ref().is_some_and(|queued| {
+            if !self.transport.is_playing() {
+                return true;
+            }
+            let block_start = self.transport.position();
+            queued.target_position < block_start.saturating_add(frames as u64)
+        });
+        if queued_ready {
+            let queued = self.audition.queued.take().expect("queued audition exists");
+            if self.transport.is_playing() {
+                start_offset = queued
+                    .target_position
+                    .saturating_sub(self.transport.position())
+                    .min(frames as u64) as usize;
+            }
+            self.audition.start(
+                queued.audio,
+                audition_fade_frames(self.sample_rate),
+                queued.looped,
+            );
+            had_voice = true;
+            let _ = self.event_tx.push(EngineEvent::AuditionStarted);
+        }
         let gain = self.audition.gain;
         if self
             .audition
             .outgoing
             .as_mut()
-            .is_some_and(|voice| render_audition_voice(voice, output, frames, channels, gain))
+            .is_some_and(|voice| render_audition_voice(voice, output, frames, channels, gain, 0))
         {
             self.audition.outgoing = None;
         }
-        if self
-            .audition
-            .active
-            .as_mut()
-            .is_some_and(|voice| render_audition_voice(voice, output, frames, channels, gain))
-        {
+        if self.audition.active.as_mut().is_some_and(|voice| {
+            render_audition_voice(voice, output, frames, channels, gain, start_offset)
+        }) {
             self.audition.active = None;
         }
-        if had_voice && self.audition.active.is_none() && self.audition.outgoing.is_none() {
+        if had_voice
+            && self.audition.active.is_none()
+            && self.audition.outgoing.is_none()
+            && self.audition.queued.is_none()
+        {
             let _ = self.event_tx.push(EngineEvent::AuditionStopped);
         }
     }
@@ -1107,15 +1172,35 @@ impl AudioEngine {
                 }
 
                 // -- Dedicated Audition Bus --
-                EngineCommand::StartAudition(audio) => {
-                    self.audition
-                        .start(audio, audition_fade_frames(self.sample_rate));
+                EngineCommand::StartAudition {
+                    audio,
+                    sync,
+                    looped,
+                } => {
+                    let fade_frames = audition_fade_frames(self.sample_rate);
+                    if self.transport.is_playing() && sync != AuditionSync::Off {
+                        let beats = if sync == AuditionSync::Bar { 4 } else { 1 };
+                        let target = next_audition_boundary(
+                            self.transport.position(),
+                            self.transport.bpm(),
+                            self.sample_rate,
+                            beats,
+                        );
+                        self.audition.queue(audio, target, fade_frames, looped);
+                        let _ = self.event_tx.push(EngineEvent::AuditionQueued);
+                    } else {
+                        self.audition.start(audio, fade_frames, looped);
+                        let _ = self.event_tx.push(EngineEvent::AuditionStarted);
+                    }
                 }
                 EngineCommand::StopAudition => {
                     self.audition.stop(audition_fade_frames(self.sample_rate));
                 }
                 EngineCommand::SetAuditionGain(gain) => {
                     self.audition.gain = gain.clamp(0.0, 2.0);
+                }
+                EngineCommand::SetAuditionLoop(looped) => {
+                    self.audition.set_looped(looped);
                 }
 
                 // -- External MIDI input --
@@ -1329,6 +1414,15 @@ fn audition_fade_frames(sample_rate: u32) -> usize {
     ((sample_rate as usize * AUDITION_FADE_MS) / 1_000).max(1)
 }
 
+fn next_audition_boundary(position: u64, bpm: f64, sample_rate: u32, beats: u64) -> u64 {
+    if bpm <= 0.0 || sample_rate == 0 {
+        return position;
+    }
+    let boundary_frames = sample_rate as f64 * 60.0 / bpm * beats.max(1) as f64;
+    let boundary_index = (position as f64 / boundary_frames).floor() + 1.0;
+    (boundary_index * boundary_frames).round() as u64
+}
+
 /// Mix one RAW audition voice. Returns true once its source or fade is done.
 fn render_audition_voice(
     voice: &mut AuditionVoice,
@@ -1336,6 +1430,7 @@ fn render_audition_voice(
     frames: usize,
     channels: usize,
     bus_gain: f32,
+    output_frame_offset: usize,
 ) -> bool {
     let audio_channels = voice.audio.num_channels();
     let audio_frames = voice.audio.num_frames();
@@ -1343,10 +1438,16 @@ fn render_audition_voice(
         return true;
     }
 
-    for frame in 0..frames {
-        let source = voice.position as usize;
+    let render_frames = frames.saturating_sub(output_frame_offset);
+    for frame in 0..render_frames {
+        let mut source = voice.position as usize;
         if source >= audio_frames {
-            return true;
+            if !voice.looped {
+                return true;
+            }
+            let crossfade_frames = voice.fade_in_frames.min(audio_frames / 2);
+            source = crossfade_frames;
+            voice.position = source as u64;
         }
         let attack = if source < voice.fade_in_frames {
             (source + 1) as f32 / voice.fade_in_frames as f32
@@ -1354,8 +1455,11 @@ fn render_audition_voice(
             1.0
         };
         let remaining_source = audio_frames.saturating_sub(source + 1);
-        let natural_release =
-            (remaining_source as f32 / voice.fade_in_frames as f32).clamp(0.0, 1.0);
+        let natural_release = if voice.looped {
+            1.0
+        } else {
+            (remaining_source as f32 / voice.fade_in_frames as f32).clamp(0.0, 1.0)
+        };
         let commanded_release = match voice.fade_out_remaining {
             Some(remaining) => {
                 let envelope = remaining.saturating_sub(1) as f32 / voice.fade_in_frames as f32;
@@ -1365,9 +1469,22 @@ fn render_audition_voice(
             None => 1.0,
         };
         let envelope = attack.min(natural_release) * commanded_release * bus_gain;
+        let crossfade_frames = voice.fade_in_frames.min(audio_frames / 2);
+        let crossfade_offset = source.saturating_sub(audio_frames - crossfade_frames);
         for ch in 0..channels {
             let source_channel = ch.min(audio_channels - 1);
-            output[frame * channels + ch] += voice.audio.sample(source_channel, source) * envelope;
+            let sample = if voice.looped
+                && crossfade_frames > 0
+                && source >= audio_frames - crossfade_frames
+            {
+                let head_gain = crossfade_offset as f32 / crossfade_frames as f32;
+                let tail_gain = 1.0 - head_gain;
+                voice.audio.sample(source_channel, source) * tail_gain
+                    + voice.audio.sample(source_channel, crossfade_offset) * head_gain
+            } else {
+                voice.audio.sample(source_channel, source)
+            };
+            output[(output_frame_offset + frame) * channels + ch] += sample * envelope;
         }
         voice.position = voice.position.saturating_add(1);
         if voice.fade_out_remaining == Some(0) {
@@ -1375,7 +1492,7 @@ fn render_audition_voice(
         }
     }
 
-    voice.position as usize >= audio_frames
+    !voice.looped && voice.position as usize >= audio_frames
 }
 
 /// Stream a block to the UI spectrum analyser as mono samples.

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -23,6 +23,14 @@ fn make_constant_audio(frames: usize, value: f32) -> Arc<DecodedAudio> {
     })
 }
 
+fn start_audition(audio: Arc<DecodedAudio>) -> EngineCommand {
+    EngineCommand::StartAudition {
+        audio,
+        sync: AuditionSync::Off,
+        looped: false,
+    }
+}
+
 #[test]
 fn new_returns_ring_buffer_endpoints() {
     let (engine, _cmd_tx, _event_rx) = AudioEngine::new();
@@ -905,7 +913,7 @@ fn audition_plays_even_when_transport_stopped() {
     let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
     let audio = make_constant_audio(4_096, 0.4);
 
-    cmd_tx.push(EngineCommand::StartAudition(audio)).unwrap();
+    cmd_tx.push(start_audition(audio)).unwrap();
 
     let mut buf = vec![0.0f32; 1_024];
     engine.process(&mut buf, 2);
@@ -921,7 +929,7 @@ fn audition_stop_uses_a_short_fade_without_stopping_transport() {
     let audio = make_constant_audio(4_096, 0.5);
 
     cmd_tx.push(EngineCommand::Play).unwrap();
-    cmd_tx.push(EngineCommand::StartAudition(audio)).unwrap();
+    cmd_tx.push(start_audition(audio)).unwrap();
     let mut started = vec![0.0f32; 1_024];
     engine.process(&mut started, 2);
     assert!(engine.transport().is_playing());
@@ -939,7 +947,7 @@ fn audition_auto_completes_at_end_of_audio() {
     let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
     let audio = make_constant_audio(512, 0.6);
 
-    cmd_tx.push(EngineCommand::StartAudition(audio)).unwrap();
+    cmd_tx.push(start_audition(audio)).unwrap();
 
     let mut buf = vec![0.0f32; 2_048];
     engine.process(&mut buf, 2);
@@ -954,13 +962,13 @@ fn newer_audition_crossfades_over_the_previous_source() {
     let a = make_constant_audio(4_096, 0.8);
     let b = make_constant_audio(4_096, 0.2);
 
-    cmd_tx.push(EngineCommand::StartAudition(a)).unwrap();
+    cmd_tx.push(start_audition(a)).unwrap();
     let mut buf = vec![0.0f32; 1_024];
     engine.process(&mut buf, 2);
     let before = buf[1_000];
     assert!(before > 0.7);
 
-    cmd_tx.push(EngineCommand::StartAudition(b)).unwrap();
+    cmd_tx.push(start_audition(b)).unwrap();
     let mut buf = vec![0.0f32; 1_024];
     engine.process(&mut buf, 2);
     assert!((buf[0] - before).abs() < 0.02, "replacement must not click");
@@ -975,12 +983,126 @@ fn audition_gain_is_independent_and_bypasses_project_master_gain() {
         .push(EngineCommand::SetTrackGain(TrackId::MASTER, 0.0))
         .unwrap();
     cmd_tx.push(EngineCommand::SetAuditionGain(0.25)).unwrap();
-    cmd_tx.push(EngineCommand::StartAudition(audio)).unwrap();
+    cmd_tx.push(start_audition(audio)).unwrap();
 
     let mut buf = vec![0.0f32; 1_024];
     engine.process(&mut buf, 2);
     let peak = buf.iter().copied().fold(0.0_f32, f32::max);
     assert!((peak - 0.2).abs() < 0.01);
+}
+
+#[test]
+fn synced_audition_starts_immediately_when_transport_is_stopped() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    cmd_tx
+        .push(EngineCommand::StartAudition {
+            audio: make_constant_audio(4_096, 0.4),
+            sync: AuditionSync::Bar,
+            looped: false,
+        })
+        .unwrap();
+
+    let mut buf = vec![0.0f32; 1_024];
+    engine.process(&mut buf, 2);
+
+    assert!(buf.iter().any(|sample| sample.abs() > 0.3));
+    assert!(!engine.transport().is_playing());
+}
+
+#[test]
+fn beat_synced_audition_queues_to_the_next_running_transport_boundary() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx.push(EngineCommand::Seek(10_000)).unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    cmd_tx
+        .push(EngineCommand::StartAudition {
+            audio: make_constant_audio(4_096, 0.4),
+            sync: AuditionSync::Beat,
+            looped: false,
+        })
+        .unwrap();
+
+    let mut buf = vec![0.0f32; 28_000];
+    engine.process(&mut buf, 2);
+
+    let boundary_offset = 22_050 - 10_000;
+    assert!(buf[..boundary_offset * 2]
+        .iter()
+        .all(|sample| sample.abs() < f32::EPSILON));
+    assert!(buf[(boundary_offset + 100) * 2..]
+        .iter()
+        .any(|sample| sample.abs() > 0.1));
+    let mut queued = false;
+    let mut started = false;
+    while let Ok(event) = event_rx.pop() {
+        queued |= matches!(event, EngineEvent::AuditionQueued);
+        started |= matches!(event, EngineEvent::AuditionStarted);
+    }
+    assert!(queued && started);
+}
+
+#[test]
+fn queued_audition_starts_immediately_if_transport_stops_before_boundary() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx.push(EngineCommand::Seek(10_000)).unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    cmd_tx
+        .push(EngineCommand::StartAudition {
+            audio: make_constant_audio(4_096, 0.4),
+            sync: AuditionSync::Bar,
+            looped: false,
+        })
+        .unwrap();
+
+    let mut queued = vec![0.0f32; 256];
+    engine.process(&mut queued, 2);
+    assert!(queued.iter().all(|sample| sample.abs() < f32::EPSILON));
+
+    cmd_tx.push(EngineCommand::Stop).unwrap();
+    let mut started = vec![0.0f32; 1_024];
+    engine.process(&mut started, 2);
+
+    assert!(started.iter().any(|sample| sample.abs() > 0.3));
+    assert!(!engine.transport().is_playing());
+}
+
+#[test]
+fn beat_and_bar_boundaries_are_deterministic() {
+    assert_eq!(next_audition_boundary(10_000, 120.0, 44_100, 1), 22_050);
+    assert_eq!(next_audition_boundary(10_000, 120.0, 44_100, 4), 88_200);
+    assert_eq!(next_audition_boundary(88_200, 120.0, 44_100, 4), 176_400);
+}
+
+#[test]
+fn audition_loop_crossfades_the_source_boundary_without_silence_or_a_click() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let samples: Vec<f32> = (0..4_096)
+        .map(|frame| -0.5 + frame as f32 / 4_095.0)
+        .collect();
+    let audio = Arc::new(DecodedAudio {
+        channels: vec![samples.clone(), samples],
+        sample_rate: 44_100,
+    });
+    cmd_tx
+        .push(EngineCommand::StartAudition {
+            audio,
+            sync: AuditionSync::Off,
+            looped: true,
+        })
+        .unwrap();
+
+    let mut buf = vec![0.0f32; 20_000];
+    engine.process(&mut buf, 2);
+
+    let left: Vec<f32> = buf.chunks_exact(2).map(|frame| frame[0]).collect();
+    assert!(left[4_500..].iter().any(|sample| sample.abs() > 0.3));
+    let largest_step = left[300..]
+        .windows(2)
+        .map(|pair| (pair[1] - pair[0]).abs())
+        .fold(0.0f32, f32::max);
+    assert!(largest_step < 0.02, "loop boundary step was {largest_step}");
 }
 
 #[test]

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -78,6 +78,10 @@ pub enum EngineEvent {
 
     /// The post-master Audition Bus became silent after stop or source end.
     AuditionStopped,
+    /// Audition is waiting for its transport beat/bar boundary.
+    AuditionQueued,
+    /// Audition crossed its requested boundary and began rendering.
+    AuditionStarted,
 }
 
 #[cfg(test)]
@@ -101,6 +105,8 @@ mod tests {
         let _started = EngineEvent::PlaybackStarted;
         let _stopped = EngineEvent::PlaybackStopped;
         let _audition_stopped = EngineEvent::AuditionStopped;
+        let _audition_queued = EngineEvent::AuditionQueued;
+        let _audition_started = EngineEvent::AuditionStarted;
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -9,7 +9,7 @@ use vibez_plugin_host::gui::PluginGuiKey;
 
 use crate::message::Message;
 use crate::plugin_window::PluginWindowEvent;
-use crate::state::{ArrangementSelection, DetailPanelTab, UiEffect};
+use crate::state::{ArrangementSelection, AuditionMode, DetailPanelTab, UiEffect};
 
 use super::*;
 
@@ -422,9 +422,26 @@ impl App {
                     }
                     EngineEvent::AuditionStopped => {
                         self.state.browser.stop_audition_state();
-                        if self.state.status_text == "RAW Audition playing" {
+                        if matches!(
+                            self.state.status_text.as_str(),
+                            "RAW Audition playing" | "WARP Audition playing"
+                        ) {
                             self.state.status_text = "Audition finished".into();
                         }
+                    }
+                    EngineEvent::AuditionQueued => {
+                        self.state.browser.audition_loading = false;
+                        self.state.browser.audition_playing = false;
+                        self.state.browser.audition_queued = true;
+                    }
+                    EngineEvent::AuditionStarted => {
+                        self.state.browser.audition_loading = false;
+                        self.state.browser.audition_queued = false;
+                        self.state.browser.audition_playing = true;
+                        self.state.status_text = match self.state.browser.audition_mode {
+                            AuditionMode::Raw => "RAW Audition playing".into(),
+                            AuditionMode::Warp => "WARP Audition playing".into(),
+                        };
                     }
                     EngineEvent::TrackMeter {
                         track_id,

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -5,14 +5,15 @@ use std::sync::Arc;
 
 use iced::Task;
 
+use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::{InstrumentKind, TrackKind};
 use vibez_core::track::MediaSourceRef;
 use vibez_dropbox::DropboxEntry;
-use vibez_engine::commands::EngineCommand;
+use vibez_engine::commands::{AuditionSync, EngineCommand};
 
 use crate::message::{BrowserImportTarget, Message};
-use crate::state::{SampleBrowserEntry, UiClip, UiDrumPad, UiTrack};
+use crate::state::{AuditionMode, SampleBrowserEntry, UiClip, UiDrumPad, UiTrack};
 
 use super::*;
 
@@ -20,6 +21,93 @@ impl App {
     pub(super) fn stop_browser_audition(&mut self) {
         self.send_command(EngineCommand::StopAudition);
         self.state.browser.stop_audition_state();
+    }
+
+    pub(super) fn start_browser_audition(&mut self, audio: Arc<DecodedAudio>) {
+        let queued =
+            self.state.transport.playing && self.state.browser.audition_sync != AuditionSync::Off;
+        self.send_command(EngineCommand::StartAudition {
+            audio,
+            sync: self.state.browser.audition_sync,
+            looped: self.state.browser.audition_loop,
+        });
+        self.state.browser.mark_audition_requested(queued);
+        let mode = match self.state.browser.audition_mode {
+            AuditionMode::Raw => "RAW",
+            AuditionMode::Warp => "WARP",
+        };
+        self.state.status_text = if queued {
+            format!("{mode} Audition queued")
+        } else {
+            format!("{mode} Audition playing")
+        };
+    }
+
+    pub(super) fn schedule_browser_bpm_detection(
+        &mut self,
+        source: MediaSourceRef,
+        audio: Arc<DecodedAudio>,
+    ) -> Task<Message> {
+        if !self.state.browser.begin_bpm_detection(&source) {
+            return Task::none();
+        }
+        let sample_rate = audio.sample_rate;
+        Task::perform(detect_clip_bpm_async(audio, sample_rate), move |estimate| {
+            Message::BrowserBpmDetected(
+                source.clone(),
+                estimate.map(|value| (value.bpm, value.confidence)),
+            )
+        })
+    }
+
+    pub(super) fn prepare_browser_warp(
+        &mut self,
+        source: MediaSourceRef,
+        raw: Arc<DecodedAudio>,
+        source_bpm: f64,
+    ) -> Task<Message> {
+        let project_bpm = self.state.transport.bpm;
+        self.state.browser.begin_audition_load(&source);
+        self.state.status_text = format!("Preparing WARP at {source_bpm:.1} BPM...");
+        Task::perform(
+            warp_browser_audition_async(raw, source_bpm, project_bpm),
+            move |result| Message::BrowserAuditionWarpReady {
+                source: source.clone(),
+                source_bpm,
+                project_bpm,
+                result,
+            },
+        )
+    }
+
+    pub(super) fn play_browser_mode(
+        &mut self,
+        source: MediaSourceRef,
+        raw: Arc<DecodedAudio>,
+    ) -> Task<Message> {
+        let detection = self.schedule_browser_bpm_detection(source.clone(), Arc::clone(&raw));
+        match self.state.browser.audition_mode {
+            AuditionMode::Raw => {
+                self.start_browser_audition(raw);
+                detection
+            }
+            AuditionMode::Warp => {
+                self.stop_browser_audition();
+                if let Some(source_bpm) = self.state.browser.audition_bpm_confirmed {
+                    Task::batch([
+                        detection,
+                        self.prepare_browser_warp(source, raw, source_bpm),
+                    ])
+                } else {
+                    self.state.status_text = if self.state.browser.audition_bpm_detecting {
+                        "Detecting source BPM; WARP awaits confirmation".into()
+                    } else {
+                        "Confirm or enter a positive source BPM for WARP".into()
+                    };
+                    detection
+                }
+            }
+        }
     }
 
     pub(super) fn selected_sample_browser_entry(&self) -> Option<&SampleBrowserEntry> {
@@ -791,7 +879,11 @@ impl App {
                         })
                     });
                 if let Some((audio, name)) = audition {
-                    self.send_command(EngineCommand::StartAudition(audio));
+                    self.send_command(EngineCommand::StartAudition {
+                        audio,
+                        sync: AuditionSync::Off,
+                        looped: false,
+                    });
                     self.state.status_text = format!("Pad {}: {}", pad_index + 1, name);
                 }
                 self.update(Message::select_drum_rack_pad(track_id, pad_index))

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -176,6 +176,7 @@ impl App {
                 ),
                 audition_enabled: ui_settings.audition_enabled,
                 audition_gain: ui_settings.audition_gain.clamp(0.0, 2.0),
+                audition_loop: ui_settings.audition_loop,
                 roots: ui_settings.sample_library_roots,
                 dropbox: dropbox_ui_state,
                 ..Default::default()
@@ -244,6 +245,9 @@ impl App {
         app.send_command(EngineCommand::SetBpm(app.state.transport.bpm));
         app.send_command(EngineCommand::SetAuditionGain(
             app.state.browser.audition_gain,
+        ));
+        app.send_command(EngineCommand::SetAuditionLoop(
+            app.state.browser.audition_loop,
         ));
 
         // Console model: the master bus carries its channel EQ from
@@ -423,6 +427,19 @@ async fn detect_clip_bpm_async(
     tokio::task::spawn_blocking(move || vibez_core::onset::detect_bpm(&audio, sample_rate))
         .await
         .unwrap_or(None)
+}
+
+async fn warp_browser_audition_async(
+    audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
+    source_bpm: f64,
+    project_bpm: f64,
+) -> Result<Arc<vibez_core::audio_buffer::DecodedAudio>, String> {
+    tokio::task::spawn_blocking(move || {
+        crate::warp::rewarp_for_load(&audio, source_bpm, project_bpm)
+            .ok_or_else(|| "Could not create pitch-preserving WARP Audition".to_string())
+    })
+    .await
+    .map_err(|error| format!("audition warp task failed: {error}"))?
 }
 
 async fn auto_warp_clip_async(input: AutoWarpInput) -> crate::message::AutoWarpOutcome {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -201,6 +201,7 @@ impl App {
             sample_browser_width: self.state.browser.dock_width,
             audition_enabled: self.state.browser.audition_enabled,
             audition_gain: self.state.browser.audition_gain,
+            audition_loop: self.state.browser.audition_loop,
             auto_warp_on_import: self.state.auto_warp_on_import,
             warp_confidence_threshold: self.state.warp_confidence_threshold,
             preferred_midi_input: self.midi_input.as_ref().map(|h| h.port_name.clone()),

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -565,7 +565,7 @@ impl App {
                     if let MediaSourceRef::LocalFile { path } = source.clone() {
                         if self.state.browser.audition_enabled {
                             self.state.browser.begin_audition_load(&source);
-                            self.state.status_text = "Loading RAW Audition...".to_string();
+                            self.state.status_text = "Preparing Audition...".to_string();
                             return Task::perform(
                                 decode_local_for_preview_async(path),
                                 move |result| {
@@ -585,7 +585,7 @@ impl App {
                 self.state.browser.select_source(source.clone());
                 self.state.browser.begin_audition_load(&source);
                 if let MediaSourceRef::LocalFile { path } = source.clone() {
-                    self.state.status_text = "Loading RAW Audition...".to_string();
+                    self.state.status_text = "Preparing Audition...".to_string();
                     return Task::perform(decode_local_for_preview_async(path), move |result| {
                         Message::LocalSamplePreviewReady(source.clone(), result)
                     });
@@ -613,6 +613,77 @@ impl App {
                     self.state.browser.audition_gain,
                 ));
                 self.persist_ui_settings();
+            }
+            Message::SetAuditionMode(mode) => {
+                if self.state.browser.audition_mode == mode {
+                    return Task::none();
+                }
+                self.stop_browser_audition();
+                self.state.browser.audition_mode = mode;
+                let Some(source) = self.state.browser.selected_source.clone() else {
+                    return Task::none();
+                };
+                let Some(raw) = self.state.browser.waveform_audio.clone() else {
+                    self.state.status_text = "Select a source to audition".into();
+                    return Task::none();
+                };
+                return self.play_browser_mode(source, raw);
+            }
+            Message::SetAuditionSync(sync) => {
+                self.state.browser.audition_sync = sync;
+                self.state.status_text = match sync {
+                    vibez_engine::commands::AuditionSync::Off => {
+                        "Audition Sync Off: starts immediately".into()
+                    }
+                    vibez_engine::commands::AuditionSync::Beat => {
+                        "Audition Sync Beat: queues only while transport runs".into()
+                    }
+                    vibez_engine::commands::AuditionSync::Bar => {
+                        "Audition Sync Bar: queues only while transport runs".into()
+                    }
+                };
+            }
+            Message::ToggleAuditionLoop => {
+                self.state.browser.audition_loop = !self.state.browser.audition_loop;
+                self.send_command(EngineCommand::SetAuditionLoop(
+                    self.state.browser.audition_loop,
+                ));
+                self.persist_ui_settings();
+                self.state.status_text = if self.state.browser.audition_loop {
+                    "Audition Loop enabled".into()
+                } else {
+                    "Audition Loop disabled".into()
+                };
+            }
+            Message::AuditionBpmEditChanged(value) => {
+                self.state.browser.audition_bpm_edit = value;
+                self.state.browser.audition_bpm_confirmed = None;
+                if self.state.browser.audition_mode == crate::state::AuditionMode::Warp
+                    && (self.state.browser.audition_playing || self.state.browser.audition_queued)
+                {
+                    self.stop_browser_audition();
+                    self.state.status_text = "Confirm the edited source BPM for WARP".into();
+                }
+            }
+            Message::ConfirmAuditionBpm => {
+                let source_bpm = match self.state.browser.confirm_audition_bpm() {
+                    Ok(value) => value,
+                    Err(error) => {
+                        self.state.status_text = error.into();
+                        return Task::none();
+                    }
+                };
+                self.state.status_text = format!("Confirmed {source_bpm:.1} source BPM");
+                if self.state.browser.audition_mode == crate::state::AuditionMode::Warp {
+                    let Some(source) = self.state.browser.selected_source.clone() else {
+                        return Task::none();
+                    };
+                    let Some(raw) = self.state.browser.waveform_audio.clone() else {
+                        return Task::none();
+                    };
+                    self.stop_browser_audition();
+                    return self.prepare_browser_warp(source, raw, source_bpm);
+                }
             }
             Message::EscapePressed => {
                 if self.state.browser.audition_playing || self.state.browser.audition_loading {
@@ -653,8 +724,8 @@ impl App {
                     .browser
                     .install_audition(source, Arc::clone(&audio))
                 {
-                    self.send_command(EngineCommand::StartAudition(audio));
-                    self.state.status_text = "RAW Audition playing".to_string();
+                    let source = self.state.browser.selected_source.clone().unwrap();
+                    return self.play_browser_mode(source, audio);
                 }
             }
             Message::LocalSamplePreviewReady(source, Err(err)) => {
@@ -666,10 +737,58 @@ impl App {
                 }
             }
             Message::BrowserWaveformReady(source, Ok(audio)) => {
-                self.state.browser.install_waveform(source, audio);
+                if self
+                    .state
+                    .browser
+                    .install_waveform(source.clone(), Arc::clone(&audio))
+                {
+                    return self.schedule_browser_bpm_detection(source, audio);
+                }
             }
             Message::BrowserWaveformReady(source, Err(err)) => {
                 self.state.browser.fail_waveform_load(&source, err);
+            }
+            Message::BrowserBpmDetected(source, estimate) => {
+                if self.state.browser.install_bpm_suggestion(source, estimate)
+                    && self.state.browser.audition_mode == crate::state::AuditionMode::Warp
+                    && self.state.browser.audition_bpm_confirmed.is_none()
+                {
+                    self.state.status_text = match estimate {
+                        Some((bpm, confidence))
+                            if confidence < self.state.warp_confidence_threshold =>
+                        {
+                            format!(
+                                "Low-confidence suggestion {bpm:.1} BPM; confirm or edit for WARP"
+                            )
+                        }
+                        Some((bpm, _)) => {
+                            format!("Suggested {bpm:.1} BPM; confirm for WARP")
+                        }
+                        None => "No BPM detected; enter a positive source BPM for WARP".into(),
+                    };
+                }
+            }
+            Message::BrowserAuditionWarpReady {
+                source,
+                source_bpm,
+                project_bpm,
+                result,
+            } => {
+                let current = self.state.browser.selected_source.as_ref() == Some(&source)
+                    && self.state.browser.audition_mode == crate::state::AuditionMode::Warp
+                    && self.state.browser.audition_bpm_confirmed == Some(source_bpm)
+                    && (self.state.transport.bpm - project_bpm).abs() < f64::EPSILON;
+                if !current {
+                    return Task::none();
+                }
+                self.state.browser.audition_loading = false;
+                match result {
+                    Ok(audio) => self.start_browser_audition(audio),
+                    Err(error) => {
+                        self.state.browser.stop_audition_state();
+                        self.state.status_text = format!("WARP Audition error: {error}");
+                    }
+                }
             }
             Message::ImportSelectedBrowserSampleToArrangement => {
                 return self.handle_import_selected_browser_sample_to_arrangement();
@@ -1193,10 +1312,9 @@ impl App {
                 if self
                     .state
                     .browser
-                    .install_audition(source, Arc::clone(&audio))
+                    .install_audition(source.clone(), Arc::clone(&audio))
                 {
-                    self.send_command(EngineCommand::StartAudition(audio));
-                    self.state.status_text = "RAW Audition playing".to_string();
+                    return self.play_browser_mode(source, audio);
                 }
             }
             Message::DropboxPreviewReady(source, Err(err)) => {

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -14,8 +14,9 @@ use vibez_dropbox::DropboxEntry;
 
 use crate::icons;
 use crate::message::Message;
-use crate::state::{SampleBrowserEntry, SampleBrowserMode};
+use crate::state::{AuditionMode, SampleBrowserEntry, SampleBrowserMode};
 use crate::theme as th;
+use vibez_engine::commands::AuditionSync;
 
 use super::*;
 
@@ -477,6 +478,64 @@ impl App {
         .on_press(Message::ToggleAuditionEnabled)
         .padding([2, 4])
         .style(browser_utility_action_style);
+        let import_label = match self.state.browser.audition_import_input() {
+            Some(input) if input.mode == AuditionMode::Raw => "IMPORT RAW".to_string(),
+            Some(input) => format!("IMPORT WARP {:.1}", input.source_bpm.unwrap_or_default()),
+            None => "IMPORT BLOCKED".to_string(),
+        };
+
+        let raw_active = self.state.browser.audition_mode == AuditionMode::Raw;
+        let raw = button(text("RAW").size(9))
+            .on_press(Message::SetAuditionMode(AuditionMode::Raw))
+            .padding([2, 5])
+            .style(move |_theme: &Theme, status| browser_place_button_style(raw_active, status));
+        let warp_active = self.state.browser.audition_mode == AuditionMode::Warp;
+        let warp = button(text("WARP").size(9))
+            .on_press(Message::SetAuditionMode(AuditionMode::Warp))
+            .padding([2, 5])
+            .style(move |_theme: &Theme, status| browser_place_button_style(warp_active, status));
+        let sync_button = |label, value| {
+            let active = self.state.browser.audition_sync == value;
+            button(text(label).size(9))
+                .on_press(Message::SetAuditionSync(value))
+                .padding([2, 4])
+                .style(move |_theme: &Theme, status| browser_place_button_style(active, status))
+        };
+        let looped = self.state.browser.audition_loop;
+        let loop_toggle = button(text(if looped { "LOOP ON" } else { "LOOP OFF" }).size(9))
+            .on_press(Message::ToggleAuditionLoop)
+            .padding([2, 4])
+            .style(move |_theme: &Theme, status| browser_place_button_style(looped, status));
+
+        let bpm_input = text_input("BPM", &self.state.browser.audition_bpm_edit)
+            .on_input(Message::AuditionBpmEditChanged)
+            .on_submit(Message::ConfirmAuditionBpm)
+            .size(10)
+            .padding([3, 5])
+            .width(Length::Fixed(62.0))
+            .style(browser_compact_input_style);
+        let confirm_bpm = button(text("CONFIRM").size(9))
+            .on_press(Message::ConfirmAuditionBpm)
+            .padding([3, 5])
+            .style(browser_utility_action_style);
+        let bpm_state = if self.state.browser.audition_bpm_detecting {
+            "DETECTING".to_string()
+        } else if let Some(confirmed) = self.state.browser.audition_bpm_confirmed {
+            format!("CONFIRMED {confirmed:.1}")
+        } else if let Some(suggestion) = self.state.browser.audition_bpm_suggestion {
+            let low = self
+                .state
+                .browser
+                .audition_bpm_confidence
+                .is_some_and(|confidence| confidence < self.state.warp_confidence_threshold);
+            if low {
+                format!("SUGGEST {suggestion:.1} · LOW")
+            } else {
+                format!("SUGGEST {suggestion:.1}")
+            }
+        } else {
+            "MANUAL FOR WARP".to_string()
+        };
 
         let waveform: Element<'_, Message> = container(
             canvas(crate::widgets::browser_waveform::BrowserWaveform {
@@ -499,14 +558,24 @@ impl App {
         let controls = row![
             play,
             stop,
-            text(if self.state.browser.audition_loading {
-                "LOADING"
+            text(if self.state.browser.dropbox.preview_in_progress {
+                "FETCHING"
+            } else if self.state.browser.audition_loading {
+                "PREPARING"
+            } else if self.state.browser.audition_queued {
+                "QUEUED"
             } else if self.state.browser.audition_playing {
                 "PLAYING"
             } else if self.state.browser.waveform_error.is_some() {
                 "UNAVAILABLE"
             } else if self.state.browser.waveform_audio.is_some() {
-                "RAW"
+                match self.state.browser.audition_mode {
+                    AuditionMode::Raw => "RAW",
+                    AuditionMode::Warp if self.state.browser.audition_bpm_confirmed.is_some() => {
+                        "WARP READY"
+                    }
+                    AuditionMode::Warp => "BPM NEEDED",
+                }
             } else {
                 "SELECT"
             })
@@ -554,6 +623,7 @@ impl App {
             row![
                 text("AUDITION").size(9).color(th::text_muted()),
                 follow_toggle,
+                text(import_label).size(9).color(th::text_dim()),
                 text(selected_label)
                     .size(10)
                     .color(th::text_dim())
@@ -562,6 +632,36 @@ impl App {
                     .wrapping(iced::widget::text::Wrapping::None)
             ]
             .spacing(5)
+            .align_y(iced::Alignment::Center),
+            row![
+                text("MODE").size(9).color(th::text_muted()),
+                raw,
+                warp,
+                text("SYNC").size(9).color(th::text_muted()),
+                sync_button("OFF", AuditionSync::Off),
+                sync_button("BEAT", AuditionSync::Beat),
+                sync_button("BAR", AuditionSync::Bar),
+                horizontal_space(),
+                loop_toggle,
+            ]
+            .spacing(3)
+            .align_y(iced::Alignment::Center),
+            row![
+                text("BPM").size(9).color(th::text_muted()),
+                bpm_input,
+                confirm_bpm,
+                text(bpm_state)
+                    .size(9)
+                    .color(if self.state.browser.audition_bpm_confirmed.is_some() {
+                        th::accent()
+                    } else {
+                        th::text_dim()
+                    })
+                    .width(Length::Fill)
+                    .align_x(iced::alignment::Horizontal::Right)
+                    .wrapping(iced::widget::text::Wrapping::None),
+            ]
+            .spacing(4)
             .align_y(iced::Alignment::Center),
             controls,
             gain_row
@@ -1356,6 +1456,24 @@ fn browser_utility_action_style(_theme: &Theme, status: button::Status) -> butto
             radius: 0.0.into(),
         },
         ..Default::default()
+    }
+}
+
+fn browser_compact_input_style(
+    _theme: &Theme,
+    _status: iced::widget::text_input::Status,
+) -> iced::widget::text_input::Style {
+    iced::widget::text_input::Style {
+        background: th::bg_dark().into(),
+        border: iced::Border {
+            color: th::border(),
+            width: 1.0,
+            radius: 0.0.into(),
+        },
+        icon: th::text_dim(),
+        placeholder: th::text_dim(),
+        value: th::text(),
+        selection: th::accent(),
     }
 }
 

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -432,12 +432,45 @@ mod tests {
         let mut browser = BrowserState::default();
         assert!(browser.audition_enabled);
         assert_eq!(browser.audition_gain, 1.0);
+        assert_eq!(browser.audition_mode, crate::state::AuditionMode::Raw);
+        assert_eq!(
+            browser.audition_sync,
+            vibez_engine::commands::AuditionSync::Off
+        );
+        assert!(!browser.audition_loop);
 
         assert!(!browser.toggle_audition_enabled());
         browser.set_audition_gain(3.0);
         assert_eq!(browser.audition_gain, 2.0);
         browser.set_audition_gain(-1.0);
         assert_eq!(browser.audition_gain, 0.0);
+    }
+
+    #[test]
+    fn warp_import_input_requires_positive_confirmed_bpm_for_the_current_source() {
+        let first = MediaSourceRef::LocalFile {
+            path: PathBuf::from("/samples/loop.wav"),
+        };
+        let second = MediaSourceRef::LocalFile {
+            path: PathBuf::from("/samples/other.wav"),
+        };
+        let mut browser = BrowserState::default();
+        browser.select_source(first.clone());
+        browser.audition_mode = crate::state::AuditionMode::Warp;
+        assert!(browser.audition_import_input().is_none());
+
+        assert!(browser.install_bpm_suggestion(first, Some((127.8, 0.42))));
+        assert_eq!(browser.audition_bpm_edit, "127.8");
+        assert_eq!(browser.confirm_audition_bpm().unwrap(), 127.8);
+        let input = browser.audition_import_input().unwrap();
+        assert_eq!(input.mode, crate::state::AuditionMode::Warp);
+        assert_eq!(input.source_bpm, Some(127.8));
+
+        browser.select_source(second);
+        assert!(browser.audition_bpm_confirmed.is_none());
+        assert!(browser.audition_import_input().is_none());
+        browser.audition_bpm_edit = "0".into();
+        assert!(browser.confirm_audition_bpm().is_err());
     }
 
     #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -11,7 +11,7 @@ use vibez_plugin_host::gui::PluginGuiKey;
 use vibez_plugin_host::PluginId;
 use vibez_project::Project;
 
-use crate::state::{SampleBrowserEntry, SampleBrowserFolder, SettingsTab};
+use crate::state::{AuditionMode, SampleBrowserEntry, SampleBrowserFolder, SettingsTab};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DrumPadParam {
@@ -266,9 +266,21 @@ pub enum Message {
     StopBrowserPreview,
     ToggleAuditionEnabled,
     SetAuditionGain(f32),
+    SetAuditionMode(AuditionMode),
+    SetAuditionSync(vibez_engine::commands::AuditionSync),
+    ToggleAuditionLoop,
+    AuditionBpmEditChanged(String),
+    ConfirmAuditionBpm,
     EscapePressed,
     LocalSamplePreviewReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
     BrowserWaveformReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
+    BrowserBpmDetected(MediaSourceRef, Option<(f64, f32)>),
+    BrowserAuditionWarpReady {
+        source: MediaSourceRef,
+        source_bpm: f64,
+        project_bpm: f64,
+        result: Result<Arc<DecodedAudio>, String>,
+    },
     DropSampleOnArrangement {
         track_id: TrackId,
         position_samples: u64,

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -10,7 +10,21 @@ use vibez_core::constants::DEFAULT_BPM;
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::track::MediaSourceRef;
 use vibez_dropbox::DropboxEntry;
+use vibez_engine::commands::AuditionSync;
 use vibez_plugin_host::PluginSettings;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AuditionMode {
+    #[default]
+    Raw,
+    Warp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AuditionImportInput {
+    pub mode: AuditionMode,
+    pub source_bpm: Option<f64>,
+}
 
 /// View domain slice: everything about how the project is being
 /// looked at, none of it part of the project itself.
@@ -289,6 +303,16 @@ pub struct BrowserState {
     pub audition_gain: f32,
     pub audition_loading: bool,
     pub audition_playing: bool,
+    pub audition_queued: bool,
+    pub audition_mode: AuditionMode,
+    pub audition_sync: AuditionSync,
+    pub audition_loop: bool,
+    pub audition_bpm_source: Option<MediaSourceRef>,
+    pub audition_bpm_suggestion: Option<f64>,
+    pub audition_bpm_confidence: Option<f32>,
+    pub audition_bpm_confirmed: Option<f64>,
+    pub audition_bpm_edit: String,
+    pub audition_bpm_detecting: bool,
     pub scan_in_progress: bool,
     pub mode: SampleBrowserMode,
     pub dropbox: DropboxUiState,
@@ -329,6 +353,16 @@ impl Default for BrowserState {
             audition_gain: 1.0,
             audition_loading: false,
             audition_playing: false,
+            audition_queued: false,
+            audition_mode: AuditionMode::default(),
+            audition_sync: AuditionSync::Off,
+            audition_loop: false,
+            audition_bpm_source: None,
+            audition_bpm_suggestion: None,
+            audition_bpm_confidence: None,
+            audition_bpm_confirmed: None,
+            audition_bpm_edit: String::new(),
+            audition_bpm_detecting: false,
             scan_in_progress: false,
             mode: SampleBrowserMode::default(),
             dropbox: DropboxUiState::default(),
@@ -525,6 +559,7 @@ impl BrowserState {
         self.selected_source = Some(source);
         if changed {
             self.clear_waveform();
+            self.clear_audition_bpm();
         }
         changed
     }
@@ -532,6 +567,7 @@ impl BrowserState {
     pub fn clear_selection(&mut self) {
         self.selected_source = None;
         self.clear_waveform();
+        self.clear_audition_bpm();
     }
 
     pub fn begin_waveform_load(&mut self, source: &MediaSourceRef) {
@@ -559,6 +595,7 @@ impl BrowserState {
     pub fn stop_audition_state(&mut self) {
         self.audition_loading = false;
         self.audition_playing = false;
+        self.audition_queued = false;
     }
 
     pub fn toggle_audition_enabled(&mut self) -> bool {
@@ -568,6 +605,81 @@ impl BrowserState {
 
     pub fn set_audition_gain(&mut self, gain: f32) {
         self.audition_gain = gain.clamp(0.0, 2.0);
+    }
+
+    pub fn mark_audition_requested(&mut self, queued: bool) {
+        self.audition_loading = false;
+        self.audition_queued = queued;
+        self.audition_playing = !queued;
+    }
+
+    pub fn begin_bpm_detection(&mut self, source: &MediaSourceRef) -> bool {
+        if self.selected_source.as_ref() != Some(source)
+            || self.audition_bpm_source.as_ref() == Some(source)
+            || self.audition_bpm_detecting
+        {
+            return false;
+        }
+        self.audition_bpm_detecting = true;
+        true
+    }
+
+    pub fn install_bpm_suggestion(
+        &mut self,
+        source: MediaSourceRef,
+        estimate: Option<(f64, f32)>,
+    ) -> bool {
+        if self.selected_source.as_ref() != Some(&source) {
+            return false;
+        }
+        self.audition_bpm_source = Some(source);
+        self.audition_bpm_detecting = false;
+        self.audition_bpm_suggestion = estimate.map(|value| value.0);
+        self.audition_bpm_confidence = estimate.map(|value| value.1);
+        if self.audition_bpm_edit.is_empty() {
+            self.audition_bpm_edit = estimate
+                .map(|value| format!("{:.1}", value.0))
+                .unwrap_or_default();
+        }
+        true
+    }
+
+    pub fn confirm_audition_bpm(&mut self) -> Result<f64, &'static str> {
+        let bpm = self
+            .audition_bpm_edit
+            .trim()
+            .parse::<f64>()
+            .map_err(|_| "Enter a positive source BPM")?;
+        if !bpm.is_finite() || bpm <= 0.0 {
+            return Err("Enter a positive source BPM");
+        }
+        self.audition_bpm_confirmed = Some(bpm);
+        Ok(bpm)
+    }
+
+    pub fn clear_audition_bpm(&mut self) {
+        self.audition_bpm_source = None;
+        self.audition_bpm_suggestion = None;
+        self.audition_bpm_confidence = None;
+        self.audition_bpm_confirmed = None;
+        self.audition_bpm_edit.clear();
+        self.audition_bpm_detecting = false;
+    }
+
+    pub fn audition_import_input(&self) -> Option<AuditionImportInput> {
+        match self.audition_mode {
+            AuditionMode::Raw => Some(AuditionImportInput {
+                mode: AuditionMode::Raw,
+                source_bpm: None,
+            }),
+            AuditionMode::Warp => {
+                self.audition_bpm_confirmed
+                    .map(|source_bpm| AuditionImportInput {
+                        mode: AuditionMode::Warp,
+                        source_bpm: Some(source_bpm),
+                    })
+            }
+        }
     }
 
     pub fn install_waveform(&mut self, source: MediaSourceRef, audio: Arc<DecodedAudio>) -> bool {

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -14,6 +14,8 @@ pub struct UiSettings {
     pub audition_enabled: bool,
     #[serde(default = "default_audition_gain")]
     pub audition_gain: f32,
+    #[serde(default)]
+    pub audition_loop: bool,
     /// Automatically detect each dropped sample's BPM and warp it to
     /// the project tempo on import. Off by default; users opt in from
     /// Settings → Warping.
@@ -43,6 +45,7 @@ impl Default for UiSettings {
             sample_browser_width: default_sample_browser_width(),
             audition_enabled: default_audition_enabled(),
             audition_gain: default_audition_gain(),
+            audition_loop: false,
             auto_warp_on_import: false,
             warp_confidence_threshold: default_warp_confidence_threshold(),
             preferred_midi_input: None,
@@ -129,6 +132,7 @@ mod tests {
         let loaded: UiSettings = serde_json::from_str(r#"{"sample_library_roots":[]}"#).unwrap();
         assert!(loaded.audition_enabled);
         assert_eq!(loaded.audition_gain, 1.0);
+        assert!(!loaded.audition_loop);
     }
 
     #[test]
@@ -136,12 +140,14 @@ mod tests {
         let settings = UiSettings {
             audition_enabled: false,
             audition_gain: 0.42,
+            audition_loop: true,
             ..Default::default()
         };
         let loaded: UiSettings =
             serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
         assert!(!loaded.audition_enabled);
         assert_eq!(loaded.audition_gain, 0.42);
+        assert!(loaded.audition_loop);
     }
 
     #[test]


### PR DESCRIPTION
## Demo

Compare a selected Local sample in RAW or pitch-preserving WARP mode, confirm source BPM before WARP, quantize audition start to Beat/Bar only while transport runs, and loop through click-safe boundaries.

## Scope

- adds RAW/WARP mode and explicit confirmed source-BPM input
- adds Off/Beat/Bar audition sync with queued/playing state
- adds persistent Loop defaulting off and click-safe boundary crossfades
- exposes the active audition mode as an explicit import input for Card 09
- keeps Browser styling flat and preserves the responsive Places + Results shell

## Verification

- cargo test -p vibez-engine (133 passed)
- cargo test -p vibez-dsp (64 passed)
- cargo test -p vibez-ui (143 passed)
- cargo clippy -p vibez-engine -p vibez-dsp -p vibez-ui --lib -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- native Xvfb smoke at 300, 410, and 650 px Browser widths; RAW, blocked WARP, stopped transport, BAR queue/start, and loop-on states captured

## Non-goals

Automatic loop/one-shot classification, REPITCH, range-based Remote streaming, and carrying the chosen mode into import (Card 09).

Stacked on #57.