### PR TITLE
Browser Card 12: materialize and cache Dropbox media

### DIFF
--- a/crates/vibez-dropbox/src/cache.rs
+++ b/crates/vibez-dropbox/src/cache.rs
@@ -1,68 +1,418 @@
-//! On-disk cache for Dropbox-sourced audio files.
+//! Disposable Media Cache for materialized Remote media.
 //!
-//! Keyed by `(path_lower, rev)`; older revisions of the same path
-//! coexist in the cache because clips in saved projects pin a
-//! specific `rev`. No eviction in v1: if this grows uncomfortably
-//! large, a size-capped LRU policy is a follow-up.
+//! Entries are keyed by provider path + revision, so a changed revision never
+//! reuses stale bytes or Derived Metadata. The persisted access sequence makes
+//! eviction deterministic without relying on filesystem timestamps.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_MEDIA_CACHE_BUDGET_BYTES: u64 = 20 * 1024 * 1024 * 1024;
+const INDEX_FILE: &str = "index.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MediaCachePolicy {
+    pub budget_bytes: u64,
+    pub automatic_eviction: bool,
+}
+
+impl Default for MediaCachePolicy {
+    fn default() -> Self {
+        Self {
+            budget_bytes: DEFAULT_MEDIA_CACHE_BUDGET_BYTES,
+            automatic_eviction: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct DerivedMetadata {
+    pub provider_revision: Option<String>,
+    pub duration_seconds: f64,
+    pub channels: u16,
+    pub sample_rate: u32,
+    pub bpm: Option<f64>,
+    pub bpm_confidence: Option<f32>,
+    #[serde(default)]
+    pub waveform_peaks: Vec<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheRecord {
+    path_lower: String,
+    revision: Option<String>,
+    file_name: String,
+    size_bytes: u64,
+    last_access_sequence: u64,
+    #[serde(default)]
+    derived_metadata: Option<DerivedMetadata>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct CacheIndex {
+    #[serde(default)]
+    access_sequence: u64,
+    #[serde(default)]
+    entries: HashMap<String, CacheRecord>,
+}
+
+#[derive(Debug)]
+struct RuntimeState {
+    policy: MediaCachePolicy,
+    protected: HashMap<String, usize>,
+}
 
 #[derive(Debug, Clone)]
 pub struct DropboxCache {
     root: PathBuf,
+    runtime: Arc<Mutex<RuntimeState>>,
+}
+
+#[derive(Debug)]
+pub struct CacheLease {
+    key: String,
+    runtime: Arc<Mutex<RuntimeState>>,
+}
+
+impl Clone for CacheLease {
+    fn clone(&self) -> Self {
+        *self
+            .runtime
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .protected
+            .entry(self.key.clone())
+            .or_insert(0) += 1;
+        Self {
+            key: self.key.clone(),
+            runtime: Arc::clone(&self.runtime),
+        }
+    }
+}
+
+impl Drop for CacheLease {
+    fn drop(&mut self) {
+        let mut runtime = self
+            .runtime
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Some(count) = runtime.protected.get_mut(&self.key) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                runtime.protected.remove(&self.key);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CacheUsage {
+    pub bytes: u64,
+    pub entries: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CacheClearReport {
+    pub removed_bytes: u64,
+    pub removed_entries: usize,
+    pub protected_entries: usize,
 }
 
 impl DropboxCache {
     pub fn new() -> Self {
+        Self::with_policy(MediaCachePolicy::default())
+    }
+
+    pub fn with_policy(policy: MediaCachePolicy) -> Self {
         let root = dirs::cache_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join("vibez")
-            .join("dropbox");
-        Self { root }
+            .join("media");
+        Self::with_root_and_policy(root, policy)
     }
 
     pub fn with_root(root: PathBuf) -> Self {
-        Self { root }
+        Self::with_root_and_policy(root, MediaCachePolicy::default())
+    }
+
+    pub fn with_root_and_policy(root: PathBuf, policy: MediaCachePolicy) -> Self {
+        Self {
+            root,
+            runtime: Arc::new(Mutex::new(RuntimeState {
+                policy,
+                protected: HashMap::new(),
+            })),
+        }
     }
 
     pub fn root(&self) -> &Path {
         &self.root
     }
 
-    /// Where a given `(path_lower, rev)` lives on disk.
-    ///
-    /// `rev` is optional so manual testing paths still produce
-    /// deterministic names. In real Dropbox responses `rev` is always
-    /// present for files.
-    pub fn path_for(&self, path_lower: &str, rev: Option<&str>) -> PathBuf {
-        let key = sanitize_path(path_lower);
-        let rev_suffix = rev.unwrap_or("norev");
-        let ext = extension_of(path_lower).unwrap_or("bin");
-        let filename = format!("{key}__{rev_suffix}.{ext}");
-        self.root.join(filename)
+    pub fn policy(&self) -> MediaCachePolicy {
+        self.runtime
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .policy
     }
 
-    pub fn is_cached(&self, path_lower: &str, rev: Option<&str>) -> bool {
-        self.path_for(path_lower, rev).is_file()
+    pub fn set_policy(&self, policy: MediaCachePolicy) -> std::io::Result<CacheUsage> {
+        self.runtime
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .policy = policy;
+        self.enforce_budget()
     }
 
-    /// Create the cache directory if missing. Safe to call every
-    /// time; recursive.
+    pub fn path_for(&self, path_lower: &str, revision: Option<&str>) -> PathBuf {
+        let key = cache_key(path_lower, revision);
+        let extension = extension_of(path_lower).unwrap_or("bin");
+        self.root.join(format!("{key}.{extension}"))
+    }
+
+    pub fn is_cached(&self, path_lower: &str, revision: Option<&str>) -> bool {
+        self.path_for(path_lower, revision).is_file()
+    }
+
+    /// Return cached bytes' path and persist an LRU touch.
+    pub fn lookup(
+        &self,
+        path_lower: &str,
+        revision: Option<&str>,
+    ) -> std::io::Result<Option<PathBuf>> {
+        let path = self.path_for(path_lower, revision);
+        if !path.is_file() {
+            return Ok(None);
+        }
+        let mut index = self.load_index().unwrap_or_default();
+        let key = cache_key(path_lower, revision);
+        let size = path.metadata()?.len();
+        let sequence = next_sequence(&mut index);
+        let record = index.entries.entry(key).or_insert_with(|| CacheRecord {
+            path_lower: path_lower.into(),
+            revision: revision.map(ToOwned::to_owned),
+            file_name: path.file_name().unwrap().to_string_lossy().into_owned(),
+            size_bytes: size,
+            last_access_sequence: sequence,
+            derived_metadata: None,
+        });
+        record.size_bytes = size;
+        record.last_access_sequence = sequence;
+        self.save_index(&index)?;
+        Ok(Some(path))
+    }
+
+    pub fn protect(&self, path_lower: &str, revision: Option<&str>) -> CacheLease {
+        let key = cache_key(path_lower, revision);
+        *self
+            .runtime
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .protected
+            .entry(key.clone())
+            .or_insert(0) += 1;
+        CacheLease {
+            key,
+            runtime: Arc::clone(&self.runtime),
+        }
+    }
+
     pub fn ensure_dir(&self) -> std::io::Result<()> {
         std::fs::create_dir_all(&self.root)
     }
 
-    /// Write `bytes` to the cache path for `(path_lower, rev)`.
+    /// Atomically commit a complete materialization, then enforce the budget.
     pub fn write(
         &self,
         path_lower: &str,
-        rev: Option<&str>,
+        revision: Option<&str>,
         bytes: &[u8],
     ) -> std::io::Result<PathBuf> {
         self.ensure_dir()?;
-        let target = self.path_for(path_lower, rev);
-        std::fs::write(&target, bytes)?;
+        let target = self.path_for(path_lower, revision);
+        let temporary = target.with_extension("materializing");
+        std::fs::write(&temporary, bytes)?;
+        std::fs::rename(&temporary, &target)?;
+
+        let mut index = self.load_index()?;
+        let sequence = next_sequence(&mut index);
+        let key = cache_key(path_lower, revision);
+        let previous_metadata = index
+            .entries
+            .get(&key)
+            .and_then(|record| record.derived_metadata.clone());
+        index.entries.insert(
+            key,
+            CacheRecord {
+                path_lower: path_lower.into(),
+                revision: revision.map(ToOwned::to_owned),
+                file_name: target.file_name().unwrap().to_string_lossy().into_owned(),
+                size_bytes: bytes.len() as u64,
+                last_access_sequence: sequence,
+                derived_metadata: previous_metadata,
+            },
+        );
+        self.save_index(&index)?;
+        self.enforce_budget()?;
         Ok(target)
+    }
+
+    pub fn store_derived_metadata(
+        &self,
+        path_lower: &str,
+        revision: Option<&str>,
+        metadata: DerivedMetadata,
+    ) -> std::io::Result<()> {
+        if metadata.provider_revision.as_deref() != revision {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Derived Metadata revision does not match the cache entry",
+            ));
+        }
+        let mut index = self.load_index()?;
+        let key = cache_key(path_lower, revision);
+        let record = index.entries.get_mut(&key).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "cache entry is missing")
+        })?;
+        record.derived_metadata = Some(metadata);
+        self.save_index(&index)
+    }
+
+    pub fn derived_metadata(
+        &self,
+        path_lower: &str,
+        revision: Option<&str>,
+    ) -> std::io::Result<Option<DerivedMetadata>> {
+        let index = self.load_index()?;
+        Ok(index
+            .entries
+            .get(&cache_key(path_lower, revision))
+            .and_then(|record| record.derived_metadata.clone())
+            .filter(|metadata| metadata.provider_revision.as_deref() == revision))
+    }
+
+    pub fn usage(&self) -> std::io::Result<CacheUsage> {
+        let index = self.load_index()?;
+        Ok(CacheUsage {
+            bytes: index.entries.values().map(|record| record.size_bytes).sum(),
+            entries: index.entries.len(),
+        })
+    }
+
+    pub fn clear(&self) -> std::io::Result<CacheClearReport> {
+        let protected = self
+            .runtime
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .protected
+            .clone();
+        let mut index = self.load_index().unwrap_or_default();
+        let mut report = CacheClearReport::default();
+        index.entries.retain(|key, record| {
+            if protected.contains_key(key) {
+                report.protected_entries += 1;
+                return true;
+            }
+            let path = self.root.join(&record.file_name);
+            match std::fs::remove_file(path) {
+                Ok(()) => {
+                    report.removed_entries += 1;
+                    report.removed_bytes += record.size_bytes;
+                    false
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+                Err(_) => true,
+            }
+        });
+        let retained_files: std::collections::HashSet<String> = index
+            .entries
+            .values()
+            .map(|record| record.file_name.clone())
+            .collect();
+        if let Ok(files) = std::fs::read_dir(&self.root) {
+            for file in files.flatten() {
+                let name = file.file_name().to_string_lossy().into_owned();
+                if name == INDEX_FILE || retained_files.contains(&name) {
+                    continue;
+                }
+                let size = file.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+                if file.file_type().is_ok_and(|kind| kind.is_file())
+                    && std::fs::remove_file(file.path()).is_ok()
+                {
+                    report.removed_entries += 1;
+                    report.removed_bytes += size;
+                }
+            }
+        }
+        self.save_index(&index)?;
+        Ok(report)
+    }
+
+    fn enforce_budget(&self) -> std::io::Result<CacheUsage> {
+        let runtime = self
+            .runtime
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let policy = runtime.policy;
+        let protected = runtime.protected.clone();
+        drop(runtime);
+        let mut index = self.load_index()?;
+        let mut usage: u64 = index.entries.values().map(|record| record.size_bytes).sum();
+        if policy.automatic_eviction && usage > policy.budget_bytes {
+            let mut candidates: Vec<(String, u64)> = index
+                .entries
+                .iter()
+                .filter(|(key, _)| !protected.contains_key(*key))
+                .map(|(key, record)| (key.clone(), record.last_access_sequence))
+                .collect();
+            candidates.sort_by_key(|(_, sequence)| *sequence);
+            for (key, _) in candidates {
+                if usage <= policy.budget_bytes {
+                    break;
+                }
+                if let Some(record) = index.entries.remove(&key) {
+                    let path = self.root.join(&record.file_name);
+                    match std::fs::remove_file(path) {
+                        Ok(()) => usage = usage.saturating_sub(record.size_bytes),
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                            usage = usage.saturating_sub(record.size_bytes);
+                        }
+                        Err(error) => {
+                            index.entries.insert(key, record);
+                            return Err(error);
+                        }
+                    }
+                }
+            }
+            self.save_index(&index)?;
+        }
+        Ok(CacheUsage {
+            bytes: usage,
+            entries: index.entries.len(),
+        })
+    }
+
+    fn load_index(&self) -> std::io::Result<CacheIndex> {
+        let path = self.root.join(INDEX_FILE);
+        match std::fs::read(path) {
+            Ok(bytes) => serde_json::from_slice(&bytes).map_err(std::io::Error::other),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(CacheIndex::default()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn save_index(&self, index: &CacheIndex) -> std::io::Result<()> {
+        self.ensure_dir()?;
+        let target = self.root.join(INDEX_FILE);
+        let temporary = self.root.join("index.json.partial");
+        std::fs::write(
+            &temporary,
+            serde_json::to_vec_pretty(index).map_err(std::io::Error::other)?,
+        )?;
+        std::fs::rename(temporary, target)
     }
 }
 
@@ -72,25 +422,34 @@ impl Default for DropboxCache {
     }
 }
 
-/// Turn a Dropbox `path_lower` like `/some/folder/kick 01.wav` into a
-/// deterministic, filesystem-safe key that is free of path separators
-/// and shell metacharacters.
-fn sanitize_path(path_lower: &str) -> String {
-    let mut out = String::with_capacity(path_lower.len());
-    for c in path_lower.chars() {
-        match c {
+fn next_sequence(index: &mut CacheIndex) -> u64 {
+    index.access_sequence = index.access_sequence.saturating_add(1);
+    index.access_sequence
+}
+
+fn cache_key(path_lower: &str, revision: Option<&str>) -> String {
+    format!(
+        "{}__{}",
+        sanitize_path(path_lower),
+        sanitize_path(revision.unwrap_or("norev"))
+    )
+}
+
+fn sanitize_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for character in path.chars() {
+        match character {
             '/' | '\\' => out.push('_'),
-            c if c.is_ascii_alphanumeric() => out.push(c),
-            '.' | '-' | '_' => out.push(c),
+            character if character.is_ascii_alphanumeric() => out.push(character),
+            '.' | '-' | '_' => out.push(character),
             _ => out.push('_'),
         }
     }
-    // Avoid leading underscore from root slash.
     out.trim_start_matches('_').to_string()
 }
 
 fn extension_of(path: &str) -> Option<&str> {
-    path.rsplit_once('.').map(|(_, ext)| ext)
+    path.rsplit_once('.').map(|(_, extension)| extension)
 }
 
 #[cfg(test)]
@@ -98,51 +457,143 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    #[test]
-    fn sanitizes_path_separators() {
-        let key = sanitize_path("/drums/kick 01.wav");
-        assert!(!key.contains('/'));
-        assert!(!key.contains(' '));
-        assert!(key.ends_with(".wav"));
+    fn cache(dir: &TempDir, budget_bytes: u64) -> DropboxCache {
+        DropboxCache::with_root_and_policy(
+            dir.path().to_path_buf(),
+            MediaCachePolicy {
+                budget_bytes,
+                automatic_eviction: true,
+            },
+        )
     }
 
     #[test]
-    fn lowercases_are_preserved() {
-        assert_eq!(sanitize_path("/a/B/c.wav"), "a_B_c.wav");
-    }
-
-    #[test]
-    fn different_revs_produce_different_paths() {
-        let cache = DropboxCache::with_root(PathBuf::from("/tmp/vibez-test"));
-        let p1 = cache.path_for("/kick.wav", Some("abc"));
-        let p2 = cache.path_for("/kick.wav", Some("def"));
-        assert_ne!(p1, p2);
-    }
-
-    #[test]
-    fn same_rev_produces_same_path() {
-        let cache = DropboxCache::with_root(PathBuf::from("/tmp/vibez-test"));
-        let p1 = cache.path_for("/kick.wav", Some("abc"));
-        let p2 = cache.path_for("/kick.wav", Some("abc"));
-        assert_eq!(p1, p2);
-    }
-
-    #[test]
-    fn write_round_trips() {
+    fn revision_changes_identity_and_invalidates_derived_metadata() {
         let dir = TempDir::new().unwrap();
-        let cache = DropboxCache::with_root(dir.path().to_path_buf());
-        let path = cache.write("/kick.wav", Some("abc"), b"hello").unwrap();
-        assert!(path.is_file());
-        assert!(cache.is_cached("/kick.wav", Some("abc")));
-        assert!(!cache.is_cached("/kick.wav", Some("different")));
-        let bytes = std::fs::read(path).unwrap();
-        assert_eq!(bytes, b"hello");
+        let cache = cache(&dir, 1_000);
+        cache.write("/kick.wav", Some("one"), b"first").unwrap();
+        cache
+            .store_derived_metadata(
+                "/kick.wav",
+                Some("one"),
+                DerivedMetadata {
+                    provider_revision: Some("one".into()),
+                    duration_seconds: 1.0,
+                    channels: 1,
+                    sample_rate: 44_100,
+                    ..DerivedMetadata::default()
+                },
+            )
+            .unwrap();
+        assert!(cache
+            .derived_metadata("/kick.wav", Some("one"))
+            .unwrap()
+            .is_some());
+        assert!(cache
+            .derived_metadata("/kick.wav", Some("two"))
+            .unwrap()
+            .is_none());
+        assert_ne!(
+            cache.path_for("/kick.wav", Some("one")),
+            cache.path_for("/kick.wav", Some("two"))
+        );
     }
 
     #[test]
-    fn no_extension_falls_back_to_bin() {
-        let cache = DropboxCache::with_root(PathBuf::from("/tmp"));
-        let path = cache.path_for("/data", Some("rev"));
-        assert!(path.to_string_lossy().ends_with(".bin"));
+    fn lru_eviction_is_deterministic_and_touch_updates_recency() {
+        let dir = TempDir::new().unwrap();
+        let cache = cache(&dir, 8);
+        cache.write("/one.wav", Some("1"), b"1111").unwrap();
+        cache.write("/two.wav", Some("1"), b"2222").unwrap();
+        cache.lookup("/one.wav", Some("1")).unwrap();
+        cache.write("/three.wav", Some("1"), b"3333").unwrap();
+        assert!(cache.is_cached("/one.wav", Some("1")));
+        assert!(!cache.is_cached("/two.wav", Some("1")));
+        assert!(cache.is_cached("/three.wav", Some("1")));
+    }
+
+    #[test]
+    fn protected_entries_survive_eviction_and_clear() {
+        let dir = TempDir::new().unwrap();
+        let cache = cache(&dir, 4);
+        let lease = cache.protect("/active.wav", Some("1"));
+        cache.write("/active.wav", Some("1"), b"active").unwrap();
+        cache.write("/other.wav", Some("1"), b"other").unwrap();
+        assert!(cache.is_cached("/active.wav", Some("1")));
+        let report = cache.clear().unwrap();
+        assert_eq!(report.protected_entries, 1);
+        assert!(cache.is_cached("/active.wav", Some("1")));
+        drop(lease);
+        let report = cache.clear().unwrap();
+        assert_eq!(report.removed_entries, 1);
+        assert!(!cache.is_cached("/active.wav", Some("1")));
+    }
+
+    #[test]
+    fn disabled_eviction_can_exceed_budget_and_reenable_repairs_usage() {
+        let dir = TempDir::new().unwrap();
+        let cache = DropboxCache::with_root_and_policy(
+            dir.path().to_path_buf(),
+            MediaCachePolicy {
+                budget_bytes: 4,
+                automatic_eviction: false,
+            },
+        );
+        cache.write("/one.wav", Some("1"), b"1111").unwrap();
+        cache.write("/two.wav", Some("1"), b"2222").unwrap();
+        assert_eq!(cache.usage().unwrap().bytes, 8);
+        let usage = cache
+            .set_policy(MediaCachePolicy {
+                budget_bytes: 4,
+                automatic_eviction: true,
+            })
+            .unwrap();
+        assert_eq!(usage.bytes, 4);
+        assert_eq!(usage.entries, 1);
+    }
+
+    #[test]
+    fn clear_removes_orphan_and_interrupted_materializations_but_not_the_index() {
+        let dir = TempDir::new().unwrap();
+        let cache_root = dir.path().join("media-cache");
+        let cache = DropboxCache::with_root_and_policy(
+            cache_root.clone(),
+            MediaCachePolicy {
+                budget_bytes: 1_000,
+                automatic_eviction: true,
+            },
+        );
+        let project_media = dir.path().join("project-media.wav");
+        let remote_catalog = dir.path().join("remote-catalog.json");
+        std::fs::write(&project_media, b"project-owned").unwrap();
+        std::fs::write(&remote_catalog, b"metadata").unwrap();
+        cache.write("/known.wav", Some("1"), b"known").unwrap();
+        std::fs::write(cache_root.join("orphan.wav"), b"orphan").unwrap();
+        std::fs::write(cache_root.join("stale.materializing"), b"partial").unwrap();
+        let report = cache.clear().unwrap();
+        assert_eq!(report.removed_entries, 3);
+        assert!(cache_root.join(INDEX_FILE).is_file());
+        assert!(!cache_root.join("orphan.wav").exists());
+        assert!(!cache_root.join("stale.materializing").exists());
+        assert_eq!(std::fs::read(project_media).unwrap(), b"project-owned");
+        assert_eq!(std::fs::read(remote_catalog).unwrap(), b"metadata");
+    }
+
+    #[test]
+    fn write_is_complete_and_usage_is_persisted_across_instances() {
+        let dir = TempDir::new().unwrap();
+        let first = cache(&dir, 1_000);
+        let path = first.write("/kick.wav", Some("abc"), b"hello").unwrap();
+        assert_eq!(std::fs::read(path).unwrap(), b"hello");
+        assert!(!dir.path().join("kick.wav__abc.materializing").exists());
+        let reopened = cache(&dir, 1_000);
+        assert_eq!(
+            reopened.usage().unwrap(),
+            CacheUsage {
+                bytes: 5,
+                entries: 1
+            }
+        );
+        assert!(reopened.lookup("/kick.wav", Some("abc")).unwrap().is_some());
     }
 }

--- a/crates/vibez-dropbox/src/lib.rs
+++ b/crates/vibez-dropbox/src/lib.rs
@@ -16,7 +16,10 @@ pub mod settings;
 pub mod types;
 
 pub use api::DropboxClient;
-pub use cache::DropboxCache;
+pub use cache::{
+    CacheClearReport, CacheLease, CacheUsage, DerivedMetadata, DropboxCache, MediaCachePolicy,
+    DEFAULT_MEDIA_CACHE_BUDGET_BYTES,
+};
 pub use oauth::{run_flow as run_oauth_flow, BrowserOpener, SystemBrowserOpener};
 pub use settings::{load_app_key_with_env_override, DropboxSettings};
 pub use types::{

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -8,6 +8,13 @@ use crate::message::{BrowserImportTarget, Message};
 
 use super::*;
 
+pub(super) const REMOTE_SELECTION_DEBOUNCE: std::time::Duration =
+    std::time::Duration::from_millis(200);
+
+fn queue_latest_remote_audition(slot: &mut Option<DropboxEntry>, entry: DropboxEntry) {
+    *slot = Some(entry);
+}
+
 impl App {
     pub(super) fn handle_connect_dropbox(&mut self) -> Task<Message> {
         let Some(app_key) = load_app_key_with_env_override(&self.dropbox_settings) else {
@@ -52,20 +59,107 @@ impl App {
         )
     }
 
+    pub(super) fn start_remote_audition(
+        &mut self,
+        entry: DropboxEntry,
+        debounce: bool,
+    ) -> Task<Message> {
+        let source = vibez_core::track::MediaSourceRef::DropboxFile {
+            path_lower: entry.path_lower.clone(),
+            display_path: entry.path_display.clone(),
+            rev: entry.rev.clone(),
+        };
+        self.state.browser.select_source(source.clone());
+        if self.remote_import_in_flight {
+            queue_latest_remote_audition(&mut self.pending_remote_audition, entry);
+            self.state.status_text = "Remote Audition queued behind active import".into();
+            return Task::none();
+        }
+        if let Some(handle) = self.remote_materialization_abort.take() {
+            handle.abort();
+        }
+        self.remote_audition_cache_lease = None;
+        let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
+        self.remote_materialization_request_id =
+            self.remote_materialization_request_id.saturating_add(1);
+        let request_id = self.remote_materialization_request_id;
+        let cached = self
+            .dropbox_cache
+            .is_cached(&entry.path_lower, entry.rev.as_deref());
+        if !cached && self.dropbox_client.is_none() {
+            self.state.browser.remote.preview_in_progress = false;
+            self.state.browser.remote.availability.insert(
+                entry.path_lower,
+                crate::state::RemoteAvailability::ReconnectRequired,
+            );
+            self.state.status_text =
+                "Reconnect Required · this Remote item is not in Media Cache".into();
+            self.state
+                .browser
+                .fail_waveform_load(&source, "Reconnect Required · uncached Remote media".into());
+            return Task::none();
+        }
+
+        if self.state.browser.audition_enabled {
+            self.state.browser.begin_audition_load(&source);
+        } else {
+            self.state.browser.begin_waveform_load(&source);
+        }
+        self.state.browser.remote.preview_in_progress = !cached;
+        self.state.browser.remote.availability.insert(
+            entry.path_lower.clone(),
+            if cached {
+                crate::state::RemoteAvailability::Cached
+            } else {
+                crate::state::RemoteAvailability::Fetching
+            },
+        );
+        self.state.status_text = if cached {
+            format!("Preparing cached Audition: {}", entry.name)
+        } else {
+            format!("Fetching Remote media: {}", entry.name)
+        };
+        let lease = self
+            .dropbox_cache
+            .protect(&entry.path_lower, entry.rev.as_deref());
+        let task = Task::perform(
+            materialize_remote_sample_async(
+                self.dropbox_client.clone(),
+                self.dropbox_cache.clone(),
+                entry,
+                lease,
+                debounce,
+            ),
+            move |result| Message::RemoteAuditionReady {
+                request_id,
+                source: source.clone(),
+                result,
+            },
+        );
+        let (task, handle) = task.abortable();
+        self.remote_materialization_abort = Some(handle);
+        task
+    }
+
     pub(super) fn handle_dropbox_import_to_arrangement(
         &mut self,
         entry: DropboxEntry,
     ) -> Task<Message> {
-        let Some(client) = self.dropbox_client.clone() else {
-            self.state.browser.remote.last_error = Some("Not connected to Dropbox".into());
-            return Task::none();
-        };
+        if let Some(handle) = self.remote_materialization_abort.take() {
+            handle.abort();
+            self.remote_materialization_request_id =
+                self.remote_materialization_request_id.saturating_add(1);
+        }
+        self.remote_audition_cache_lease = None;
+        let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
+        let client = self.dropbox_client.clone();
         let cache = self.dropbox_cache.clone();
         let target = BrowserImportTarget::ArrangementClip(self.state.arrangement.selected_track);
         let Some(treatment) = self.state.browser.audition_import_input() else {
             self.state.status_text = "Confirm source BPM before WARP import".into();
             return Task::none();
         };
+        self.remote_import_in_flight = true;
         self.state.status_text = format!("Importing {}...", entry.name);
         Task::perform(
             fetch_dropbox_sample_async(client, cache, entry),
@@ -79,10 +173,14 @@ impl App {
     }
 
     pub(super) fn handle_dropbox_import_to_device(&mut self, entry: DropboxEntry) -> Task<Message> {
-        let Some(client) = self.dropbox_client.clone() else {
-            self.state.browser.remote.last_error = Some("Not connected to Dropbox".into());
-            return Task::none();
-        };
+        if let Some(handle) = self.remote_materialization_abort.take() {
+            handle.abort();
+            self.remote_materialization_request_id =
+                self.remote_materialization_request_id.saturating_add(1);
+        }
+        self.remote_audition_cache_lease = None;
+        let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
+        let client = self.dropbox_client.clone();
         let Some(target) = self.selected_browser_device_target() else {
             self.state.status_text = "Select a Sampler or Drum Pad track first".into();
             return Task::none();
@@ -92,6 +190,7 @@ impl App {
             self.state.status_text = "Confirm source BPM before WARP import".into();
             return Task::none();
         };
+        self.remote_import_in_flight = true;
         self.state.status_text = format!("Importing {}...", entry.name);
         Task::perform(
             fetch_dropbox_sample_async(client, cache, entry),
@@ -102,5 +201,41 @@ impl App {
                 Err(err) => Message::BrowserSampleDecodeError(err),
             },
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(path: &str) -> DropboxEntry {
+        DropboxEntry {
+            path_lower: path.into(),
+            path_display: path.into(),
+            name: path.rsplit('/').next().unwrap().into(),
+            is_folder: false,
+            rev: Some("1".into()),
+            size: None,
+        }
+    }
+
+    #[test]
+    fn remote_selection_debounce_is_exactly_two_hundred_milliseconds() {
+        assert_eq!(
+            REMOTE_SELECTION_DEBOUNCE,
+            std::time::Duration::from_millis(200)
+        );
+    }
+
+    #[test]
+    fn import_priority_defers_audition_and_retains_only_latest_selection() {
+        let mut pending = None;
+        queue_latest_remote_audition(&mut pending, entry("/one.wav"));
+        queue_latest_remote_audition(&mut pending, entry("/two.wav"));
+        queue_latest_remote_audition(&mut pending, entry("/winner.wav"));
+        assert_eq!(
+            pending.as_ref().map(|entry| entry.path_lower.as_str()),
+            Some("/winner.wav")
+        );
     }
 }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -495,10 +495,14 @@ impl App {
                 display_path,
                 rev,
             } => {
-                let Some(client) = self.dropbox_client.clone() else {
-                    self.state.status_text = "Not connected to Dropbox for this drop".to_string();
-                    return Task::none();
-                };
+                if let Some(handle) = self.remote_materialization_abort.take() {
+                    handle.abort();
+                    self.remote_materialization_request_id =
+                        self.remote_materialization_request_id.saturating_add(1);
+                }
+                self.remote_audition_cache_lease = None;
+                let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
+                let client = self.dropbox_client.clone();
                 let cache = self.dropbox_cache.clone();
                 let name = display_path
                     .rsplit_once('/')
@@ -512,6 +516,7 @@ impl App {
                     rev,
                     size: None,
                 };
+                self.remote_import_in_flight = true;
                 self.state.status_text = format!("Dropping {name}...");
                 Task::perform(
                     fetch_dropbox_sample_async(client, cache, entry),

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -58,6 +58,11 @@ struct App {
     dropbox_settings: DropboxSettings,
     dropbox_cache: DropboxCache,
     dropbox_client: Option<Arc<DropboxClient>>,
+    remote_materialization_abort: Option<iced::task::Handle>,
+    remote_materialization_request_id: u64,
+    remote_audition_cache_lease: Option<vibez_dropbox::CacheLease>,
+    remote_import_in_flight: bool,
+    pending_remote_audition: Option<DropboxEntry>,
 
     // External MIDI input (USB keyboard, Ableton Push, virtual cable...).
     // Dropping the handle closes the port.
@@ -145,7 +150,11 @@ impl App {
         };
 
         let dropbox_settings = DropboxSettings::load();
-        let dropbox_cache = DropboxCache::new();
+        let dropbox_cache = DropboxCache::with_policy(vibez_dropbox::MediaCachePolicy {
+            budget_bytes: ui_settings.media_cache_budget_bytes,
+            automatic_eviction: ui_settings.media_cache_automatic_eviction,
+        });
+        let cache_usage = dropbox_cache.usage().unwrap_or_default();
         let resolved_key = load_app_key_with_env_override(&dropbox_settings);
         let dropbox_client = match (&resolved_key, &dropbox_settings.tokens) {
             (Some(key), Some(tokens)) => {
@@ -178,6 +187,10 @@ impl App {
             has_app_key: resolved_key.is_some(),
             catalog: remote_catalog,
             catalog_state: remote_catalog_state,
+            cache_usage_bytes: cache_usage.bytes,
+            cache_entries: cache_usage.entries,
+            cache_budget_bytes: ui_settings.media_cache_budget_bytes,
+            cache_automatic_eviction: ui_settings.media_cache_automatic_eviction,
             ..Default::default()
         };
 
@@ -257,6 +270,11 @@ impl App {
             dropbox_settings,
             dropbox_cache,
             dropbox_client,
+            remote_materialization_abort: None,
+            remote_materialization_request_id: 0,
+            remote_audition_cache_lease: None,
+            remote_import_in_flight: false,
+            pending_remote_audition: None,
             midi_input,
             midi_input_ports: Vec::new(),
         };
@@ -651,7 +669,7 @@ async fn connect_dropbox_async(
 }
 
 async fn fetch_dropbox_sample_async(
-    client: Arc<DropboxClient>,
+    client: Option<Arc<DropboxClient>>,
     cache: DropboxCache,
     entry: DropboxEntry,
 ) -> Result<
@@ -662,10 +680,24 @@ async fn fetch_dropbox_sample_async(
     ),
     String,
 > {
-    let local = client
-        .download_to_cache(&entry, &cache)
-        .await
-        .map_err(|e| e.to_string())?;
+    let _lease = cache.protect(&entry.path_lower, entry.rev.as_deref());
+    let local = match cache
+        .lookup(&entry.path_lower, entry.rev.as_deref())
+        .map_err(|error| format!("Media Cache lookup failed: {error}"))?
+    {
+        Some(path) => path,
+        None => {
+            let client = client.ok_or_else(|| {
+                "Reconnect Required · uncached Remote media cannot be imported".to_string()
+            })?;
+            let bytes = client.download(&entry.path_lower).await.map_err(|error| {
+                format!("Remote materialization failed for {}: {error}", entry.name)
+            })?;
+            cache
+                .write(&entry.path_lower, entry.rev.as_deref(), &bytes)
+                .map_err(|error| format!("Media Cache write failed: {error}"))?
+        }
+    };
     let decoded = tokio::task::spawn_blocking(move || {
         vibez_audio_io::file_io::decode_audio_file(&local).map_err(|e| e.to_string())
     })
@@ -677,6 +709,89 @@ async fn fetch_dropbox_sample_async(
         rev: entry.rev.clone(),
     };
     Ok((Arc::new(decoded), entry.name, source))
+}
+
+async fn materialize_remote_sample_async(
+    client: Option<Arc<DropboxClient>>,
+    cache: DropboxCache,
+    entry: DropboxEntry,
+    lease: vibez_dropbox::CacheLease,
+    debounce: bool,
+) -> Result<crate::message::RemoteMaterializedSample, String> {
+    if debounce
+        && cache
+            .lookup(&entry.path_lower, entry.rev.as_deref())
+            .map_err(|error| format!("Media Cache lookup failed: {error}"))?
+            .is_none()
+    {
+        tokio::time::sleep(dropbox_io::REMOTE_SELECTION_DEBOUNCE).await;
+    }
+
+    let local = match cache
+        .lookup(&entry.path_lower, entry.rev.as_deref())
+        .map_err(|error| format!("Media Cache lookup failed: {error}"))?
+    {
+        Some(path) => path,
+        None => {
+            let client = client.ok_or_else(|| {
+                "Reconnect Required · uncached Remote media cannot be materialized".to_string()
+            })?;
+            let bytes = client.download(&entry.path_lower).await.map_err(|error| {
+                format!("Remote materialization failed for {}: {error}", entry.name)
+            })?;
+            cache
+                .write(&entry.path_lower, entry.rev.as_deref(), &bytes)
+                .map_err(|error| format!("Media Cache write failed: {error}"))?
+        }
+    };
+
+    let revision = entry.rev.clone();
+    let (decoded, metadata) = tokio::task::spawn_blocking(move || {
+        let decoded = vibez_audio_io::file_io::decode_audio_file(&local)
+            .map_err(|error| error.to_string())?;
+        let estimate = vibez_core::onset::detect_bpm(&decoded, decoded.sample_rate);
+        let bucket_count = 64usize;
+        let frames_per_bucket = decoded.num_frames().max(1).div_ceil(bucket_count);
+        let waveform_peaks = (0..bucket_count)
+            .map(|bucket| {
+                let start = bucket * frames_per_bucket;
+                let end = (start + frames_per_bucket).min(decoded.num_frames());
+                (0..decoded.num_channels())
+                    .map(|channel| {
+                        let (min, max) = decoded.peak_in_range(channel, start, end);
+                        min.abs().max(max.abs())
+                    })
+                    .fold(0.0_f32, f32::max)
+            })
+            .collect();
+        let metadata = vibez_dropbox::DerivedMetadata {
+            provider_revision: revision,
+            duration_seconds: decoded.duration_seconds(),
+            channels: decoded.num_channels().try_into().unwrap_or(u16::MAX),
+            sample_rate: decoded.sample_rate,
+            bpm: estimate.map(|value| value.bpm),
+            bpm_confidence: estimate.map(|value| value.confidence),
+            waveform_peaks,
+        };
+        Ok::<_, String>((Arc::new(decoded), metadata))
+    })
+    .await
+    .map_err(|error| format!("decode task failed: {error}"))??;
+    cache
+        .store_derived_metadata(&entry.path_lower, entry.rev.as_deref(), metadata.clone())
+        .map_err(|error| format!("Derived Metadata save failed: {error}"))?;
+    let source = MediaSourceRef::DropboxFile {
+        path_lower: entry.path_lower,
+        display_path: entry.path_display,
+        rev: entry.rev,
+    };
+    Ok(crate::message::RemoteMaterializedSample {
+        audio: decoded,
+        name: entry.name,
+        source,
+        lease,
+        metadata,
+    })
 }
 
 async fn export_async(
@@ -1269,5 +1384,91 @@ mod project_format_v1_tests {
             Some(MediaSourceRef::ProjectMedia { .. })
         ));
         assert_eq!(loaded.project.tracks[0].id, track.id);
+    }
+
+    #[tokio::test]
+    async fn cached_remote_media_materializes_without_a_client_and_persists_metadata() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("source.wav");
+        let audio = DecodedAudio {
+            channels: vec![vec![0.0, 0.5, -0.5, 0.25]],
+            sample_rate: 44_100,
+        };
+        vibez_audio_io::file_io::write_wav_file(&source_path, &audio).unwrap();
+        let cache = DropboxCache::with_root(directory.path().join("media-cache"));
+        cache
+            .write(
+                "/megalodon/source.wav",
+                Some("rev-1"),
+                &std::fs::read(source_path).unwrap(),
+            )
+            .unwrap();
+        let entry = DropboxEntry {
+            path_lower: "/megalodon/source.wav".into(),
+            path_display: "/Megalodon/Source.wav".into(),
+            name: "Source.wav".into(),
+            is_folder: false,
+            rev: Some("rev-1".into()),
+            size: None,
+        };
+        let lease = cache.protect(&entry.path_lower, entry.rev.as_deref());
+        let materialized =
+            materialize_remote_sample_async(None, cache.clone(), entry, lease, false)
+                .await
+                .unwrap();
+        assert_eq!(materialized.audio.num_frames(), audio.num_frames());
+        assert_eq!(
+            materialized.metadata.provider_revision.as_deref(),
+            Some("rev-1")
+        );
+        assert_eq!(materialized.metadata.channels, 1);
+        assert_eq!(materialized.metadata.sample_rate, 44_100);
+        assert!(cache
+            .derived_metadata("/megalodon/source.wav", Some("rev-1"))
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn dropping_a_debounced_uncached_request_before_200ms_materializes_nothing() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = DropboxCache::with_root(directory.path().join("media-cache"));
+        let entry = DropboxEntry {
+            path_lower: "/megalodon/transient.wav".into(),
+            path_display: "/Megalodon/Transient.wav".into(),
+            name: "Transient.wav".into(),
+            is_folder: false,
+            rev: Some("rev-1".into()),
+            size: None,
+        };
+        let lease = cache.protect(&entry.path_lower, entry.rev.as_deref());
+        let future = materialize_remote_sample_async(None, cache.clone(), entry, lease, true);
+        tokio::pin!(future);
+        tokio::select! {
+            _ = tokio::time::sleep(std::time::Duration::from_millis(20)) => {}
+            result = &mut future => panic!("debounced request completed early: {result:?}"),
+        }
+        drop(future);
+        assert!(!cache.is_cached("/megalodon/transient.wav", Some("rev-1")));
+        assert_eq!(cache.usage().unwrap(), vibez_dropbox::CacheUsage::default());
+    }
+
+    #[tokio::test]
+    async fn uncached_degraded_materialization_requires_explicit_reconnect() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = DropboxCache::with_root(directory.path().join("media-cache"));
+        let entry = DropboxEntry {
+            path_lower: "/megalodon/uncached.wav".into(),
+            path_display: "/Megalodon/Uncached.wav".into(),
+            name: "Uncached.wav".into(),
+            is_folder: false,
+            rev: Some("rev-1".into()),
+            size: None,
+        };
+        let lease = cache.protect(&entry.path_lower, entry.rev.as_deref());
+        let error = materialize_remote_sample_async(None, cache, entry, lease, false)
+            .await
+            .unwrap_err();
+        assert!(error.contains("Reconnect Required"));
     }
 }

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -183,6 +183,13 @@ impl App {
     }
 
     pub(super) fn reset_to_new_project(&mut self) {
+        if let Some(handle) = self.remote_materialization_abort.take() {
+            handle.abort();
+            self.remote_materialization_request_id =
+                self.remote_materialization_request_id.saturating_add(1);
+        }
+        self.remote_audition_cache_lease = None;
+        let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
         self.clear_project_runtime();
         self.ensure_master_eq();
         self.state.transport.bpm = vibez_core::constants::DEFAULT_BPM;
@@ -206,6 +213,8 @@ impl App {
             warp_confidence_threshold: self.state.warp_confidence_threshold,
             preferred_midi_input: self.midi_input.as_ref().map(|h| h.port_name.clone()),
             theme: Some(self.state.current_theme_name.clone()),
+            media_cache_budget_bytes: self.state.browser.remote.cache_budget_bytes,
+            media_cache_automatic_eviction: self.state.browser.remote.cache_automatic_eviction,
         };
         if let Err(err) = settings.save() {
             self.state.status_text = format!("UI settings save error: {err}");

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -630,12 +630,27 @@ impl App {
                 }
             }
             Message::StopBrowserPreview => {
+                if let Some(handle) = self.remote_materialization_abort.take() {
+                    handle.abort();
+                    self.remote_materialization_request_id =
+                        self.remote_materialization_request_id.saturating_add(1);
+                }
+                self.remote_audition_cache_lease = None;
+                let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
+                self.state.browser.remote.preview_in_progress = false;
                 self.stop_browser_audition();
                 self.state.status_text = "Audition stopped".to_string();
             }
             Message::ToggleAuditionEnabled => {
                 let enabled = self.state.browser.toggle_audition_enabled();
                 if !enabled {
+                    if let Some(handle) = self.remote_materialization_abort.take() {
+                        handle.abort();
+                        self.remote_materialization_request_id =
+                            self.remote_materialization_request_id.saturating_add(1);
+                    }
+                    self.remote_audition_cache_lease = None;
+                    let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
                     self.stop_browser_audition();
                 }
                 self.persist_ui_settings();
@@ -858,7 +873,27 @@ impl App {
                 return self.handle_load_selected_browser_sample_to_device();
             }
             Message::BrowserSampleDecoded(target, treatment, audio, name, source) => {
-                return self.prepare_browser_sample_import(target, treatment, audio, name, source);
+                let was_remote_import = matches!(&source, MediaSourceRef::DropboxFile { .. });
+                if was_remote_import {
+                    let usage = self
+                        .dropbox_cache
+                        .set_policy(self.dropbox_cache.policy())
+                        .unwrap_or_default();
+                    self.state.browser.remote.cache_usage_bytes = usage.bytes;
+                    self.state.browser.remote.cache_entries = usage.entries;
+                    self.remote_import_in_flight = false;
+                }
+                let import =
+                    self.prepare_browser_sample_import(target, treatment, audio, name, source);
+                let pending_audition = if was_remote_import {
+                    self.pending_remote_audition
+                        .take()
+                        .map(|entry| self.start_remote_audition(entry, true))
+                        .unwrap_or_else(Task::none)
+                } else {
+                    Task::none()
+                };
+                return Task::batch([import, pending_audition]);
             }
             Message::BrowserImportPrepared { target, payload } => {
                 return self.apply_browser_import_prepared(target, payload);
@@ -881,6 +916,12 @@ impl App {
             }
             Message::BrowserSampleDecodeError(err) => {
                 self.state.status_text = format!("Browser import error: {err}");
+                if self.remote_import_in_flight {
+                    self.remote_import_in_flight = false;
+                    if let Some(entry) = self.pending_remote_audition.take() {
+                        return self.start_remote_audition(entry, true);
+                    }
+                }
             }
 
             // -- File menu --
@@ -1390,50 +1431,177 @@ impl App {
                     ),
                 };
             }
-            Message::DropboxPreview(entry) => {
-                let Some(client) = self.dropbox_client.clone() else {
-                    self.state.browser.remote.last_error = Some("Not connected to Dropbox".into());
+            Message::SetMediaCacheBudgetGiB(gib) => {
+                let gib = gib.clamp(1.0, 500.0);
+                let bytes = (gib as f64 * 1024.0 * 1024.0 * 1024.0) as u64;
+                self.state.browser.remote.cache_budget_bytes = bytes;
+                match self
+                    .dropbox_cache
+                    .set_policy(vibez_dropbox::MediaCachePolicy {
+                        budget_bytes: bytes,
+                        automatic_eviction: self.state.browser.remote.cache_automatic_eviction,
+                    }) {
+                    Ok(usage) => {
+                        self.state.browser.remote.cache_usage_bytes = usage.bytes;
+                        self.state.browser.remote.cache_entries = usage.entries;
+                        self.state.browser.remote.cache_error = None;
+                    }
+                    Err(error) => {
+                        self.state.browser.remote.cache_error = Some(error.to_string());
+                    }
+                }
+                self.persist_ui_settings();
+            }
+            Message::ToggleMediaCacheAutomaticEviction => {
+                let enabled = !self.state.browser.remote.cache_automatic_eviction;
+                self.state.browser.remote.cache_automatic_eviction = enabled;
+                match self
+                    .dropbox_cache
+                    .set_policy(vibez_dropbox::MediaCachePolicy {
+                        budget_bytes: self.state.browser.remote.cache_budget_bytes,
+                        automatic_eviction: enabled,
+                    }) {
+                    Ok(usage) => {
+                        self.state.browser.remote.cache_usage_bytes = usage.bytes;
+                        self.state.browser.remote.cache_entries = usage.entries;
+                        self.state.browser.remote.cache_error = None;
+                    }
+                    Err(error) => {
+                        self.state.browser.remote.cache_error = Some(error.to_string());
+                    }
+                }
+                self.persist_ui_settings();
+            }
+            Message::ClearMediaCache => match self.dropbox_cache.clear() {
+                Ok(report) => {
+                    let usage = self.dropbox_cache.usage().unwrap_or_default();
+                    self.state.browser.remote.cache_usage_bytes = usage.bytes;
+                    self.state.browser.remote.cache_entries = usage.entries;
+                    self.state.browser.remote.cache_error = None;
+                    self.state.status_text = format!(
+                        "Cleared {} Media Cache item(s); {} active item(s) protected",
+                        report.removed_entries, report.protected_entries
+                    );
+                }
+                Err(error) => {
+                    self.state.browser.remote.cache_error = Some(error.to_string());
+                    self.state.status_text = format!("Media Cache clear failed: {error}");
+                }
+            },
+            Message::ClickRemoteBrowserEntry(entry) => {
+                if self.state.browser.drag_source.is_some() {
+                    self.state.browser.cancel_media_drag();
+                    self.state.status_text = "Drag cancelled".into();
                     return Task::none();
-                };
+                }
                 let source = MediaSourceRef::DropboxFile {
-                    path_lower: entry.path_lower.clone(),
-                    display_path: entry.path_display.clone(),
-                    rev: entry.rev.clone(),
+                    path_lower: entry.provider_item_id.clone(),
+                    display_path: entry.path.clone(),
+                    rev: entry.revision.clone(),
                 };
-                self.state.browser.select_source(source.clone());
-                self.state.browser.begin_audition_load(&source);
-                let cache = self.dropbox_cache.clone();
-                self.state.browser.remote.preview_in_progress = true;
-                self.state.status_text = format!("Fetching preview: {}", entry.name);
-                return Task::perform(
-                    fetch_dropbox_sample_async(client, cache, entry),
-                    move |result| {
-                        Message::DropboxPreviewReady(
-                            source.clone(),
-                            result.map(|(audio, _, _)| audio),
-                        )
-                    },
-                );
-            }
-            Message::DropboxPreviewReady(source, Ok(audio)) => {
-                self.state.browser.remote.preview_in_progress = false;
-                if self
-                    .state
+                let changed = self.state.browser.selected_source.as_ref() != Some(&source);
+                self.state
                     .browser
-                    .install_audition(source.clone(), Arc::clone(&audio))
-                {
-                    return self.play_browser_mode(source, audio);
+                    .update(BrowserMsg::SelectRemoteEntry(entry.clone()));
+                if changed {
+                    return self.start_remote_audition(
+                        DropboxEntry {
+                            path_lower: entry.provider_item_id,
+                            path_display: entry.path,
+                            name: entry.name,
+                            is_folder: false,
+                            rev: entry.revision,
+                            size: entry.size,
+                        },
+                        true,
+                    );
                 }
             }
-            Message::DropboxPreviewReady(source, Err(err)) => {
-                self.state.browser.remote.preview_in_progress = false;
-                let is_current = self.state.browser.selected_source.as_ref() == Some(&source);
-                self.state.browser.fail_waveform_load(&source, err.clone());
-                self.state.browser.remote.last_error = Some(err.clone());
-                if is_current {
-                    self.stop_browser_audition();
-                    self.state.status_text = format!("Preview error: {err}");
+            Message::RemoteAuditionReady {
+                request_id,
+                source,
+                result,
+            } => {
+                if request_id != self.remote_materialization_request_id {
+                    return Task::none();
                 }
+                self.remote_materialization_abort = None;
+                self.state.browser.remote.preview_in_progress = false;
+                let path_lower = match &source {
+                    MediaSourceRef::DropboxFile { path_lower, .. } => path_lower.clone(),
+                    _ => return Task::none(),
+                };
+                match result {
+                    Ok(materialized) => {
+                        self.state
+                            .browser
+                            .remote
+                            .availability
+                            .insert(path_lower.clone(), crate::state::RemoteAvailability::Cached);
+                        if let Some(entry) = self
+                            .state
+                            .browser
+                            .remote
+                            .catalog
+                            .entries
+                            .iter_mut()
+                            .find(|entry| entry.provider_item_id == path_lower)
+                        {
+                            entry.derived_metadata = Some(materialized.metadata.clone());
+                        }
+                        if let Err(error) =
+                            crate::remote_provider::RemoteCatalogStore::for_dropbox()
+                                .save(&self.state.browser.remote.catalog)
+                        {
+                            self.state.browser.remote.cache_error = Some(error);
+                        }
+                        let usage = self.dropbox_cache.usage().unwrap_or_default();
+                        self.state.browser.remote.cache_usage_bytes = usage.bytes;
+                        self.state.browser.remote.cache_entries = usage.entries;
+                        self.remote_audition_cache_lease = Some(materialized.lease);
+                        if self.state.browser.selected_source.as_ref() != Some(&source) {
+                            return Task::none();
+                        }
+                        if self.state.browser.audition_enabled {
+                            if self
+                                .state
+                                .browser
+                                .install_audition(source.clone(), Arc::clone(&materialized.audio))
+                            {
+                                return self.play_browser_mode(source, materialized.audio);
+                            }
+                        } else {
+                            self.state
+                                .browser
+                                .install_waveform(source, materialized.audio);
+                            self.state.status_text =
+                                format!("Cached Remote media: {}", materialized.name);
+                        }
+                    }
+                    Err(error) => {
+                        let availability = if error.contains("Reconnect Required") {
+                            crate::state::RemoteAvailability::ReconnectRequired
+                        } else {
+                            crate::state::RemoteAvailability::Unavailable {
+                                error: error.clone(),
+                            }
+                        };
+                        self.state
+                            .browser
+                            .remote
+                            .availability
+                            .insert(path_lower, availability);
+                        self.state
+                            .browser
+                            .fail_waveform_load(&source, error.clone());
+                        self.state.browser.remote.last_error = Some(error.clone());
+                        self.stop_browser_audition();
+                        self.state.status_text = format!("Remote Audition unavailable: {error}");
+                    }
+                }
+            }
+            Message::DropboxPreview(entry) => {
+                return self.start_remote_audition(entry, false);
             }
             Message::DropboxImportToArrangement(entry) => {
                 return self.handle_dropbox_import_to_arrangement(entry);

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -1383,11 +1383,64 @@ impl App {
         for entry in results {
             let selected = remote.selected_path.as_deref() == Some(&entry.provider_item_id);
             let cell_color = if selected { th::text() } else { th::text_dim() };
-            let context = if entry.parent_path.is_empty() {
+            let mut context = if entry.parent_path.is_empty() {
                 remote.catalog.connection_name.clone()
             } else {
                 format!("{} · {}", remote.catalog.connection_name, entry.parent_path)
             };
+            let metadata = entry.derived_metadata.as_ref().filter(|metadata| {
+                metadata.provider_revision.as_deref() == entry.revision.as_deref()
+            });
+            if let Some(metadata) = metadata {
+                let channels = match metadata.channels {
+                    1 => "MONO".into(),
+                    2 => "STEREO".into(),
+                    channels => format!("{channels} CH"),
+                };
+                context = format!("{channels} · {} HZ · {context}", metadata.sample_rate);
+            }
+            let availability = if entry.is_folder {
+                crate::state::RemoteAvailability::RemoteOnly
+            } else {
+                match remote.availability.get(&entry.provider_item_id) {
+                    Some(crate::state::RemoteAvailability::Fetching) => {
+                        crate::state::RemoteAvailability::Fetching
+                    }
+                    Some(crate::state::RemoteAvailability::Unavailable { error }) => {
+                        crate::state::RemoteAvailability::Unavailable {
+                            error: error.clone(),
+                        }
+                    }
+                    _ if self
+                        .dropbox_cache
+                        .is_cached(&entry.provider_item_id, entry.revision.as_deref()) =>
+                    {
+                        crate::state::RemoteAvailability::Cached
+                    }
+                    _ if remote.connected => crate::state::RemoteAvailability::RemoteOnly,
+                    _ => crate::state::RemoteAvailability::ReconnectRequired,
+                }
+            };
+            let availability_color = match &availability {
+                crate::state::RemoteAvailability::Fetching => th::accent(),
+                crate::state::RemoteAvailability::ReconnectRequired
+                | crate::state::RemoteAvailability::Unavailable { .. } => th::danger(),
+                crate::state::RemoteAvailability::RemoteOnly
+                | crate::state::RemoteAvailability::Cached => cell_color,
+            };
+            if matches!(
+                availability,
+                crate::state::RemoteAvailability::ReconnectRequired
+            ) {
+                context = format!("RECONNECT REQUIRED · {context}");
+            }
+            let bpm = metadata
+                .and_then(|metadata| metadata.bpm)
+                .map(|bpm| format!("{bpm:.0}"))
+                .unwrap_or_else(|| "—".into());
+            let length = metadata
+                .map(|metadata| format_browser_duration(metadata.duration_seconds))
+                .unwrap_or_else(|| "—".into());
             let name_cell = column![
                 text(if entry.is_folder {
                     format!("› {}", entry.name)
@@ -1411,17 +1464,17 @@ impl App {
             let cells: Element<'_, Message> = if wide_columns {
                 row![
                     name_cell,
-                    text("—")
+                    text(bpm)
                         .size(10)
                         .color(cell_color)
                         .width(Length::Fixed(36.0)),
-                    text("—")
+                    text(length)
                         .size(10)
                         .color(cell_color)
                         .width(Length::Fixed(50.0)),
-                    text("REMOTE")
+                    text(availability.label())
                         .size(9)
-                        .color(cell_color)
+                        .color(availability_color)
                         .width(Length::Fixed(48.0))
                 ]
                 .spacing(4)
@@ -1430,9 +1483,9 @@ impl App {
             } else {
                 row![
                     name_cell,
-                    text("REMOTE")
+                    text(availability.label())
                         .size(9)
-                        .color(cell_color)
+                        .color(availability_color)
                         .width(Length::Fixed(42.0))
                 ]
                 .align_y(iced::Alignment::Center)
@@ -1443,7 +1496,7 @@ impl App {
                     entry.provider_item_id.clone(),
                 ))
             } else {
-                Message::Browser(BrowserMsg::SelectRemoteEntry((*entry).clone()))
+                Message::ClickRemoteBrowserEntry((*entry).clone())
             };
             let body = container(cells).padding([6, 8]).width(Length::Fill);
             let interactive: Element<'_, Message> = if entry.is_folder {
@@ -1771,7 +1824,10 @@ fn browser_place_button_style(active: bool, status: button::Status) -> button::S
     }
 }
 
-fn browser_utility_action_style(_theme: &Theme, status: button::Status) -> button::Style {
+pub(super) fn browser_utility_action_style(
+    _theme: &Theme,
+    status: button::Status,
+) -> button::Style {
     button::Style {
         background: matches!(status, button::Status::Hovered | button::Status::Pressed)
             .then(|| th::bg_hover().into()),

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -12,6 +12,7 @@ use crate::message::Message;
 use crate::state::SettingsTab;
 use crate::theme as th;
 
+use super::views_browser::browser_utility_action_style;
 use super::*;
 
 impl App {
@@ -616,6 +617,48 @@ impl App {
                 horizontal_space().width(Length::Shrink).into()
             };
 
+        let budget_gib =
+            self.state.browser.remote.cache_budget_bytes as f32 / (1024.0 * 1024.0 * 1024.0);
+        let cache_usage = text(format!(
+            "{} across {} item(s)",
+            format_settings_bytes(self.state.browser.remote.cache_usage_bytes),
+            self.state.browser.remote.cache_entries
+        ))
+        .size(11)
+        .color(th::text_dim());
+        let budget = slider(1.0..=500.0, budget_gib, Message::SetMediaCacheBudgetGiB)
+            .step(1.0)
+            .width(Length::Fill);
+        let eviction_enabled = self.state.browser.remote.cache_automatic_eviction;
+        let eviction = button(
+            text(if eviction_enabled {
+                "LRU EVICTION ON"
+            } else {
+                "LRU EVICTION OFF"
+            })
+            .size(10)
+            .color(if eviction_enabled {
+                th::accent()
+            } else {
+                th::text_dim()
+            }),
+        )
+        .on_press(Message::ToggleMediaCacheAutomaticEviction)
+        .padding([5, 8])
+        .style(browser_utility_action_style);
+        let clear = button(text("CLEAR CACHE").size(10).color(th::text_dim()))
+            .on_press(Message::ClearMediaCache)
+            .padding([5, 8])
+            .style(browser_utility_action_style);
+        let cache_error: Element<'_, Message> = self
+            .state
+            .browser
+            .remote
+            .cache_error
+            .as_ref()
+            .map(|error| text(error).size(10).color(th::danger()).into())
+            .unwrap_or_else(|| horizontal_space().width(Length::Shrink).into());
+
         column![
             title,
             hint,
@@ -625,6 +668,20 @@ impl App {
                 .spacing(8)
                 .align_y(iced::Alignment::Center),
             error_line,
+            text("MEDIA CACHE").size(10).color(th::text_muted()),
+            row![
+                cache_usage,
+                horizontal_space(),
+                text(format!("{budget_gib:.0} GiB budget"))
+                    .size(11)
+                    .color(th::text_dim())
+            ]
+            .align_y(iced::Alignment::Center),
+            budget,
+            row![eviction, clear]
+                .spacing(8)
+                .align_y(iced::Alignment::Center),
+            cache_error,
         ]
         .spacing(10)
         .into()
@@ -920,5 +977,18 @@ impl App {
         column![title, hint, list, divider(), save_row]
             .spacing(10)
             .into()
+    }
+}
+
+fn format_settings_bytes(bytes: u64) -> String {
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    const MIB: f64 = 1024.0 * 1024.0;
+    const KIB: f64 = 1024.0;
+    if bytes as f64 >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB)
+    } else if bytes as f64 >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB)
+    } else {
+        format!("{:.1} KiB", bytes as f64 / KIB)
     }
 }

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -679,6 +679,7 @@ mod tests {
             is_folder: false,
             revision: Some("rev-7".into()),
             size: Some(2048),
+            derived_metadata: None,
         }));
         assert_eq!(
             browser.selected_source,

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -89,6 +89,15 @@ pub struct DropboxConnectOutcome {
     pub tokens: DropboxTokens,
 }
 
+#[derive(Debug, Clone)]
+pub struct RemoteMaterializedSample {
+    pub audio: Arc<DecodedAudio>,
+    pub name: String,
+    pub source: MediaSourceRef,
+    pub lease: vibez_dropbox::CacheLease,
+    pub metadata: vibez_dropbox::DerivedMetadata,
+}
+
 /// Successful background result from `quantize_audio_clip_async`.
 #[derive(Debug, Clone)]
 pub struct AudioQuantizeSuccess {
@@ -436,8 +445,16 @@ pub enum Message {
     DisconnectDropbox,
     RefreshRemoteConnection,
     RemoteCatalogRefreshed(crate::remote_provider::RemoteRefreshResult),
+    SetMediaCacheBudgetGiB(f32),
+    ToggleMediaCacheAutomaticEviction,
+    ClearMediaCache,
+    ClickRemoteBrowserEntry(crate::remote_provider::RemoteCatalogEntry),
+    RemoteAuditionReady {
+        request_id: u64,
+        source: MediaSourceRef,
+        result: Result<RemoteMaterializedSample, String>,
+    },
     DropboxPreview(DropboxEntry),
-    DropboxPreviewReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
     DropboxImportToArrangement(DropboxEntry),
     DropboxImportToDevice(DropboxEntry),
 }

--- a/crates/vibez-ui/src/remote_provider.rs
+++ b/crates/vibez-ui/src/remote_provider.rs
@@ -11,13 +11,13 @@ use std::path::PathBuf;
 use std::pin::Pin;
 
 use serde::{Deserialize, Serialize};
-use vibez_dropbox::{DropboxClient, DropboxError, DropboxListItem};
+use vibez_dropbox::{DerivedMetadata, DropboxClient, DropboxError, DropboxListItem};
 
 pub const DROPBOX_PROVIDER_ID: &str = "dropbox";
 pub const DROPBOX_CONNECTION_ID: &str = "dropbox-primary";
 pub const DROPBOX_CONNECTION_NAME: &str = "Alex's Dropbox";
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RemoteCatalogEntry {
     pub provider_item_id: String,
     pub path: String,
@@ -26,6 +26,8 @@ pub struct RemoteCatalogEntry {
     pub is_folder: bool,
     pub revision: Option<String>,
     pub size: Option<u64>,
+    #[serde(default)]
+    pub derived_metadata: Option<DerivedMetadata>,
 }
 
 impl RemoteCatalogEntry {
@@ -41,7 +43,7 @@ impl RemoteCatalogEntry {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RemoteCatalogSnapshot {
     pub provider_id: String,
     pub connection_id: String,
@@ -62,13 +64,13 @@ impl Default for RemoteCatalogSnapshot {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RemoteChange {
-    Upsert(RemoteCatalogEntry),
+    Upsert(Box<RemoteCatalogEntry>),
     Delete { provider_item_id: String },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RemotePage {
     pub changes: Vec<RemoteChange>,
     pub checkpoint: String,
@@ -131,7 +133,7 @@ impl RemoteProvider for DropboxRemoteProvider {
                 .map(|item| match item {
                     DropboxListItem::Entry(entry) => {
                         let parent_path = parent_remote_path(&entry.path_lower);
-                        RemoteChange::Upsert(RemoteCatalogEntry {
+                        RemoteChange::Upsert(Box::new(RemoteCatalogEntry {
                             provider_item_id: entry.path_lower,
                             path: entry.path_display,
                             parent_path,
@@ -139,7 +141,8 @@ impl RemoteProvider for DropboxRemoteProvider {
                             is_folder: entry.is_folder,
                             revision: entry.rev,
                             size: entry.size,
-                        })
+                            derived_metadata: None,
+                        }))
                     }
                     DropboxListItem::Deleted { path_lower } => RemoteChange::Delete {
                         provider_item_id: path_lower,
@@ -232,7 +235,13 @@ pub fn reconcile_remote_catalog(
     for change in &result.changes {
         match change {
             RemoteChange::Upsert(entry) => {
-                entries.insert(entry.provider_item_id.clone(), entry.clone());
+                let entry = entry.as_ref();
+                let mut refreshed = entry.clone();
+                refreshed.derived_metadata = entries
+                    .get(&entry.provider_item_id)
+                    .filter(|current| current.revision == entry.revision)
+                    .and_then(|current| current.derived_metadata.clone());
+                entries.insert(entry.provider_item_id.clone(), refreshed);
             }
             RemoteChange::Delete { provider_item_id } => {
                 entries.remove(provider_item_id);
@@ -341,6 +350,7 @@ mod tests {
             is_folder: false,
             revision: Some("1".into()),
             size: Some(42),
+            derived_metadata: None,
         }
     }
 
@@ -349,12 +359,14 @@ mod tests {
         let provider = FakeProvider {
             pages: Mutex::new(VecDeque::from([
                 Ok(RemotePage {
-                    changes: vec![RemoteChange::Upsert(entry("/Megalodon/Kick.wav"))],
+                    changes: vec![RemoteChange::Upsert(Box::new(entry("/Megalodon/Kick.wav")))],
                     checkpoint: "page-1".into(),
                     has_more: true,
                 }),
                 Ok(RemotePage {
-                    changes: vec![RemoteChange::Upsert(entry("/Megalodon/Snare.wav"))],
+                    changes: vec![RemoteChange::Upsert(Box::new(entry(
+                        "/Megalodon/Snare.wav",
+                    )))],
                     checkpoint: "complete".into(),
                     has_more: false,
                 }),
@@ -372,7 +384,7 @@ mod tests {
         let provider = FakeProvider {
             pages: Mutex::new(VecDeque::from([
                 Ok(RemotePage {
-                    changes: vec![RemoteChange::Upsert(entry("/new.wav"))],
+                    changes: vec![RemoteChange::Upsert(Box::new(entry("/new.wav")))],
                     checkpoint: "unsafe".into(),
                     has_more: true,
                 }),
@@ -437,7 +449,7 @@ mod tests {
                 RemoteChange::Delete {
                     provider_item_id: "/old.wav".into(),
                 },
-                RemoteChange::Upsert(entry("/new.wav")),
+                RemoteChange::Upsert(Box::new(entry("/new.wav"))),
             ],
             checkpoint: Some("next".into()),
             error: None,
@@ -459,7 +471,10 @@ mod tests {
             &mut snapshot,
             &RemoteRefreshResult {
                 pages: 1,
-                changes: vec![RemoteChange::Upsert(first), RemoteChange::Upsert(second)],
+                changes: vec![
+                    RemoteChange::Upsert(Box::new(first)),
+                    RemoteChange::Upsert(Box::new(second)),
+                ],
                 checkpoint: Some("complete".into()),
                 error: None,
             },
@@ -469,6 +484,46 @@ mod tests {
             snapshot.entries[0].provider_item_id,
             snapshot.entries[1].provider_item_id
         );
+    }
+
+    #[test]
+    fn refresh_preserves_derived_metadata_only_for_the_same_provider_revision() {
+        let mut existing = entry("/Megalodon/Kick.wav");
+        existing.derived_metadata = Some(DerivedMetadata {
+            provider_revision: Some("1".into()),
+            duration_seconds: 2.0,
+            channels: 2,
+            sample_rate: 48_000,
+            ..DerivedMetadata::default()
+        });
+        let mut snapshot = RemoteCatalogSnapshot {
+            entries: vec![existing],
+            ..RemoteCatalogSnapshot::default()
+        };
+        let same_revision = entry("/Megalodon/Kick.wav");
+        reconcile_remote_catalog(
+            &mut snapshot,
+            &RemoteRefreshResult {
+                pages: 1,
+                changes: vec![RemoteChange::Upsert(Box::new(same_revision))],
+                checkpoint: Some("same".into()),
+                error: None,
+            },
+        );
+        assert!(snapshot.entries[0].derived_metadata.is_some());
+
+        let mut changed_revision = entry("/Megalodon/Kick.wav");
+        changed_revision.revision = Some("2".into());
+        reconcile_remote_catalog(
+            &mut snapshot,
+            &RemoteRefreshResult {
+                pages: 1,
+                changes: vec![RemoteChange::Upsert(Box::new(changed_revision))],
+                checkpoint: Some("changed".into()),
+                error: None,
+            },
+        );
+        assert!(snapshot.entries[0].derived_metadata.is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -886,6 +886,27 @@ pub enum RemoteCatalogState {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteAvailability {
+    RemoteOnly,
+    Cached,
+    Fetching,
+    ReconnectRequired,
+    Unavailable { error: String },
+}
+
+impl RemoteAvailability {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::RemoteOnly => "REMOTE",
+            Self::Cached => "CACHED",
+            Self::Fetching => "FETCH",
+            Self::ReconnectRequired => "RETRY",
+            Self::Unavailable { .. } => "ERROR",
+        }
+    }
+}
+
 impl RemoteCatalogState {
     pub fn label(&self) -> &'static str {
         match self {
@@ -932,7 +953,7 @@ mod remote_catalog_state_tests {
 
 /// Provider-neutral Browser state for Remote Connections. Dropbox V1 auth
 /// fields remain here because Dropbox is the sole shipped adapter.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct RemoteUiState {
     pub connected: bool,
     pub account_email: Option<String>,
@@ -953,6 +974,37 @@ pub struct RemoteUiState {
     pub selected_path: Option<String>,
     /// A preview fetch / playback is in flight.
     pub preview_in_progress: bool,
+    pub availability: HashMap<String, RemoteAvailability>,
+    pub cache_usage_bytes: u64,
+    pub cache_entries: usize,
+    pub cache_budget_bytes: u64,
+    pub cache_automatic_eviction: bool,
+    pub cache_error: Option<String>,
+}
+
+impl Default for RemoteUiState {
+    fn default() -> Self {
+        Self {
+            connected: false,
+            account_email: None,
+            app_key_input: String::new(),
+            has_app_key: false,
+            auth_in_progress: false,
+            last_error: None,
+            catalog: RemoteCatalogSnapshot::default(),
+            catalog_state: RemoteCatalogState::default(),
+            current_path: String::new(),
+            expanded: HashSet::new(),
+            selected_path: None,
+            preview_in_progress: false,
+            availability: HashMap::new(),
+            cache_usage_bytes: 0,
+            cache_entries: 0,
+            cache_budget_bytes: vibez_dropbox::DEFAULT_MEDIA_CACHE_BUDGET_BYTES,
+            cache_automatic_eviction: true,
+            cache_error: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -35,6 +35,10 @@ pub struct UiSettings {
     /// the default Charcoal.
     #[serde(default)]
     pub theme: Option<String>,
+    #[serde(default = "default_media_cache_budget_bytes")]
+    pub media_cache_budget_bytes: u64,
+    #[serde(default = "default_media_cache_automatic_eviction")]
+    pub media_cache_automatic_eviction: bool,
 }
 
 impl Default for UiSettings {
@@ -50,6 +54,8 @@ impl Default for UiSettings {
             warp_confidence_threshold: default_warp_confidence_threshold(),
             preferred_midi_input: None,
             theme: None,
+            media_cache_budget_bytes: default_media_cache_budget_bytes(),
+            media_cache_automatic_eviction: default_media_cache_automatic_eviction(),
         }
     }
 }
@@ -81,6 +87,14 @@ impl UiSettings {
 }
 
 fn default_sample_browser_open() -> bool {
+    true
+}
+
+fn default_media_cache_budget_bytes() -> u64 {
+    vibez_dropbox::DEFAULT_MEDIA_CACHE_BUDGET_BYTES
+}
+
+fn default_media_cache_automatic_eviction() -> bool {
     true
 }
 
@@ -148,6 +162,16 @@ mod tests {
         assert!(!loaded.audition_enabled);
         assert_eq!(loaded.audition_gain, 0.42);
         assert!(loaded.audition_loop);
+    }
+
+    #[test]
+    fn old_settings_receive_the_twenty_gib_media_cache_policy() {
+        let loaded: UiSettings = serde_json::from_str(r#"{"sample_library_roots":[]}"#).unwrap();
+        assert_eq!(
+            loaded.media_cache_budget_bytes,
+            vibez_dropbox::DEFAULT_MEDIA_CACHE_BUDGET_BYTES
+        );
+        assert!(loaded.media_cache_automatic_eviction);
     }
 
     #[test]


### PR DESCRIPTION
## Outcome
- materializes uncached Remote samples after a 200 ms latest-selection-wins debounce
- auditions cached media offline through the existing RAW/WARP bus and gives imports priority
- adds revision-bound derived metadata and a configurable protected 20 GiB LRU Media Cache
- exposes Fetching, Cached, Reconnect Required, usage, eviction, and scoped clear states

## Verification
- `cargo test -p vibez-dropbox` (19 passed)
- `cargo test -p vibez-ui --lib` (172 passed)
- `cargo clippy -p vibez-dropbox --lib -- -D warnings`
- `cargo clippy -p vibez-ui --lib -- -D warnings`
- native Xvfb smoke: cached offline audition, uncached reconnect state, and cache settings

## Chain
Depends on #61. This is a feature PR, not a release PR.