### PR TITLE
Browser Card 11: browse Dropbox through Remote Provider

### DIFF
--- a/crates/vibez-dropbox/src/api.rs
+++ b/crates/vibez-dropbox/src/api.rs
@@ -12,7 +12,10 @@ use tokio::sync::Mutex;
 
 use crate::cache::DropboxCache;
 use crate::oauth::refresh_access_token;
-use crate::types::{AccountInfo, DropboxEntry, DropboxError, DropboxResult, Tokens};
+use crate::types::{
+    AccountInfo, DropboxEntry, DropboxError, DropboxListItem, DropboxListPage, DropboxResult,
+    Tokens,
+};
 
 const API_BASE: &str = "https://api.dropboxapi.com";
 const CONTENT_BASE: &str = "https://content.dropboxapi.com";
@@ -73,6 +76,36 @@ impl DropboxClient {
     /// path: `""` means the root. Pagination is handled here; callers
     /// receive the full list.
     pub async fn list_folder(&self, path: &str) -> DropboxResult<Vec<DropboxEntry>> {
+        let mut page = self.list_folder_page(path, false, None).await?;
+        let mut out: Vec<DropboxEntry> = page
+            .items
+            .into_iter()
+            .filter_map(|item| match item {
+                DropboxListItem::Entry(entry) => Some(entry),
+                DropboxListItem::Deleted { .. } => None,
+            })
+            .collect();
+        while page.has_more {
+            page = self
+                .list_folder_page(path, false, Some(&page.cursor))
+                .await?;
+            out.extend(page.items.into_iter().filter_map(|item| match item {
+                DropboxListItem::Entry(entry) => Some(entry),
+                DropboxListItem::Deleted { .. } => None,
+            }));
+        }
+
+        Ok(out)
+    }
+
+    /// Fetch one metadata page. A missing cursor starts a listing; a cursor
+    /// continues either pagination or Dropbox's delta stream.
+    pub async fn list_folder_page(
+        &self,
+        path: &str,
+        recursive: bool,
+        cursor: Option<&str>,
+    ) -> DropboxResult<DropboxListPage> {
         #[derive(Deserialize)]
         struct Page {
             entries: Vec<ApiEntry>,
@@ -80,32 +113,30 @@ impl DropboxClient {
             has_more: bool,
         }
 
-        let body = serde_json::json!({
-            "path": path,
-            "recursive": false,
-            "include_deleted": false,
-            "include_has_explicit_shared_members": false,
-            "include_mounted_folders": true,
-            "include_non_downloadable_files": false,
-        });
-
-        let mut page: Page = self
-            .post_json(&format!("{API_BASE}/2/files/list_folder"), &body)
-            .await?;
-
-        let mut out: Vec<DropboxEntry> = page.entries.into_iter().map(Into::into).collect();
-        while page.has_more {
-            let cont_body = serde_json::json!({ "cursor": page.cursor });
-            page = self
-                .post_json(
-                    &format!("{API_BASE}/2/files/list_folder/continue"),
-                    &cont_body,
-                )
-                .await?;
-            out.extend(page.entries.into_iter().map(Into::into));
-        }
-
-        Ok(out)
+        let (url, body) = if let Some(cursor) = cursor {
+            (
+                format!("{API_BASE}/2/files/list_folder/continue"),
+                serde_json::json!({ "cursor": cursor }),
+            )
+        } else {
+            (
+                format!("{API_BASE}/2/files/list_folder"),
+                serde_json::json!({
+                    "path": path,
+                    "recursive": recursive,
+                    "include_deleted": true,
+                    "include_has_explicit_shared_members": false,
+                    "include_mounted_folders": true,
+                    "include_non_downloadable_files": false,
+                }),
+            )
+        };
+        let page: Page = self.post_json(&url, &body).await?;
+        Ok(DropboxListPage {
+            items: page.entries.into_iter().filter_map(Into::into).collect(),
+            cursor: page.cursor,
+            has_more: page.has_more,
+        })
     }
 
     /// Download a file. Returns the raw bytes. The UI wraps this in
@@ -242,11 +273,13 @@ enum ApiEntry {
         path_lower: String,
         path_display: String,
     },
+    #[serde(rename = "deleted")]
+    Deleted { path_lower: String },
     #[serde(other)]
     Other,
 }
 
-impl From<ApiEntry> for DropboxEntry {
+impl From<ApiEntry> for Option<DropboxListItem> {
     fn from(entry: ApiEntry) -> Self {
         match entry {
             ApiEntry::File {
@@ -255,27 +288,37 @@ impl From<ApiEntry> for DropboxEntry {
                 path_display,
                 rev,
                 size,
-            } => DropboxEntry {
+            } => Some(DropboxListItem::Entry(DropboxEntry {
                 path_lower,
                 path_display,
                 name,
                 is_folder: false,
                 rev,
                 size,
-            },
+            })),
             ApiEntry::Folder {
                 name,
                 path_lower,
                 path_display,
-            } => DropboxEntry {
+            } => Some(DropboxListItem::Entry(DropboxEntry {
                 path_lower,
                 path_display,
                 name,
                 is_folder: true,
                 rev: None,
                 size: None,
-            },
-            ApiEntry::Other => DropboxEntry {
+            })),
+            ApiEntry::Deleted { path_lower } => Some(DropboxListItem::Deleted { path_lower }),
+            ApiEntry::Other => None,
+        }
+    }
+}
+
+impl From<ApiEntry> for DropboxEntry {
+    fn from(entry: ApiEntry) -> Self {
+        match Option::<DropboxListItem>::from(entry) {
+            Some(DropboxListItem::Entry(entry)) => entry,
+            _ => DropboxEntry {
                 path_lower: String::new(),
                 path_display: String::new(),
                 name: String::new(),
@@ -324,5 +367,18 @@ mod tests {
         assert!(entry.is_folder);
         assert_eq!(entry.name, "Drums");
         assert!(entry.rev.is_none());
+    }
+
+    #[test]
+    fn api_entry_preserves_deleted_identity_for_delta_reconciliation() {
+        let parsed: ApiEntry =
+            serde_json::from_str(r#"{ ".tag": "deleted", "path_lower": "/drums/old-kick.wav" }"#)
+                .unwrap();
+        assert_eq!(
+            Option::<DropboxListItem>::from(parsed),
+            Some(DropboxListItem::Deleted {
+                path_lower: "/drums/old-kick.wav".into(),
+            })
+        );
     }
 }

--- a/crates/vibez-dropbox/src/lib.rs
+++ b/crates/vibez-dropbox/src/lib.rs
@@ -19,4 +19,7 @@ pub use api::DropboxClient;
 pub use cache::DropboxCache;
 pub use oauth::{run_flow as run_oauth_flow, BrowserOpener, SystemBrowserOpener};
 pub use settings::{load_app_key_with_env_override, DropboxSettings};
-pub use types::{AccountInfo, DropboxEntry, DropboxError, DropboxResult, Tokens};
+pub use types::{
+    AccountInfo, DropboxEntry, DropboxError, DropboxListItem, DropboxListPage, DropboxResult,
+    Tokens,
+};

--- a/crates/vibez-dropbox/src/types.rs
+++ b/crates/vibez-dropbox/src/types.rs
@@ -42,6 +42,19 @@ pub struct DropboxEntry {
     pub size: Option<u64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DropboxListItem {
+    Entry(DropboxEntry),
+    Deleted { path_lower: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DropboxListPage {
+    pub items: Vec<DropboxListItem>,
+    pub cursor: String,
+    pub has_more: bool,
+}
+
 impl DropboxEntry {
     pub fn file_extension(&self) -> Option<&str> {
         self.name.rsplit_once('.').map(|(_, ext)| ext)

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -117,9 +117,6 @@ impl App {
         if action.persist_settings {
             self.persist_ui_settings();
         }
-        if action.expand_dropbox_root && self.dropbox_client.is_some() {
-            return self.update(Message::DropboxExpandFolder(String::new()));
-        }
         if !action.debounce_root_scans.is_empty() {
             return Task::batch(
                 action

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -11,18 +11,18 @@ use super::*;
 impl App {
     pub(super) fn handle_connect_dropbox(&mut self) -> Task<Message> {
         let Some(app_key) = load_app_key_with_env_override(&self.dropbox_settings) else {
-            self.state.browser.dropbox.last_error = Some(
+            self.state.browser.remote.last_error = Some(
                 "No Dropbox app key set. Register an app at dropbox.com/developers/apps \
                     and paste the App key above."
                     .into(),
             );
             return Task::none();
         };
-        if self.state.browser.dropbox.auth_in_progress {
+        if self.state.browser.remote.auth_in_progress {
             return Task::none();
         }
-        self.state.browser.dropbox.auth_in_progress = true;
-        self.state.browser.dropbox.last_error = None;
+        self.state.browser.remote.auth_in_progress = true;
+        self.state.browser.remote.last_error = None;
         self.state.status_text = "Opening Dropbox authorisation...".to_string();
         Task::perform(connect_dropbox_async(app_key), |result| {
             Message::DropboxConnected(
@@ -31,39 +31,24 @@ impl App {
         })
     }
 
-    pub(super) fn handle_dropbox_expand_folder(&mut self, path: String) -> Task<Message> {
-        self.state.browser.dropbox.expanded.insert(path.clone());
-        if self.state.browser.dropbox.folders.contains_key(&path)
-            || self
-                .state
-                .browser
-                .dropbox
-                .listing_in_progress
-                .contains(&path)
-        {
-            return Task::none();
-        }
+    pub(super) fn handle_remote_catalog_refresh(&mut self) -> Task<Message> {
         let Some(client) = self.dropbox_client.clone() else {
-            self.state.browser.dropbox.last_error = Some("Not connected to Dropbox".into());
+            self.state.browser.remote.catalog_state =
+                crate::state::RemoteCatalogState::AuthenticationRequired {
+                    error: "Connect Dropbox in Settings to refresh".into(),
+                };
             return Task::none();
         };
-        self.state
-            .browser
-            .dropbox
-            .listing_in_progress
-            .insert(path.clone());
+        self.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Refreshing;
+        let checkpoint = self.state.browser.remote.catalog.checkpoint.clone();
         Task::perform(
-            list_dropbox_folder_async(client, path),
-            |result| match result {
-                Ok((path, entries)) => Message::DropboxFolderListed {
-                    path,
-                    result: Ok(entries),
-                },
-                Err(err) => Message::DropboxFolderListed {
-                    path: String::new(),
-                    result: Err(err),
-                },
+            async move {
+                let provider =
+                    crate::remote_provider::DropboxRemoteProvider::new((*client).clone());
+                crate::remote_provider::refresh_remote_catalog(&provider, checkpoint.as_deref())
+                    .await
             },
+            Message::RemoteCatalogRefreshed,
         )
     }
 
@@ -72,7 +57,7 @@ impl App {
         entry: DropboxEntry,
     ) -> Task<Message> {
         let Some(client) = self.dropbox_client.clone() else {
-            self.state.browser.dropbox.last_error = Some("Not connected to Dropbox".into());
+            self.state.browser.remote.last_error = Some("Not connected to Dropbox".into());
             return Task::none();
         };
         let cache = self.dropbox_cache.clone();
@@ -95,7 +80,7 @@ impl App {
 
     pub(super) fn handle_dropbox_import_to_device(&mut self, entry: DropboxEntry) -> Task<Message> {
         let Some(client) = self.dropbox_client.clone() else {
-            self.state.browser.dropbox.last_error = Some("Not connected to Dropbox".into());
+            self.state.browser.remote.last_error = Some("Not connected to Dropbox".into());
             return Task::none();
         };
         let Some(target) = self.selected_browser_device_target() else {

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -739,13 +739,22 @@ impl App {
     }
 
     pub(super) fn selected_dropbox_entry(&self) -> Option<DropboxEntry> {
-        let selected = self.state.browser.dropbox.selected_path.as_ref()?;
-        for entries in self.state.browser.dropbox.folders.values() {
-            if let Some(entry) = entries.iter().find(|e| &e.path_lower == selected) {
-                return Some(entry.clone());
-            }
-        }
-        None
+        let selected = self.state.browser.remote.selected_path.as_ref()?;
+        self.state
+            .browser
+            .remote
+            .catalog
+            .entries
+            .iter()
+            .find(|entry| &entry.provider_item_id == selected && !entry.is_folder)
+            .map(|entry| DropboxEntry {
+                path_lower: entry.provider_item_id.clone(),
+                path_display: entry.path.clone(),
+                name: entry.name.clone(),
+                is_folder: false,
+                rev: entry.revision.clone(),
+                size: entry.size,
+            })
     }
 
     pub(super) fn handle_add_clip_to_track(&mut self, track_id: TrackId) -> Task<Message> {

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -153,11 +153,31 @@ impl App {
             }
             _ => None,
         };
-        let dropbox_ui_state = crate::state::DropboxUiState {
+        let catalog_store = crate::remote_provider::RemoteCatalogStore::for_dropbox();
+        let (remote_catalog, mut remote_catalog_state) = match catalog_store.load() {
+            Ok(catalog) => (catalog, crate::state::RemoteCatalogState::Ready),
+            Err(error) => (
+                crate::remote_provider::RemoteCatalogSnapshot::default(),
+                crate::state::RemoteCatalogState::Stale { error },
+            ),
+        };
+        if dropbox_client.is_none()
+            && matches!(
+                remote_catalog_state,
+                crate::state::RemoteCatalogState::Ready
+            )
+        {
+            remote_catalog_state = crate::state::RemoteCatalogState::AuthenticationRequired {
+                error: "Sign in to refresh; showing the last saved Remote catalog".into(),
+            };
+        }
+        let remote_ui_state = crate::state::RemoteUiState {
             connected: dropbox_client.is_some(),
             account_email: dropbox_settings.account_email.clone(),
             app_key_input: dropbox_settings.app_key.clone().unwrap_or_default(),
             has_app_key: resolved_key.is_some(),
+            catalog: remote_catalog,
+            catalog_state: remote_catalog_state,
             ..Default::default()
         };
 
@@ -178,7 +198,7 @@ impl App {
                 audition_gain: ui_settings.audition_gain.clamp(0.0, 2.0),
                 audition_loop: ui_settings.audition_loop,
                 roots: ui_settings.sample_library_roots,
-                dropbox: dropbox_ui_state,
+                remote: remote_ui_state,
                 ..Default::default()
             },
             ..Default::default()
@@ -255,7 +275,7 @@ impl App {
         app.ensure_master_eq();
 
         let roots = app.state.browser.roots.clone();
-        let startup_task = Task::batch(roots.into_iter().map(|root| {
+        let local_startup_task = Task::batch(roots.into_iter().map(|root| {
             let revision = app.state.browser.begin_root_scan(&root, false);
             Task::perform(scan_sample_root_async(root.clone()), move |result| {
                 Message::Browser(BrowserMsg::LocalRootCatalogReconciled {
@@ -265,6 +285,12 @@ impl App {
                 })
             })
         }));
+        let remote_startup_task = if app.dropbox_client.is_some() {
+            app.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Refreshing;
+            Task::done(Message::RefreshRemoteConnection)
+        } else {
+            Task::none()
+        };
 
         // `vibez <project.vzp>` opens a project straight from the
         // command line (also how file-manager associations launch
@@ -276,7 +302,10 @@ impl App {
             .map(|p| Task::done(Message::ProjectOpenPathSelected(Some(p))))
             .unwrap_or_else(Task::none);
 
-        (app, Task::batch([startup_task, open_task]))
+        (
+            app,
+            Task::batch([local_startup_task, remote_startup_task, open_task]),
+        )
     }
 
     /// Find a theme by name: built-ins first, then the scanned user
@@ -619,14 +648,6 @@ async fn connect_dropbox_async(
     let info = client.current_account().await.map_err(|e| e.to_string())?;
     let tokens = client.tokens().await;
     Ok((info, tokens))
-}
-
-async fn list_dropbox_folder_async(
-    client: Arc<DropboxClient>,
-    path: String,
-) -> Result<(String, Vec<DropboxEntry>), String> {
-    let entries = client.list_folder(&path).await.map_err(|e| e.to_string())?;
-    Ok((path, entries))
 }
 
 async fn fetch_dropbox_sample_async(

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -1298,12 +1298,12 @@ impl App {
 
             // -- Dropbox --
             Message::SaveDropboxAppKey => {
-                let value = self.state.browser.dropbox.app_key_input.trim().to_string();
+                let value = self.state.browser.remote.app_key_input.trim().to_string();
                 self.dropbox_settings.app_key = if value.is_empty() { None } else { Some(value) };
                 if let Err(err) = self.dropbox_settings.save() {
-                    self.state.browser.dropbox.last_error = Some(format!("save settings: {err}"));
+                    self.state.browser.remote.last_error = Some(format!("save settings: {err}"));
                 }
-                self.state.browser.dropbox.has_app_key =
+                self.state.browser.remote.has_app_key =
                     load_app_key_with_env_override(&self.dropbox_settings).is_some();
                 self.state.status_text = "Dropbox app key saved".to_string();
             }
@@ -1311,7 +1311,7 @@ impl App {
                 return self.handle_connect_dropbox();
             }
             Message::DropboxConnected(Ok(outcome)) => {
-                self.state.browser.dropbox.auth_in_progress = false;
+                self.state.browser.remote.auth_in_progress = false;
                 if let Some(app_key) = load_app_key_with_env_override(&self.dropbox_settings) {
                     let client = DropboxClient::new(app_key, outcome.tokens.clone());
                     self.dropbox_client = Some(Arc::new(client));
@@ -1319,46 +1319,80 @@ impl App {
                 self.dropbox_settings.tokens = Some(outcome.tokens.clone());
                 self.dropbox_settings.account_email = Some(outcome.info.email.clone());
                 if let Err(err) = self.dropbox_settings.save() {
-                    self.state.browser.dropbox.last_error = Some(format!("save settings: {err}"));
+                    self.state.browser.remote.last_error = Some(format!("save settings: {err}"));
                 }
-                self.state.browser.dropbox.connected = true;
-                self.state.browser.dropbox.account_email = Some(outcome.info.email.clone());
+                self.state.browser.remote.connected = true;
+                self.state.browser.remote.account_email = Some(outcome.info.email.clone());
                 self.state.status_text = format!("Dropbox connected: {}", outcome.info.email);
+                return self.handle_remote_catalog_refresh();
             }
             Message::DropboxConnected(Err(err)) => {
-                self.state.browser.dropbox.auth_in_progress = false;
-                self.state.browser.dropbox.last_error = Some(err.clone());
+                self.state.browser.remote.auth_in_progress = false;
+                self.state.browser.remote.last_error = Some(err.clone());
                 self.state.status_text = format!("Dropbox connect failed: {err}");
             }
             Message::DisconnectDropbox => {
                 self.dropbox_client = None;
                 self.dropbox_settings.clear_tokens();
                 let _ = self.dropbox_settings.save();
-                self.state.browser.dropbox = crate::state::DropboxUiState {
-                    app_key_input: self.state.browser.dropbox.app_key_input.clone(),
-                    has_app_key: self.state.browser.dropbox.has_app_key,
-                    ..Default::default()
+                self.state.browser.remote.connected = false;
+                self.state.browser.remote.account_email = None;
+                self.state.browser.remote.auth_in_progress = false;
+                self.state.browser.remote.preview_in_progress = false;
+                self.state.browser.remote.catalog_state =
+                    crate::state::RemoteCatalogState::AuthenticationRequired {
+                        error: "Disconnected; showing the last saved catalog".into(),
+                    };
+                self.state.status_text =
+                    "Dropbox disconnected; saved Remote catalog remains available".to_string();
+            }
+            Message::RefreshRemoteConnection => {
+                return self.handle_remote_catalog_refresh();
+            }
+            Message::RemoteCatalogRefreshed(result) => {
+                crate::remote_provider::reconcile_remote_catalog(
+                    &mut self.state.browser.remote.catalog,
+                    &result,
+                );
+                let save_error = crate::remote_provider::RemoteCatalogStore::for_dropbox()
+                    .save(&self.state.browser.remote.catalog)
+                    .err();
+                self.state.browser.remote.catalog_state = match (&result.error, save_error) {
+                    (Some(error), _)
+                        if error.kind
+                            == crate::remote_provider::RemoteProviderErrorKind::Authentication =>
+                    {
+                        crate::state::RemoteCatalogState::AuthenticationRequired {
+                            error: error.message.clone(),
+                        }
+                    }
+                    (Some(error), _) if result.pages > 0 => {
+                        crate::state::RemoteCatalogState::Partial {
+                            pages: result.pages,
+                            error: error.message.clone(),
+                        }
+                    }
+                    (Some(error), _) => crate::state::RemoteCatalogState::Stale {
+                        error: error.message.clone(),
+                    },
+                    (None, Some(error)) => crate::state::RemoteCatalogState::Stale { error },
+                    (None, None) => crate::state::RemoteCatalogState::Ready,
                 };
-                self.state.status_text = "Dropbox disconnected".to_string();
-            }
-            Message::DropboxExpandFolder(path) => {
-                return self.handle_dropbox_expand_folder(path);
-            }
-            Message::DropboxFolderListed { path, result } => {
-                self.state.browser.dropbox.listing_in_progress.remove(&path);
-                match result {
-                    Ok(entries) => {
-                        self.state.browser.dropbox.folders.insert(path, entries);
-                    }
-                    Err(err) => {
-                        self.state.browser.dropbox.last_error = Some(err.clone());
-                        self.state.status_text = format!("Dropbox error: {err}");
-                    }
-                }
+                let item_count = self.state.browser.remote.catalog.entries.len();
+                self.state.status_text = match result.error {
+                    None => format!(
+                        "Remote catalog refreshed: {item_count} items across {} page(s)",
+                        result.pages
+                    ),
+                    Some(error) => format!(
+                        "Remote catalog kept {} items after refresh error: {}",
+                        item_count, error.message
+                    ),
+                };
             }
             Message::DropboxPreview(entry) => {
                 let Some(client) = self.dropbox_client.clone() else {
-                    self.state.browser.dropbox.last_error = Some("Not connected to Dropbox".into());
+                    self.state.browser.remote.last_error = Some("Not connected to Dropbox".into());
                     return Task::none();
                 };
                 let source = MediaSourceRef::DropboxFile {
@@ -1369,7 +1403,7 @@ impl App {
                 self.state.browser.select_source(source.clone());
                 self.state.browser.begin_audition_load(&source);
                 let cache = self.dropbox_cache.clone();
-                self.state.browser.dropbox.preview_in_progress = true;
+                self.state.browser.remote.preview_in_progress = true;
                 self.state.status_text = format!("Fetching preview: {}", entry.name);
                 return Task::perform(
                     fetch_dropbox_sample_async(client, cache, entry),
@@ -1382,7 +1416,7 @@ impl App {
                 );
             }
             Message::DropboxPreviewReady(source, Ok(audio)) => {
-                self.state.browser.dropbox.preview_in_progress = false;
+                self.state.browser.remote.preview_in_progress = false;
                 if self
                     .state
                     .browser
@@ -1392,10 +1426,10 @@ impl App {
                 }
             }
             Message::DropboxPreviewReady(source, Err(err)) => {
-                self.state.browser.dropbox.preview_in_progress = false;
+                self.state.browser.remote.preview_in_progress = false;
                 let is_current = self.state.browser.selected_source.as_ref() == Some(&source);
                 self.state.browser.fail_waveform_load(&source, err.clone());
-                self.state.browser.dropbox.last_error = Some(err.clone());
+                self.state.browser.remote.last_error = Some(err.clone());
                 if is_current {
                     self.stop_browser_audition();
                     self.state.status_text = format!("Preview error: {err}");

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -9,13 +9,11 @@ use iced::widget::{
 use iced::{Element, Length, Theme};
 
 use crate::domains::browser::BrowserMsg;
-use vibez_core::track::MediaSourceRef;
-use vibez_dropbox::DropboxEntry;
-
 use crate::icons;
 use crate::message::Message;
 use crate::state::{AuditionMode, SampleBrowserEntry, SampleBrowserMode};
 use crate::theme as th;
+use vibez_core::track::MediaSourceRef;
 use vibez_engine::commands::AuditionSync;
 
 use super::*;
@@ -96,18 +94,52 @@ impl App {
                 .align_y(iced::Alignment::Center)
                 .into()
             }
-            SampleBrowserMode::Dropbox => row![
-                text("SCOPE").size(9).color(th::text_muted()),
-                text("REMOTE CATALOG").size(9).color(th::text_dim())
-            ]
-            .spacing(5)
-            .align_y(iced::Alignment::Center)
-            .into(),
+            SampleBrowserMode::Remote => {
+                let scope_label = match self.state.browser.search_scope {
+                    crate::state::BrowserSearchScope::SelectedFolder => "THIS FOLDER",
+                    crate::state::BrowserSearchScope::Root => "THIS CONNECTION",
+                    crate::state::BrowserSearchScope::Everywhere => "EVERYWHERE",
+                };
+                let location = self
+                    .state
+                    .browser
+                    .remote
+                    .current_path
+                    .rsplit('/')
+                    .find(|part| !part.is_empty())
+                    .unwrap_or("Alex's Dropbox");
+                row![
+                    button(
+                        row![
+                            text("SCOPE").size(9).color(th::text_muted()),
+                            text(scope_label).size(9).color(th::text())
+                        ]
+                        .spacing(5)
+                    )
+                    .on_press(Message::Browser(BrowserMsg::CycleSearchScope))
+                    .padding([3, 0])
+                    .style(browser_utility_action_style),
+                    horizontal_space(),
+                    text(location)
+                        .size(9)
+                        .color(th::text_dim())
+                        .wrapping(iced::widget::text::Wrapping::None)
+                ]
+                .align_y(iced::Alignment::Center)
+                .into()
+            }
         };
 
         let body: Element<'_, Message> = match self.state.browser.mode {
+            SampleBrowserMode::Local
+                if !self.state.browser.search.trim().is_empty()
+                    && self.state.browser.search_scope
+                        == crate::state::BrowserSearchScope::Everywhere =>
+            {
+                self.view_remote_browser()
+            }
             SampleBrowserMode::Local => self.view_local_sample_browser(),
-            SampleBrowserMode::Dropbox => self.view_dropbox_browser(),
+            SampleBrowserMode::Remote => self.view_remote_browser(),
         };
 
         let content: Element<'_, Message> = row![
@@ -165,7 +197,7 @@ impl App {
 
     fn view_browser_places(&self) -> Element<'_, Message> {
         let local_active = self.state.browser.mode == SampleBrowserMode::Local;
-        let remote_active = self.state.browser.mode == SampleBrowserMode::Dropbox;
+        let remote_active = self.state.browser.mode == SampleBrowserMode::Remote;
         let place_button = |label: &'static str, active: bool, mode| {
             button(
                 row![
@@ -295,26 +327,42 @@ impl App {
         places = places.push(place_button(
             "Remote",
             remote_active,
-            SampleBrowserMode::Dropbox,
+            SampleBrowserMode::Remote,
         ));
-        let connection_color = if self.state.browser.dropbox.connected {
-            th::text_dim()
-        } else {
-            th::text_muted()
-        };
-        places = places.push(row![
-            horizontal_space().width(Length::Fixed(22.0)),
-            container(
-                text(if self.state.browser.dropbox.connected {
-                    "Alex's Dropbox"
-                } else {
-                    "Disconnected"
-                })
+        let connection_active = remote_active && self.state.browser.remote.current_path.is_empty();
+        let connection = button(
+            text(self.state.browser.remote.catalog.connection_name.as_str())
                 .size(10)
-                .color(connection_color),
-            )
-            .padding([3, 0]),
-        ]);
+                .color(if connection_active {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                })
+                .wrapping(iced::widget::text::Wrapping::None),
+        )
+        .on_press(Message::Browser(BrowserMsg::SelectRemoteFolder(
+            String::new(),
+        )))
+        .padding([4, 2])
+        .width(Length::Fill)
+        .style(move |_theme: &Theme, status| browser_place_button_style(connection_active, status));
+        places = places.push(
+            row![
+                horizontal_space().width(Length::Fixed(14.0)),
+                text("▾").size(10).color(th::text_muted()),
+                connection,
+                text(self.state.browser.remote.catalog_state.label())
+                    .size(8)
+                    .color(th::text_muted())
+            ]
+            .spacing(2)
+            .align_y(iced::Alignment::Center),
+        );
+        let mut remote_rows = Vec::new();
+        self.render_remote_places_tree("", 1, &mut remote_rows);
+        for remote_row in remote_rows {
+            places = places.push(remote_row);
+        }
 
         let add = button(
             row![
@@ -433,6 +481,85 @@ impl App {
         }
     }
 
+    fn render_remote_places_tree<'a>(
+        &'a self,
+        parent: &str,
+        depth: usize,
+        rows: &mut Vec<Element<'a, Message>>,
+    ) {
+        let mut children: Vec<_> = self
+            .state
+            .browser
+            .remote
+            .catalog
+            .entries
+            .iter()
+            .filter(|entry| entry.is_folder && entry.parent_path == parent)
+            .collect();
+        children.sort_by_key(|entry| entry.name.to_ascii_lowercase());
+        for folder in children {
+            let expanded = self
+                .state
+                .browser
+                .remote
+                .expanded
+                .contains(&folder.provider_item_id);
+            let active = self.state.browser.mode == SampleBrowserMode::Remote
+                && self.state.browser.remote.current_path == folder.provider_item_id;
+            let has_children = self
+                .state
+                .browser
+                .remote
+                .catalog
+                .entries
+                .iter()
+                .any(|entry| entry.is_folder && entry.parent_path == folder.provider_item_id);
+            let toggle: Element<'a, Message> = if has_children {
+                button(
+                    text(if expanded { "▾" } else { "▸" })
+                        .size(10)
+                        .color(th::text_muted()),
+                )
+                .on_press(Message::Browser(BrowserMsg::ToggleRemoteFolder(
+                    folder.provider_item_id.clone(),
+                )))
+                .padding([3, 2])
+                .style(browser_utility_action_style)
+                .into()
+            } else {
+                container(text("·").size(9).color(th::text_muted()))
+                    .padding([3, 3])
+                    .into()
+            };
+            let select = button(
+                text(folder.name.clone())
+                    .size(9)
+                    .color(if active { th::accent() } else { th::text_dim() })
+                    .height(Length::Fixed(12.0))
+                    .wrapping(iced::widget::text::Wrapping::None),
+            )
+            .on_press(Message::Browser(BrowserMsg::SelectRemoteFolder(
+                folder.provider_item_id.clone(),
+            )))
+            .padding([3, 1])
+            .width(Length::Fill)
+            .style(move |_theme: &Theme, status| browser_place_button_style(active, status));
+            rows.push(
+                row![
+                    horizontal_space().width(Length::Fixed((depth as f32 * 8.0).min(40.0))),
+                    toggle,
+                    select
+                ]
+                .spacing(1)
+                .align_y(iced::Alignment::Center)
+                .into(),
+            );
+            if expanded {
+                self.render_remote_places_tree(&folder.provider_item_id, depth + 1, rows);
+            }
+        }
+    }
+
     fn view_browser_audition_footer(&self) -> Element<'_, Message> {
         let selected_local = self.selected_sample_browser_entry();
         let selected_dropbox = self.selected_dropbox_entry();
@@ -440,7 +567,7 @@ impl App {
             SampleBrowserMode::Local => selected_local
                 .map(|entry| entry.name.clone())
                 .unwrap_or_else(|| "No source selected".into()),
-            SampleBrowserMode::Dropbox => selected_dropbox
+            SampleBrowserMode::Remote => selected_dropbox
                 .as_ref()
                 .map(|entry| entry.name.clone())
                 .unwrap_or_else(|| "No source selected".into()),
@@ -450,7 +577,7 @@ impl App {
             SampleBrowserMode::Local => {
                 selected_local.map(|entry| Message::PreviewLocalEntry(entry.source.clone()))
             }
-            SampleBrowserMode::Dropbox => selected_dropbox
+            SampleBrowserMode::Remote => selected_dropbox
                 .as_ref()
                 .filter(|entry| entry.is_supported_audio())
                 .map(|entry| Message::DropboxPreview(entry.clone())),
@@ -558,7 +685,7 @@ impl App {
         let controls = row![
             play,
             stop,
-            text(if self.state.browser.dropbox.preview_in_progress {
+            text(if self.state.browser.remote.preview_in_progress {
                 "FETCHING"
             } else if self.state.browser.audition_loading {
                 "PREPARING"
@@ -1138,69 +1265,358 @@ impl App {
             .into()
     }
 
-    pub(super) fn view_dropbox_browser(&self) -> Element<'_, Message> {
-        if !self.state.browser.dropbox.connected {
-            let hint = if self.state.browser.dropbox.auth_in_progress {
-                "Waiting for browser authorisation..."
+    pub(super) fn view_remote_browser(&self) -> Element<'_, Message> {
+        let browser = &self.state.browser;
+        let remote = &browser.remote;
+        let query = browser.search.trim().to_ascii_lowercase();
+        let searching = !query.is_empty();
+        let current = remote.current_path.as_str();
+        let in_current_tree = |entry: &crate::remote_provider::RemoteCatalogEntry| {
+            current.is_empty()
+                || entry.provider_item_id == current
+                || entry
+                    .provider_item_id
+                    .strip_prefix(current)
+                    .is_some_and(|rest| rest.starts_with('/'))
+        };
+        let mut results: Vec<&crate::remote_provider::RemoteCatalogEntry> = remote
+            .catalog
+            .entries
+            .iter()
+            .filter(|entry| entry.is_folder || entry.is_supported_audio())
+            .filter(|entry| {
+                if searching {
+                    let in_scope = match browser.search_scope {
+                        crate::state::BrowserSearchScope::SelectedFolder => in_current_tree(entry),
+                        crate::state::BrowserSearchScope::Root
+                        | crate::state::BrowserSearchScope::Everywhere => true,
+                    };
+                    in_scope
+                        && (entry.name.to_ascii_lowercase().contains(&query)
+                            || entry.path.to_ascii_lowercase().contains(&query))
+                } else {
+                    entry.parent_path == current
+                }
+            })
+            .collect();
+        results.sort_by(|left, right| {
+            (!left.is_folder, left.name.to_ascii_lowercase())
+                .cmp(&(!right.is_folder, right.name.to_ascii_lowercase()))
+        });
+        let mut local_everywhere: Vec<&SampleBrowserEntry> =
+            if searching && browser.search_scope == crate::state::BrowserSearchScope::Everywhere {
+                browser
+                    .entries
+                    .iter()
+                    .filter(|entry| {
+                        entry.name.to_ascii_lowercase().contains(&query)
+                            || entry
+                                .relative_path
+                                .to_string_lossy()
+                                .to_ascii_lowercase()
+                                .contains(&query)
+                    })
+                    .collect()
             } else {
-                "Connect in Settings > Dropbox to browse your library."
+                Vec::new()
             };
-            return container(
-                column![
-                    text("RESULTS").size(9).color(th::text_muted()),
-                    text("Remote Connection unavailable")
-                        .size(13)
-                        .color(th::text()),
-                    text(hint).size(11).color(th::text_dim())
-                ]
-                .spacing(8)
-                .padding(12),
-            )
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .style(browser_results_style)
-            .into();
-        }
-
-        let mut rows: Vec<Element<'_, Message>> = Vec::new();
-        self.render_dropbox_tree(String::new(), 0, &mut rows);
-        if rows.is_empty() {
-            let msg = if self.state.browser.dropbox.listing_in_progress.contains("") {
-                "Listing your Dropbox..."
-            } else {
-                "Empty (or still fetching)."
-            };
-            rows.push(text(msg).size(11).color(th::text_dim()).into());
-        }
-        let mut entries_col = column![].spacing(2);
-        for row in rows {
-            entries_col = entries_col.push(row);
-        }
-        let status: Element<'_, Message> =
-            if let Some(error) = self.state.browser.dropbox.last_error.clone() {
-                text(format!("Error · {error}"))
+        local_everywhere.sort_by_key(|entry| entry.name.to_ascii_lowercase());
+        let total_results = results.len() + local_everywhere.len();
+        let visible_results = total_results.min(browser.results_visible_limit);
+        let remote_visible = results.len().min(visible_results);
+        results.truncate(remote_visible);
+        local_everywhere.truncate(visible_results.saturating_sub(remote_visible));
+        let wide_columns = browser.results_use_wide_columns(self.state.view.window_width);
+        let table_header: Element<'_, Message> = if wide_columns {
+            row![
+                text("NAME")
                     .size(9)
-                    .color(th::danger())
+                    .color(th::text_muted())
+                    .width(Length::Fill),
+                text("BPM")
+                    .size(9)
+                    .color(th::text_muted())
+                    .width(Length::Fixed(36.0)),
+                text("LENGTH")
+                    .size(9)
+                    .color(th::text_muted())
+                    .width(Length::Fixed(50.0)),
+                text("AVAIL")
+                    .size(9)
+                    .color(th::text_muted())
+                    .width(Length::Fixed(48.0))
+            ]
+            .spacing(4)
+            .padding([5, 8])
+            .into()
+        } else {
+            row![
+                text("NAME")
+                    .size(9)
+                    .color(th::text_muted())
+                    .width(Length::Fill),
+                text("AVAIL")
+                    .size(9)
+                    .color(th::text_muted())
+                    .width(Length::Fixed(42.0))
+            ]
+            .padding([5, 8])
+            .into()
+        };
+        let mut entries_col = column![].spacing(0);
+        let catalog_notice = match &remote.catalog_state {
+            crate::state::RemoteCatalogState::Stale { error }
+            | crate::state::RemoteCatalogState::AuthenticationRequired { error } => {
+                Some(error.clone())
+            }
+            crate::state::RemoteCatalogState::Partial { pages, error } => {
+                Some(format!("Partial refresh after {pages} page(s) · {error}"))
+            }
+            crate::state::RemoteCatalogState::Ready
+            | crate::state::RemoteCatalogState::Refreshing => None,
+        };
+        if let Some(notice) = catalog_notice {
+            entries_col = entries_col
+                .push(container(text(notice).size(9).color(th::danger())).padding([5, 8]))
+                .push(browser_row_divider());
+        }
+        for entry in results {
+            let selected = remote.selected_path.as_deref() == Some(&entry.provider_item_id);
+            let cell_color = if selected { th::text() } else { th::text_dim() };
+            let context = if entry.parent_path.is_empty() {
+                remote.catalog.connection_name.clone()
+            } else {
+                format!("{} · {}", remote.catalog.connection_name, entry.parent_path)
+            };
+            let name_cell = column![
+                text(if entry.is_folder {
+                    format!("› {}", entry.name)
+                } else {
+                    entry.name.clone()
+                })
+                .size(12)
+                .color(th::text())
+                .width(Length::Fill)
+                .height(Length::Fixed(14.0))
+                .wrapping(iced::widget::text::Wrapping::None),
+                text(context)
+                    .size(9)
+                    .color(cell_color)
+                    .width(Length::Fill)
+                    .height(Length::Fixed(11.0))
+                    .wrapping(iced::widget::text::Wrapping::None)
+            ]
+            .spacing(2)
+            .width(Length::Fill);
+            let cells: Element<'_, Message> = if wide_columns {
+                row![
+                    name_cell,
+                    text("—")
+                        .size(10)
+                        .color(cell_color)
+                        .width(Length::Fixed(36.0)),
+                    text("—")
+                        .size(10)
+                        .color(cell_color)
+                        .width(Length::Fixed(50.0)),
+                    text("REMOTE")
+                        .size(9)
+                        .color(cell_color)
+                        .width(Length::Fixed(48.0))
+                ]
+                .spacing(4)
+                .align_y(iced::Alignment::Center)
+                .into()
+            } else {
+                row![
+                    name_cell,
+                    text("REMOTE")
+                        .size(9)
+                        .color(cell_color)
+                        .width(Length::Fixed(42.0))
+                ]
+                .align_y(iced::Alignment::Center)
+                .into()
+            };
+            let message = if entry.is_folder {
+                Message::Browser(BrowserMsg::SelectRemoteFolder(
+                    entry.provider_item_id.clone(),
+                ))
+            } else {
+                Message::Browser(BrowserMsg::SelectRemoteEntry((*entry).clone()))
+            };
+            let body = container(cells).padding([6, 8]).width(Length::Fill);
+            let interactive: Element<'_, Message> = if entry.is_folder {
+                button(body)
+                    .on_press(message)
+                    .padding(0)
+                    .width(Length::Fill)
+                    .style(browser_utility_action_style)
                     .into()
             } else {
-                let account = self
-                    .state
-                    .browser
-                    .dropbox
-                    .account_email
-                    .clone()
-                    .unwrap_or_else(|| "Connected".into());
-                text(account).size(9).color(th::text_dim()).into()
+                let source = MediaSourceRef::DropboxFile {
+                    path_lower: entry.provider_item_id.clone(),
+                    display_path: entry.path.clone(),
+                    rev: entry.revision.clone(),
+                };
+                mouse_area(body)
+                    .on_press(Message::BeginPendingBrowserDrag(source, entry.name.clone()))
+                    .on_release(message)
+                    .into()
             };
+            let selection_marker = container(text(""))
+                .width(Length::Fixed(2.0))
+                .height(Length::Fixed(43.0))
+                .style(move |_theme: &Theme| container::Style {
+                    background: selected.then(|| th::accent().into()),
+                    ..Default::default()
+                });
+            entries_col = entries_col
+                .push(
+                    container(row![selection_marker, interactive])
+                        .width(Length::Fill)
+                        .style(move |_theme: &Theme| container::Style {
+                            background: selected.then(|| th::accent_dim().into()),
+                            ..Default::default()
+                        }),
+                )
+                .push(browser_row_divider());
+        }
+        for entry in local_everywhere {
+            let selected = browser.selected_source.as_ref() == Some(&entry.source);
+            let cell_color = if selected { th::text() } else { th::text_dim() };
+            let name_cell = column![
+                text(entry.name.as_str())
+                    .size(12)
+                    .color(th::text())
+                    .width(Length::Fill)
+                    .height(Length::Fixed(14.0))
+                    .wrapping(iced::widget::text::Wrapping::None),
+                text(format!(
+                    "Local · {}/{}",
+                    browser_root_name(&entry.root_path),
+                    entry.relative_path.display()
+                ))
+                .size(9)
+                .color(cell_color)
+                .width(Length::Fill)
+                .height(Length::Fixed(11.0))
+                .wrapping(iced::widget::text::Wrapping::None)
+            ]
+            .spacing(2)
+            .width(Length::Fill);
+            let cells: Element<'_, Message> = if wide_columns {
+                row![
+                    name_cell,
+                    text("—")
+                        .size(10)
+                        .color(cell_color)
+                        .width(Length::Fixed(36.0)),
+                    text(
+                        entry
+                            .duration_seconds
+                            .map(format_browser_duration)
+                            .unwrap_or_else(|| "—".into())
+                    )
+                    .size(10)
+                    .color(cell_color)
+                    .width(Length::Fixed(50.0)),
+                    text("LOCAL")
+                        .size(9)
+                        .color(cell_color)
+                        .width(Length::Fixed(48.0))
+                ]
+                .spacing(4)
+                .align_y(iced::Alignment::Center)
+                .into()
+            } else {
+                row![
+                    name_cell,
+                    text("LOCAL")
+                        .size(9)
+                        .color(cell_color)
+                        .width(Length::Fixed(42.0))
+                ]
+                .align_y(iced::Alignment::Center)
+                .into()
+            };
+            let body = container(cells).padding([6, 8]).width(Length::Fill);
+            let interactive: Element<'_, Message> = mouse_area(body)
+                .on_press(Message::BeginPendingBrowserDrag(
+                    entry.source.clone(),
+                    entry.name.clone(),
+                ))
+                .on_release(Message::ClickLocalBrowserEntry(entry.source.clone()))
+                .into();
+            let selection_marker = container(text(""))
+                .width(Length::Fixed(2.0))
+                .height(Length::Fixed(43.0))
+                .style(move |_theme: &Theme| container::Style {
+                    background: selected.then(|| th::accent().into()),
+                    ..Default::default()
+                });
+            entries_col = entries_col
+                .push(
+                    container(row![selection_marker, interactive])
+                        .width(Length::Fill)
+                        .style(move |_theme: &Theme| container::Style {
+                            background: selected.then(|| th::accent_dim().into()),
+                            ..Default::default()
+                        }),
+                )
+                .push(browser_row_divider());
+        }
+        if total_results == 0 {
+            let empty = if remote.catalog.entries.is_empty() {
+                "No saved Remote metadata yet; connect and refresh when available"
+            } else if searching {
+                "No media or folders match this scope"
+            } else {
+                "This Remote folder has no child folders or supported media"
+            };
+            entries_col = entries_col
+                .push(container(text(empty).size(11).color(th::text_dim())).padding([8, 4]));
+        }
+        if browser.has_more_results(total_results) {
+            entries_col = entries_col.push(
+                button(text("SHOW MORE").size(9).color(th::text_dim()))
+                    .on_press(Message::Browser(BrowserMsg::ShowMoreLocalResults))
+                    .padding([7, 8])
+                    .width(Length::Fill)
+                    .style(browser_utility_action_style),
+            );
+        }
+        let refresh = button(text("REFRESH").size(9).color(th::text_dim()))
+            .on_press(Message::RefreshRemoteConnection)
+            .padding([3, 5])
+            .style(browser_utility_action_style);
+        let state_color = if matches!(
+            remote.catalog_state,
+            crate::state::RemoteCatalogState::Stale { .. }
+                | crate::state::RemoteCatalogState::Partial { .. }
+                | crate::state::RemoteCatalogState::AuthenticationRequired { .. }
+        ) {
+            th::danger()
+        } else {
+            th::text_dim()
+        };
 
         container(
             column![
                 row![
                     text("RESULTS").size(9).color(th::text_muted()),
                     horizontal_space(),
-                    status
+                    text(format!(
+                        "{} · {visible_results}/{total_results}",
+                        remote.catalog_state.label()
+                    ))
+                    .size(9)
+                    .color(state_color),
+                    refresh
                 ]
+                .spacing(5)
                 .align_y(iced::Alignment::Center),
+                table_header,
                 scrollable(
                     container(entries_col)
                         .width(Length::Fill)
@@ -1214,7 +1630,7 @@ impl App {
                     scrollable::Scrollbar::default()
                 ))
             ]
-            .spacing(6)
+            .spacing(0)
             .padding(8)
             .height(Length::Fill),
         )
@@ -1222,133 +1638,6 @@ impl App {
         .height(Length::Fill)
         .style(browser_results_style)
         .into()
-    }
-
-    pub(super) fn render_dropbox_tree(
-        &self,
-        path: String,
-        depth: usize,
-        rows: &mut Vec<Element<'_, Message>>,
-    ) {
-        let Some(entries) = self.state.browser.dropbox.folders.get(&path) else {
-            return;
-        };
-        let mut sorted: Vec<&DropboxEntry> = entries.iter().collect();
-        sorted.sort_by(|a, b| {
-            (!a.is_folder, a.name.to_lowercase()).cmp(&(!b.is_folder, b.name.to_lowercase()))
-        });
-        for entry in sorted {
-            let expanded = self
-                .state
-                .browser
-                .dropbox
-                .expanded
-                .contains(&entry.path_lower);
-            let selected =
-                self.state.browser.dropbox.selected_path.as_deref() == Some(&entry.path_lower);
-
-            let prefix = if entry.is_folder {
-                if expanded {
-                    "v "
-                } else {
-                    "> "
-                }
-            } else if entry.is_supported_audio() {
-                "· "
-            } else {
-                "  "
-            };
-            let indent = "  ".repeat(depth);
-            let label = format!("{indent}{prefix}{}", entry.name);
-            let msg = if entry.is_folder {
-                if expanded {
-                    Message::Browser(BrowserMsg::DropboxCollapseFolder(entry.path_lower.clone()))
-                } else {
-                    Message::DropboxExpandFolder(entry.path_lower.clone())
-                }
-            } else {
-                Message::Browser(BrowserMsg::DropboxSelectEntry(entry.clone()))
-            };
-            if entry.is_supported_audio() {
-                // Audio rows use a container + mouse_area so press events
-                // reach us (iced Button captures ButtonPressed, which would
-                // hide the drag from mouse_area).
-                let text_color = if selected { th::accent() } else { th::text() };
-                let row_body = container(text(label).size(11).color(text_color))
-                    .padding([3, 6])
-                    .width(Length::Fill);
-                let source = MediaSourceRef::DropboxFile {
-                    path_lower: entry.path_lower.clone(),
-                    display_path: entry.path_display.clone(),
-                    rev: entry.rev.clone(),
-                };
-                let dragger: Element<'_, Message> = mouse_area(row_body)
-                    .on_press(Message::BeginPendingBrowserDrag(source, entry.name.clone()))
-                    .on_release(msg)
-                    .into();
-                let selection_marker = container(text(""))
-                    .width(Length::Fixed(2.0))
-                    .height(Length::Fixed(25.0))
-                    .style(move |_theme: &Theme| container::Style {
-                        background: selected.then(|| th::accent().into()),
-                        ..Default::default()
-                    });
-                rows.push(
-                    container(
-                        row![selection_marker, dragger]
-                            .spacing(2)
-                            .align_y(iced::Alignment::Center),
-                    )
-                    .width(Length::Fill)
-                    .style(move |_theme: &Theme| container::Style {
-                        background: selected.then(|| th::accent_dim().into()),
-                        ..Default::default()
-                    })
-                    .into(),
-                );
-            } else {
-                // Folders + non-audio entries keep the button path since they
-                // don't participate in drag.
-                let btn = button(text(label).size(11).color(if selected {
-                    th::accent()
-                } else if entry.is_folder {
-                    th::text()
-                } else {
-                    th::text_dim()
-                }))
-                .on_press(msg)
-                .padding([3, 6])
-                .width(Length::Fill)
-                .style(move |_theme: &Theme, status| {
-                    let bg = if selected {
-                        Some(th::accent_dim().into())
-                    } else {
-                        match status {
-                            button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::bg_hover().into())
-                            }
-                            _ => None,
-                        }
-                    };
-                    button::Style {
-                        background: bg,
-                        text_color: if selected { th::accent() } else { th::text() },
-                        border: iced::Border {
-                            radius: 0.0.into(),
-                            ..Default::default()
-                        },
-                        ..Default::default()
-                    }
-                });
-                rows.push(btn.into());
-            }
-
-            rows.push(browser_row_divider());
-
-            if entry.is_folder && expanded {
-                self.render_dropbox_tree(entry.path_lower.clone(), depth + 1, rows);
-            }
-        }
     }
 }
 

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -500,7 +500,7 @@ impl App {
         .size(11)
         .color(th::text_dim());
 
-        let app_key_input = text_input("App key", &self.state.browser.dropbox.app_key_input)
+        let app_key_input = text_input("App key", &self.state.browser.remote.app_key_input)
             .on_input(|s| Message::Browser(BrowserMsg::SetDropboxAppKey(s)))
             .on_submit(Message::SaveDropboxAppKey)
             .size(13)
@@ -531,11 +531,11 @@ impl App {
             .spacing(8)
             .align_y(iced::Alignment::Center);
 
-        let account_line: Element<'_, Message> = if self.state.browser.dropbox.connected {
+        let account_line: Element<'_, Message> = if self.state.browser.remote.connected {
             let email = self
                 .state
                 .browser
-                .dropbox
+                .remote
                 .account_email
                 .clone()
                 .unwrap_or_else(|| "connected".into());
@@ -543,7 +543,7 @@ impl App {
                 .size(12)
                 .color(th::accent())
                 .into()
-        } else if self.state.browser.dropbox.auth_in_progress {
+        } else if self.state.browser.remote.auth_in_progress {
             text("Waiting for browser authorisation...")
                 .size(12)
                 .color(th::text_dim())
@@ -553,10 +553,10 @@ impl App {
         };
 
         let can_connect =
-            self.state.browser.dropbox.has_app_key && !self.state.browser.dropbox.auth_in_progress;
-        let connect_label = if self.state.browser.dropbox.auth_in_progress {
+            self.state.browser.remote.has_app_key && !self.state.browser.remote.auth_in_progress;
+        let connect_label = if self.state.browser.remote.auth_in_progress {
             "Connecting..."
-        } else if self.state.browser.dropbox.connected {
+        } else if self.state.browser.remote.connected {
             "Reconnect"
         } else {
             "Connect"
@@ -586,7 +586,7 @@ impl App {
             })
         };
 
-        let disconnect_btn: Element<'_, Message> = if self.state.browser.dropbox.connected {
+        let disconnect_btn: Element<'_, Message> = if self.state.browser.remote.connected {
             button(text("Disconnect").size(12).color(th::text_dim()))
                 .on_press(Message::DisconnectDropbox)
                 .padding([6, 12])
@@ -610,7 +610,7 @@ impl App {
         };
 
         let error_line: Element<'_, Message> =
-            if let Some(err) = self.state.browser.dropbox.last_error.clone() {
+            if let Some(err) = self.state.browser.remote.last_error.clone() {
                 text(err).size(11).color(th::danger()).into()
             } else {
                 horizontal_space().width(Length::Shrink).into()

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -1,18 +1,17 @@
-//! Browser domain: the sample library, Dropbox browsing state, and
+//! Browser domain: local and remote sample browsing state, and
 //! drag-and-drop from the browser into the arrangement.
 //!
 //! Only the synchronous state transitions live here. Anything that
-//! spawns work (file dialogs, decode, Dropbox HTTP) stays in app.rs
+//! spawns work (file dialogs, decode, provider HTTP) stays in app.rs
 //! as an iced Task and routes results back through these messages.
 
 use std::path::PathBuf;
 
+use crate::message::{LocalRootWatchEvent, SampleLibraryScanResult};
+use crate::remote_provider::RemoteCatalogEntry;
+use crate::state::{BrowserState, LocalRootCatalogState, SampleBrowserMode};
 use vibez_core::id::TrackId;
 use vibez_core::track::MediaSourceRef;
-use vibez_dropbox::DropboxEntry;
-
-use crate::message::{LocalRootWatchEvent, SampleLibraryScanResult};
-use crate::state::{BrowserState, LocalRootCatalogState, SampleBrowserMode};
 
 /// Messages the browser domain handles (sync tranche).
 #[derive(Debug, Clone)]
@@ -68,8 +67,9 @@ pub enum BrowserMsg {
         result: Result<SampleLibraryScanResult, String>,
     },
     RemoveSampleLibraryRoot(PathBuf),
-    DropboxCollapseFolder(String),
-    DropboxSelectEntry(DropboxEntry),
+    SelectRemoteFolder(String),
+    ToggleRemoteFolder(String),
+    SelectRemoteEntry(RemoteCatalogEntry),
     SetDropboxAppKey(String),
 }
 
@@ -80,10 +80,6 @@ pub struct BrowserAction {
     pub status: Option<String>,
     /// UI settings changed (browser visibility, library roots).
     pub persist_settings: bool,
-    /// Dropbox mode was entered with no cached root listing; the
-    /// router should kick off a root list_folder call if a client is
-    /// connected.
-    pub expand_dropbox_root: bool,
     /// Decode a Local selection for the truthful Audition waveform without
     /// starting playback.
     pub load_waveform: Option<MediaSourceRef>,
@@ -146,14 +142,7 @@ impl BrowserState {
             }
             BrowserMsg::SetSampleBrowserMode(mode) => {
                 self.mode = mode;
-                if mode == crate::state::SampleBrowserMode::Dropbox
-                    && !self.dropbox.folders.contains_key("")
-                    && !self.dropbox.listing_in_progress.contains("")
-                {
-                    // The router only acts on this when a Dropbox
-                    // client is actually connected.
-                    action.expand_dropbox_root = true;
-                }
+                self.reset_results_window();
             }
             BrowserMsg::BeginPendingDrag {
                 source,
@@ -373,19 +362,33 @@ impl BrowserState {
                 action.persist_settings = true;
                 action.status = Some("Removed sample root".to_string());
             }
-            BrowserMsg::DropboxCollapseFolder(path) => {
-                self.dropbox.expanded.remove(&path);
+            BrowserMsg::SelectRemoteFolder(path) => {
+                self.remote.current_path = path;
+                if !self.remote.current_path.is_empty() {
+                    self.remote
+                        .expanded
+                        .insert(self.remote.current_path.clone());
+                }
+                self.remote.selected_path = None;
+                self.search_scope = crate::state::BrowserSearchScope::SelectedFolder;
+                self.clear_selection();
+                self.reset_results_window();
             }
-            BrowserMsg::DropboxSelectEntry(entry) => {
-                self.dropbox.selected_path = Some(entry.path_lower.clone());
+            BrowserMsg::ToggleRemoteFolder(path) => {
+                if !self.remote.expanded.remove(&path) {
+                    self.remote.expanded.insert(path);
+                }
+            }
+            BrowserMsg::SelectRemoteEntry(entry) => {
+                self.remote.selected_path = Some(entry.provider_item_id.clone());
                 self.select_source(MediaSourceRef::DropboxFile {
-                    path_lower: entry.path_lower,
-                    display_path: entry.path_display,
-                    rev: entry.rev,
+                    path_lower: entry.provider_item_id,
+                    display_path: entry.path,
+                    rev: entry.revision,
                 });
             }
             BrowserMsg::SetDropboxAppKey(key) => {
-                self.dropbox.app_key_input = key;
+                self.remote.app_key_input = key;
             }
         }
         action
@@ -632,13 +635,72 @@ mod tests {
     }
 
     #[test]
-    fn dropbox_mode_requests_root_listing_once() {
+    fn remote_mode_uses_the_persisted_catalog_without_requesting_network_work() {
         let mut b = BrowserState::default();
-        let action = b.update(BrowserMsg::SetSampleBrowserMode(SampleBrowserMode::Dropbox));
-        assert!(action.expand_dropbox_root);
-        b.dropbox.folders.insert(String::new(), Vec::new());
-        let action = b.update(BrowserMsg::SetSampleBrowserMode(SampleBrowserMode::Dropbox));
-        assert!(!action.expand_dropbox_root);
+        let action = b.update(BrowserMsg::SetSampleBrowserMode(SampleBrowserMode::Remote));
+        assert_eq!(b.mode, SampleBrowserMode::Remote);
+        assert_eq!(action, BrowserAction::default());
+    }
+
+    #[test]
+    fn remote_navigation_cycles_folder_connection_and_everywhere_scopes() {
+        let mut browser = BrowserState::default();
+        browser.update(BrowserMsg::SetSampleBrowserMode(SampleBrowserMode::Remote));
+        browser.update(BrowserMsg::SelectRemoteFolder("/megalodon".into()));
+        assert_eq!(browser.remote.current_path, "/megalodon");
+        assert!(browser.remote.expanded.contains("/megalodon"));
+        assert_eq!(
+            browser.search_scope,
+            crate::state::BrowserSearchScope::SelectedFolder
+        );
+
+        browser.update(BrowserMsg::CycleSearchScope);
+        assert_eq!(browser.search_scope, crate::state::BrowserSearchScope::Root);
+        browser.update(BrowserMsg::CycleSearchScope);
+        assert_eq!(
+            browser.search_scope,
+            crate::state::BrowserSearchScope::Everywhere
+        );
+        browser.update(BrowserMsg::CycleSearchScope);
+        assert_eq!(
+            browser.search_scope,
+            crate::state::BrowserSearchScope::SelectedFolder
+        );
+    }
+
+    #[test]
+    fn remote_selection_preserves_provider_identity_and_source_location() {
+        let mut browser = BrowserState::default();
+        browser.update(BrowserMsg::SelectRemoteEntry(RemoteCatalogEntry {
+            provider_item_id: "/megalodon/kick.wav".into(),
+            path: "/Megalodon/Kick.wav".into(),
+            parent_path: "/megalodon".into(),
+            name: "Kick.wav".into(),
+            is_folder: false,
+            revision: Some("rev-7".into()),
+            size: Some(2048),
+        }));
+        assert_eq!(
+            browser.selected_source,
+            Some(MediaSourceRef::DropboxFile {
+                path_lower: "/megalodon/kick.wav".into(),
+                display_path: "/Megalodon/Kick.wav".into(),
+                rev: Some("rev-7".into()),
+            })
+        );
+        assert_eq!(
+            browser.remote.selected_path.as_deref(),
+            Some("/megalodon/kick.wav")
+        );
+    }
+
+    #[test]
+    fn remote_search_edits_are_catalog_only_and_request_no_provider_effect() {
+        let mut browser = BrowserState::default();
+        browser.mode = SampleBrowserMode::Remote;
+        let action = browser.update(BrowserMsg::SampleBrowserSearchChanged("kick".into()));
+        assert_eq!(browser.search, "kick");
+        assert_eq!(action, BrowserAction::default());
     }
 
     #[test]

--- a/crates/vibez-ui/src/lib.rs
+++ b/crates/vibez-ui/src/lib.rs
@@ -3,6 +3,7 @@ mod domains;
 pub mod icons;
 mod message;
 pub mod plugin_window;
+mod remote_provider;
 mod services;
 mod spectrum;
 mod state;

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -434,11 +434,8 @@ pub enum Message {
     ConnectDropbox,
     DropboxConnected(Result<DropboxConnectOutcome, String>),
     DisconnectDropbox,
-    DropboxExpandFolder(String),
-    DropboxFolderListed {
-        path: String,
-        result: Result<Vec<DropboxEntry>, String>,
-    },
+    RefreshRemoteConnection,
+    RemoteCatalogRefreshed(crate::remote_provider::RemoteRefreshResult),
     DropboxPreview(DropboxEntry),
     DropboxPreviewReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
     DropboxImportToArrangement(DropboxEntry),

--- a/crates/vibez-ui/src/remote_provider.rs
+++ b/crates/vibez-ui/src/remote_provider.rs
@@ -1,0 +1,495 @@
+//! Provider-neutral metadata catalog for Browser Remote Connections.
+//!
+//! V1 ships a Dropbox adapter, but Browser state and persistence depend only
+//! on this boundary. Remote media bytes remain a materialization concern.
+
+use std::collections::HashMap;
+use std::future::Future;
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
+use std::pin::Pin;
+
+use serde::{Deserialize, Serialize};
+use vibez_dropbox::{DropboxClient, DropboxError, DropboxListItem};
+
+pub const DROPBOX_PROVIDER_ID: &str = "dropbox";
+pub const DROPBOX_CONNECTION_ID: &str = "dropbox-primary";
+pub const DROPBOX_CONNECTION_NAME: &str = "Alex's Dropbox";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteCatalogEntry {
+    pub provider_item_id: String,
+    pub path: String,
+    pub parent_path: String,
+    pub name: String,
+    pub is_folder: bool,
+    pub revision: Option<String>,
+    pub size: Option<u64>,
+}
+
+impl RemoteCatalogEntry {
+    pub fn is_supported_audio(&self) -> bool {
+        !self.is_folder
+            && self
+                .name
+                .rsplit_once('.')
+                .and_then(|(_, extension)| {
+                    vibez_core::audio_format::audio_format_for_extension(extension)
+                })
+                .is_some()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteCatalogSnapshot {
+    pub provider_id: String,
+    pub connection_id: String,
+    pub connection_name: String,
+    pub checkpoint: Option<String>,
+    pub entries: Vec<RemoteCatalogEntry>,
+}
+
+impl Default for RemoteCatalogSnapshot {
+    fn default() -> Self {
+        Self {
+            provider_id: DROPBOX_PROVIDER_ID.into(),
+            connection_id: DROPBOX_CONNECTION_ID.into(),
+            connection_name: DROPBOX_CONNECTION_NAME.into(),
+            checkpoint: None,
+            entries: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteChange {
+    Upsert(RemoteCatalogEntry),
+    Delete { provider_item_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePage {
+    pub changes: Vec<RemoteChange>,
+    pub checkpoint: String,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteProviderErrorKind {
+    Authentication,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteProviderError {
+    pub kind: RemoteProviderErrorKind,
+    pub message: String,
+}
+
+type RemoteProviderFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<RemotePage, RemoteProviderError>> + Send + 'a>>;
+
+/// Metadata-only provider contract. A future Drive or S3 adapter can implement
+/// this without changing Browser state, search, persistence, or rendering.
+pub trait RemoteProvider: Send + Sync {
+    fn provider_id(&self) -> &'static str;
+    fn connection_id(&self) -> &str;
+    fn fetch_metadata_page<'a>(&'a self, checkpoint: Option<&'a str>) -> RemoteProviderFuture<'a>;
+}
+
+#[derive(Clone)]
+pub struct DropboxRemoteProvider {
+    client: DropboxClient,
+}
+
+impl DropboxRemoteProvider {
+    pub fn new(client: DropboxClient) -> Self {
+        Self { client }
+    }
+}
+
+impl RemoteProvider for DropboxRemoteProvider {
+    fn provider_id(&self) -> &'static str {
+        DROPBOX_PROVIDER_ID
+    }
+
+    fn connection_id(&self) -> &str {
+        DROPBOX_CONNECTION_ID
+    }
+
+    fn fetch_metadata_page<'a>(&'a self, checkpoint: Option<&'a str>) -> RemoteProviderFuture<'a> {
+        Box::pin(async move {
+            let page = self
+                .client
+                .list_folder_page("", true, checkpoint)
+                .await
+                .map_err(remote_error_from_dropbox)?;
+            let changes = page
+                .items
+                .into_iter()
+                .map(|item| match item {
+                    DropboxListItem::Entry(entry) => {
+                        let parent_path = parent_remote_path(&entry.path_lower);
+                        RemoteChange::Upsert(RemoteCatalogEntry {
+                            provider_item_id: entry.path_lower,
+                            path: entry.path_display,
+                            parent_path,
+                            name: entry.name,
+                            is_folder: entry.is_folder,
+                            revision: entry.rev,
+                            size: entry.size,
+                        })
+                    }
+                    DropboxListItem::Deleted { path_lower } => RemoteChange::Delete {
+                        provider_item_id: path_lower,
+                    },
+                })
+                .collect();
+            Ok(RemotePage {
+                changes,
+                checkpoint: page.cursor,
+                has_more: page.has_more,
+            })
+        })
+    }
+}
+
+fn remote_error_from_dropbox(error: DropboxError) -> RemoteProviderError {
+    let kind = match &error {
+        DropboxError::NotAuthenticated | DropboxError::MissingAppKey => {
+            RemoteProviderErrorKind::Authentication
+        }
+        DropboxError::Api { status: 401, .. } => RemoteProviderErrorKind::Authentication,
+        _ => RemoteProviderErrorKind::Unavailable,
+    };
+    RemoteProviderError {
+        kind,
+        message: error.to_string(),
+    }
+}
+
+fn parent_remote_path(path: &str) -> String {
+    path.rsplit_once('/')
+        .map(|(parent, _)| parent.to_string())
+        .unwrap_or_default()
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoteRefreshResult {
+    pub pages: usize,
+    pub changes: Vec<RemoteChange>,
+    /// Set only after the refresh reaches a complete provider checkpoint.
+    pub checkpoint: Option<String>,
+    pub error: Option<RemoteProviderError>,
+}
+
+pub async fn refresh_remote_catalog<P: RemoteProvider>(
+    provider: &P,
+    checkpoint: Option<&str>,
+) -> RemoteRefreshResult {
+    debug_assert_eq!(provider.provider_id(), DROPBOX_PROVIDER_ID);
+    debug_assert_eq!(provider.connection_id(), DROPBOX_CONNECTION_ID);
+    let mut cursor = checkpoint.map(ToOwned::to_owned);
+    let mut pages = 0;
+    let mut changes = Vec::new();
+    loop {
+        match provider.fetch_metadata_page(cursor.as_deref()).await {
+            Ok(page) => {
+                pages += 1;
+                changes.extend(page.changes);
+                cursor = Some(page.checkpoint);
+                if !page.has_more {
+                    return RemoteRefreshResult {
+                        pages,
+                        changes,
+                        checkpoint: cursor,
+                        error: None,
+                    };
+                }
+            }
+            Err(error) => {
+                return RemoteRefreshResult {
+                    pages,
+                    changes,
+                    checkpoint: None,
+                    error: Some(error),
+                };
+            }
+        }
+    }
+}
+
+pub fn reconcile_remote_catalog(
+    snapshot: &mut RemoteCatalogSnapshot,
+    result: &RemoteRefreshResult,
+) {
+    let mut entries: HashMap<String, RemoteCatalogEntry> = snapshot
+        .entries
+        .drain(..)
+        .map(|entry| (entry.provider_item_id.clone(), entry))
+        .collect();
+    for change in &result.changes {
+        match change {
+            RemoteChange::Upsert(entry) => {
+                entries.insert(entry.provider_item_id.clone(), entry.clone());
+            }
+            RemoteChange::Delete { provider_item_id } => {
+                entries.remove(provider_item_id);
+            }
+        }
+    }
+    snapshot.entries = entries.into_values().collect();
+    snapshot.entries.sort_by(|left, right| {
+        left.path
+            .to_ascii_lowercase()
+            .cmp(&right.path.to_ascii_lowercase())
+    });
+    if let Some(checkpoint) = &result.checkpoint {
+        snapshot.checkpoint = Some(checkpoint.clone());
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoteCatalogStore {
+    path: PathBuf,
+}
+
+impl RemoteCatalogStore {
+    pub fn for_dropbox() -> Self {
+        let base = dirs::data_local_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("vibez")
+            .join("remote-catalogs");
+        Self {
+            path: base.join(format!("{DROPBOX_CONNECTION_ID}.json")),
+        }
+    }
+
+    #[cfg(test)]
+    fn at(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn load(&self) -> Result<RemoteCatalogSnapshot, String> {
+        match std::fs::read(&self.path) {
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .map_err(|error| format!("remote catalog is invalid: {error}")),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                Ok(RemoteCatalogSnapshot::default())
+            }
+            Err(error) => Err(format!("could not read remote catalog: {error}")),
+        }
+    }
+
+    pub fn save(&self, snapshot: &RemoteCatalogSnapshot) -> Result<(), String> {
+        let parent = self
+            .path
+            .parent()
+            .ok_or("remote catalog path has no parent")?;
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("could not create remote catalog folder: {error}"))?;
+        let temporary = self.path.with_extension("json.partial");
+        let bytes = serde_json::to_vec_pretty(snapshot)
+            .map_err(|error| format!("could not encode remote catalog: {error}"))?;
+        std::fs::write(&temporary, bytes)
+            .map_err(|error| format!("could not write remote catalog: {error}"))?;
+        std::fs::rename(&temporary, &self.path)
+            .map_err(|error| format!("could not commit remote catalog: {error}"))
+    }
+
+    #[cfg(test)]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    struct FakeProvider {
+        pages: Mutex<VecDeque<Result<RemotePage, RemoteProviderError>>>,
+    }
+
+    impl RemoteProvider for FakeProvider {
+        fn provider_id(&self) -> &'static str {
+            DROPBOX_PROVIDER_ID
+        }
+
+        fn connection_id(&self) -> &str {
+            DROPBOX_CONNECTION_ID
+        }
+
+        fn fetch_metadata_page<'a>(
+            &'a self,
+            _checkpoint: Option<&'a str>,
+        ) -> RemoteProviderFuture<'a> {
+            Box::pin(async move { self.pages.lock().unwrap().pop_front().unwrap() })
+        }
+    }
+
+    fn entry(path: &str) -> RemoteCatalogEntry {
+        RemoteCatalogEntry {
+            provider_item_id: path.to_ascii_lowercase(),
+            path: path.into(),
+            parent_path: parent_remote_path(&path.to_ascii_lowercase()),
+            name: path.rsplit('/').next().unwrap().into(),
+            is_folder: false,
+            revision: Some("1".into()),
+            size: Some(42),
+        }
+    }
+
+    #[tokio::test]
+    async fn pagination_commits_only_the_final_checkpoint() {
+        let provider = FakeProvider {
+            pages: Mutex::new(VecDeque::from([
+                Ok(RemotePage {
+                    changes: vec![RemoteChange::Upsert(entry("/Megalodon/Kick.wav"))],
+                    checkpoint: "page-1".into(),
+                    has_more: true,
+                }),
+                Ok(RemotePage {
+                    changes: vec![RemoteChange::Upsert(entry("/Megalodon/Snare.wav"))],
+                    checkpoint: "complete".into(),
+                    has_more: false,
+                }),
+            ])),
+        };
+        let result = refresh_remote_catalog(&provider, None).await;
+        assert_eq!(result.pages, 2);
+        assert_eq!(result.changes.len(), 2);
+        assert_eq!(result.checkpoint.as_deref(), Some("complete"));
+        assert!(result.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn partial_failure_keeps_changes_but_not_an_incomplete_checkpoint() {
+        let provider = FakeProvider {
+            pages: Mutex::new(VecDeque::from([
+                Ok(RemotePage {
+                    changes: vec![RemoteChange::Upsert(entry("/new.wav"))],
+                    checkpoint: "unsafe".into(),
+                    has_more: true,
+                }),
+                Err(RemoteProviderError {
+                    kind: RemoteProviderErrorKind::Unavailable,
+                    message: "offline".into(),
+                }),
+            ])),
+        };
+        let result = refresh_remote_catalog(&provider, Some("prior")).await;
+        let mut snapshot = RemoteCatalogSnapshot {
+            checkpoint: Some("prior".into()),
+            entries: vec![entry("/old.wav")],
+            ..RemoteCatalogSnapshot::default()
+        };
+        reconcile_remote_catalog(&mut snapshot, &result);
+        assert_eq!(result.pages, 1);
+        assert!(result.error.is_some());
+        assert_eq!(snapshot.checkpoint.as_deref(), Some("prior"));
+        assert_eq!(snapshot.entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn offline_first_page_failure_keeps_the_last_usable_catalog_exactly() {
+        let provider = FakeProvider {
+            pages: Mutex::new(VecDeque::from([Err(RemoteProviderError {
+                kind: RemoteProviderErrorKind::Unavailable,
+                message: "offline".into(),
+            })])),
+        };
+        let mut snapshot = RemoteCatalogSnapshot {
+            checkpoint: Some("stable".into()),
+            entries: vec![entry("/Megalodon/Kick.wav")],
+            ..RemoteCatalogSnapshot::default()
+        };
+        let before = snapshot.clone();
+        let result = refresh_remote_catalog(&provider, snapshot.checkpoint.as_deref()).await;
+        reconcile_remote_catalog(&mut snapshot, &result);
+        assert_eq!(result.pages, 0);
+        assert_eq!(snapshot, before);
+    }
+
+    #[test]
+    fn dropbox_authentication_failures_are_visible_to_the_remote_boundary() {
+        let error = remote_error_from_dropbox(DropboxError::Api {
+            status: 401,
+            body: "expired_access_token".into(),
+        });
+        assert_eq!(error.kind, RemoteProviderErrorKind::Authentication);
+        assert!(error.message.contains("401"));
+    }
+
+    #[test]
+    fn reconcile_is_idempotent_and_applies_deletions() {
+        let mut snapshot = RemoteCatalogSnapshot {
+            entries: vec![entry("/old.wav")],
+            ..RemoteCatalogSnapshot::default()
+        };
+        let result = RemoteRefreshResult {
+            pages: 1,
+            changes: vec![
+                RemoteChange::Delete {
+                    provider_item_id: "/old.wav".into(),
+                },
+                RemoteChange::Upsert(entry("/new.wav")),
+            ],
+            checkpoint: Some("next".into()),
+            error: None,
+        };
+        reconcile_remote_catalog(&mut snapshot, &result);
+        reconcile_remote_catalog(&mut snapshot, &result);
+        assert_eq!(snapshot.entries, vec![entry("/new.wav")]);
+        assert_eq!(snapshot.checkpoint.as_deref(), Some("next"));
+    }
+
+    #[test]
+    fn identical_names_at_distinct_source_identities_remain_distinct_entries() {
+        let mut first = entry("/Megalodon/Kick.wav");
+        let mut second = entry("/Shared/Kick.wav");
+        first.name = "Kick.wav".into();
+        second.name = "Kick.wav".into();
+        let mut snapshot = RemoteCatalogSnapshot::default();
+        reconcile_remote_catalog(
+            &mut snapshot,
+            &RemoteRefreshResult {
+                pages: 1,
+                changes: vec![RemoteChange::Upsert(first), RemoteChange::Upsert(second)],
+                checkpoint: Some("complete".into()),
+                error: None,
+            },
+        );
+        assert_eq!(snapshot.entries.len(), 2);
+        assert_ne!(
+            snapshot.entries[0].provider_item_id,
+            snapshot.entries[1].provider_item_id
+        );
+    }
+
+    #[test]
+    fn store_round_trips_and_reports_corruption_without_erasing_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RemoteCatalogStore::at(dir.path().join("catalog.json"));
+        let snapshot = RemoteCatalogSnapshot {
+            entries: vec![entry("/Megalodon/Kick.wav")],
+            ..RemoteCatalogSnapshot::default()
+        };
+        store.save(&snapshot).unwrap();
+        assert_eq!(store.load().unwrap(), snapshot);
+        std::fs::write(store.path(), b"not-json").unwrap();
+        assert!(store.load().unwrap_err().contains("invalid"));
+        assert_eq!(std::fs::read(store.path()).unwrap(), b"not-json");
+    }
+
+    #[test]
+    fn support_filter_uses_the_shared_audio_matrix() {
+        assert!(entry("/Idea.M4A").is_supported_audio());
+        assert!(!entry("/notes.txt").is_supported_audio());
+        assert!(!entry("/raw.aac").is_supported_audio());
+    }
+}

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -9,9 +9,10 @@ use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::constants::DEFAULT_BPM;
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::track::MediaSourceRef;
-use vibez_dropbox::DropboxEntry;
 use vibez_engine::commands::AuditionSync;
 use vibez_plugin_host::PluginSettings;
+
+use crate::remote_provider::RemoteCatalogSnapshot;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AuditionMode {
@@ -263,7 +264,7 @@ impl UndoHistory {
 pub enum SampleBrowserMode {
     #[default]
     Local,
-    Dropbox,
+    Remote,
 }
 
 pub const BROWSER_DOCK_MIN_WIDTH: f32 = 300.0;
@@ -306,7 +307,7 @@ impl LocalRootCatalogState {
     }
 }
 
-/// Browser domain slice: sample library, Dropbox browsing, and
+/// Browser domain slice: local and remote sample browsing, and
 /// drag-and-drop from the browser into the arrangement.
 #[derive(Debug, Clone)]
 pub struct BrowserState {
@@ -353,7 +354,7 @@ pub struct BrowserState {
     pub audition_bpm_detecting: bool,
     pub scan_in_progress: bool,
     pub mode: SampleBrowserMode,
-    pub dropbox: DropboxUiState,
+    pub remote: RemoteUiState,
     pub pending_drag: Option<PendingMediaDrag>,
     pub drag_source: Option<MediaSourceRef>,
     pub drag_label: Option<String>,
@@ -400,7 +401,7 @@ impl Default for BrowserState {
             audition_bpm_detecting: false,
             scan_in_progress: false,
             mode: SampleBrowserMode::default(),
-            dropbox: DropboxUiState::default(),
+            remote: RemoteUiState::default(),
             pending_drag: None,
             drag_source: None,
             drag_label: None,
@@ -529,6 +530,21 @@ impl BrowserState {
     }
 
     pub fn cycle_search_scope(&mut self) {
+        if self.mode == SampleBrowserMode::Remote {
+            self.search_scope = match self.search_scope {
+                BrowserSearchScope::SelectedFolder if self.remote.current_path.is_empty() => {
+                    BrowserSearchScope::Everywhere
+                }
+                BrowserSearchScope::SelectedFolder => BrowserSearchScope::Root,
+                BrowserSearchScope::Root => BrowserSearchScope::Everywhere,
+                BrowserSearchScope::Everywhere if self.remote.current_path.is_empty() => {
+                    BrowserSearchScope::SelectedFolder
+                }
+                BrowserSearchScope::Everywhere => BrowserSearchScope::SelectedFolder,
+            };
+            self.reset_results_window();
+            return;
+        }
         self.search_scope = match self.search_scope {
             BrowserSearchScope::SelectedFolder
                 if self.current_folder.is_some()
@@ -853,9 +869,71 @@ impl BrowserState {
     }
 }
 
-/// UI-side state for the Dropbox browser and Settings tab.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum RemoteCatalogState {
+    #[default]
+    Ready,
+    Refreshing,
+    Stale {
+        error: String,
+    },
+    Partial {
+        pages: usize,
+        error: String,
+    },
+    AuthenticationRequired {
+        error: String,
+    },
+}
+
+impl RemoteCatalogState {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Ready => "READY",
+            Self::Refreshing => "REFRESHING",
+            Self::Stale { .. } => "STALE",
+            Self::Partial { .. } => "PARTIAL",
+            Self::AuthenticationRequired { .. } => "SIGN IN",
+        }
+    }
+}
+
+#[cfg(test)]
+mod remote_catalog_state_tests {
+    use super::RemoteCatalogState;
+
+    #[test]
+    fn refresh_auth_stale_and_partial_states_have_distinct_labels() {
+        assert_eq!(RemoteCatalogState::Refreshing.label(), "REFRESHING");
+        assert_eq!(
+            RemoteCatalogState::AuthenticationRequired {
+                error: "sign in".into()
+            }
+            .label(),
+            "SIGN IN"
+        );
+        assert_eq!(
+            RemoteCatalogState::Stale {
+                error: "offline".into()
+            }
+            .label(),
+            "STALE"
+        );
+        assert_eq!(
+            RemoteCatalogState::Partial {
+                pages: 1,
+                error: "offline".into()
+            }
+            .label(),
+            "PARTIAL"
+        );
+    }
+}
+
+/// Provider-neutral Browser state for Remote Connections. Dropbox V1 auth
+/// fields remain here because Dropbox is the sole shipped adapter.
 #[derive(Debug, Default, Clone)]
-pub struct DropboxUiState {
+pub struct RemoteUiState {
     pub connected: bool,
     pub account_email: Option<String>,
     /// App key entered in settings (may be empty until the user pastes one).
@@ -865,13 +943,13 @@ pub struct DropboxUiState {
     /// An OAuth flow is in progress; Connect button is disabled.
     pub auth_in_progress: bool,
     pub last_error: Option<String>,
-    /// Listing cache keyed by Dropbox folder path (`""` for root).
-    pub folders: HashMap<String, Vec<DropboxEntry>>,
-    /// Paths for which a list_folder call is currently in flight.
-    pub listing_in_progress: HashSet<String>,
-    /// Paths expanded in the tree UI.
+    pub catalog: RemoteCatalogSnapshot,
+    pub catalog_state: RemoteCatalogState,
+    /// Current provider folder (`""` means the connection root).
+    pub current_path: String,
+    /// Paths expanded beneath the connection in Places.
     pub expanded: HashSet<String>,
-    /// `path_lower` of the currently-selected Dropbox entry, if any.
+    /// Provider item identity of the current Remote selection.
     pub selected_path: Option<String>,
     /// A preview fetch / playback is in flight.
     pub preview_in_progress: bool,


### PR DESCRIPTION
## Demo outcome

Dropbox is a Remote Connection beneath Remote, using the same flat Places/Results table and catalog-only scoped search as Local. The metadata catalog loads before network work and remains usable through offline, auth, stale, and partial refresh states.

## What changed

- added a provider-neutral metadata page/change/checkpoint boundary with a Dropbox adapter
- persisted an atomic metadata-only Remote Catalog and reconciled paginated deltas/deletions idempotently
- replaced Dropbox-specific Browser mode/state with Remote Connection state
- rendered Alex's Dropbox and Megalodon in Places plus a responsive Remote Results table
- added current-folder, connection, and Everywhere search; Everywhere retains distinct Local and Remote source rows
- kept refresh/auth/stale/partial errors visible without erasing the last catalog

## Non-goals

No Remote media materialization/cache policy work, new providers, or source mutation. Existing preview/import adapters are not expanded by this card.

## Verification

- `cargo test -p vibez-dropbox` (19 passed)
- `cargo test -p vibez-ui --lib` (165 passed)
- strict lib Clippy for `vibez-dropbox` and `vibez-ui`
- `cargo fmt --all` and `git diff --check`
- native Xvfb smoke: `/tmp/vibez-card-11-offline-megalodon.png`
- native Xvfb scoped search: `/tmp/vibez-card-11-offline-everywhere-search.png`

## Chain

Base: Card 10 PR #60. This is a feature PR, not a release PR.