### PR TITLE
Browser Card 09: import Local media to explicit targets

### DIFF
--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -13,6 +13,19 @@ pub enum MediaSourceRef {
     LocalFile {
         path: PathBuf,
     },
+    /// Project-owned bytes copied to a staging area before the first save.
+    /// This reference must never survive in a committed project document.
+    StagedProjectMedia {
+        id: String,
+        file_name: String,
+        staging_path: PathBuf,
+        source_path: PathBuf,
+    },
+    /// Playback-critical media embedded in a Project Format V1 container.
+    ProjectMedia {
+        id: String,
+        file_name: String,
+    },
     DropboxFile {
         path_lower: String,
         display_path: String,
@@ -28,6 +41,8 @@ impl MediaSourceRef {
                 .file_name()
                 .map(|name| name.to_string_lossy().to_string())
                 .unwrap_or_else(|| path.display().to_string()),
+            MediaSourceRef::StagedProjectMedia { file_name, .. }
+            | MediaSourceRef::ProjectMedia { file_name, .. } => file_name.clone(),
             MediaSourceRef::DropboxFile { display_path, .. } => PathBuf::from(display_path)
                 .file_name()
                 .map(|name| name.to_string_lossy().to_string())

--- a/crates/vibez-project/src/bin/project-format-v1-proof.rs
+++ b/crates/vibez-project/src/bin/project-format-v1-proof.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-use vibez_project::project_format_v1_proof::{
-    abort_mid_save, hex_sha256, representative_document, ProofContainer, Provenance, StagedMedia,
+use vibez_project::project_format_v1::{
+    abort_mid_save, hex_sha256, representative_document, ProjectContainer, Provenance, StagedMedia,
 };
 
 const ASSET_BYTES: usize = 32 * 1024 * 1024;
@@ -69,7 +69,7 @@ fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
 
     let mut document = representative_document();
     let (mut container, full_save) =
-        ProofContainer::create_from_staged(&container_path, &mut document, &staged)?;
+        ProjectContainer::create_from_staged(&container_path, &mut document, &staged)?;
     assert!(!local_stage.exists() && !remote_stage.exists());
     assert_eq!(container.read_media("local-break")?, local_bytes);
     assert_eq!(container.read_media("remote-vocal")?, remote_bytes);
@@ -93,7 +93,7 @@ fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
     drop(container);
 
     let reopen_started = Instant::now();
-    let reopened = ProofContainer::open(&container_path)?;
+    let reopened = ProjectContainer::open(&container_path)?;
     let reopened_document = reopened.load_document()?;
     let reopen_elapsed = reopen_started.elapsed();
     assert_eq!(serde_json::to_vec(&reopened_document)?, committed_json);
@@ -113,7 +113,7 @@ fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
     );
 
     let recovered_started = Instant::now();
-    let recovered = ProofContainer::open(&container_path)?;
+    let recovered = ProjectContainer::open(&container_path)?;
     let recovered_document = recovered.load_document()?;
     let recovery_elapsed = recovered_started.elapsed();
     assert_eq!(serde_json::to_vec(&recovered_document)?, committed_json);
@@ -123,7 +123,7 @@ fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(recovered.read_media("local-break")?, local_bytes);
 
-    let save_as_container = ProofContainer::open(&save_as_path)?;
+    let save_as_container = ProjectContainer::open(&save_as_path)?;
     assert_eq!(
         serde_json::to_vec(&save_as_container.load_document()?)?,
         committed_json

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use vibez_core::midi::NoteClipInfo;
 use vibez_core::track::{ClipInfo, TrackInfo};
 
-pub mod project_format_v1_proof;
+pub mod project_format_v1;
 
 /// A serializable project containing tracks and clips.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/vibez-project/src/project_format_v1.rs
+++ b/crates/vibez-project/src/project_format_v1.rs
@@ -1,17 +1,18 @@
-//! Bounded Project Format V1 container proof.
+//! Production Project Format V1 SQLite container.
 //!
-//! This module deliberately does not replace [`crate::Project`]'s production
-//! JSON save/load path. It exists to measure and validate the SQLite-backed
-//! container proposed for Project Format V1 before production persistence is
-//! built on it.
+//! Project documents and playback-critical Project Media commit together.
+//! The container preserves unchanged media rows during ordinary saves and can
+//! create a self-contained Save As copy without returning to Source Storage.
 
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Transaction};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use vibez_core::track::{InstrumentStateInfo, MediaSourceRef, TrackInfo};
 
 use crate::Project;
 
@@ -91,8 +92,20 @@ pub struct SaveObservation {
     pub media_bytes_written: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectFileFormat {
+    V1,
+    LegacyJson,
+}
+
+#[derive(Debug, Clone)]
+pub struct SaveResult {
+    pub project: Project,
+    pub observation: SaveObservation,
+}
+
 #[derive(Debug)]
-pub enum ProofError {
+pub enum ProjectFormatError {
     Io(std::io::Error),
     Sql(rusqlite::Error),
     Json(serde_json::Error),
@@ -101,14 +114,14 @@ pub enum ProofError {
     ExistingDestination(PathBuf),
 }
 
-impl std::fmt::Display for ProofError {
+impl std::fmt::Display for ProjectFormatError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Io(error) => write!(f, "I/O error: {error}"),
             Self::Sql(error) => write!(f, "SQLite error: {error}"),
             Self::Json(error) => write!(f, "JSON error: {error}"),
             Self::InvalidContainer(message) => {
-                write!(f, "invalid Project Format V1 proof container: {message}")
+                write!(f, "invalid Project Format V1 container: {message}")
             }
             Self::MissingMedia(id) => write!(f, "project media {id:?} was not found"),
             Self::ExistingDestination(path) => {
@@ -118,42 +131,42 @@ impl std::fmt::Display for ProofError {
     }
 }
 
-impl std::error::Error for ProofError {}
+impl std::error::Error for ProjectFormatError {}
 
-impl From<std::io::Error> for ProofError {
+impl From<std::io::Error> for ProjectFormatError {
     fn from(value: std::io::Error) -> Self {
         Self::Io(value)
     }
 }
 
-impl From<rusqlite::Error> for ProofError {
+impl From<rusqlite::Error> for ProjectFormatError {
     fn from(value: rusqlite::Error) -> Self {
         Self::Sql(value)
     }
 }
 
-impl From<serde_json::Error> for ProofError {
+impl From<serde_json::Error> for ProjectFormatError {
     fn from(value: serde_json::Error) -> Self {
         Self::Json(value)
     }
 }
 
-pub struct ProofContainer {
+pub struct ProjectContainer {
     path: PathBuf,
     connection: Connection,
 }
 
-impl ProofContainer {
-    /// First-save proof: transactionally creates a new container and takes
+impl ProjectContainer {
+    /// First save: transactionally creates a new container and takes
     /// ownership of staged bytes. Staging files are removed only after commit.
     pub fn create_from_staged(
         path: impl AsRef<Path>,
         document: &mut ProjectDocumentV1,
         staged_media: &[StagedMedia],
-    ) -> Result<(Self, SaveObservation), ProofError> {
+    ) -> Result<(Self, SaveObservation), ProjectFormatError> {
         let path = path.as_ref();
         if path.exists() {
-            return Err(ProofError::ExistingDestination(path.to_path_buf()));
+            return Err(ProjectFormatError::ExistingDestination(path.to_path_buf()));
         }
 
         let started = Instant::now();
@@ -164,12 +177,21 @@ impl ProofContainer {
 
         let transaction = connection.transaction()?;
         let mut media_bytes_written = 0_u64;
+        let mut media_rows_written = 0_usize;
         for staged in staged_media {
             let content = fs::read(&staged.path)?;
             let entry = media_entry(staged, &content);
-            insert_media(&transaction, &entry, &content)?;
-            media_bytes_written += content.len() as u64;
-            document.project_media.push(entry);
+            if insert_media(&transaction, &entry, &content)? {
+                media_rows_written += 1;
+                media_bytes_written += content.len() as u64;
+            }
+            if !document
+                .project_media
+                .iter()
+                .any(|item| item.id == entry.id)
+            {
+                document.project_media.push(entry);
+            }
         }
         write_document(&transaction, document)?;
         transaction.commit()?;
@@ -178,13 +200,13 @@ impl ProofContainer {
         // longer needed. Cleanup failure is intentionally non-fatal because
         // losing the newly committed Project Media would be worse.
         for staged in staged_media {
-            let _ = fs::remove_file(&staged.path);
+            cleanup_staging_copy(staged);
         }
 
         let observation = SaveObservation {
             elapsed: started.elapsed(),
             container_bytes: fs::metadata(path)?.len(),
-            media_rows_written: staged_media.len(),
+            media_rows_written,
             media_bytes_written,
         };
         Ok((
@@ -196,7 +218,7 @@ impl ProofContainer {
         ))
     }
 
-    pub fn open(path: impl AsRef<Path>) -> Result<Self, ProofError> {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, ProjectFormatError> {
         let path = path.as_ref();
         let connection = Connection::open_with_flags(
             path,
@@ -210,7 +232,7 @@ impl ProofContainer {
         })
     }
 
-    pub fn load_document(&self) -> Result<ProjectDocumentV1, ProofError> {
+    pub fn load_document(&self) -> Result<ProjectDocumentV1, ProjectFormatError> {
         let json: Vec<u8> = self.connection.query_row(
             "SELECT json FROM project_document WHERE singleton = 1",
             [],
@@ -218,7 +240,7 @@ impl ProofContainer {
         )?;
         let document: ProjectDocumentV1 = serde_json::from_slice(&json)?;
         if document.format_version != FORMAT_VERSION {
-            return Err(ProofError::InvalidContainer(format!(
+            return Err(ProjectFormatError::InvalidContainer(format!(
                 "document version is {}, expected {FORMAT_VERSION}",
                 document.format_version
             )));
@@ -226,7 +248,7 @@ impl ProofContainer {
         Ok(document)
     }
 
-    pub fn read_media(&self, id: &str) -> Result<Vec<u8>, ProofError> {
+    pub fn read_media(&self, id: &str) -> Result<Vec<u8>, ProjectFormatError> {
         self.connection
             .query_row(
                 "SELECT content FROM project_media WHERE id = ?1",
@@ -234,10 +256,10 @@ impl ProofContainer {
                 |row| row.get(0),
             )
             .optional()?
-            .ok_or_else(|| ProofError::MissingMedia(id.to_owned()))
+            .ok_or_else(|| ProjectFormatError::MissingMedia(id.to_owned()))
     }
 
-    pub fn media_fingerprint(&self, id: &str) -> Result<(i64, String, u64), ProofError> {
+    pub fn media_fingerprint(&self, id: &str) -> Result<(i64, String, u64), ProjectFormatError> {
         self.connection
             .query_row(
                 "SELECT rowid, sha256, byte_len FROM project_media WHERE id = ?1",
@@ -245,7 +267,7 @@ impl ProofContainer {
                 |row| Ok((row.get(0)?, row.get(1)?, row.get::<_, i64>(2)? as u64)),
             )
             .optional()?
-            .ok_or_else(|| ProofError::MissingMedia(id.to_owned()))
+            .ok_or_else(|| ProjectFormatError::MissingMedia(id.to_owned()))
     }
 
     /// Incrementally updates only the versioned project document. The media
@@ -253,7 +275,7 @@ impl ProofContainer {
     pub fn save_document(
         &mut self,
         document: &ProjectDocumentV1,
-    ) -> Result<SaveObservation, ProofError> {
+    ) -> Result<SaveObservation, ProjectFormatError> {
         let started = Instant::now();
         let transaction = self.connection.transaction()?;
         write_document(&transaction, document)?;
@@ -266,14 +288,58 @@ impl ProofContainer {
         })
     }
 
+    /// Commits newly staged Project Media and the document in one transaction.
+    /// Existing content-addressed rows are retained without rewriting.
+    pub fn save_with_staged(
+        &mut self,
+        document: &mut ProjectDocumentV1,
+        staged_media: &[StagedMedia],
+    ) -> Result<SaveObservation, ProjectFormatError> {
+        let started = Instant::now();
+        let transaction = self.connection.transaction()?;
+        let mut media_rows_written = 0_usize;
+        let mut media_bytes_written = 0_u64;
+        for staged in staged_media {
+            let content = fs::read(&staged.path)?;
+            let entry = media_entry(staged, &content);
+            if insert_media(&transaction, &entry, &content)? {
+                media_rows_written += 1;
+                media_bytes_written += content.len() as u64;
+            }
+            if !document
+                .project_media
+                .iter()
+                .any(|item| item.id == entry.id)
+            {
+                document.project_media.push(entry);
+            }
+        }
+        write_document(&transaction, document)?;
+        transaction.commit()?;
+        for staged in staged_media {
+            cleanup_staging_copy(staged);
+        }
+        Ok(SaveObservation {
+            elapsed: started.elapsed(),
+            container_bytes: fs::metadata(&self.path)?.len(),
+            media_rows_written,
+            media_bytes_written,
+        })
+    }
+
     /// Creates a self-contained snapshot without changing the source path.
-    pub fn save_as(&self, destination: impl AsRef<Path>) -> Result<SaveObservation, ProofError> {
+    pub fn save_as(
+        &self,
+        destination: impl AsRef<Path>,
+    ) -> Result<SaveObservation, ProjectFormatError> {
         let destination = destination.as_ref();
         if destination.exists() {
-            return Err(ProofError::ExistingDestination(destination.to_path_buf()));
+            return Err(ProjectFormatError::ExistingDestination(
+                destination.to_path_buf(),
+            ));
         }
         let destination_text = destination.to_str().ok_or_else(|| {
-            ProofError::InvalidContainer("Save As destination is not valid UTF-8".into())
+            ProjectFormatError::InvalidContainer("Save As destination is not valid UTF-8".into())
         })?;
         let started = Instant::now();
         self.connection
@@ -281,7 +347,7 @@ impl ProofContainer {
         let reopened = Self::open(destination)?;
         let document = reopened.load_document()?;
         if document.format_version != FORMAT_VERSION {
-            return Err(ProofError::InvalidContainer(
+            return Err(ProjectFormatError::InvalidContainer(
                 "Save As lost format marker".into(),
             ));
         }
@@ -292,6 +358,192 @@ impl ProofContainer {
             media_bytes_written: 0,
         })
     }
+}
+
+pub fn detect_project_format(path: &Path) -> Result<ProjectFileFormat, ProjectFormatError> {
+    let mut header = [0_u8; 16];
+    let read = fs::File::open(path)?.read(&mut header)?;
+    if read == header.len() && &header == b"SQLite format 3\0" {
+        let container = ProjectContainer::open(path)?;
+        container.load_document()?;
+        Ok(ProjectFileFormat::V1)
+    } else {
+        Ok(ProjectFileFormat::LegacyJson)
+    }
+}
+
+/// Copies Local Source Storage into a Vibez-owned staging location before an
+/// unsaved project begins depending on it. The content hash is the eventual
+/// Project Media identity, so repeated imports reuse the same staged bytes.
+pub fn stage_local_file(path: &Path) -> Result<MediaSourceRef, ProjectFormatError> {
+    let content = fs::read(path)?;
+    let id = hex_sha256(&content);
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "project-media".to_string());
+    let root = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
+        .join("vibez")
+        .join("staged-project-media");
+    fs::create_dir_all(&root)?;
+    let safe_name: String = file_name
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let staging_path = root.join(format!("{id}-{safe_name}"));
+    if !staging_path.exists() {
+        let temporary = root.join(format!(".{id}.partial"));
+        fs::write(&temporary, content)?;
+        fs::rename(temporary, &staging_path)?;
+    }
+    Ok(MediaSourceRef::StagedProjectMedia {
+        id,
+        file_name,
+        staging_path,
+        source_path: path.to_path_buf(),
+    })
+}
+
+/// Saves a production Project Format V1 container. `source_container` is the
+/// currently open V1 path, when any; a different destination performs Save As
+/// by copying that self-contained container before committing the new document.
+pub fn save_project_v1(
+    destination: &Path,
+    source_container: Option<&Path>,
+    mut project: Project,
+) -> Result<SaveResult, ProjectFormatError> {
+    let same_container = source_container.is_some_and(|source| source == destination);
+    let mut staged_media = Vec::new();
+    prepare_project_media(&mut project, &mut staged_media)?;
+
+    let (mut container, mut document) = if same_container {
+        let container = ProjectContainer::open(destination)?;
+        let document = container.load_document()?;
+        (container, document)
+    } else if let Some(source) = source_container.filter(|source| source.exists()) {
+        if destination.exists() {
+            return Err(ProjectFormatError::ExistingDestination(
+                destination.to_path_buf(),
+            ));
+        }
+        let source = ProjectContainer::open(source)?;
+        source.save_as(destination)?;
+        let copied = ProjectContainer::open(destination)?;
+        let document = copied.load_document()?;
+        (copied, document)
+    } else {
+        let mut document = ProjectDocumentV1::new(project.clone());
+        let (_container, observation) =
+            ProjectContainer::create_from_staged(destination, &mut document, &staged_media)?;
+        return Ok(SaveResult {
+            project,
+            observation,
+        });
+    };
+
+    document.project = project.clone();
+    let observation = container.save_with_staged(&mut document, &staged_media)?;
+    Ok(SaveResult {
+        project,
+        observation,
+    })
+}
+
+fn prepare_project_media(
+    project: &mut Project,
+    staged_media: &mut Vec<StagedMedia>,
+) -> Result<(), ProjectFormatError> {
+    for clip in &mut project.clips {
+        if let Some(source) = &mut clip.source {
+            prepare_source(source, staged_media)?;
+            clip.file_path = None;
+        }
+    }
+    for track in &mut project.tracks {
+        prepare_track_sources(track, staged_media)?;
+    }
+    if let Some(master) = &mut project.master {
+        prepare_track_sources(master, staged_media)?;
+    }
+    for bus in &mut project.buses {
+        prepare_track_sources(bus, staged_media)?;
+    }
+    Ok(())
+}
+
+fn prepare_track_sources(
+    track: &mut TrackInfo,
+    staged_media: &mut Vec<StagedMedia>,
+) -> Result<(), ProjectFormatError> {
+    match &mut track.native_instrument {
+        Some(InstrumentStateInfo::Sampler {
+            source: Some(source),
+            ..
+        }) => prepare_source(source, staged_media)?,
+        Some(InstrumentStateInfo::DrumRack { pads }) => {
+            for pad in pads {
+                if let Some(source) = &mut pad.source {
+                    prepare_source(source, staged_media)?;
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn prepare_source(
+    source: &mut MediaSourceRef,
+    staged_media: &mut Vec<StagedMedia>,
+) -> Result<(), ProjectFormatError> {
+    let (path, file_name, provenance) = match source {
+        MediaSourceRef::LocalFile { path } => {
+            let file_name = path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "project-media".to_string());
+            (
+                path.clone(),
+                file_name,
+                Provenance::Local {
+                    source_path: path.clone(),
+                },
+            )
+        }
+        MediaSourceRef::StagedProjectMedia {
+            file_name,
+            staging_path,
+            source_path,
+            ..
+        } => (
+            staging_path.clone(),
+            file_name.clone(),
+            Provenance::Local {
+                source_path: source_path.clone(),
+            },
+        ),
+        MediaSourceRef::ProjectMedia { .. } | MediaSourceRef::DropboxFile { .. } => return Ok(()),
+    };
+    let content = fs::read(&path)?;
+    let id = hex_sha256(&content);
+    if !staged_media.iter().any(|item| item.id == id) {
+        staged_media.push(StagedMedia {
+            id: id.clone(),
+            file_name: file_name.clone(),
+            path,
+            provenance,
+        });
+    }
+    *source = MediaSourceRef::ProjectMedia { id, file_name };
+    Ok(())
 }
 
 /// Starts a real transaction, overwrites the document and a media row, then
@@ -323,12 +575,12 @@ fn configure_connection(connection: &Connection) -> Result<(), rusqlite::Error> 
     Ok(())
 }
 
-fn validate_container(connection: &Connection) -> Result<(), ProofError> {
+fn validate_container(connection: &Connection) -> Result<(), ProjectFormatError> {
     let application_id: u32 =
         connection.query_row("PRAGMA application_id", [], |row| row.get(0))?;
     let user_version: u32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     if application_id != APPLICATION_ID || user_version != FORMAT_VERSION {
-        return Err(ProofError::InvalidContainer(format!(
+        return Err(ProjectFormatError::InvalidContainer(format!(
             "application_id={application_id:#x}, user_version={user_version}"
         )));
     }
@@ -338,9 +590,9 @@ fn validate_container(connection: &Connection) -> Result<(), ProofError> {
 fn write_document(
     transaction: &Transaction<'_>,
     document: &ProjectDocumentV1,
-) -> Result<(), ProofError> {
+) -> Result<(), ProjectFormatError> {
     if document.format_version != FORMAT_VERSION {
-        return Err(ProofError::InvalidContainer(format!(
+        return Err(ProjectFormatError::InvalidContainer(format!(
             "cannot save document version {} as version {FORMAT_VERSION}",
             document.format_version
         )));
@@ -356,9 +608,9 @@ fn insert_media(
     transaction: &Transaction<'_>,
     entry: &ProjectMediaEntry,
     content: &[u8],
-) -> Result<(), ProofError> {
-    transaction.execute(
-        "INSERT INTO project_media(id, file_name, byte_len, sha256, provenance_json, content) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+) -> Result<bool, ProjectFormatError> {
+    let inserted = transaction.execute(
+        "INSERT OR IGNORE INTO project_media(id, file_name, byte_len, sha256, provenance_json, content) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
         params![
             entry.id,
             entry.file_name,
@@ -368,7 +620,17 @@ fn insert_media(
             content
         ],
     )?;
-    Ok(())
+    Ok(inserted == 1)
+}
+
+fn cleanup_staging_copy(staged: &StagedMedia) {
+    let disposable = match &staged.provenance {
+        Provenance::Local { source_path } => source_path != &staged.path,
+        Provenance::Remote { .. } => true,
+    };
+    if disposable {
+        let _ = fs::remove_file(&staged.path);
+    }
 }
 
 fn media_entry(staged: &StagedMedia, content: &[u8]) -> ProjectMediaEntry {

--- a/crates/vibez-project/src/project_format_v1.rs
+++ b/crates/vibez-project/src/project_format_v1.rs
@@ -7,6 +7,7 @@
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Transaction};
@@ -19,6 +20,7 @@ use crate::Project;
 pub const FORMAT_VERSION: u32 = 1;
 /// ASCII `VZP1`, stored in SQLite's application-id header field.
 pub const APPLICATION_ID: u32 = 0x565a_5031;
+static STAGING_NONCE: AtomicU64 = AtomicU64::new(0);
 
 const SCHEMA: &str = r#"
 CREATE TABLE project_document (
@@ -377,11 +379,22 @@ pub fn detect_project_format(path: &Path) -> Result<ProjectFileFormat, ProjectFo
 /// Project Media identity, so repeated imports reuse the same staged bytes.
 pub fn stage_local_file(path: &Path) -> Result<MediaSourceRef, ProjectFormatError> {
     let content = fs::read(path)?;
-    let id = hex_sha256(&content);
     let file_name = path
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
         .unwrap_or_else(|| "project-media".to_string());
+    stage_local_content(path, &file_name, &content)
+}
+
+/// Stages Vibez-derived bytes while retaining the authoritative Local source
+/// as provenance. Used when a device import deliberately bakes the heard WARP
+/// treatment into project-owned media without touching Source Storage.
+pub fn stage_local_content(
+    source_path: &Path,
+    file_name: &str,
+    content: &[u8],
+) -> Result<MediaSourceRef, ProjectFormatError> {
+    let id = hex_sha256(content);
     let root = std::env::var_os("XDG_CACHE_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(std::env::temp_dir)
@@ -400,15 +413,19 @@ pub fn stage_local_file(path: &Path) -> Result<MediaSourceRef, ProjectFormatErro
         .collect();
     let staging_path = root.join(format!("{id}-{safe_name}"));
     if !staging_path.exists() {
-        let temporary = root.join(format!(".{id}.partial"));
+        let nonce = STAGING_NONCE.fetch_add(1, Ordering::Relaxed);
+        let temporary = root.join(format!(
+            ".{id}-{safe_name}-{}-{nonce}.partial",
+            std::process::id()
+        ));
         fs::write(&temporary, content)?;
         fs::rename(temporary, &staging_path)?;
     }
     Ok(MediaSourceRef::StagedProjectMedia {
         id,
-        file_name,
+        file_name: file_name.to_string(),
         staging_path,
-        source_path: path.to_path_buf(),
+        source_path: source_path.to_path_buf(),
     })
 }
 

--- a/crates/vibez-project/tests/project_format_v1.rs
+++ b/crates/vibez-project/tests/project_format_v1.rs
@@ -2,10 +2,13 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use vibez_project::project_format_v1_proof::{
-    hex_sha256, representative_document, ProofContainer, Provenance, StagedMedia, APPLICATION_ID,
-    FORMAT_VERSION,
+use vibez_core::id::ClipId;
+use vibez_core::track::{ClipInfo, MediaSourceRef, TrackInfo};
+use vibez_project::project_format_v1::{
+    detect_project_format, hex_sha256, representative_document, save_project_v1, stage_local_file,
+    ProjectContainer, ProjectFileFormat, Provenance, StagedMedia, APPLICATION_ID, FORMAT_VERSION,
 };
+use vibez_project::Project;
 
 fn stage(path: PathBuf, id: &str, seed: u8) -> (StagedMedia, Vec<u8>) {
     let bytes: Vec<u8> = (0..2 * 1024 * 1024)
@@ -39,7 +42,7 @@ fn representative_container_roundtrips_incrementally_and_save_as() {
     let mut document = representative_document();
 
     let (mut container, full_save) =
-        ProofContainer::create_from_staged(&path, &mut document, &[staged]).unwrap();
+        ProjectContainer::create_from_staged(&path, &mut document, &[staged]).unwrap();
     assert_eq!(full_save.media_rows_written, 1);
     assert_eq!(full_save.media_bytes_written, media_bytes.len() as u64);
     assert!(
@@ -80,7 +83,7 @@ fn representative_container_roundtrips_incrementally_and_save_as() {
 
     let save_as = container.save_as(&save_as_path).unwrap();
     assert!(save_as.container_bytes > media_bytes.len() as u64);
-    let copied = ProofContainer::open(&save_as_path).unwrap();
+    let copied = ProjectContainer::open(&save_as_path).unwrap();
     assert_eq!(
         serde_json::to_vec(&copied.load_document().unwrap()).unwrap(),
         serde_json::to_vec(&document).unwrap()
@@ -93,7 +96,7 @@ fn format_markers_are_explicit_and_file_is_not_zip() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("proof.vzp");
     let mut document = representative_document();
-    let (container, _) = ProofContainer::create_from_staged(&path, &mut document, &[]).unwrap();
+    let (container, _) = ProjectContainer::create_from_staged(&path, &mut document, &[]).unwrap();
     drop(container);
 
     let bytes = fs::read(&path).unwrap();
@@ -119,7 +122,7 @@ fn process_interruption_preserves_last_committed_document_and_media() {
     let (staged, media_bytes) = stage(directory.path().join("proof.staged"), "proof-media", 83);
     let mut document = representative_document();
     let (container, _) =
-        ProofContainer::create_from_staged(&path, &mut document, &[staged]).unwrap();
+        ProjectContainer::create_from_staged(&path, &mut document, &[staged]).unwrap();
     let committed_json = serde_json::to_vec(&container.load_document().unwrap()).unwrap();
     let committed_fingerprint = container.media_fingerprint("proof-media").unwrap();
     drop(container);
@@ -132,7 +135,7 @@ fn process_interruption_preserves_last_committed_document_and_media() {
         .unwrap();
     assert_eq!(status.code(), Some(86));
 
-    let recovered = ProofContainer::open(&path).unwrap();
+    let recovered = ProjectContainer::open(&path).unwrap();
     assert_eq!(
         serde_json::to_vec(&recovered.load_document().unwrap()).unwrap(),
         committed_json
@@ -144,5 +147,101 @@ fn process_interruption_preserves_last_committed_document_and_media() {
     assert_eq!(
         hex_sha256(&recovered.read_media("proof-media").unwrap()),
         hex_sha256(&media_bytes)
+    );
+}
+
+fn project_with_source(source: MediaSourceRef) -> Project {
+    let track = TrackInfo::new("Audio");
+    Project {
+        tracks: vec![track.clone()],
+        clips: vec![ClipInfo {
+            id: ClipId::new(),
+            track_id: track.id,
+            name: source.display_name(),
+            position: 0,
+            source_offset: 0,
+            duration: 128,
+            source: Some(source),
+            file_path: None,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 128,
+            original_bpm: Some(120.0),
+            warped: false,
+            warped_to_bpm: None,
+        }],
+        ..Project::default()
+    }
+}
+
+#[test]
+fn production_save_is_self_contained_incremental_and_save_as_reuses_media() {
+    let directory = tempfile::tempdir().unwrap();
+    let source_path = directory.path().join("source.wav");
+    let path = directory.path().join("song.vzp");
+    let save_as_path = directory.path().join("song-copy.vzp");
+    let bytes = b"playback-critical-media".repeat(1024);
+    fs::write(&source_path, &bytes).unwrap();
+    let project = project_with_source(MediaSourceRef::LocalFile {
+        path: source_path.clone(),
+    });
+
+    let first = save_project_v1(&path, None, project).unwrap();
+    assert_eq!(first.observation.media_rows_written, 1);
+    assert_eq!(detect_project_format(&path).unwrap(), ProjectFileFormat::V1);
+    fs::remove_file(&source_path).unwrap();
+
+    let container = ProjectContainer::open(&path).unwrap();
+    let document = container.load_document().unwrap();
+    let MediaSourceRef::ProjectMedia { id, .. } =
+        document.project.clips[0].source.as_ref().unwrap()
+    else {
+        panic!("committed project must reference Project Media");
+    };
+    assert_eq!(container.read_media(id).unwrap(), bytes);
+    let fingerprint = container.media_fingerprint(id).unwrap();
+    drop(container);
+
+    let incremental = save_project_v1(&path, Some(&path), first.project.clone()).unwrap();
+    assert_eq!(incremental.observation.media_rows_written, 0);
+    let reopened = ProjectContainer::open(&path).unwrap();
+    assert_eq!(reopened.media_fingerprint(id).unwrap(), fingerprint);
+    drop(reopened);
+
+    let save_as = save_project_v1(&save_as_path, Some(&path), incremental.project).unwrap();
+    assert_eq!(save_as.observation.media_rows_written, 0);
+    let copied = ProjectContainer::open(save_as_path).unwrap();
+    assert_eq!(copied.read_media(id).unwrap(), bytes);
+}
+
+#[test]
+fn unsaved_project_uses_staged_copy_before_first_save() {
+    let directory = tempfile::tempdir().unwrap();
+    let source_path = directory.path().join("fragile-source.wav");
+    let path = directory.path().join("staged.vzp");
+    let bytes = b"staged-before-save".repeat(512);
+    fs::write(&source_path, &bytes).unwrap();
+    let staged_source = stage_local_file(&source_path).unwrap();
+    let MediaSourceRef::StagedProjectMedia { staging_path, .. } = &staged_source else {
+        panic!("local import must become Staged Project Media");
+    };
+    let staging_path = staging_path.clone();
+    fs::remove_file(source_path).unwrap();
+
+    let saved = save_project_v1(&path, None, project_with_source(staged_source)).unwrap();
+    assert!(
+        !staging_path.exists(),
+        "commit should consume the staging copy"
+    );
+    let MediaSourceRef::ProjectMedia { id, .. } = saved.project.clips[0].source.as_ref().unwrap()
+    else {
+        panic!("saved project must no longer reference staging");
+    };
+    assert_eq!(
+        ProjectContainer::open(path)
+            .unwrap()
+            .read_media(id)
+            .unwrap(),
+        bytes
     );
 }

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -147,10 +147,6 @@ impl App {
                 })
             });
         }
-        if let Some((track_id, beat, source)) = action.drop_on_arrangement {
-            let position_samples = self.state.beats_to_samples(beat);
-            return self.dispatch_drop_on_arrangement(track_id, position_samples, source);
-        }
         if let Some(source) = action.load_waveform {
             self.state.browser.begin_waveform_load(&source);
             if let MediaSourceRef::LocalFile { path } = source.clone() {

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -77,12 +77,16 @@ impl App {
         };
         let cache = self.dropbox_cache.clone();
         let target = BrowserImportTarget::ArrangementClip(self.state.arrangement.selected_track);
+        let Some(treatment) = self.state.browser.audition_import_input() else {
+            self.state.status_text = "Confirm source BPM before WARP import".into();
+            return Task::none();
+        };
         self.state.status_text = format!("Importing {}...", entry.name);
         Task::perform(
             fetch_dropbox_sample_async(client, cache, entry),
             move |result| match result {
                 Ok((audio, name, source)) => {
-                    Message::BrowserSampleDecoded(target.clone(), audio, name, source)
+                    Message::BrowserSampleDecoded(target.clone(), treatment, audio, name, source)
                 }
                 Err(err) => Message::BrowserSampleDecodeError(err),
             },
@@ -99,12 +103,16 @@ impl App {
             return Task::none();
         };
         let cache = self.dropbox_cache.clone();
+        let Some(treatment) = self.state.browser.audition_import_input() else {
+            self.state.status_text = "Confirm source BPM before WARP import".into();
+            return Task::none();
+        };
         self.state.status_text = format!("Importing {}...", entry.name);
         Task::perform(
             fetch_dropbox_sample_async(client, cache, entry),
             move |result| match result {
                 Ok((audio, name, source)) => {
-                    Message::BrowserSampleDecoded(target.clone(), audio, name, source)
+                    Message::BrowserSampleDecoded(target.clone(), treatment, audio, name, source)
                 }
                 Err(err) => Message::BrowserSampleDecodeError(err),
             },

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -36,6 +36,17 @@ pub(crate) fn global_key_handler(
         return Some(Message::EscapePressed);
     }
 
+    // Enter: the focused Browser selection always means Arrangement Import.
+    // Text inputs capture Enter before this global ignored-event subscription.
+    if !modifiers.control()
+        && !modifiers.alt()
+        && !modifiers.shift()
+        && !modifiers.logo()
+        && matches!(key, iced::keyboard::Key::Named(Named::Enter))
+    {
+        return Some(Message::ImportSelectedBrowserSampleToArrangement);
+    }
+
     // Delete/Backspace: context-resolved in update() (selected notes
     // first, then selected clips) and ignored while renaming.
     if !modifiers.control()
@@ -190,6 +201,17 @@ mod tests {
             wider,
             Some(Message::Browser(BrowserMsg::NudgeDockWidth(delta))) if delta == 40.0
         ));
+    }
+
+    #[test]
+    fn enter_is_always_arrangement_import() {
+        use iced::keyboard::{key::Named, Key, Modifiers};
+
+        assert!(matches!(
+            global_key_handler(Key::Named(Named::Enter), Modifiers::empty()),
+            Some(Message::ImportSelectedBrowserSampleToArrangement)
+        ));
+        assert!(global_key_handler(Key::Named(Named::Enter), Modifiers::SHIFT).is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -12,7 +12,7 @@ use vibez_core::track::MediaSourceRef;
 use vibez_dropbox::DropboxEntry;
 use vibez_engine::commands::{AuditionSync, EngineCommand};
 
-use crate::message::{BrowserImportTarget, Message};
+use crate::message::{BrowserImportTarget, Message, PreparedBrowserImport};
 use crate::state::{AuditionMode, SampleBrowserEntry, UiClip, UiDrumPad, UiTrack};
 
 use super::*;
@@ -223,89 +223,87 @@ impl App {
         id
     }
 
-    pub(super) fn add_audio_clip_to_track(
+    pub(super) fn prepare_browser_sample_import(
         &mut self,
-        track_id: TrackId,
-        audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
+        target: BrowserImportTarget,
+        treatment: crate::state::AuditionImportInput,
+        raw: Arc<vibez_core::audio_buffer::DecodedAudio>,
         name: String,
         source: MediaSourceRef,
     ) -> Task<Message> {
-        let clip_id = ClipId::new();
-        let existing_end = self
-            .state
-            .find_track(track_id)
-            .map(|track| {
-                track
-                    .clips
-                    .iter()
-                    .map(|clip| clip.position.saturating_add(clip.duration))
-                    .max()
-                    .unwrap_or(0)
-            })
-            .unwrap_or(0);
-        let duration = audio.num_frames() as u64;
-
-        self.send_command(EngineCommand::AddClip {
-            track_id,
-            clip_id,
-            audio: Arc::clone(&audio),
-            position: existing_end,
-            source_offset: 0,
-            duration,
-            loop_enabled: false,
-            loop_start: 0,
-            loop_end: 0,
-        });
-
-        if let Some(track) = self.state.find_track_mut(track_id) {
-            track.clips.push(UiClip {
-                id: clip_id,
-                name: name.clone(),
-                audio: Arc::clone(&audio),
-                source: Some(source),
-                position: existing_end,
-                source_offset: 0,
-                duration,
-                loop_enabled: false,
-                loop_start: 0,
-                loop_end: 0,
-                original_bpm: None,
-                warped: false,
-                warped_to_bpm: None,
-                original_audio: None,
-            });
-        }
-
-        self.state.arrangement.selected_track = Some(track_id);
-        self.state.status_text = format!("Added clip: {name}");
-        self.schedule_auto_warp_if_enabled(track_id, clip_id, audio)
+        let project_bpm = self.state.transport.bpm;
+        self.state.status_text = match treatment.mode {
+            AuditionMode::Raw => format!("Preparing RAW import: {name}"),
+            AuditionMode::Warp => format!("Preparing WARP import: {name}"),
+        };
+        let retained_target = target.clone();
+        Task::perform(
+            prepare_browser_import_audio_async(target, treatment, raw, source, project_bpm),
+            move |result| match result {
+                Ok((audio, original_audio, source)) => Message::BrowserImportPrepared {
+                    target: retained_target.clone(),
+                    payload: PreparedBrowserImport {
+                        treatment,
+                        audio,
+                        original_audio,
+                        name: name.clone(),
+                        source,
+                    },
+                },
+                Err(error) => Message::BrowserSampleDecodeError(error),
+            },
+        )
     }
 
-    pub(super) fn apply_browser_sample_decoded(
+    pub(super) fn apply_browser_import_prepared(
         &mut self,
         target: BrowserImportTarget,
-        audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
-        name: String,
-        source: MediaSourceRef,
+        payload: PreparedBrowserImport,
     ) -> Task<Message> {
         match target {
             BrowserImportTarget::ArrangementClip(preferred_track) => {
                 let track_id = self.ensure_audio_track_for_import(preferred_track);
-                self.add_audio_clip_to_track(track_id, audio, name, source)
+                let position = self.state.transport.position_samples;
+                self.add_audio_clip_to_track_at(track_id, position, payload)
             }
             BrowserImportTarget::ArrangementClipAt {
                 track_id,
                 position_samples,
-            } => self.add_audio_clip_to_track_at(track_id, position_samples, audio, name, source),
+            } => self.add_audio_clip_to_track_at(track_id, position_samples, payload),
+            BrowserImportTarget::ArrangementNewTrackAt { position_samples } => {
+                let track_id = self.ensure_audio_track_for_import(None);
+                self.add_audio_clip_to_track_at(track_id, position_samples, payload)
+            }
             BrowserImportTarget::Sampler(track_id) => {
-                self.apply_sampler_sample_loaded(track_id, audio, name, source);
+                let PreparedBrowserImport {
+                    treatment,
+                    audio,
+                    name,
+                    source,
+                    ..
+                } = payload;
+                self.apply_sampler_sample_loaded(track_id, audio, name.clone(), source);
+                self.state.status_text =
+                    format!("Imported '{name}' to Sampler ({})", treatment.mode.label());
                 Task::none()
             }
             BrowserImportTarget::DrumRackPad {
                 track_id,
                 pad_index,
             } => {
-                self.apply_drum_rack_pad_loaded(track_id, pad_index, audio, name, source);
+                let PreparedBrowserImport {
+                    treatment,
+                    audio,
+                    name,
+                    source,
+                    ..
+                } = payload;
+                self.apply_drum_rack_pad_loaded(track_id, pad_index, audio, name.clone(), source);
+                self.state.status_text = format!(
+                    "Imported '{name}' to Drum Rack pad {} ({})",
+                    pad_index + 1,
+                    treatment.mode.label()
+                );
                 Task::none()
             }
         }
@@ -315,10 +313,15 @@ impl App {
         &mut self,
         track_id: TrackId,
         position_samples: u64,
-        audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
-        name: String,
-        source: MediaSourceRef,
+        payload: PreparedBrowserImport,
     ) -> Task<Message> {
+        let PreparedBrowserImport {
+            treatment,
+            audio,
+            original_audio,
+            name,
+            source,
+        } = payload;
         // Guard: if the target is not an audio track, refuse rather than
         // silently redirecting the drop. Prevents the "clip lands on the
         // wrong lane" surprise.
@@ -339,6 +342,10 @@ impl App {
 
         let clip_id = ClipId::new();
         let duration = audio.num_frames() as u64;
+        let (original_bpm, warped, warped_to_bpm) = match treatment.mode {
+            AuditionMode::Raw => (None, false, None),
+            AuditionMode::Warp => (treatment.source_bpm, true, Some(self.state.transport.bpm)),
+        };
 
         self.send_command(EngineCommand::AddClip {
             track_id,
@@ -363,15 +370,24 @@ impl App {
                 loop_enabled: false,
                 loop_start: 0,
                 loop_end: 0,
-                original_bpm: None,
-                warped: false,
-                warped_to_bpm: None,
-                original_audio: None,
+                original_bpm,
+                warped,
+                warped_to_bpm,
+                original_audio,
             });
         }
         self.state.arrangement.selected_track = Some(track_id);
-        self.state.status_text = format!("Dropped '{name}' on {track_name}");
-        self.schedule_auto_warp_if_enabled(track_id, clip_id, audio)
+        let beat = if self.state.transport.sample_rate > 0 && self.state.transport.bpm > 0.0 {
+            position_samples as f64 * self.state.transport.bpm
+                / (self.state.transport.sample_rate as f64 * 60.0)
+        } else {
+            0.0
+        };
+        self.state.status_text = format!(
+            "Imported '{name}' to {track_name} at beat {beat:.2} ({})",
+            treatment.mode.label()
+        );
+        Task::none()
     }
 
     pub(super) fn dispatch_drop_on_arrangement(
@@ -392,6 +408,18 @@ impl App {
         source: MediaSourceRef,
         target: BrowserImportTarget,
     ) -> Task<Message> {
+        let Some(treatment) = self.state.browser.audition_import_input() else {
+            self.state.status_text =
+                "Confirm a positive source BPM before importing in WARP mode".into();
+            return Task::none();
+        };
+        if treatment.mode == AuditionMode::Warp
+            && self.state.browser.selected_source.as_ref() != Some(&source)
+        {
+            self.state.status_text =
+                "Select this source and confirm its BPM before WARP import".into();
+            return Task::none();
+        }
         match source {
             MediaSourceRef::LocalFile { path } => {
                 let name = path
@@ -404,6 +432,7 @@ impl App {
                     move |result| match result {
                         Ok((audio, source)) => Message::BrowserSampleDecoded(
                             target.clone(),
+                            treatment,
                             Arc::new(audio),
                             name.clone(),
                             source,
@@ -430,6 +459,7 @@ impl App {
                     move |result| match result {
                         Ok(audio) => Message::BrowserSampleDecoded(
                             target.clone(),
+                            treatment,
                             Arc::new(audio),
                             name.clone(),
                             retained_source.clone(),
@@ -451,6 +481,7 @@ impl App {
                     move |result| match result {
                         Ok((audio, source, name)) => Message::BrowserSampleDecoded(
                             target.clone(),
+                            treatment,
                             Arc::new(audio),
                             name,
                             source,
@@ -487,6 +518,7 @@ impl App {
                     move |result| match result {
                         Ok((audio, decoded_name, source)) => Message::BrowserSampleDecoded(
                             target.clone(),
+                            treatment,
                             audio,
                             decoded_name,
                             source,
@@ -804,7 +836,7 @@ impl App {
             track.clips.push(UiClip {
                 id: clip_id,
                 name: name.clone(),
-                audio,
+                audio: Arc::clone(&audio),
                 source: Some(source),
                 position: existing_end,
                 source_offset: 0,
@@ -820,7 +852,7 @@ impl App {
         }
 
         self.state.status_text = format!("Added clip: {name}");
-        Task::none()
+        self.schedule_auto_warp_if_enabled(track_id, clip_id, audio)
     }
 
     pub(super) fn handle_drum_rack_pad_file_selected(
@@ -901,7 +933,7 @@ impl App {
     ) -> Task<Message> {
         match self.state.browser.drag_source.take() {
             Some(source) => {
-                self.state.browser.drag_label = None;
+                self.state.browser.cancel_media_drag();
                 self.dispatch_drop_for_target(
                     source,
                     BrowserImportTarget::DrumRackPad {
@@ -944,28 +976,21 @@ impl App {
 
     pub(super) fn handle_import_selected_browser_sample_to_arrangement(&mut self) -> Task<Message> {
         if let Some(entry) = self.selected_sample_browser_entry().cloned() {
-            let target = BrowserImportTarget::ArrangementClip(
-                self.state.arrangement.selected_track.filter(|track_id| {
-                    self.state
-                        .find_track(*track_id)
-                        .is_some_and(|track| matches!(track.kind, TrackKind::Audio))
-                }),
-            );
-            if let MediaSourceRef::LocalFile { path } = &entry.source {
-                let name = entry.name.clone();
-                self.state.status_text = format!("Loading {name}...");
-                return Task::perform(decode_and_stage_local_async(path.clone()), move |result| {
-                    match result {
-                        Ok((audio, source)) => Message::BrowserSampleDecoded(
-                            target.clone(),
-                            Arc::new(audio),
-                            name.clone(),
-                            source,
-                        ),
-                        Err(err) => Message::BrowserSampleDecodeError(err),
-                    }
-                });
-            }
+            let position_samples = self.state.transport.position_samples;
+            let selected_audio = self.state.arrangement.selected_track.filter(|track_id| {
+                self.state
+                    .find_track(*track_id)
+                    .is_some_and(|track| matches!(track.kind, TrackKind::Audio))
+            });
+            let target = match selected_audio {
+                Some(track_id) => BrowserImportTarget::ArrangementClipAt {
+                    track_id,
+                    position_samples,
+                },
+                None => BrowserImportTarget::ArrangementNewTrackAt { position_samples },
+            };
+            self.state.status_text = format!("Importing {} at playhead...", entry.name);
+            return self.dispatch_drop_for_target(entry.source, target);
         }
         Task::none()
     }
@@ -979,21 +1004,7 @@ impl App {
                 "Select a sampler or drum rack track to load from the browser".to_string();
             return Task::none();
         };
-        if let MediaSourceRef::LocalFile { path } = &entry.source {
-            let name = entry.name.clone();
-            self.state.status_text = format!("Loading {name}...");
-            return Task::perform(decode_and_stage_local_async(path.clone()), move |result| {
-                match result {
-                    Ok((audio, source)) => Message::BrowserSampleDecoded(
-                        target.clone(),
-                        Arc::new(audio),
-                        name.clone(),
-                        source,
-                    ),
-                    Err(err) => Message::BrowserSampleDecodeError(err),
-                }
-            });
-        }
-        Task::none()
+        self.state.status_text = format!("Loading {}...", entry.name);
+        self.dispatch_drop_for_target(entry.source, target)
     }
 }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -305,17 +305,66 @@ impl App {
                     .file_name()
                     .map(|s| s.to_string_lossy().to_string())
                     .unwrap_or_default();
-                let ret_source = MediaSourceRef::LocalFile { path: path.clone() };
                 self.state.status_text = format!("Dropping {name}...");
-                Task::perform(decode_file_async(path), move |result| match result {
-                    Ok(audio) => Message::BrowserSampleDecoded(
-                        target.clone(),
-                        Arc::new(audio),
-                        name.clone(),
-                        ret_source.clone(),
-                    ),
-                    Err(err) => Message::BrowserSampleDecodeError(err),
-                })
+                Task::perform(
+                    decode_and_stage_local_async(path),
+                    move |result| match result {
+                        Ok((audio, source)) => Message::BrowserSampleDecoded(
+                            target.clone(),
+                            Arc::new(audio),
+                            name.clone(),
+                            source,
+                        ),
+                        Err(err) => Message::BrowserSampleDecodeError(err),
+                    },
+                )
+            }
+            MediaSourceRef::StagedProjectMedia {
+                id,
+                file_name,
+                staging_path,
+                source_path,
+            } => {
+                let name = file_name.clone();
+                let retained_source = MediaSourceRef::StagedProjectMedia {
+                    id,
+                    file_name,
+                    staging_path: staging_path.clone(),
+                    source_path,
+                };
+                Task::perform(
+                    decode_file_async(staging_path),
+                    move |result| match result {
+                        Ok(audio) => Message::BrowserSampleDecoded(
+                            target.clone(),
+                            Arc::new(audio),
+                            name.clone(),
+                            retained_source.clone(),
+                        ),
+                        Err(err) => Message::BrowserSampleDecodeError(err),
+                    },
+                )
+            }
+            MediaSourceRef::ProjectMedia { id, file_name } => {
+                let name = file_name.clone();
+                let retained_source = MediaSourceRef::ProjectMedia { id, file_name };
+                let container_path = self.state.project.current_path.clone();
+                Task::perform(
+                    async move {
+                        hydrate_saved_source(container_path.as_ref(), None, &retained_source, &name)
+                            .await
+                            .map(|audio| (audio, retained_source, name))
+                    },
+                    move |result| match result {
+                        Ok((audio, source, name)) => Message::BrowserSampleDecoded(
+                            target.clone(),
+                            Arc::new(audio),
+                            name,
+                            source,
+                        ),
+                        Err(err) => Message::BrowserSampleDecodeError(err),
+                    },
+                )
             }
             MediaSourceRef::DropboxFile {
                 path_lower,
@@ -607,18 +656,19 @@ impl App {
                 .unwrap_or_default();
             self.state.status_text = format!("Loading {file_name}...");
             let clip_id = ClipId::new();
-            let source = MediaSourceRef::LocalFile { path: path.clone() };
-
-            return Task::perform(decode_file_async(path), move |result| match result {
-                Ok(audio) => Message::ClipAudioDecoded(
-                    track_id,
-                    clip_id,
-                    Arc::new(audio),
-                    file_name.clone(),
-                    source.clone(),
-                ),
-                Err(e) => Message::ClipDecodeError(track_id, e),
-            });
+            return Task::perform(
+                decode_and_stage_local_async(path),
+                move |result| match result {
+                    Ok((audio, source)) => Message::ClipAudioDecoded(
+                        track_id,
+                        clip_id,
+                        Arc::new(audio),
+                        file_name.clone(),
+                        source,
+                    ),
+                    Err(e) => Message::ClipDecodeError(track_id, e),
+                },
+            );
         }
         Task::none()
     }
@@ -692,18 +742,19 @@ impl App {
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_default();
             self.state.status_text = format!("Loading {file_name}...");
-            let source = MediaSourceRef::LocalFile { path: path.clone() };
-
-            return Task::perform(decode_file_async(path), move |result| match result {
-                Ok(audio) => Message::DrumRackPadSampleDecoded(
-                    track_id,
-                    pad_index,
-                    Arc::new(audio),
-                    file_name.clone(),
-                    source.clone(),
-                ),
-                Err(e) => Message::DrumRackPadDecodeError(track_id, pad_index, e),
-            });
+            return Task::perform(
+                decode_and_stage_local_async(path),
+                move |result| match result {
+                    Ok((audio, source)) => Message::DrumRackPadSampleDecoded(
+                        track_id,
+                        pad_index,
+                        Arc::new(audio),
+                        file_name.clone(),
+                        source,
+                    ),
+                    Err(e) => Message::DrumRackPadDecodeError(track_id, pad_index, e),
+                },
+            );
         }
         Task::none()
     }
@@ -804,21 +855,19 @@ impl App {
                 }),
             );
             if let MediaSourceRef::LocalFile { path } = &entry.source {
-                let source = entry.source.clone();
                 let name = entry.name.clone();
                 self.state.status_text = format!("Loading {name}...");
-                return Task::perform(
-                    decode_file_async(path.clone()),
-                    move |result| match result {
-                        Ok(audio) => Message::BrowserSampleDecoded(
+                return Task::perform(decode_and_stage_local_async(path.clone()), move |result| {
+                    match result {
+                        Ok((audio, source)) => Message::BrowserSampleDecoded(
                             target.clone(),
                             Arc::new(audio),
                             name.clone(),
-                            source.clone(),
+                            source,
                         ),
                         Err(err) => Message::BrowserSampleDecodeError(err),
-                    },
-                );
+                    }
+                });
             }
         }
         Task::none()
@@ -834,21 +883,19 @@ impl App {
             return Task::none();
         };
         if let MediaSourceRef::LocalFile { path } = &entry.source {
-            let source = entry.source.clone();
             let name = entry.name.clone();
             self.state.status_text = format!("Loading {name}...");
-            return Task::perform(
-                decode_file_async(path.clone()),
-                move |result| match result {
-                    Ok(audio) => Message::BrowserSampleDecoded(
+            return Task::perform(decode_and_stage_local_async(path.clone()), move |result| {
+                match result {
+                    Ok((audio, source)) => Message::BrowserSampleDecoded(
                         target.clone(),
                         Arc::new(audio),
                         name.clone(),
-                        source.clone(),
+                        source,
                     ),
                     Err(err) => Message::BrowserSampleDecodeError(err),
-                },
-            );
+                }
+            });
         }
         Task::none()
     }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use iced::{Subscription, Task, Theme};
@@ -24,7 +24,7 @@ use vibez_project::Project;
 use crate::icons;
 use crate::message::{
     LoadedClipData, LoadedDrumRackPadData, LoadedSamplerData, Message, ProjectLoadResult,
-    SampleLibraryScanResult,
+    ProjectSaveResult, SampleLibraryScanResult,
 };
 use crate::plugin_window::{PluginRawPtr, PluginWindowManager};
 use crate::state::AppState;
@@ -382,13 +382,52 @@ async fn decode_file_async(
     .map_err(|e| format!("decode task failed: {e}"))?
 }
 
-async fn save_project_async(path: PathBuf, project: Project) -> Result<PathBuf, String> {
+async fn decode_and_stage_local_async(
+    path: PathBuf,
+) -> Result<(vibez_core::audio_buffer::DecodedAudio, MediaSourceRef), String> {
     tokio::task::spawn_blocking(move || {
-        let save_path = path;
-        project
-            .save_to_file(&save_path)
-            .map(|_| save_path)
-            .map_err(|err| err.to_string())
+        let audio = file_io::decode_audio_file(&path).map_err(|error| error.to_string())?;
+        let source = vibez_project::project_format_v1::stage_local_file(&path)
+            .map_err(|error| error.to_string())?;
+        Ok((audio, source))
+    })
+    .await
+    .map_err(|error| format!("decode/stage task failed: {error}"))?
+}
+
+async fn save_project_async(
+    path: PathBuf,
+    source_path: Option<PathBuf>,
+    project: Project,
+) -> Result<ProjectSaveResult, String> {
+    tokio::task::spawn_blocking(move || {
+        let is_v1_destination = path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("vzp"));
+        if is_v1_destination {
+            let v1_source = source_path.as_deref().filter(|source| {
+                vibez_project::project_format_v1::detect_project_format(source).is_ok_and(
+                    |format| format == vibez_project::project_format_v1::ProjectFileFormat::V1,
+                )
+            });
+            let saved =
+                vibez_project::project_format_v1::save_project_v1(&path, v1_source, project)
+                    .map_err(|error| error.to_string())?;
+            Ok(ProjectSaveResult {
+                path,
+                project: saved.project,
+                observation: Some(saved.observation),
+            })
+        } else {
+            project
+                .save_to_file(&path)
+                .map_err(|error| error.to_string())?;
+            Ok(ProjectSaveResult {
+                path,
+                project,
+                observation: None,
+            })
+        }
     })
     .await
     .map_err(|err| format!("save task failed: {err}"))?
@@ -582,8 +621,25 @@ async fn load_project_async(
     dropbox: Option<(Arc<DropboxClient>, DropboxCache)>,
 ) -> Result<ProjectLoadResult, String> {
     let load_path = path.clone();
-    let project = tokio::task::spawn_blocking(move || {
-        Project::load_from_file(&load_path).map_err(|err| err.to_string())
+    let (project, container_path) = tokio::task::spawn_blocking(move || {
+        match vibez_project::project_format_v1::detect_project_format(&load_path)
+            .map_err(|error| error.to_string())?
+        {
+            vibez_project::project_format_v1::ProjectFileFormat::V1 => {
+                let container =
+                    vibez_project::project_format_v1::ProjectContainer::open(&load_path)
+                        .map_err(|error| error.to_string())?;
+                let document = container
+                    .load_document()
+                    .map_err(|error| error.to_string())?;
+                Ok((document.project, Some(load_path)))
+            }
+            vibez_project::project_format_v1::ProjectFileFormat::LegacyJson => {
+                Project::load_from_file(&load_path)
+                    .map(|project| (project, None))
+                    .map_err(|error| error.to_string())
+            }
+        }
     })
     .await
     .map_err(|err| format!("load task failed: {err}"))??;
@@ -595,22 +651,17 @@ async fn load_project_async(
 
     for clip in &project.clips {
         match clip.resolved_source().cloned() {
-            Some(MediaSourceRef::LocalFile { path: clip_path }) => {
-                match decode_blocking(clip_path).await {
-                    Ok(audio) => {
-                        clips.push(finish_loaded_clip(clip.clone(), Arc::new(audio)).await)
-                    }
-                    Err(err) => warnings.push(format!("Skipped clip '{}' ({})", clip.name, err)),
-                }
-            }
-            Some(source @ MediaSourceRef::DropboxFile { .. }) => {
-                match hydrate_dropbox_source(dropbox.as_ref(), &source, &clip.name).await {
-                    Ok(audio) => {
-                        clips.push(finish_loaded_clip(clip.clone(), Arc::new(audio)).await)
-                    }
-                    Err(err) => warnings.push(err),
-                }
-            }
+            Some(source) => match hydrate_saved_source(
+                container_path.as_ref(),
+                dropbox.as_ref(),
+                &source,
+                &clip.name,
+            )
+            .await
+            {
+                Ok(audio) => clips.push(finish_loaded_clip(clip.clone(), Arc::new(audio)).await),
+                Err(err) => warnings.push(format!("Skipped clip '{}' ({})", clip.name, err)),
+            },
             None => warnings.push(format!(
                 "Skipped clip '{}' (missing source reference)",
                 clip.name
@@ -624,32 +675,24 @@ async fn load_project_async(
                 InstrumentStateInfo::Sampler {
                     source: Some(source),
                     ..
-                } => match source {
-                    MediaSourceRef::LocalFile { path: sample_path } => {
-                        match decode_blocking(sample_path.clone()).await {
-                            Ok(audio) => sampler_samples.push(LoadedSamplerData {
-                                track_id: track.id,
-                                source: source.clone(),
-                                audio: Arc::new(audio),
-                                name: source.display_name(),
-                            }),
-                            Err(err) => warnings.push(format!(
-                                "Skipped sampler source on '{}' ({})",
-                                track.name, err
-                            )),
-                        }
-                    }
-                    MediaSourceRef::DropboxFile { .. } => {
-                        match hydrate_dropbox_source(dropbox.as_ref(), source, &track.name).await {
-                            Ok(audio) => sampler_samples.push(LoadedSamplerData {
-                                track_id: track.id,
-                                source: source.clone(),
-                                audio: Arc::new(audio),
-                                name: source.display_name(),
-                            }),
-                            Err(err) => warnings.push(err),
-                        }
-                    }
+                } => match hydrate_saved_source(
+                    container_path.as_ref(),
+                    dropbox.as_ref(),
+                    source,
+                    &track.name,
+                )
+                .await
+                {
+                    Ok(audio) => sampler_samples.push(LoadedSamplerData {
+                        track_id: track.id,
+                        source: source.clone(),
+                        audio: Arc::new(audio),
+                        name: source.display_name(),
+                    }),
+                    Err(err) => warnings.push(format!(
+                        "Skipped sampler source on '{}' ({})",
+                        track.name, err
+                    )),
                 },
                 InstrumentStateInfo::DrumRack { pads } => {
                     for (pad_index, pad) in pads.iter().enumerate() {
@@ -657,38 +700,23 @@ async fn load_project_async(
                             continue;
                         };
                         let label = format!("drum pad {} on '{}'", pad_index + 1, track.name);
-                        match source {
-                            MediaSourceRef::LocalFile { path: sample_path } => {
-                                match decode_blocking(sample_path.clone()).await {
-                                    Ok(audio) => {
-                                        drum_rack_pad_samples.push(LoadedDrumRackPadData {
-                                            track_id: track.id,
-                                            pad_index,
-                                            source: source.clone(),
-                                            audio: Arc::new(audio),
-                                            name: source.display_name(),
-                                            state: pad.clone(),
-                                        })
-                                    }
-                                    Err(err) => warnings.push(format!("Skipped {label} ({err})")),
-                                }
-                            }
-                            MediaSourceRef::DropboxFile { .. } => {
-                                match hydrate_dropbox_source(dropbox.as_ref(), source, &label).await
-                                {
-                                    Ok(audio) => {
-                                        drum_rack_pad_samples.push(LoadedDrumRackPadData {
-                                            track_id: track.id,
-                                            pad_index,
-                                            source: source.clone(),
-                                            audio: Arc::new(audio),
-                                            name: source.display_name(),
-                                            state: pad.clone(),
-                                        })
-                                    }
-                                    Err(err) => warnings.push(err),
-                                }
-                            }
+                        match hydrate_saved_source(
+                            container_path.as_ref(),
+                            dropbox.as_ref(),
+                            source,
+                            &label,
+                        )
+                        .await
+                        {
+                            Ok(audio) => drum_rack_pad_samples.push(LoadedDrumRackPadData {
+                                track_id: track.id,
+                                pad_index,
+                                source: source.clone(),
+                                audio: Arc::new(audio),
+                                name: source.display_name(),
+                                state: pad.clone(),
+                            }),
+                            Err(err) => warnings.push(format!("Skipped {label} ({err})")),
                         }
                     }
                 }
@@ -705,6 +733,45 @@ async fn load_project_async(
         drum_rack_pad_samples,
         warnings,
     })
+}
+
+async fn hydrate_saved_source(
+    container_path: Option<&PathBuf>,
+    dropbox: Option<&(Arc<DropboxClient>, DropboxCache)>,
+    source: &MediaSourceRef,
+    label: &str,
+) -> Result<vibez_core::audio_buffer::DecodedAudio, String> {
+    match source {
+        MediaSourceRef::LocalFile { path }
+        | MediaSourceRef::StagedProjectMedia {
+            staging_path: path, ..
+        } => decode_blocking(path.clone()).await,
+        MediaSourceRef::ProjectMedia { id, file_name } => {
+            let container_path = container_path
+                .cloned()
+                .ok_or_else(|| format!("{label} has Project Media without a V1 container"))?;
+            let id = id.clone();
+            let extension = Path::new(file_name)
+                .extension()
+                .map(|value| value.to_string_lossy().into_owned());
+            tokio::task::spawn_blocking(move || {
+                let container =
+                    vibez_project::project_format_v1::ProjectContainer::open(container_path)
+                        .map_err(|error| error.to_string())?;
+                let bytes = container
+                    .read_media(&id)
+                    .map_err(|error| error.to_string())?;
+                vibez_audio_io::file_io::decode_audio_cursor(
+                    std::io::Cursor::new(bytes),
+                    extension.as_deref(),
+                )
+                .map_err(|error| error.to_string())
+            })
+            .await
+            .map_err(|error| format!("Project Media decode task failed: {error}"))?
+        }
+        MediaSourceRef::DropboxFile { .. } => hydrate_dropbox_source(dropbox, source, label).await,
+    }
 }
 
 async fn decode_blocking(path: PathBuf) -> Result<vibez_core::audio_buffer::DecodedAudio, String> {
@@ -779,4 +846,58 @@ async fn scan_sample_library_async(roots: Vec<PathBuf>) -> Result<SampleLibraryS
     })
     .await
     .map_err(|err| format!("scan task failed: {err}"))?
+}
+
+#[cfg(test)]
+mod project_format_v1_tests {
+    use super::*;
+    use vibez_core::audio_buffer::DecodedAudio;
+    use vibez_core::id::ClipId;
+    use vibez_core::track::TrackInfo;
+
+    #[tokio::test]
+    async fn v1_reopen_decodes_embedded_audio_after_source_removal() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("source.wav");
+        let project_path = directory.path().join("self-contained.vzp");
+        let audio = DecodedAudio {
+            channels: vec![vec![0.0, 0.25, -0.5, 0.75, -1.0]],
+            sample_rate: 44_100,
+        };
+        vibez_audio_io::file_io::write_wav_file(&source_path, &audio).unwrap();
+        let track = TrackInfo::new("Audio");
+        let project = Project {
+            tracks: vec![track.clone()],
+            clips: vec![ClipInfo {
+                id: ClipId::new(),
+                track_id: track.id,
+                name: "source.wav".into(),
+                position: 0,
+                source_offset: 0,
+                duration: audio.num_frames() as u64,
+                source: Some(MediaSourceRef::LocalFile {
+                    path: source_path.clone(),
+                }),
+                file_path: Some(source_path.clone()),
+                loop_enabled: false,
+                loop_start: 0,
+                loop_end: audio.num_frames() as u64,
+                original_bpm: None,
+                warped: false,
+                warped_to_bpm: None,
+            }],
+            ..Project::default()
+        };
+        vibez_project::project_format_v1::save_project_v1(&project_path, None, project).unwrap();
+        std::fs::remove_file(source_path).unwrap();
+
+        let loaded = load_project_async(project_path, None).await.unwrap();
+        assert_eq!(loaded.clips.len(), 1);
+        assert_eq!(loaded.clips[0].audio.num_frames(), audio.num_frames());
+        assert!(matches!(
+            loaded.project.clips[0].source,
+            Some(MediaSourceRef::ProjectMedia { .. })
+        ));
+        assert_eq!(loaded.project.tracks[0].id, track.id);
+    }
 }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -481,6 +481,91 @@ async fn warp_browser_audition_async(
     .map_err(|error| format!("audition warp task failed: {error}"))?
 }
 
+async fn prepare_browser_import_audio_async(
+    target: crate::message::BrowserImportTarget,
+    treatment: crate::state::AuditionImportInput,
+    raw: Arc<vibez_core::audio_buffer::DecodedAudio>,
+    source: MediaSourceRef,
+    project_bpm: f64,
+) -> Result<
+    (
+        Arc<vibez_core::audio_buffer::DecodedAudio>,
+        Option<Arc<vibez_core::audio_buffer::DecodedAudio>>,
+        MediaSourceRef,
+    ),
+    String,
+> {
+    if treatment.mode == crate::state::AuditionMode::Raw {
+        return Ok((raw, None, source));
+    }
+    let source_bpm = treatment
+        .source_bpm
+        .filter(|bpm| bpm.is_finite() && *bpm > 0.0)
+        .ok_or_else(|| "Confirm a positive source BPM before WARP import".to_string())?;
+    let frames = raw.num_frames() as u64;
+    let success = crate::warp::warp_clip_async(crate::warp::WarpClipInput {
+        audio: Arc::clone(&raw),
+        fields_frames: frames,
+        source_offset: 0,
+        duration: frames,
+        loop_start: 0,
+        loop_end: frames,
+        clip_bpm: source_bpm,
+        project_bpm,
+    })
+    .await?;
+    let device_target = matches!(
+        target,
+        crate::message::BrowserImportTarget::Sampler(_)
+            | crate::message::BrowserImportTarget::DrumRackPad { .. }
+    );
+    if !device_target {
+        return Ok((success.audio, Some(success.original_audio), source));
+    }
+
+    let rendered = Arc::clone(&success.audio);
+    let staged = tokio::task::spawn_blocking(move || {
+        let (source_path, original_name) = match source {
+            MediaSourceRef::StagedProjectMedia {
+                source_path,
+                file_name,
+                ..
+            } => (source_path, file_name),
+            MediaSourceRef::LocalFile { path } => {
+                let file_name = path
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "warped-import.wav".into());
+                (path, file_name)
+            }
+            _ => return Err("WARP device import requires materialized Local media".to_string()),
+        };
+        let stem = std::path::Path::new(&original_name)
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned())
+            .filter(|stem| !stem.is_empty())
+            .unwrap_or_else(|| "sample".into());
+        let file_name = format!("{stem}-warped.wav");
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        let temporary = std::env::temp_dir().join(format!(
+            "vibez-warp-import-{}-{nonce}.wav",
+            std::process::id()
+        ));
+        vibez_audio_io::file_io::write_wav_file(&temporary, &rendered)
+            .map_err(|error| error.to_string())?;
+        let content = std::fs::read(&temporary).map_err(|error| error.to_string())?;
+        let _ = std::fs::remove_file(&temporary);
+        vibez_project::project_format_v1::stage_local_content(&source_path, &file_name, &content)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("WARP device staging task failed: {error}"))??;
+    Ok((success.audio, None, staged))
+}
+
 async fn auto_warp_clip_async(input: AutoWarpInput) -> crate::message::AutoWarpOutcome {
     use crate::message::AutoWarpOutcome;
     let audio_for_detect = Arc::clone(&input.audio);
@@ -865,7 +950,126 @@ mod project_format_v1_tests {
     use super::*;
     use vibez_core::audio_buffer::DecodedAudio;
     use vibez_core::id::ClipId;
-    use vibez_core::track::TrackInfo;
+    use vibez_core::midi::{InstrumentKind, TrackKind};
+    use vibez_core::track::{InstrumentStateInfo, TrackInfo};
+
+    fn one_second_audio() -> Arc<DecodedAudio> {
+        Arc::new(DecodedAudio {
+            channels: vec![vec![0.25; 44_100]],
+            sample_rate: 44_100,
+        })
+    }
+
+    #[tokio::test]
+    async fn warp_arrangement_import_reopens_from_project_media_without_local_source() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("loop.wav");
+        let project_path = directory.path().join("warp-import.vzp");
+        let raw = one_second_audio();
+        vibez_audio_io::file_io::write_wav_file(&source_path, &raw).unwrap();
+        let source = vibez_project::project_format_v1::stage_local_file(&source_path).unwrap();
+        let treatment = crate::state::AuditionImportInput {
+            mode: crate::state::AuditionMode::Warp,
+            source_bpm: Some(120.0),
+        };
+        let (warped, original, staged) = prepare_browser_import_audio_async(
+            crate::message::BrowserImportTarget::ArrangementNewTrackAt {
+                position_samples: 0,
+            },
+            treatment,
+            Arc::clone(&raw),
+            source,
+            60.0,
+        )
+        .await
+        .unwrap();
+        assert_eq!(warped.num_frames(), 88_200);
+        assert_eq!(original.unwrap().num_frames(), raw.num_frames());
+
+        let track = TrackInfo::new("Audio");
+        let project = Project {
+            tracks: vec![track.clone()],
+            clips: vec![ClipInfo {
+                id: ClipId::new(),
+                track_id: track.id,
+                name: "loop.wav".into(),
+                position: 0,
+                source_offset: 0,
+                duration: warped.num_frames() as u64,
+                source: Some(staged),
+                file_path: None,
+                loop_enabled: false,
+                loop_start: 0,
+                loop_end: 0,
+                original_bpm: Some(120.0),
+                warped: true,
+                warped_to_bpm: Some(60.0),
+            }],
+            ..Project::default()
+        };
+        vibez_project::project_format_v1::save_project_v1(&project_path, None, project).unwrap();
+        std::fs::remove_file(source_path).unwrap();
+
+        let loaded = load_project_async(project_path, None).await.unwrap();
+        assert_eq!(loaded.clips[0].audio.num_frames(), warped.num_frames());
+        assert!(matches!(
+            loaded.project.clips[0].source,
+            Some(MediaSourceRef::ProjectMedia { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn warp_sampler_import_bakes_heard_audio_into_project_media() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("device-loop.wav");
+        let project_path = directory.path().join("warp-device.vzp");
+        let raw = one_second_audio();
+        vibez_audio_io::file_io::write_wav_file(&source_path, &raw).unwrap();
+        let source = vibez_project::project_format_v1::stage_local_file(&source_path).unwrap();
+        let mut track = TrackInfo::new("Sampler");
+        track.kind = TrackKind::Midi;
+        track.instrument = Some(InstrumentKind::Sampler);
+        let (warped, original, staged) = prepare_browser_import_audio_async(
+            crate::message::BrowserImportTarget::Sampler(track.id),
+            crate::state::AuditionImportInput {
+                mode: crate::state::AuditionMode::Warp,
+                source_bpm: Some(120.0),
+            },
+            raw,
+            source,
+            60.0,
+        )
+        .await
+        .unwrap();
+        assert!(original.is_none(), "device media is the baked WARP buffer");
+        track.native_instrument = Some(InstrumentStateInfo::Sampler {
+            params: Vec::new(),
+            source: Some(staged),
+        });
+        let project = Project {
+            tracks: vec![track],
+            ..Project::default()
+        };
+        vibez_project::project_format_v1::save_project_v1(&project_path, None, project).unwrap();
+        std::fs::remove_file(source_path).unwrap();
+
+        let loaded = load_project_async(project_path, None).await.unwrap();
+        assert_eq!(loaded.sampler_samples.len(), 1);
+        assert_eq!(
+            loaded.sampler_samples[0].audio.num_frames(),
+            warped.num_frames()
+        );
+        assert!(matches!(
+            loaded.project.tracks[0]
+                .native_instrument
+                .as_ref()
+                .and_then(|state| match state {
+                    InstrumentStateInfo::Sampler { source, .. } => source.as_ref(),
+                    _ => None,
+                }),
+            Some(MediaSourceRef::ProjectMedia { .. })
+        ));
+    }
 
     #[tokio::test]
     async fn v1_reopen_decodes_embedded_audio_after_source_removal() {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -307,7 +307,9 @@ impl App {
                     source: clip.source.clone(),
                     file_path: clip.source.as_ref().and_then(|source| match source {
                         MediaSourceRef::LocalFile { path } => Some(path.clone()),
-                        MediaSourceRef::DropboxFile { .. } => None,
+                        MediaSourceRef::StagedProjectMedia { .. }
+                        | MediaSourceRef::ProjectMedia { .. }
+                        | MediaSourceRef::DropboxFile { .. } => None,
                     }),
                     loop_enabled: clip.loop_enabled,
                     loop_start: clip.loop_start,
@@ -364,6 +366,32 @@ impl App {
                 .iter()
                 .map(|bus| self.track_info_from_ui(bus))
                 .collect(),
+        }
+    }
+
+    pub(super) fn apply_saved_project_sources(&mut self, project: &Project) {
+        for saved_clip in &project.clips {
+            if let Some(track) = self.state.find_track_mut(saved_clip.track_id) {
+                if let Some(clip) = track.clips.iter_mut().find(|clip| clip.id == saved_clip.id) {
+                    clip.source = saved_clip.source.clone();
+                }
+            }
+        }
+        for saved_track in &project.tracks {
+            let Some(track) = self.state.find_track_mut(saved_track.id) else {
+                continue;
+            };
+            match &saved_track.native_instrument {
+                Some(InstrumentStateInfo::Sampler { source, .. }) => {
+                    track.sample_source = source.clone();
+                }
+                Some(InstrumentStateInfo::DrumRack { pads }) => {
+                    for (slot, saved_pad) in track.drum_rack_pads.iter_mut().zip(pads) {
+                        slot.source = saved_pad.source.clone();
+                    }
+                }
+                _ => {}
+            }
         }
     }
 

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -331,16 +331,16 @@ impl App {
                         .map(|n| n.to_string_lossy().to_string())
                         .unwrap_or_default();
                     self.state.status_text = format!("Loading {file_name}...");
-                    let source = MediaSourceRef::LocalFile { path: path.clone() };
-
-                    return Task::perform(decode_file_async(path), move |result| match result {
-                        Ok(audio) => Message::SamplerSampleDecoded(
-                            track_id,
-                            Arc::new(audio),
-                            file_name.clone(),
-                            source.clone(),
-                        ),
-                        Err(e) => Message::SamplerDecodeError(track_id, e),
+                    return Task::perform(decode_and_stage_local_async(path), move |result| {
+                        match result {
+                            Ok((audio, source)) => Message::SamplerSampleDecoded(
+                                track_id,
+                                Arc::new(audio),
+                                file_name.clone(),
+                                source,
+                            ),
+                            Err(e) => Message::SamplerDecodeError(track_id, e),
+                        }
                     });
                 }
             }
@@ -634,7 +634,10 @@ impl App {
                 self.state.project.file_menu_open = false;
                 let project = self.project_from_state();
                 if let Some(path) = self.state.project.current_path.clone() {
-                    return Task::perform(save_project_async(path, project), Message::ProjectSaved);
+                    return Task::perform(
+                        save_project_async(path.clone(), Some(path), project),
+                        |result| Message::ProjectSaved(Box::new(result)),
+                    );
                 }
                 return self.update(Message::SaveProjectAs);
             }
@@ -645,7 +648,7 @@ impl App {
                         let handle = rfd::AsyncFileDialog::new()
                             .set_title("Save Vibez Project")
                             .set_file_name("Untitled.vzp")
-                            .add_filter("Vibez Project", &["vzp", "vibez"])
+                            .add_filter("Vibez Project Format V1", &["vzp"])
                             .save_file()
                             .await;
                         handle.map(|file| file.path().to_path_buf())
@@ -667,11 +670,17 @@ impl App {
             }
             Message::ProjectSavePathSelected(path) => {
                 if let Some(mut path) = path {
-                    if path.extension().is_none() {
+                    if !path
+                        .extension()
+                        .is_some_and(|extension| extension.eq_ignore_ascii_case("vzp"))
+                    {
                         path.set_extension("vzp");
                     }
                     let project = self.project_from_state();
-                    return Task::perform(save_project_async(path, project), Message::ProjectSaved);
+                    return Task::perform(
+                        save_project_async(path, self.state.project.current_path.clone(), project),
+                        |result| Message::ProjectSaved(Box::new(result)),
+                    );
                 }
             }
             Message::ProjectLoaded(result) => match *result {
@@ -682,11 +691,12 @@ impl App {
                     self.state.status_text = format!("Project load error: {err}");
                 }
             },
-            Message::ProjectSaved(result) => match result {
-                Ok(path) => {
-                    self.state.project.current_path = Some(path.clone());
+            Message::ProjectSaved(result) => match *result {
+                Ok(saved) => {
+                    self.apply_saved_project_sources(&saved.project);
+                    self.state.project.current_path = Some(saved.path.clone());
                     self.state.project.dirty = false;
-                    self.state.status_text = format!("Saved {}", path.display());
+                    self.state.status_text = format!("Saved {}", saved.path.display());
                 }
                 Err(err) => {
                     self.state.status_text = format!("Project save error: {err}");

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -97,7 +97,7 @@ impl App {
                 | Message::Arrangement(ArrangementMsg::AddInstrumentTrack)
                 | Message::SamplerSampleDecoded(..)
                 | Message::DrumRackPadSampleDecoded(..)
-                | Message::BrowserSampleDecoded(..)
+                | Message::BrowserImportPrepared { .. }
                 | Message::Arrangement(ArrangementMsg::SetClipLoopRegion { .. })
                 | Message::Arrangement(ArrangementMsg::MoveAudioClip { .. })
                 | Message::Arrangement(ArrangementMsg::MoveNoteClipPosition { .. })
@@ -233,6 +233,24 @@ impl App {
                     let action = self.state.browser.update(browser_msg);
                     if action.persist_settings {
                         self.persist_ui_settings();
+                    }
+                }
+                let pending_drag_msg = match &msg {
+                    ViewMsg::CursorMoved(x, y) if self.state.browser.pending_drag.is_some() => {
+                        Some(BrowserMsg::PendingDragMoved { x: *x, y: *y })
+                    }
+                    ViewMsg::MouseReleased if self.state.browser.pending_drag.is_some() => {
+                        Some(BrowserMsg::EndDragSample)
+                    }
+                    ViewMsg::MouseReleased if self.state.browser.drag_source.is_some() => {
+                        Some(BrowserMsg::EndDragSample)
+                    }
+                    _ => None,
+                };
+                if let Some(browser_msg) = pending_drag_msg {
+                    let action = self.state.browser.update(browser_msg);
+                    if let Some(status) = action.status {
+                        self.state.status_text = status;
                     }
                 }
                 let ctx = crate::domains::view::ViewCtx {
@@ -560,6 +578,11 @@ impl App {
                 }));
             }
             Message::ClickLocalBrowserEntry(source) => {
+                if self.state.browser.drag_source.is_some() {
+                    self.state.browser.cancel_media_drag();
+                    self.state.status_text = "Drag cancelled".into();
+                    return Task::none();
+                }
                 let changed = self.state.browser.select_source(source.clone());
                 if changed {
                     if let MediaSourceRef::LocalFile { path } = source.clone() {
@@ -580,6 +603,15 @@ impl App {
                         );
                     }
                 }
+            }
+            Message::BeginPendingBrowserDrag(source, label) => {
+                let action = self.state.browser.update(BrowserMsg::BeginPendingDrag {
+                    source,
+                    label,
+                    origin_x: self.state.view.cursor_x,
+                    origin_y: self.state.view.cursor_y,
+                });
+                return self.apply_browser_action(action);
             }
             Message::PreviewLocalEntry(source) => {
                 self.state.browser.select_source(source.clone());
@@ -686,9 +718,17 @@ impl App {
                 }
             }
             Message::EscapePressed => {
-                if self.state.browser.audition_playing || self.state.browser.audition_loading {
+                if self.state.browser.audition_playing
+                    || self.state.browser.audition_loading
+                    || self.state.browser.audition_queued
+                {
                     self.stop_browser_audition();
                     self.state.status_text = "Audition stopped".into();
+                } else if self.state.browser.drag_source.is_some()
+                    || self.state.browser.pending_drag.is_some()
+                {
+                    self.state.browser.cancel_media_drag();
+                    self.state.status_text = "Drag cancelled".into();
                 } else {
                     return self.update(Message::View(ViewMsg::CancelEditing));
                 }
@@ -701,8 +741,23 @@ impl App {
                 let Some(source) = self.state.browser.drag_source.take() else {
                     return Task::none();
                 };
-                self.state.browser.drag_label = None;
+                self.state.browser.cancel_media_drag();
                 return self.dispatch_drop_on_arrangement(track_id, position_samples, source);
+            }
+            Message::DropSampleOnEmptyArrangement => {
+                let Some(source) = self.state.browser.drag_source.take() else {
+                    return Task::none();
+                };
+                let beat = match self.state.browser.drag_target.take() {
+                    Some(crate::state::BrowserDropTarget::EmptyArrangement { beat }) => beat,
+                    _ => self.state.position_beats(),
+                };
+                self.state.browser.cancel_media_drag();
+                let position_samples = self.state.beats_to_samples(beat);
+                return self.dispatch_drop_for_target(
+                    source,
+                    BrowserImportTarget::ArrangementNewTrackAt { position_samples },
+                );
             }
             Message::DropSampleOnDrumPad {
                 track_id,
@@ -714,7 +769,7 @@ impl App {
                 let Some(source) = self.state.browser.drag_source.take() else {
                     return Task::none();
                 };
-                self.state.browser.drag_label = None;
+                self.state.browser.cancel_media_drag();
                 return self
                     .dispatch_drop_for_target(source, BrowserImportTarget::Sampler(track_id));
             }
@@ -796,8 +851,11 @@ impl App {
             Message::LoadSelectedBrowserSampleToDevice => {
                 return self.handle_load_selected_browser_sample_to_device();
             }
-            Message::BrowserSampleDecoded(target, audio, name, source) => {
-                return self.apply_browser_sample_decoded(target, audio, name, source);
+            Message::BrowserSampleDecoded(target, treatment, audio, name, source) => {
+                return self.prepare_browser_sample_import(target, treatment, audio, name, source);
+            }
+            Message::BrowserImportPrepared { target, payload } => {
+                return self.apply_browser_import_prepared(target, payload);
             }
             Message::ClipAutoWarpReady {
                 track_id,
@@ -816,7 +874,7 @@ impl App {
                 return self.apply_arrangement_action(action);
             }
             Message::BrowserSampleDecodeError(err) => {
-                self.state.status_text = format!("Browser load error: {err}");
+                self.state.status_text = format!("Browser import error: {err}");
             }
 
             // -- File menu --

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -954,10 +954,10 @@ impl App {
             };
             let entry_body = container(table_cells).padding([6, 8]).width(Length::Fill);
             let entry_dragger: Element<'_, Message> = mouse_area(entry_body)
-                .on_press(Message::Browser(BrowserMsg::StartDragSample {
-                    source: entry.source.clone(),
-                    label: entry.name.clone(),
-                }))
+                .on_press(Message::BeginPendingBrowserDrag(
+                    entry.source.clone(),
+                    entry.name.clone(),
+                ))
                 .on_release(Message::ClickLocalBrowserEntry(entry.source.clone()))
                 .into();
             let selection_marker = container(text(""))
@@ -1268,10 +1268,7 @@ impl App {
                     rev: entry.rev.clone(),
                 };
                 let dragger: Element<'_, Message> = mouse_area(row_body)
-                    .on_press(Message::Browser(BrowserMsg::StartDragSample {
-                        source,
-                        label: entry.name.clone(),
-                    }))
+                    .on_press(Message::BeginPendingBrowserDrag(source, entry.name.clone()))
                     .on_release(msg)
                     .into();
                 let selection_marker = container(text(""))

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -9,6 +9,7 @@ use vibez_core::id::TrackId;
 use vibez_core::track::MediaSourceRef;
 use vibez_plugin_host::gui::PluginGuiKey;
 
+use crate::domains::browser::BrowserMsg;
 use crate::icons;
 use crate::message::{DrumPadParam, Message};
 use crate::state::UiTrack;
@@ -678,8 +679,26 @@ impl App {
         let card = Self::device_card(
             column![title, Self::device_body(body.into())].width(Length::Fixed(560.0)),
         );
+        let drop_target = matches!(
+            self.state.browser.drag_target,
+            Some(crate::state::BrowserDropTarget::Sampler { track_id: target }) if target == track_id
+        );
+        let card = container(card).style(move |_theme: &Theme| container::Style {
+            border: iced::Border {
+                color: if drop_target {
+                    th::accent()
+                } else {
+                    iced::Color::TRANSPARENT
+                },
+                width: if drop_target { 2.0 } else { 0.0 },
+                radius: 0.0.into(),
+            },
+            ..Default::default()
+        });
         // The whole card accepts browser drops, like drum pads.
         mouse_area(card)
+            .on_enter(Message::Browser(BrowserMsg::DragHoverSampler { track_id }))
+            .on_exit(Message::Browser(BrowserMsg::ClearDragTarget))
             .on_release(Message::DropSampleOnSampler { track_id })
             .into()
     }
@@ -707,6 +726,13 @@ impl App {
                 let pad_index = row_index * 4 + col_index;
                 let pad = &track.drum_rack_pads[pad_index];
                 let active = selected_pad == pad_index;
+                let drop_target = matches!(
+                    self.state.browser.drag_target,
+                    Some(crate::state::BrowserDropTarget::DrumRackPad {
+                        track_id: target_track,
+                        pad_index: target_pad,
+                    }) if target_track == track_id && target_pad == pad_index
+                );
                 // Hard-truncated single line: wrapping names change
                 // the tile height and blow the card's height budget
                 // (clipped knobs, dogfood screenshot 2026-07-06).
@@ -743,7 +769,7 @@ impl App {
                 .height(Length::Fixed(30.0))
                 .style(move |_theme: &Theme| container::Style {
                     background: Some(
-                        if active {
+                        if drop_target || active {
                             th::accent_dim()
                         } else {
                             th::bg_dark()
@@ -752,19 +778,26 @@ impl App {
                     ),
                     text_color: Some(if active { th::accent() } else { th::text() }),
                     border: iced::Border {
-                        color: if active {
+                        color: if drop_target {
+                            th::accent()
+                        } else if active {
                             th::accent_dim()
                         } else {
                             th::border()
                         },
-                        width: 1.0,
-                        radius: 4.0.into(),
+                        width: if drop_target { 2.0 } else { 1.0 },
+                        radius: 0.0.into(),
                     },
                     ..Default::default()
                 });
                 // on_release handler selects the pad when no drag is active,
                 // otherwise routes through DropSampleOnDrumPad.
                 let pad_cell: Element<'a, Message> = mouse_area(pad_body)
+                    .on_enter(Message::Browser(BrowserMsg::DragHoverDrumRackPad {
+                        track_id,
+                        pad_index,
+                    }))
+                    .on_exit(Message::Browser(BrowserMsg::ClearDragTarget))
                     .on_release(Message::DropSampleOnDrumPad {
                         track_id,
                         pad_index,

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -60,6 +60,53 @@ impl App {
         let base_layout: Element<'_, Message> = mouse_area(layout_container)
             .on_release(Message::Browser(BrowserMsg::EndDragSample))
             .into();
+        let base_layout: Element<'_, Message> = if let Some(label) =
+            self.state.browser.drag_label.as_ref()
+        {
+            let mode = match self.state.browser.audition_mode {
+                crate::state::AuditionMode::Raw => "RAW",
+                crate::state::AuditionMode::Warp => "WARP",
+            };
+            let length = self
+                .state
+                .browser
+                .drag_preview_beats(self.state.transport.bpm)
+                .map(|beats| format!(" · {beats:.2} beats"))
+                .unwrap_or_default();
+            let (target, valid) = match self.state.browser.drag_target {
+                Some(crate::state::BrowserDropTarget::ArrangementLane {
+                    beat, compatible, ..
+                }) => (
+                    if compatible {
+                        format!("AUDIO LANE · BEAT {beat:.2}")
+                    } else {
+                        "INVALID · MIDI/INSTRUMENT LANE".into()
+                    },
+                    Some(compatible),
+                ),
+                Some(crate::state::BrowserDropTarget::EmptyArrangement { beat }) => {
+                    (format!("NEW AUDIO TRACK · BEAT {beat:.2}"), Some(true))
+                }
+                Some(crate::state::BrowserDropTarget::Sampler { .. }) => {
+                    ("LOAD SAMPLER".into(), Some(true))
+                }
+                Some(crate::state::BrowserDropTarget::DrumRackPad { pad_index, .. }) => {
+                    (format!("ASSIGN DRUM PAD {}", pad_index + 1), Some(true))
+                }
+                None => ("CHOOSE A DROP TARGET".into(), None),
+            };
+            let ghost = canvas(crate::widgets::browser_drag_ghost::BrowserDragGhost {
+                cursor: iced::Point::new(self.state.view.cursor_x, self.state.view.cursor_y),
+                title: format!("{label} · {mode}{length}"),
+                detail: target,
+                valid,
+            })
+            .width(Length::Fill)
+            .height(Length::Fill);
+            stack![base_layout, ghost].into()
+        } else {
+            base_layout
+        };
 
         if self.state.settings_open {
             stack![base_layout, self.view_settings_modal()].into()
@@ -270,13 +317,27 @@ impl App {
 
     pub(super) fn view_arrangement(&self) -> Element<'_, Message> {
         if self.state.arrangement.tracks.is_empty() {
-            let prompt = text("Right-click or Ctrl+T to add a track")
-                .size(16)
-                .color(th::text_dim());
+            let browser_drag_active = self.state.browser.drag_source.is_some();
+            let empty_beat = match self.state.browser.drag_target {
+                Some(crate::state::BrowserDropTarget::EmptyArrangement { beat }) => Some(beat),
+                _ => None,
+            };
+            let prompt_text = if browser_drag_active {
+                empty_beat
+                    .map(|beat| format!("DROP → NEW AUDIO TRACK · BEAT {beat:.2}"))
+                    .unwrap_or_else(|| "DROP → NEW AUDIO TRACK".into())
+            } else {
+                "Right-click or Ctrl+T to add a track".into()
+            };
+            let prompt = text(prompt_text).size(16).color(if browser_drag_active {
+                th::accent()
+            } else {
+                th::text_dim()
+            });
 
             let centered = center(prompt).width(Length::Fill).height(Length::Fill);
 
-            return mouse_area(
+            let mut area = mouse_area(
                 container(centered)
                     .width(Length::Fill)
                     .height(Length::FillPortion(5))
@@ -289,8 +350,24 @@ impl App {
                 x: 400.0,
                 y: 300.0,
                 target: ContextMenuTarget::ArrangementEmpty,
-            }))
-            .into();
+            }));
+            if browser_drag_active {
+                let grid = self.state.view.grid_config();
+                let pixels_per_beat = 20.0 * self.state.view.zoom_level;
+                let scroll = self.state.view.scroll_offset_beats;
+                area = area
+                    .on_move(move |point| {
+                        let beat = grid.snap_beat(
+                            point.x as f64 / pixels_per_beat as f64 + scroll,
+                            pixels_per_beat,
+                        );
+                        Message::Browser(BrowserMsg::DragHoverEmptyArrangement {
+                            beat: beat.max(0.0),
+                        })
+                    })
+                    .on_release(Message::DropSampleOnEmptyArrangement);
+            }
+            return area.into();
         }
 
         let playhead_beats = self.state.position_beats();
@@ -394,6 +471,20 @@ impl App {
             .map(|t| t.kind.is_midi())
             .collect();
         let total_track_count = self.state.arrangement.tracks.len();
+        let browser_drag_duration = self
+            .state
+            .browser
+            .drag_preview_beats(self.state.transport.bpm);
+        let browser_drag_detail = self.state.browser.drag_label.as_ref().map(|label| {
+            let mode = match self.state.browser.audition_mode {
+                crate::state::AuditionMode::Raw => "RAW",
+                crate::state::AuditionMode::Warp => "WARP",
+            };
+            match browser_drag_duration {
+                Some(beats) => format!("{label} · {mode} · {beats:.2} beats"),
+                None => format!("{label} · {mode}"),
+            }
+        });
 
         // Track rows: header widgets + clip canvas
         let mut track_rows = column![].spacing(0);
@@ -460,11 +551,32 @@ impl App {
                 self.state.arrangement.selection_end_beats,
                 self.state.arrangement.time_selection_track,
                 self.state.browser.drag_source.is_some(),
+                browser_drag_duration,
+                browser_drag_detail.clone(),
             );
-            let clip_canvas: Element<'_, Message> = canvas(clip_canvas_widget)
-                .width(Length::Fill)
-                .height(Length::Fixed(70.0))
-                .into();
+            let track_id = track.id;
+            let compatible = !track.kind.is_midi();
+            let grid = self.state.view.grid_config();
+            let pixels_per_beat = 20.0 * zoom_level;
+            let scroll = scroll_offset;
+            let clip_canvas: Element<'_, Message> = mouse_area(
+                canvas(clip_canvas_widget)
+                    .width(Length::Fill)
+                    .height(Length::Fixed(70.0)),
+            )
+            .on_move(move |point| {
+                let beat = grid.snap_beat(
+                    point.x as f64 / pixels_per_beat as f64 + scroll,
+                    pixels_per_beat,
+                );
+                Message::Browser(BrowserMsg::DragHoverTrack {
+                    track_id,
+                    beat: beat.max(0.0),
+                    compatible,
+                })
+            })
+            .on_exit(Message::Browser(BrowserMsg::ClearDragTarget))
+            .into();
 
             let track_row = row![header, clip_canvas].height(Length::Fixed(70.0));
 
@@ -473,6 +585,62 @@ impl App {
             if automation_open {
                 track_rows = self.push_automation_lanes(track_rows, track, track_color);
             }
+        }
+
+        if self.state.browser.drag_source.is_some() {
+            let grid = self.state.view.grid_config();
+            let pixels_per_beat = 20.0 * self.state.view.zoom_level;
+            let scroll = self.state.view.scroll_offset_beats;
+            let empty_beat = match self.state.browser.drag_target {
+                Some(crate::state::BrowserDropTarget::EmptyArrangement { beat }) => Some(beat),
+                _ => None,
+            };
+            let label = empty_beat
+                .map(|beat| format!("NEW AUDIO TRACK · BEAT {beat:.2}"))
+                .unwrap_or_else(|| "NEW AUDIO TRACK".into());
+            let header = container(text("+").size(14).color(th::accent()))
+                .width(Length::Fixed(
+                    crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH,
+                ))
+                .height(Length::Fixed(54.0))
+                .align_x(iced::alignment::Horizontal::Center)
+                .align_y(iced::alignment::Vertical::Center)
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(th::bg_surface().into()),
+                    border: iced::Border {
+                        color: th::divider(),
+                        width: 1.0,
+                        radius: 0.0.into(),
+                    },
+                    ..Default::default()
+                });
+            let zone = mouse_area(
+                container(text(label).size(12).color(th::accent()))
+                    .padding([0, 10])
+                    .width(Length::Fill)
+                    .height(Length::Fixed(54.0))
+                    .align_y(iced::alignment::Vertical::Center)
+                    .style(|_theme: &Theme| container::Style {
+                        background: Some(th::accent_dim().into()),
+                        border: iced::Border {
+                            color: th::accent(),
+                            width: 1.0,
+                            radius: 0.0.into(),
+                        },
+                        ..Default::default()
+                    }),
+            )
+            .on_move(move |point| {
+                let beat = grid.snap_beat(
+                    point.x as f64 / pixels_per_beat as f64 + scroll,
+                    pixels_per_beat,
+                );
+                Message::Browser(BrowserMsg::DragHoverEmptyArrangement {
+                    beat: beat.max(0.0),
+                })
+            })
+            .on_release(Message::DropSampleOnEmptyArrangement);
+            track_rows = track_rows.push(row![header, zone].height(Length::Fixed(54.0)));
         }
 
         // ── Returns + master: automation-only channels ──

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -29,16 +29,33 @@ pub enum BrowserMsg {
     ShowMoreLocalResults,
     SelectSampleBrowserEntry(MediaSourceRef),
     SetSampleBrowserMode(SampleBrowserMode),
-    StartDragSample {
+    BeginPendingDrag {
         source: MediaSourceRef,
         label: String,
+        origin_x: f32,
+        origin_y: f32,
     },
-    /// Fired by a clip canvas whenever the cursor moves while a sample
-    /// drag is in flight and the cursor is inside that lane.
+    PendingDragMoved {
+        x: f32,
+        y: f32,
+    },
     DragHoverTrack {
         track_id: TrackId,
         beat: f64,
+        compatible: bool,
     },
+    DragHoverEmptyArrangement {
+        beat: f64,
+    },
+    DragHoverSampler {
+        track_id: TrackId,
+    },
+    DragHoverDrumRackPad {
+        track_id: TrackId,
+        pad_index: usize,
+    },
+    ClearDragTarget,
+    CancelDrag(String),
     EndDragSample,
     LocalRootWatchEvent(LocalRootWatchEvent),
     ReconcileLocalRoot {
@@ -67,9 +84,6 @@ pub struct BrowserAction {
     /// router should kick off a root list_folder call if a client is
     /// connected.
     pub expand_dropbox_root: bool,
-    /// A drag was released over a lane: import `source` onto this
-    /// track at this beat.
-    pub drop_on_arrangement: Option<(TrackId, f64, MediaSourceRef)>,
     /// Decode a Local selection for the truthful Audition waveform without
     /// starting playback.
     pub load_waveform: Option<MediaSourceRef>,
@@ -141,31 +155,81 @@ impl BrowserState {
                     action.expand_dropbox_root = true;
                 }
             }
-            BrowserMsg::StartDragSample { source, label } => {
-                action.status = Some(format!("Dragging {label} - drop on a lane or drum pad"));
-                self.drag_source = Some(source);
-                self.drag_label = Some(label);
-                self.drag_hover_track = None;
-                self.drag_hover_beat = 0.0;
+            BrowserMsg::BeginPendingDrag {
+                source,
+                label,
+                origin_x,
+                origin_y,
+            } => {
+                self.begin_pending_drag(source, label, origin_x, origin_y);
             }
-            BrowserMsg::DragHoverTrack { track_id, beat } => {
-                self.drag_hover_track = Some(track_id);
-                self.drag_hover_beat = beat;
+            BrowserMsg::PendingDragMoved { x, y } => {
+                if self.move_pending_drag(x, y) {
+                    let label = self.drag_label.as_deref().unwrap_or("media");
+                    action.status = Some(format!(
+                        "Moving {label} - choose an audio lane, empty Arrange, Sampler, or Drum Rack pad"
+                    ));
+                }
+            }
+            BrowserMsg::DragHoverTrack {
+                track_id,
+                beat,
+                compatible,
+            } => {
+                if self.drag_source.is_none() {
+                    return action;
+                }
+                self.drag_target = Some(crate::state::BrowserDropTarget::ArrangementLane {
+                    track_id,
+                    beat,
+                    compatible,
+                });
+                action.status = Some(if compatible {
+                    format!("Audio lane at beat {beat:.2}")
+                } else {
+                    "Invalid target: audio cannot be imported to a MIDI/instrument lane".into()
+                });
+            }
+            BrowserMsg::DragHoverEmptyArrangement { beat } => {
+                if self.drag_source.is_none() {
+                    return action;
+                }
+                self.drag_target = Some(crate::state::BrowserDropTarget::EmptyArrangement { beat });
+                action.status = Some(format!("New audio track at beat {beat:.2}"));
+            }
+            BrowserMsg::DragHoverSampler { track_id } => {
+                if self.drag_source.is_none() {
+                    return action;
+                }
+                self.drag_target = Some(crate::state::BrowserDropTarget::Sampler { track_id });
+                action.status = Some("Load Sampler sample zone".into());
+            }
+            BrowserMsg::DragHoverDrumRackPad {
+                track_id,
+                pad_index,
+            } => {
+                if self.drag_source.is_none() {
+                    return action;
+                }
+                self.drag_target = Some(crate::state::BrowserDropTarget::DrumRackPad {
+                    track_id,
+                    pad_index,
+                });
+                action.status = Some(format!("Assign Drum Rack pad {}", pad_index + 1));
+            }
+            BrowserMsg::ClearDragTarget => {
+                self.drag_target = None;
+            }
+            BrowserMsg::CancelDrag(reason) => {
+                self.cancel_media_drag();
+                action.status = Some(reason);
             }
             BrowserMsg::EndDragSample => {
-                if let Some(source) = self.drag_source.take() {
-                    self.drag_label = None;
-                    // If a drop target was hovered recently, route the drop
-                    // there instead of cancelling. Protects against
-                    // sub-pixel release-outside-bounds misses.
-                    if let Some(track_id) = self.drag_hover_track.take() {
-                        let beat = self.drag_hover_beat;
-                        self.drag_hover_beat = 0.0;
-                        action.drop_on_arrangement = Some((track_id, beat, source));
-                        return action;
-                    }
-                    self.drag_hover_beat = 0.0;
+                if self.drag_source.is_some() {
+                    self.cancel_media_drag();
                     action.status = Some("Drag cancelled".to_string());
+                } else {
+                    self.cancel_pending_drag();
                 }
             }
             BrowserMsg::LocalRootWatchEvent(event) => match event {
@@ -474,41 +538,97 @@ mod tests {
     }
 
     #[test]
-    fn end_drag_over_lane_requests_drop() {
+    fn click_motion_stays_pending_until_six_pixel_threshold() {
         let mut b = BrowserState::default();
-        let tid = TrackId::new();
         let source = MediaSourceRef::LocalFile {
             path: PathBuf::from("/tmp/kick.wav"),
         };
-        b.update(BrowserMsg::StartDragSample {
+        b.update(BrowserMsg::BeginPendingDrag {
             source: source.clone(),
             label: "kick.wav".to_string(),
+            origin_x: 10.0,
+            origin_y: 20.0,
         });
-        assert!(b.selected_source.is_none());
-        assert!(!b.audition_loading);
-        assert!(!b.audition_playing);
+        b.update(BrowserMsg::PendingDragMoved { x: 15.9, y: 20.0 });
+        assert!(b.pending_drag.is_some());
+        assert!(b.drag_source.is_none());
+
+        b.update(BrowserMsg::PendingDragMoved { x: 16.0, y: 20.0 });
+        assert!(b.pending_drag.is_some());
+        let action = b.update(BrowserMsg::PendingDragMoved { x: 16.1, y: 20.0 });
+        assert_eq!(b.drag_source, Some(source));
+        assert!(b.pending_drag.is_none());
+        assert!(action.status.unwrap().starts_with("Moving kick.wav"));
+    }
+
+    #[test]
+    fn arrangement_hover_reports_compatible_and_invalid_targets() {
+        let mut b = BrowserState::default();
+        let tid = TrackId::new();
+        b.drag_source = Some(MediaSourceRef::LocalFile {
+            path: PathBuf::from("/tmp/kick.wav"),
+        });
         b.update(BrowserMsg::DragHoverTrack {
             track_id: tid,
             beat: 8.0,
+            compatible: true,
         });
-        let action = b.update(BrowserMsg::EndDragSample);
-        assert_eq!(action.drop_on_arrangement, Some((tid, 8.0, source)));
-        assert!(b.drag_source.is_none());
-        assert!(b.drag_label.is_none());
+        assert_eq!(
+            b.drag_target,
+            Some(crate::state::BrowserDropTarget::ArrangementLane {
+                track_id: tid,
+                beat: 8.0,
+                compatible: true,
+            })
+        );
+        let action = b.update(BrowserMsg::DragHoverTrack {
+            track_id: tid,
+            beat: 8.5,
+            compatible: false,
+        });
+        assert!(action.status.unwrap().starts_with("Invalid target"));
+    }
+
+    #[test]
+    fn drag_preview_reports_exact_raw_and_warp_musical_lengths() {
+        let source = MediaSourceRef::LocalFile {
+            path: PathBuf::from("/tmp/loop.wav"),
+        };
+        let mut browser = BrowserState {
+            drag_source: Some(source.clone()),
+            waveform_source: Some(source.clone()),
+            waveform_audio: Some(std::sync::Arc::new(
+                vibez_core::audio_buffer::DecodedAudio {
+                    channels: vec![vec![0.25; 44_100]],
+                    sample_rate: 44_100,
+                },
+            )),
+            ..BrowserState::default()
+        };
+        assert_eq!(browser.drag_preview_beats(120.0), Some(2.0));
+
+        browser.selected_source = Some(source);
+        browser.audition_mode = crate::state::AuditionMode::Warp;
+        browser.audition_bpm_confirmed = Some(120.0);
+        assert_eq!(browser.drag_preview_beats(60.0), Some(2.0));
     }
 
     #[test]
     fn end_drag_without_target_cancels() {
         let mut b = BrowserState::default();
-        b.update(BrowserMsg::StartDragSample {
+        b.update(BrowserMsg::BeginPendingDrag {
             source: MediaSourceRef::LocalFile {
                 path: PathBuf::from("/tmp/kick.wav"),
             },
             label: "kick.wav".to_string(),
+            origin_x: 0.0,
+            origin_y: 0.0,
         });
+        b.update(BrowserMsg::PendingDragMoved { x: 7.0, y: 0.0 });
         let action = b.update(BrowserMsg::EndDragSample);
-        assert_eq!(action.drop_on_arrangement, None);
         assert_eq!(action.status.as_deref(), Some("Drag cancelled"));
+        assert!(b.drag_source.is_none());
+        assert!(b.drag_target.is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -12,7 +12,9 @@ use vibez_plugin_host::PluginId;
 use vibez_project::project_format_v1::SaveObservation;
 use vibez_project::Project;
 
-use crate::state::{AuditionMode, SampleBrowserEntry, SampleBrowserFolder, SettingsTab};
+use crate::state::{
+    AuditionImportInput, AuditionMode, SampleBrowserEntry, SampleBrowserFolder, SettingsTab,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DrumPadParam {
@@ -139,11 +141,23 @@ pub enum BrowserImportTarget {
         track_id: TrackId,
         position_samples: u64,
     },
+    ArrangementNewTrackAt {
+        position_samples: u64,
+    },
     Sampler(TrackId),
     DrumRackPad {
         track_id: TrackId,
         pad_index: usize,
     },
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedBrowserImport {
+    pub treatment: AuditionImportInput,
+    pub audio: Arc<DecodedAudio>,
+    pub original_audio: Option<Arc<DecodedAudio>>,
+    pub name: String,
+    pub source: MediaSourceRef,
 }
 
 #[derive(Debug, Clone)]
@@ -269,6 +283,8 @@ pub enum Message {
     RescanSampleLibrary,
     /// Select a Local source; starts RAW Audition when selection-follow is on.
     ClickLocalBrowserEntry(MediaSourceRef),
+    /// Mouse-down creates a Pending Drag at the globally tracked cursor.
+    BeginPendingBrowserDrag(MediaSourceRef, String),
     /// Explicit Play in the persistent Audition footer.
     PreviewLocalEntry(MediaSourceRef),
     StopBrowserPreview,
@@ -293,6 +309,7 @@ pub enum Message {
         track_id: TrackId,
         position_samples: u64,
     },
+    DropSampleOnEmptyArrangement,
     DropSampleOnDrumPad {
         track_id: TrackId,
         pad_index: usize,
@@ -304,10 +321,15 @@ pub enum Message {
     LoadSelectedBrowserSampleToDevice,
     BrowserSampleDecoded(
         BrowserImportTarget,
+        AuditionImportInput,
         Arc<DecodedAudio>,
         String,
         MediaSourceRef,
     ),
+    BrowserImportPrepared {
+        target: BrowserImportTarget,
+        payload: PreparedBrowserImport,
+    },
     BrowserSampleDecodeError(String),
 
     // Settings

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -9,6 +9,7 @@ use vibez_core::track::{ClipInfo, DrumPadState, MediaSourceRef};
 use vibez_dropbox::{AccountInfo, DropboxEntry, Tokens as DropboxTokens};
 use vibez_plugin_host::gui::PluginGuiKey;
 use vibez_plugin_host::PluginId;
+use vibez_project::project_format_v1::SaveObservation;
 use vibez_project::Project;
 
 use crate::state::{SampleBrowserEntry, SettingsTab};
@@ -145,6 +146,13 @@ pub struct ProjectLoadResult {
 }
 
 #[derive(Debug, Clone)]
+pub struct ProjectSaveResult {
+    pub path: PathBuf,
+    pub project: Project,
+    pub observation: Option<SaveObservation>,
+}
+
+#[derive(Debug, Clone)]
 pub enum Message {
     /// Transport domain (playback, tempo, arrangement loop).
     Transport(crate::domains::transport::TransportMsg),
@@ -222,7 +230,7 @@ pub enum Message {
     ProjectOpenPathSelected(Option<PathBuf>),
     ProjectSavePathSelected(Option<PathBuf>),
     ProjectLoaded(Box<Result<ProjectLoadResult, String>>),
-    ProjectSaved(Result<PathBuf, String>),
+    ProjectSaved(Box<Result<ProjectSaveResult, String>>),
     /// Settings: toggle auto-warp-on-import.
     ToggleAutoWarpOnImport,
     /// Settings: set warp detection confidence threshold.

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -20,10 +20,48 @@ pub enum AuditionMode {
     Warp,
 }
 
+impl AuditionMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Raw => "RAW",
+            Self::Warp => "WARP",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AuditionImportInput {
     pub mode: AuditionMode,
     pub source_bpm: Option<f64>,
+}
+
+pub const MEDIA_DRAG_THRESHOLD_PX: f32 = 6.0;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingMediaDrag {
+    pub source: MediaSourceRef,
+    pub label: String,
+    pub origin_x: f32,
+    pub origin_y: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BrowserDropTarget {
+    ArrangementLane {
+        track_id: TrackId,
+        beat: f64,
+        compatible: bool,
+    },
+    EmptyArrangement {
+        beat: f64,
+    },
+    Sampler {
+        track_id: TrackId,
+    },
+    DrumRackPad {
+        track_id: TrackId,
+        pad_index: usize,
+    },
 }
 
 /// View domain slice: everything about how the project is being
@@ -316,13 +354,10 @@ pub struct BrowserState {
     pub scan_in_progress: bool,
     pub mode: SampleBrowserMode,
     pub dropbox: DropboxUiState,
+    pub pending_drag: Option<PendingMediaDrag>,
     pub drag_source: Option<MediaSourceRef>,
     pub drag_label: Option<String>,
-    /// Most recent track the cursor has been confirmed over while a drag
-    /// is in flight. Used as the drop target if the release happens on a
-    /// sub-pixel boundary between lanes.
-    pub drag_hover_track: Option<TrackId>,
-    pub drag_hover_beat: f64,
+    pub drag_target: Option<BrowserDropTarget>,
 }
 
 impl Default for BrowserState {
@@ -366,10 +401,10 @@ impl Default for BrowserState {
             scan_in_progress: false,
             mode: SampleBrowserMode::default(),
             dropbox: DropboxUiState::default(),
+            pending_drag: None,
             drag_source: None,
             drag_label: None,
-            drag_hover_track: None,
-            drag_hover_beat: 0.0,
+            drag_target: None,
         }
     }
 }
@@ -679,6 +714,80 @@ impl BrowserState {
                         source_bpm: Some(source_bpm),
                     })
             }
+        }
+    }
+
+    pub fn begin_pending_drag(
+        &mut self,
+        source: MediaSourceRef,
+        label: String,
+        origin_x: f32,
+        origin_y: f32,
+    ) {
+        self.cancel_media_drag();
+        self.pending_drag = Some(PendingMediaDrag {
+            source,
+            label,
+            origin_x,
+            origin_y,
+        });
+    }
+
+    pub fn move_pending_drag(&mut self, x: f32, y: f32) -> bool {
+        let Some(pending) = self.pending_drag.as_ref() else {
+            return false;
+        };
+        let dx = x - pending.origin_x;
+        let dy = y - pending.origin_y;
+        if dx * dx + dy * dy <= MEDIA_DRAG_THRESHOLD_PX * MEDIA_DRAG_THRESHOLD_PX {
+            return false;
+        }
+        let pending = self.pending_drag.take().expect("pending drag exists");
+        self.drag_source = Some(pending.source);
+        self.drag_label = Some(pending.label);
+        self.drag_target = None;
+        true
+    }
+
+    pub fn cancel_pending_drag(&mut self) {
+        self.pending_drag = None;
+    }
+
+    pub fn cancel_media_drag(&mut self) {
+        self.pending_drag = None;
+        self.drag_source = None;
+        self.drag_label = None;
+        self.drag_target = None;
+    }
+
+    pub fn drag_preview_beats(&self, project_bpm: f64) -> Option<f64> {
+        let source = self.drag_source.as_ref()?;
+        if self.waveform_source.as_ref()? != source {
+            return None;
+        }
+        let audio = self.waveform_audio.as_ref()?;
+        if audio.sample_rate == 0 || audio.num_frames() == 0 {
+            return None;
+        }
+        let seconds = audio.num_frames() as f64 / audio.sample_rate as f64;
+        match self.audition_import_input()? {
+            AuditionImportInput {
+                mode: AuditionMode::Raw,
+                ..
+            } => (project_bpm > 0.0).then_some(seconds * project_bpm / 60.0),
+            AuditionImportInput {
+                mode: AuditionMode::Warp,
+                source_bpm: Some(source_bpm),
+            } if project_bpm > 0.0 => {
+                let target_frames = crate::warp::warp_target_frames(
+                    audio.num_frames(),
+                    audio.sample_rate as f64,
+                    source_bpm,
+                    project_bpm,
+                );
+                Some(target_frames as f64 * project_bpm / (audio.sample_rate as f64 * 60.0))
+            }
+            _ => None,
         }
     }
 

--- a/crates/vibez-ui/src/widgets/browser_drag_ghost.rs
+++ b/crates/vibez-ui/src/widgets/browser_drag_ghost.rs
@@ -1,0 +1,65 @@
+use iced::mouse;
+use iced::widget::canvas;
+use iced::{Point, Rectangle, Renderer, Size, Theme};
+
+use crate::message::Message;
+use crate::theme;
+
+#[derive(Debug, Clone)]
+pub struct BrowserDragGhost {
+    pub cursor: Point,
+    pub title: String,
+    pub detail: String,
+    pub valid: Option<bool>,
+}
+
+impl canvas::Program<Message> for BrowserDragGhost {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let width = 292.0_f32.min((bounds.width - 16.0).max(120.0));
+        let height = 46.0;
+        let x = (self.cursor.x + 14.0).min((bounds.width - width - 8.0).max(8.0));
+        let y = (self.cursor.y + 14.0).min((bounds.height - height - 8.0).max(8.0));
+        let color = match self.valid {
+            Some(true) => theme::accent(),
+            Some(false) => theme::danger(),
+            None => theme::text_dim(),
+        };
+
+        frame.fill_rectangle(
+            Point::new(x, y),
+            Size::new(width, height),
+            theme::bg_elevated(),
+        );
+        let outline = canvas::Path::rectangle(Point::new(x, y), Size::new(width, height));
+        frame.stroke(
+            &outline,
+            canvas::Stroke::default().with_color(color).with_width(1.0),
+        );
+        frame.fill_rectangle(Point::new(x, y), Size::new(3.0, height), color);
+        frame.fill_text(canvas::Text {
+            content: self.title.clone(),
+            position: Point::new(x + 11.0, y + 7.0),
+            color: theme::text(),
+            size: 12.0.into(),
+            ..Default::default()
+        });
+        frame.fill_text(canvas::Text {
+            content: self.detail.clone(),
+            position: Point::new(x + 11.0, y + 25.0),
+            color,
+            size: 10.0.into(),
+            ..Default::default()
+        });
+        vec![frame.into_geometry()]
+    }
+}

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -1,5 +1,6 @@
 pub mod audio_clip_detail;
 pub mod automation_lane;
+pub mod browser_drag_ghost;
 pub mod browser_waveform;
 pub mod effect_knob;
 pub mod effect_slot;

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -82,6 +82,10 @@ pub struct TrackClipCanvas {
     /// True while a sample is being drag-dropped from the browser.
     /// Controls whether mouse-up on this lane emits `DropSampleOnArrangement`.
     pub sample_drop_active: bool,
+    /// Musical length shown by the placement preview. RAW derives this at the
+    /// project tempo; WARP retains the source's confirmed musical length.
+    pub sample_drop_duration_beats: Option<f64>,
+    pub sample_drop_detail: Option<String>,
     /// The track name this canvas was constructed with. Drawn on the drop
     /// indicator so the user can verify which lane will receive the drop.
     pub track_name: String,
@@ -114,6 +118,8 @@ impl TrackClipCanvas {
         selection_end_beats: f64,
         time_selection_track: Option<TrackId>,
         sample_drop_active: bool,
+        sample_drop_duration_beats: Option<f64>,
+        sample_drop_detail: Option<String>,
     ) -> Self {
         let clips = track
             .clips
@@ -178,6 +184,8 @@ impl TrackClipCanvas {
             selection_end_beats,
             time_selection_track,
             sample_drop_active,
+            sample_drop_duration_beats,
+            sample_drop_detail,
             track_name: track.name.clone(),
         }
     }
@@ -194,7 +202,7 @@ impl TrackClipCanvas {
         x as f64 / self.pixels_per_beat() as f64 + self.scroll_offset_beats
     }
 
-    fn snapped_beat(&self, beat: f64) -> f64 {
+    pub(super) fn snapped_beat(&self, beat: f64) -> f64 {
         self.grid.snap_beat(beat, self.pixels_per_beat())
     }
 
@@ -447,24 +455,6 @@ impl canvas::Program<Message> for TrackClipCanvas {
 
             // -- Drag: move, resize, or region select --
             canvas::Event::Mouse(iced::mouse::Event::CursorMoved { .. }) => {
-                // If a sample drag from the browser is in flight and the
-                // cursor is over this lane, publish a hover update so the
-                // global drop handler can route a release here even if
-                // the release lands on a sub-pixel boundary outside
-                // `cursor.position_in(bounds)`.
-                if self.sample_drop_active {
-                    if let Some(local) = cursor.position_in(bounds) {
-                        let beat = self.snapped_beat(self.x_to_beat(local.x).max(0.0));
-                        return (
-                            canvas::event::Status::Ignored,
-                            Some(Message::Browser(BrowserMsg::DragHoverTrack {
-                                track_id,
-                                beat,
-                            })),
-                        );
-                    }
-                }
-
                 if let Some(ref drag) = state.drag {
                     if let Some(pos) = cursor.position() {
                         let local_x = pos.x - bounds.x;
@@ -646,6 +636,16 @@ impl canvas::Program<Message> for TrackClipCanvas {
                 // inside this lane on release, emit a drop message.
                 if self.sample_drop_active {
                     if let Some(pos) = cursor.position_in(bounds) {
+                        if self.is_instrument {
+                            state.drag = None;
+                            return (
+                                canvas::event::Status::Captured,
+                                Some(Message::Browser(BrowserMsg::CancelDrag(
+                                    "Invalid target: audio cannot be imported to a MIDI/instrument lane"
+                                        .into(),
+                                ))),
+                            );
+                        }
                         // Snap the drop position to the nearest beat so it
                         // matches the indicator drawn in `draw`.
                         let beat = self.snapped_beat(self.x_to_beat(pos.x).max(0.0));

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -75,10 +75,13 @@ impl TrackClipCanvas {
         // True when a sample drag is active and the cursor is hovering this
         // lane. Used to paint a drop indicator.
         let drop_hover = self.sample_drop_active && cursor.position_in(bounds).is_some();
+        let drop_compatible = !self.is_instrument;
 
         // Background
-        let bg_color = if drop_hover {
+        let bg_color = if drop_hover && drop_compatible {
             theme::accent_dim()
+        } else if drop_hover {
+            theme::with_alpha(theme::danger(), 0.16)
         } else if self.selected {
             theme::track_bg_selected()
         } else {
@@ -566,6 +569,11 @@ impl TrackClipCanvas {
         // cursor x + the track name overlaid so the user can verify which
         // lane will receive the drop.
         if drop_hover {
+            let target_color = if drop_compatible {
+                theme::accent()
+            } else {
+                theme::danger()
+            };
             let outline = canvas::Path::rectangle(
                 iced::Point::new(1.0, 1.0),
                 iced::Size::new(w - 2.0, h - 2.0),
@@ -573,12 +581,12 @@ impl TrackClipCanvas {
             frame.stroke(
                 &outline,
                 canvas::Stroke::default()
-                    .with_color(theme::accent())
+                    .with_color(target_color)
                     .with_width(2.0),
             );
             if let Some(local) = cursor.position_in(bounds) {
-                let beat = self.x_to_beat(local.x).max(0.0);
-                let snapped_x = self.beat_to_x(beat.round());
+                let beat = self.snapped_beat(self.x_to_beat(local.x).max(0.0));
+                let snapped_x = self.beat_to_x(beat);
                 if snapped_x >= 0.0 && snapped_x <= w {
                     let drop_line = canvas::Path::line(
                         iced::Point::new(snapped_x, 0.0),
@@ -587,19 +595,46 @@ impl TrackClipCanvas {
                     frame.stroke(
                         &drop_line,
                         canvas::Stroke::default()
-                            .with_color(theme::accent())
+                            .with_color(target_color)
                             .with_width(2.0),
                     );
                 }
+                if drop_compatible {
+                    if let Some(duration_beats) = self.sample_drop_duration_beats {
+                        let preview_width = (duration_beats * self.pixels_per_beat() as f64) as f32;
+                        let visible_width = preview_width.min((w - snapped_x).max(0.0));
+                        if visible_width > 0.0 {
+                            frame.fill_rectangle(
+                                iced::Point::new(snapped_x, 2.0),
+                                iced::Size::new(visible_width, h - 4.0),
+                                theme::with_alpha(theme::accent(), 0.18),
+                            );
+                        }
+                    }
+                }
+                frame.fill_text(canvas::Text {
+                    content: if drop_compatible {
+                        format!("Beat {beat:.2} · {}", self.track_name)
+                    } else {
+                        "INVALID · MIDI/instrument lane".into()
+                    },
+                    position: iced::Point::new(8.0, 8.0),
+                    color: target_color,
+                    size: 13.0.into(),
+                    ..Default::default()
+                });
+                if drop_compatible {
+                    if let Some(detail) = self.sample_drop_detail.as_ref() {
+                        frame.fill_text(canvas::Text {
+                            content: detail.clone(),
+                            position: iced::Point::new(8.0, 28.0),
+                            color: theme::text(),
+                            size: 11.0.into(),
+                            ..Default::default()
+                        });
+                    }
+                }
             }
-            // "Dropping to <track>" label inside the lane.
-            frame.fill_text(canvas::Text {
-                content: format!("Drop on: {}", self.track_name),
-                position: iced::Point::new(8.0, 8.0),
-                color: theme::accent(),
-                size: 14.0.into(),
-                ..Default::default()
-            });
         }
 
         vec![frame.into_geometry()]


### PR DESCRIPTION
## Demo

Import the selected Local source at the playhead with Enter, or drag it beyond the 6 px threshold to an explicit audio lane, empty Arrange area, Sampler zone, or Drum Rack pad. The resulting RAW/WARP treatment is a single undoable mutation and reopens from Project Media after Source Storage is removed.

## Scope

- adds pending-drag threshold, cancellation, explicit valid/invalid drop targets, and exact snapped placement previews
- makes Enter import to the selected audio lane or a new audio track at the playhead, never to a device
- imports RAW without implicit auto-warp and prepares confirmed-BPM WARP before mutation
- keeps arrangement WARP imports reproducible from raw Project Media plus warp metadata
- bakes device WARP imports into truthful project-owned WAV media
- preserves the approved flat Browser/table layout and adds only transient square drag/target feedback

## Verification

- cargo test -p vibez-project (14 unit + 5 integration passed)
- cargo test -p vibez-ui --lib (149 passed)
- cargo test -p vibez-engine -p vibez-dsp (133 + 64 passed)
- cargo clippy -p vibez-project -p vibez-ui --lib -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- native Xvfb proof: sub-threshold click, held explicit-target preview, RAW drop at beat 21.50, one-step undo, Enter at beat 0.00, and confirmed 122 BPM WARP to project 120 BPM

## Non-goals

Multi-select/batch import, modifier-specific drag meanings, touch long-press, Remote materialization, and broader Arrange editing.

Stacked on #58. This branch also merges the self-contained Project Media dependency from #53, which Card 09 requires for source-removal/reopen proof.