### PR TITLE
Browser Card 13: import Remote media as Project Media

### DIFF
--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -6,6 +6,41 @@ use crate::effect::EffectInfo;
 use crate::id::{ClipId, TrackId};
 use crate::midi::{InstrumentKind, TrackKind};
 
+/// Credential-free identity retained after external media becomes project-owned.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MediaProvenance {
+    Local {
+        source_path: PathBuf,
+    },
+    Remote {
+        provider: String,
+        connection_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        connection_name: Option<String>,
+        source_id: String,
+        source_path: String,
+        revision: Option<String>,
+    },
+}
+
+impl MediaProvenance {
+    pub fn display_label(&self) -> String {
+        match self {
+            Self::Local { source_path } => source_path.display().to_string(),
+            Self::Remote {
+                connection_id,
+                connection_name,
+                source_path,
+                ..
+            } => format!(
+                "{} · {source_path}",
+                connection_name.as_deref().unwrap_or(connection_id)
+            ),
+        }
+    }
+}
+
 /// Canonical reference to media outside the project file.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -21,10 +56,20 @@ pub enum MediaSourceRef {
         staging_path: PathBuf,
         source_path: PathBuf,
     },
+    /// Remote bytes copied out of disposable Media Cache into managed staging.
+    /// Provider identity is descriptive provenance, never a playback path.
+    StagedRemoteProjectMedia {
+        id: String,
+        file_name: String,
+        staging_path: PathBuf,
+        provenance: Box<MediaProvenance>,
+    },
     /// Playback-critical media embedded in a Project Format V1 container.
     ProjectMedia {
         id: String,
         file_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provenance: Option<Box<MediaProvenance>>,
     },
     DropboxFile {
         path_lower: String,
@@ -42,11 +87,21 @@ impl MediaSourceRef {
                 .map(|name| name.to_string_lossy().to_string())
                 .unwrap_or_else(|| path.display().to_string()),
             MediaSourceRef::StagedProjectMedia { file_name, .. }
+            | MediaSourceRef::StagedRemoteProjectMedia { file_name, .. }
             | MediaSourceRef::ProjectMedia { file_name, .. } => file_name.clone(),
             MediaSourceRef::DropboxFile { display_path, .. } => PathBuf::from(display_path)
                 .file_name()
                 .map(|name| name.to_string_lossy().to_string())
                 .unwrap_or_else(|| display_path.clone()),
+        }
+    }
+
+    pub fn provenance(&self) -> Option<&MediaProvenance> {
+        match self {
+            Self::StagedProjectMedia { .. } => None,
+            Self::StagedRemoteProjectMedia { provenance, .. } => Some(provenance.as_ref()),
+            Self::ProjectMedia { provenance, .. } => provenance.as_deref(),
+            Self::LocalFile { .. } | Self::DropboxFile { .. } => None,
         }
     }
 }

--- a/crates/vibez-project/src/bin/project-format-v1-proof.rs
+++ b/crates/vibez-project/src/bin/project-format-v1-proof.rs
@@ -60,6 +60,7 @@ fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
             provenance: Provenance::Remote {
                 provider: "dropbox".into(),
                 connection_id: "alex-dropbox".into(),
+                connection_name: Some("Alex's Dropbox".into()),
                 source_id: "id:proof-remote-vocal".into(),
                 source_path: "/Megalodon/Vocals/remote-vocal.wav".into(),
                 revision: Some("proof-rev-1".into()),

--- a/crates/vibez-project/src/project_format_v1.rs
+++ b/crates/vibez-project/src/project_format_v1.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Transaction};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use vibez_core::track::{InstrumentStateInfo, MediaSourceRef, TrackInfo};
+use vibez_core::track::{InstrumentStateInfo, MediaProvenance, MediaSourceRef, TrackInfo};
 
 use crate::Project;
 
@@ -46,6 +46,8 @@ pub enum Provenance {
     Remote {
         provider: String,
         connection_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        connection_name: Option<String>,
         source_id: String,
         source_path: String,
         revision: Option<String>,
@@ -112,6 +114,7 @@ pub enum ProjectFormatError {
     Sql(rusqlite::Error),
     Json(serde_json::Error),
     InvalidContainer(String),
+    InvalidProvenance(String),
     MissingMedia(String),
     ExistingDestination(PathBuf),
 }
@@ -125,6 +128,7 @@ impl std::fmt::Display for ProjectFormatError {
             Self::InvalidContainer(message) => {
                 write!(f, "invalid Project Format V1 container: {message}")
             }
+            Self::InvalidProvenance(message) => write!(f, "invalid media provenance: {message}"),
             Self::MissingMedia(id) => write!(f, "project media {id:?} was not found"),
             Self::ExistingDestination(path) => {
                 write!(f, "Save As destination already exists: {}", path.display())
@@ -395,6 +399,20 @@ pub fn stage_local_content(
     content: &[u8],
 ) -> Result<MediaSourceRef, ProjectFormatError> {
     let id = hex_sha256(content);
+    let staging_path = write_staging_copy(&id, file_name, content)?;
+    Ok(MediaSourceRef::StagedProjectMedia {
+        id,
+        file_name: file_name.to_string(),
+        staging_path,
+        source_path: source_path.to_path_buf(),
+    })
+}
+
+fn write_staging_copy(
+    id: &str,
+    file_name: &str,
+    content: &[u8],
+) -> Result<PathBuf, ProjectFormatError> {
     let root = std::env::var_os("XDG_CACHE_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(std::env::temp_dir)
@@ -421,11 +439,39 @@ pub fn stage_local_content(
         fs::write(&temporary, content)?;
         fs::rename(temporary, &staging_path)?;
     }
-    Ok(MediaSourceRef::StagedProjectMedia {
+    Ok(staging_path)
+}
+
+/// Copies a complete Remote materialization into project-owned staging while
+/// retaining only credential-free Source Location identity.
+pub fn stage_remote_file(
+    path: &Path,
+    file_name: &str,
+    provenance: MediaProvenance,
+) -> Result<MediaSourceRef, ProjectFormatError> {
+    let content = fs::read(path)?;
+    stage_remote_content(file_name, &content, provenance)
+}
+
+/// Stages Vibez-derived Remote bytes, used when a WARP device import bakes the
+/// heard treatment before the first project save.
+pub fn stage_remote_content(
+    file_name: &str,
+    content: &[u8],
+    provenance: MediaProvenance,
+) -> Result<MediaSourceRef, ProjectFormatError> {
+    if !matches!(provenance, MediaProvenance::Remote { .. }) {
+        return Err(ProjectFormatError::InvalidProvenance(
+            "Remote staging requires Remote provenance".into(),
+        ));
+    }
+    let id = hex_sha256(content);
+    let staging_path = write_staging_copy(&id, file_name, content)?;
+    Ok(MediaSourceRef::StagedRemoteProjectMedia {
         id,
         file_name: file_name.to_string(),
         staging_path,
-        source_path: source_path.to_path_buf(),
+        provenance: Box::new(provenance),
     })
 }
 
@@ -547,10 +593,21 @@ fn prepare_source(
                 source_path: source_path.clone(),
             },
         ),
+        MediaSourceRef::StagedRemoteProjectMedia {
+            file_name,
+            staging_path,
+            provenance,
+            ..
+        } => (
+            staging_path.clone(),
+            file_name.clone(),
+            project_provenance(provenance),
+        ),
         MediaSourceRef::ProjectMedia { .. } | MediaSourceRef::DropboxFile { .. } => return Ok(()),
     };
     let content = fs::read(&path)?;
     let id = hex_sha256(&content);
+    let retained_provenance = core_provenance(&provenance);
     if !staged_media.iter().any(|item| item.id == id) {
         staged_media.push(StagedMedia {
             id: id.clone(),
@@ -559,8 +616,58 @@ fn prepare_source(
             provenance,
         });
     }
-    *source = MediaSourceRef::ProjectMedia { id, file_name };
+    *source = MediaSourceRef::ProjectMedia {
+        id,
+        file_name,
+        provenance: Some(Box::new(retained_provenance)),
+    };
     Ok(())
+}
+
+fn project_provenance(provenance: &MediaProvenance) -> Provenance {
+    match provenance {
+        MediaProvenance::Local { source_path } => Provenance::Local {
+            source_path: source_path.clone(),
+        },
+        MediaProvenance::Remote {
+            provider,
+            connection_id,
+            connection_name,
+            source_id,
+            source_path,
+            revision,
+        } => Provenance::Remote {
+            provider: provider.clone(),
+            connection_id: connection_id.clone(),
+            connection_name: connection_name.clone(),
+            source_id: source_id.clone(),
+            source_path: source_path.clone(),
+            revision: revision.clone(),
+        },
+    }
+}
+
+fn core_provenance(provenance: &Provenance) -> MediaProvenance {
+    match provenance {
+        Provenance::Local { source_path } => MediaProvenance::Local {
+            source_path: source_path.clone(),
+        },
+        Provenance::Remote {
+            provider,
+            connection_id,
+            connection_name,
+            source_id,
+            source_path,
+            revision,
+        } => MediaProvenance::Remote {
+            provider: provider.clone(),
+            connection_id: connection_id.clone(),
+            connection_name: connection_name.clone(),
+            source_id: source_id.clone(),
+            source_path: source_path.clone(),
+            revision: revision.clone(),
+        },
+    }
 }
 
 /// Starts a real transaction, overwrites the document and a media row, then

--- a/crates/vibez-project/tests/project_format_v1.rs
+++ b/crates/vibez-project/tests/project_format_v1.rs
@@ -6,7 +6,8 @@ use vibez_core::id::ClipId;
 use vibez_core::track::{ClipInfo, MediaSourceRef, TrackInfo};
 use vibez_project::project_format_v1::{
     detect_project_format, hex_sha256, representative_document, save_project_v1, stage_local_file,
-    ProjectContainer, ProjectFileFormat, Provenance, StagedMedia, APPLICATION_ID, FORMAT_VERSION,
+    stage_remote_file, ProjectContainer, ProjectFileFormat, Provenance, StagedMedia,
+    APPLICATION_ID, FORMAT_VERSION,
 };
 use vibez_project::Project;
 
@@ -23,6 +24,7 @@ fn stage(path: PathBuf, id: &str, seed: u8) -> (StagedMedia, Vec<u8>) {
             provenance: Provenance::Remote {
                 provider: "dropbox".into(),
                 connection_id: "proof-connection".into(),
+                connection_name: None,
                 source_id: format!("id:{id}"),
                 source_path: format!("/Megalodon/{id}.wav"),
                 revision: Some("proof-rev".into()),
@@ -244,4 +246,75 @@ fn unsaved_project_uses_staged_copy_before_first_save() {
             .unwrap(),
         bytes
     );
+}
+
+#[test]
+fn remote_import_becomes_self_contained_project_media_with_safe_provenance() {
+    let directory = tempfile::tempdir().unwrap();
+    let materialized = directory.path().join("remote-cache.wav");
+    let project_path = directory.path().join("remote-owned.vzp");
+    let bytes = b"complete-remote-media".repeat(512);
+    fs::write(&materialized, &bytes).unwrap();
+    let staged = stage_remote_file(
+        &materialized,
+        "Kick.wav",
+        vibez_core::track::MediaProvenance::Remote {
+            provider: "dropbox".into(),
+            connection_id: "dropbox-primary".into(),
+            connection_name: Some("Alex's Dropbox".into()),
+            source_id: "id:megalodon-kick".into(),
+            source_path: "/Megalodon/Kick.wav".into(),
+            revision: Some("rev-7".into()),
+        },
+    )
+    .unwrap();
+    let MediaSourceRef::StagedRemoteProjectMedia { staging_path, .. } = &staged else {
+        panic!("Remote import must leave disposable cache for managed staging");
+    };
+    let staging_path = staging_path.clone();
+    fs::remove_file(&materialized).unwrap();
+
+    let saved = save_project_v1(&project_path, None, project_with_source(staged)).unwrap();
+    assert!(
+        !staging_path.exists(),
+        "transaction consumes Remote staging"
+    );
+    let MediaSourceRef::ProjectMedia {
+        id,
+        provenance: Some(provenance),
+        ..
+    } = saved.project.clips[0].source.as_ref().unwrap()
+    else {
+        panic!("saved Remote import must resolve only to Project Media");
+    };
+    assert_eq!(
+        ProjectContainer::open(&project_path)
+            .unwrap()
+            .read_media(id)
+            .unwrap(),
+        bytes
+    );
+    assert!(matches!(
+        provenance.as_ref(),
+        vibez_core::track::MediaProvenance::Remote {
+            provider,
+            connection_id,
+            source_path,
+            revision: Some(revision),
+            ..
+        } if provider == "dropbox"
+            && connection_id == "dropbox-primary"
+            && source_path == "/Megalodon/Kick.wav"
+            && revision == "rev-7"
+    ));
+
+    let document = ProjectContainer::open(project_path)
+        .unwrap()
+        .load_document()
+        .unwrap();
+    let json = serde_json::to_string(&document).unwrap();
+    assert!(json.contains("/Megalodon/Kick.wav"));
+    assert!(!json.contains("access_token"));
+    assert!(!json.contains("refresh_token"));
+    assert!(!json.contains("secret"));
 }

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -15,7 +15,58 @@ fn queue_latest_remote_audition(slot: &mut Option<DropboxEntry>, entry: DropboxE
     *slot = Some(entry);
 }
 
+pub(super) fn remote_import_result_is_current(current: u64, result: u64) -> bool {
+    current == result
+}
+
 impl App {
+    pub(super) fn start_remote_import(
+        &mut self,
+        entry: DropboxEntry,
+        target: BrowserImportTarget,
+        treatment: crate::state::AuditionImportInput,
+    ) -> Task<Message> {
+        if let Some(handle) = self.remote_import_abort.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.remote_materialization_abort.take() {
+            handle.abort();
+            self.remote_materialization_request_id =
+                self.remote_materialization_request_id.saturating_add(1);
+        }
+        self.remote_audition_cache_lease = None;
+        let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
+        self.remote_import_request_id = self.remote_import_request_id.saturating_add(1);
+        let request_id = self.remote_import_request_id;
+        self.remote_import_in_flight = true;
+        self.state.browser.remote.availability.insert(
+            entry.path_lower.clone(),
+            if self
+                .dropbox_cache
+                .is_cached(&entry.path_lower, entry.rev.as_deref())
+            {
+                crate::state::RemoteAvailability::Cached
+            } else {
+                crate::state::RemoteAvailability::Fetching
+            },
+        );
+        self.state.status_text = format!("Importing Remote media: {}", entry.name);
+        let client = self.dropbox_client.clone();
+        let cache = self.dropbox_cache.clone();
+        let task = Task::perform(
+            fetch_dropbox_sample_async(client, cache, entry),
+            move |result| Message::RemoteImportReady {
+                request_id,
+                target: target.clone(),
+                treatment,
+                result,
+            },
+        );
+        let (task, handle) = task.abortable();
+        self.remote_import_abort = Some(handle);
+        task
+    }
+
     pub(super) fn handle_connect_dropbox(&mut self) -> Task<Message> {
         let Some(app_key) = load_app_key_with_env_override(&self.dropbox_settings) else {
             self.state.browser.remote.last_error = Some(
@@ -145,62 +196,24 @@ impl App {
         &mut self,
         entry: DropboxEntry,
     ) -> Task<Message> {
-        if let Some(handle) = self.remote_materialization_abort.take() {
-            handle.abort();
-            self.remote_materialization_request_id =
-                self.remote_materialization_request_id.saturating_add(1);
-        }
-        self.remote_audition_cache_lease = None;
-        let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
-        let client = self.dropbox_client.clone();
-        let cache = self.dropbox_cache.clone();
         let target = BrowserImportTarget::ArrangementClip(self.state.arrangement.selected_track);
         let Some(treatment) = self.state.browser.audition_import_input() else {
             self.state.status_text = "Confirm source BPM before WARP import".into();
             return Task::none();
         };
-        self.remote_import_in_flight = true;
-        self.state.status_text = format!("Importing {}...", entry.name);
-        Task::perform(
-            fetch_dropbox_sample_async(client, cache, entry),
-            move |result| match result {
-                Ok((audio, name, source)) => {
-                    Message::BrowserSampleDecoded(target.clone(), treatment, audio, name, source)
-                }
-                Err(err) => Message::BrowserSampleDecodeError(err),
-            },
-        )
+        self.start_remote_import(entry, target, treatment)
     }
 
     pub(super) fn handle_dropbox_import_to_device(&mut self, entry: DropboxEntry) -> Task<Message> {
-        if let Some(handle) = self.remote_materialization_abort.take() {
-            handle.abort();
-            self.remote_materialization_request_id =
-                self.remote_materialization_request_id.saturating_add(1);
-        }
-        self.remote_audition_cache_lease = None;
-        let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
-        let client = self.dropbox_client.clone();
         let Some(target) = self.selected_browser_device_target() else {
             self.state.status_text = "Select a Sampler or Drum Pad track first".into();
             return Task::none();
         };
-        let cache = self.dropbox_cache.clone();
         let Some(treatment) = self.state.browser.audition_import_input() else {
             self.state.status_text = "Confirm source BPM before WARP import".into();
             return Task::none();
         };
-        self.remote_import_in_flight = true;
-        self.state.status_text = format!("Importing {}...", entry.name);
-        Task::perform(
-            fetch_dropbox_sample_async(client, cache, entry),
-            move |result| match result {
-                Ok((audio, name, source)) => {
-                    Message::BrowserSampleDecoded(target.clone(), treatment, audio, name, source)
-                }
-                Err(err) => Message::BrowserSampleDecodeError(err),
-            },
-        )
+        self.start_remote_import(entry, target, treatment)
     }
 }
 
@@ -237,5 +250,12 @@ mod tests {
             pending.as_ref().map(|entry| entry.path_lower.as_str()),
             Some("/winner.wav")
         );
+    }
+
+    #[test]
+    fn cancelled_or_superseded_remote_import_results_cannot_create_project_media() {
+        assert!(remote_import_result_is_current(7, 7));
+        assert!(!remote_import_result_is_current(8, 7));
+        assert!(!remote_import_result_is_current(9, 7));
     }
 }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -282,9 +282,15 @@ impl App {
                     source,
                     ..
                 } = payload;
+                let provenance = source.provenance().map(|value| value.display_label());
                 self.apply_sampler_sample_loaded(track_id, audio, name.clone(), source);
-                self.state.status_text =
-                    format!("Imported '{name}' to Sampler ({})", treatment.mode.label());
+                self.state.status_text = format!(
+                    "Imported '{name}' to Sampler ({}){}",
+                    treatment.mode.label(),
+                    provenance
+                        .map(|value| format!(" · source {value}"))
+                        .unwrap_or_default()
+                );
                 Task::none()
             }
             BrowserImportTarget::DrumRackPad {
@@ -298,11 +304,15 @@ impl App {
                     source,
                     ..
                 } = payload;
+                let provenance = source.provenance().map(|value| value.display_label());
                 self.apply_drum_rack_pad_loaded(track_id, pad_index, audio, name.clone(), source);
                 self.state.status_text = format!(
-                    "Imported '{name}' to Drum Rack pad {} ({})",
+                    "Imported '{name}' to Drum Rack pad {} ({}){}",
                     pad_index + 1,
-                    treatment.mode.label()
+                    treatment.mode.label(),
+                    provenance
+                        .map(|value| format!(" · source {value}"))
+                        .unwrap_or_default()
                 );
                 Task::none()
             }
@@ -322,6 +332,7 @@ impl App {
             name,
             source,
         } = payload;
+        let provenance = source.provenance().map(|value| value.display_label());
         // Guard: if the target is not an audio track, refuse rather than
         // silently redirecting the drop. Prevents the "clip lands on the
         // wrong lane" surprise.
@@ -384,8 +395,11 @@ impl App {
             0.0
         };
         self.state.status_text = format!(
-            "Imported '{name}' to {track_name} at beat {beat:.2} ({})",
-            treatment.mode.label()
+            "Imported '{name}' to {track_name} at beat {beat:.2} ({}){}",
+            treatment.mode.label(),
+            provenance
+                .map(|value| format!(" · source {value}"))
+                .unwrap_or_default()
         );
         Task::none()
     }
@@ -468,9 +482,44 @@ impl App {
                     },
                 )
             }
-            MediaSourceRef::ProjectMedia { id, file_name } => {
+            MediaSourceRef::StagedRemoteProjectMedia {
+                id,
+                file_name,
+                staging_path,
+                provenance,
+            } => {
                 let name = file_name.clone();
-                let retained_source = MediaSourceRef::ProjectMedia { id, file_name };
+                let retained_source = MediaSourceRef::StagedRemoteProjectMedia {
+                    id,
+                    file_name,
+                    staging_path: staging_path.clone(),
+                    provenance,
+                };
+                Task::perform(
+                    decode_file_async(staging_path),
+                    move |result| match result {
+                        Ok(audio) => Message::BrowserSampleDecoded(
+                            target.clone(),
+                            treatment,
+                            Arc::new(audio),
+                            name.clone(),
+                            retained_source.clone(),
+                        ),
+                        Err(err) => Message::BrowserSampleDecodeError(err),
+                    },
+                )
+            }
+            MediaSourceRef::ProjectMedia {
+                id,
+                file_name,
+                provenance,
+            } => {
+                let name = file_name.clone();
+                let retained_source = MediaSourceRef::ProjectMedia {
+                    id,
+                    file_name,
+                    provenance,
+                };
                 let container_path = self.state.project.current_path.clone();
                 Task::perform(
                     async move {
@@ -495,15 +544,6 @@ impl App {
                 display_path,
                 rev,
             } => {
-                if let Some(handle) = self.remote_materialization_abort.take() {
-                    handle.abort();
-                    self.remote_materialization_request_id =
-                        self.remote_materialization_request_id.saturating_add(1);
-                }
-                self.remote_audition_cache_lease = None;
-                let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
-                let client = self.dropbox_client.clone();
-                let cache = self.dropbox_cache.clone();
                 let name = display_path
                     .rsplit_once('/')
                     .map(|(_, n)| n.to_string())
@@ -516,21 +556,7 @@ impl App {
                     rev,
                     size: None,
                 };
-                self.remote_import_in_flight = true;
-                self.state.status_text = format!("Dropping {name}...");
-                Task::perform(
-                    fetch_dropbox_sample_async(client, cache, entry),
-                    move |result| match result {
-                        Ok((audio, decoded_name, source)) => Message::BrowserSampleDecoded(
-                            target.clone(),
-                            treatment,
-                            audio,
-                            decoded_name,
-                            source,
-                        ),
-                        Err(err) => Message::BrowserSampleDecodeError(err),
-                    },
-                )
+                self.start_remote_import(entry, target, treatment)
             }
         }
     }
@@ -992,7 +1018,8 @@ impl App {
     }
 
     pub(super) fn handle_import_selected_browser_sample_to_arrangement(&mut self) -> Task<Message> {
-        if let Some(entry) = self.selected_sample_browser_entry().cloned() {
+        if let Some(source) = self.state.browser.selected_source.clone() {
+            let name = source.display_name();
             let position_samples = self.state.transport.position_samples;
             let selected_audio = self.state.arrangement.selected_track.filter(|track_id| {
                 self.state
@@ -1006,14 +1033,14 @@ impl App {
                 },
                 None => BrowserImportTarget::ArrangementNewTrackAt { position_samples },
             };
-            self.state.status_text = format!("Importing {} at playhead...", entry.name);
-            return self.dispatch_drop_for_target(entry.source, target);
+            self.state.status_text = format!("Importing {name} at playhead...");
+            return self.dispatch_drop_for_target(source, target);
         }
         Task::none()
     }
 
     pub(super) fn handle_load_selected_browser_sample_to_device(&mut self) -> Task<Message> {
-        let Some(entry) = self.selected_sample_browser_entry().cloned() else {
+        let Some(source) = self.state.browser.selected_source.clone() else {
             return Task::none();
         };
         let Some(target) = self.selected_browser_device_target() else {
@@ -1021,7 +1048,7 @@ impl App {
                 "Select a sampler or drum rack track to load from the browser".to_string();
             return Task::none();
         };
-        self.state.status_text = format!("Loading {}...", entry.name);
-        self.dispatch_drop_for_target(entry.source, target)
+        self.state.status_text = format!("Loading {}...", source.display_name());
+        self.dispatch_drop_for_target(source, target)
     }
 }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -59,6 +59,8 @@ struct App {
     dropbox_cache: DropboxCache,
     dropbox_client: Option<Arc<DropboxClient>>,
     remote_materialization_abort: Option<iced::task::Handle>,
+    remote_import_abort: Option<iced::task::Handle>,
+    remote_import_request_id: u64,
     remote_materialization_request_id: u64,
     remote_audition_cache_lease: Option<vibez_dropbox::CacheLease>,
     remote_import_in_flight: bool,
@@ -271,6 +273,8 @@ impl App {
             dropbox_cache,
             dropbox_client,
             remote_materialization_abort: None,
+            remote_import_abort: None,
+            remote_import_request_id: 0,
             remote_materialization_request_id: 0,
             remote_audition_cache_lease: None,
             remote_import_in_flight: false,
@@ -572,21 +576,7 @@ async fn prepare_browser_import_audio_async(
 
     let rendered = Arc::clone(&success.audio);
     let staged = tokio::task::spawn_blocking(move || {
-        let (source_path, original_name) = match source {
-            MediaSourceRef::StagedProjectMedia {
-                source_path,
-                file_name,
-                ..
-            } => (source_path, file_name),
-            MediaSourceRef::LocalFile { path } => {
-                let file_name = path
-                    .file_name()
-                    .map(|name| name.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| "warped-import.wav".into());
-                (path, file_name)
-            }
-            _ => return Err("WARP device import requires materialized Local media".to_string()),
-        };
+        let original_name = source.display_name();
         let stem = std::path::Path::new(&original_name)
             .file_stem()
             .map(|stem| stem.to_string_lossy().into_owned())
@@ -605,8 +595,43 @@ async fn prepare_browser_import_audio_async(
             .map_err(|error| error.to_string())?;
         let content = std::fs::read(&temporary).map_err(|error| error.to_string())?;
         let _ = std::fs::remove_file(&temporary);
-        vibez_project::project_format_v1::stage_local_content(&source_path, &file_name, &content)
-            .map_err(|error| error.to_string())
+        match source {
+            MediaSourceRef::StagedProjectMedia { source_path, .. }
+            | MediaSourceRef::LocalFile { path: source_path } => {
+                vibez_project::project_format_v1::stage_local_content(
+                    &source_path,
+                    &file_name,
+                    &content,
+                )
+                .map_err(|error| error.to_string())
+            }
+            MediaSourceRef::StagedRemoteProjectMedia { provenance, .. } => match *provenance {
+                vibez_core::track::MediaProvenance::Remote {
+                    provider,
+                    connection_id,
+                    connection_name,
+                    source_id,
+                    source_path,
+                    revision,
+                } => vibez_project::project_format_v1::stage_remote_content(
+                    &file_name,
+                    &content,
+                    vibez_core::track::MediaProvenance::Remote {
+                        provider,
+                        connection_id,
+                        connection_name,
+                        source_id,
+                        source_path,
+                        revision,
+                    },
+                )
+                .map_err(|error| error.to_string()),
+                vibez_core::track::MediaProvenance::Local { .. } => {
+                    Err("Remote staging carried Local provenance".to_string())
+                }
+            },
+            _ => Err("WARP device import requires materialized Project Media".to_string()),
+        }
     })
     .await
     .map_err(|error| format!("WARP device staging task failed: {error}"))??;
@@ -698,16 +723,30 @@ async fn fetch_dropbox_sample_async(
                 .map_err(|error| format!("Media Cache write failed: {error}"))?
         }
     };
+    let decode_path = local.clone();
     let decoded = tokio::task::spawn_blocking(move || {
-        vibez_audio_io::file_io::decode_audio_file(&local).map_err(|e| e.to_string())
+        vibez_audio_io::file_io::decode_audio_file(&decode_path).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| format!("decode task failed: {e}"))??;
-    let source = MediaSourceRef::DropboxFile {
-        path_lower: entry.path_lower.clone(),
-        display_path: entry.path_display.clone(),
-        rev: entry.rev.clone(),
-    };
+    let staging_entry = entry.clone();
+    let source = tokio::task::spawn_blocking(move || {
+        vibez_project::project_format_v1::stage_remote_file(
+            &local,
+            &staging_entry.name,
+            vibez_core::track::MediaProvenance::Remote {
+                provider: crate::remote_provider::DROPBOX_PROVIDER_ID.into(),
+                connection_id: crate::remote_provider::DROPBOX_CONNECTION_ID.into(),
+                connection_name: Some(crate::remote_provider::DROPBOX_CONNECTION_NAME.into()),
+                source_id: staging_entry.path_lower,
+                source_path: staging_entry.path_display,
+                revision: staging_entry.rev,
+            },
+        )
+        .map_err(|error| format!("Remote Project Media staging failed: {error}"))
+    })
+    .await
+    .map_err(|error| format!("Remote Project Media staging task failed: {error}"))??;
     Ok((Arc::new(decoded), entry.name, source))
 }
 
@@ -997,8 +1036,11 @@ async fn hydrate_saved_source(
         MediaSourceRef::LocalFile { path }
         | MediaSourceRef::StagedProjectMedia {
             staging_path: path, ..
+        }
+        | MediaSourceRef::StagedRemoteProjectMedia {
+            staging_path: path, ..
         } => decode_blocking(path.clone()).await,
-        MediaSourceRef::ProjectMedia { id, file_name } => {
+        MediaSourceRef::ProjectMedia { id, file_name, .. } => {
             let container_path = container_path
                 .cloned()
                 .ok_or_else(|| format!("{label} has Project Media without a V1 container"))?;
@@ -1427,6 +1469,118 @@ mod project_format_v1_tests {
             .derived_metadata("/megalodon/source.wav", Some("rev-1"))
             .unwrap()
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn remote_warp_import_reopens_after_cache_clear_without_dropbox() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("remote-loop.wav");
+        let project_path = directory.path().join("remote-owned.vzp");
+        let raw = one_second_audio();
+        vibez_audio_io::file_io::write_wav_file(&source_path, &raw).unwrap();
+        let cache = DropboxCache::with_root(directory.path().join("media-cache"));
+        cache
+            .write(
+                "/megalodon/remote-loop.wav",
+                Some("rev-9"),
+                &std::fs::read(&source_path).unwrap(),
+            )
+            .unwrap();
+        let entry = DropboxEntry {
+            path_lower: "/megalodon/remote-loop.wav".into(),
+            path_display: "/Megalodon/Remote Loop.wav".into(),
+            name: "Remote Loop.wav".into(),
+            is_folder: false,
+            rev: Some("rev-9".into()),
+            size: None,
+        };
+        let (decoded, name, staged) = fetch_dropbox_sample_async(None, cache.clone(), entry)
+            .await
+            .unwrap();
+        assert!(matches!(
+            staged,
+            MediaSourceRef::StagedRemoteProjectMedia { .. }
+        ));
+        let treatment = crate::state::AuditionImportInput {
+            mode: crate::state::AuditionMode::Warp,
+            source_bpm: Some(120.0),
+        };
+        let (warped, original, staged) = prepare_browser_import_audio_async(
+            crate::message::BrowserImportTarget::ArrangementNewTrackAt {
+                position_samples: 0,
+            },
+            treatment,
+            decoded,
+            staged,
+            60.0,
+        )
+        .await
+        .unwrap();
+        assert_eq!(warped.num_frames(), 88_200);
+        assert_eq!(original.unwrap().num_frames(), raw.num_frames());
+
+        cache.clear().unwrap();
+        std::fs::remove_file(source_path).unwrap();
+        let track = TrackInfo::new("Audio");
+        let project = Project {
+            tracks: vec![track.clone()],
+            clips: vec![ClipInfo {
+                id: ClipId::new(),
+                track_id: track.id,
+                name,
+                position: 0,
+                source_offset: 0,
+                duration: warped.num_frames() as u64,
+                source: Some(staged),
+                file_path: None,
+                loop_enabled: false,
+                loop_start: 0,
+                loop_end: 0,
+                original_bpm: Some(120.0),
+                warped: true,
+                warped_to_bpm: Some(60.0),
+            }],
+            ..Project::default()
+        };
+        vibez_project::project_format_v1::save_project_v1(&project_path, None, project).unwrap();
+
+        let reopened = load_project_async(project_path.clone(), None)
+            .await
+            .unwrap();
+        assert_eq!(reopened.clips[0].audio.num_frames(), warped.num_frames());
+        assert_audible(Arc::clone(&reopened.clips[0].audio), "Remote WARP reopen");
+        let Some(MediaSourceRef::ProjectMedia {
+            provenance: Some(provenance),
+            ..
+        }) = reopened.project.clips[0].source.as_ref()
+        else {
+            panic!("reopened clip must carry Remote provenance on Project Media");
+        };
+        let vibez_core::track::MediaProvenance::Remote {
+            provider,
+            connection_id,
+            connection_name,
+            source_path,
+            revision,
+            ..
+        } = provenance.as_ref()
+        else {
+            panic!("reopened clip provenance must remain Remote");
+        };
+        assert_eq!(provider, "dropbox");
+        assert_eq!(connection_id, "dropbox-primary");
+        assert_eq!(connection_name.as_deref(), Some("Alex's Dropbox"));
+        assert_eq!(source_path, "/Megalodon/Remote Loop.wav");
+        assert_eq!(revision.as_deref(), Some("rev-9"));
+        let serialized = serde_json::to_string(
+            &vibez_project::project_format_v1::ProjectContainer::open(project_path)
+                .unwrap()
+                .load_document()
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(!serialized.contains("access_token"));
+        assert!(!serialized.contains("refresh_token"));
     }
 
     #[tokio::test]

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -183,6 +183,11 @@ impl App {
     }
 
     pub(super) fn reset_to_new_project(&mut self) {
+        if let Some(handle) = self.remote_import_abort.take() {
+            handle.abort();
+            self.remote_import_request_id = self.remote_import_request_id.saturating_add(1);
+            self.remote_import_in_flight = false;
+        }
         if let Some(handle) = self.remote_materialization_abort.take() {
             handle.abort();
             self.remote_materialization_request_id =
@@ -322,6 +327,7 @@ impl App {
                     file_path: clip.source.as_ref().and_then(|source| match source {
                         MediaSourceRef::LocalFile { path } => Some(path.clone()),
                         MediaSourceRef::StagedProjectMedia { .. }
+                        | MediaSourceRef::StagedRemoteProjectMedia { .. }
                         | MediaSourceRef::ProjectMedia { .. }
                         | MediaSourceRef::DropboxFile { .. } => None,
                     }),
@@ -410,6 +416,7 @@ impl App {
     }
 
     pub(super) fn rebuild_from_loaded_project(&mut self, loaded: ProjectLoadResult) {
+        let remote_provenance = first_remote_provenance_label(&loaded.project);
         self.clear_project_runtime();
 
         // Seed the global id counter past every persisted id BEFORE
@@ -791,11 +798,14 @@ impl App {
             self.state.arrangement.tracks.first().map(|track| track.id);
         self.state.project.current_path = Some(loaded.path.clone());
         self.state.project.dirty = false;
+        let provenance_suffix = remote_provenance
+            .map(|label| format!(" · Remote source {label}"))
+            .unwrap_or_default();
         self.state.status_text = if loaded.warnings.is_empty() {
-            format!("Opened {}", loaded.path.display())
+            format!("Opened {}{provenance_suffix}", loaded.path.display())
         } else {
             format!(
-                "Opened {} with {} warning(s)",
+                "Opened {} with {} warning(s){provenance_suffix}",
                 loaded.path.display(),
                 loaded.warnings.len()
             )
@@ -1138,4 +1148,27 @@ impl App {
         self.state.status_text = format!("Exporting to {}...", path.display());
         Task::perform(export_async(request, path), Message::ExportComplete)
     }
+}
+
+fn first_remote_provenance_label(project: &Project) -> Option<String> {
+    let track_sources = project.tracks.iter().flat_map(|track| {
+        let sampler = match &track.native_instrument {
+            Some(InstrumentStateInfo::Sampler { source, .. }) => source.iter().collect::<Vec<_>>(),
+            Some(InstrumentStateInfo::DrumRack { pads }) => {
+                pads.iter().filter_map(|pad| pad.source.as_ref()).collect()
+            }
+            _ => Vec::new(),
+        };
+        sampler
+    });
+    project
+        .clips
+        .iter()
+        .filter_map(|clip| clip.source.as_ref())
+        .chain(track_sources)
+        .filter_map(MediaSourceRef::provenance)
+        .find_map(|provenance| match provenance {
+            vibez_core::track::MediaProvenance::Remote { .. } => Some(provenance.display_label()),
+            vibez_core::track::MediaProvenance::Local { .. } => None,
+        })
 }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -745,6 +745,18 @@ impl App {
                 {
                     self.stop_browser_audition();
                     self.state.status_text = "Audition stopped".into();
+                } else if self.remote_import_in_flight {
+                    if let Some(handle) = self.remote_import_abort.take() {
+                        handle.abort();
+                    }
+                    self.remote_import_request_id = self.remote_import_request_id.saturating_add(1);
+                    self.remote_import_in_flight = false;
+                    let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
+                    self.state.status_text =
+                        "Remote import cancelled; no project media added".into();
+                    if let Some(entry) = self.pending_remote_audition.take() {
+                        return self.start_remote_audition(entry, true);
+                    }
                 } else if self.state.browser.drag_source.is_some()
                     || self.state.browser.pending_drag.is_some()
                 {
@@ -873,7 +885,11 @@ impl App {
                 return self.handle_load_selected_browser_sample_to_device();
             }
             Message::BrowserSampleDecoded(target, treatment, audio, name, source) => {
-                let was_remote_import = matches!(&source, MediaSourceRef::DropboxFile { .. });
+                let was_remote_import = matches!(
+                    &source,
+                    MediaSourceRef::DropboxFile { .. }
+                        | MediaSourceRef::StagedRemoteProjectMedia { .. }
+                );
                 if was_remote_import {
                     let usage = self
                         .dropbox_cache
@@ -894,6 +910,34 @@ impl App {
                     Task::none()
                 };
                 return Task::batch([import, pending_audition]);
+            }
+            Message::RemoteImportReady {
+                request_id,
+                target,
+                treatment,
+                result,
+            } => {
+                if !dropbox_io::remote_import_result_is_current(
+                    self.remote_import_request_id,
+                    request_id,
+                ) {
+                    if let Ok((
+                        _,
+                        _,
+                        MediaSourceRef::StagedRemoteProjectMedia { staging_path, .. },
+                    )) = result
+                    {
+                        let _ = std::fs::remove_file(staging_path);
+                    }
+                    return Task::none();
+                }
+                self.remote_import_abort = None;
+                return match result {
+                    Ok((audio, name, source)) => self.update(Message::BrowserSampleDecoded(
+                        target, treatment, audio, name, source,
+                    )),
+                    Err(error) => self.update(Message::BrowserSampleDecodeError(error)),
+                };
             }
             Message::BrowserImportPrepared { target, payload } => {
                 return self.apply_browser_import_prepared(target, payload);
@@ -917,7 +961,9 @@ impl App {
             Message::BrowserSampleDecodeError(err) => {
                 self.state.status_text = format!("Browser import error: {err}");
                 if self.remote_import_in_flight {
+                    self.remote_import_abort = None;
                     self.remote_import_in_flight = false;
+                    let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
                     if let Some(entry) = self.pending_remote_audition.take() {
                         return self.start_remote_audition(entry, true);
                     }

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -454,6 +454,12 @@ pub enum Message {
         source: MediaSourceRef,
         result: Result<RemoteMaterializedSample, String>,
     },
+    RemoteImportReady {
+        request_id: u64,
+        target: BrowserImportTarget,
+        treatment: AuditionImportInput,
+        result: Result<(Arc<DecodedAudio>, String, MediaSourceRef), String>,
+    },
     DropboxPreview(DropboxEntry),
     DropboxImportToArrangement(DropboxEntry),
     DropboxImportToDevice(DropboxEntry),


### PR DESCRIPTION
## Outcome
- routes Remote Enter and Media Drag through the same provider-neutral import targets as Local
- copies complete Remote bytes out of disposable cache into managed Staged Media before project mutation
- embeds staged bytes transactionally as Project Media and reopens without cache, source, network, or Dropbox auth
- retains credential-free provider/connection/path/revision provenance and displays it after import/reopen
- adds abortable, generation-checked Remote imports with progress and recoverable errors

## Verification
- `cargo test -p vibez-project` (14 unit + 6 integration passed)
- `cargo test -p vibez-ui --lib` (174 passed)
- strict Clippy passed for project and UI libraries/tests
- native Xvfb smoke imported cached Dropbox Kick with Enter into a new audio track and displayed Remote provenance

## Chain
Depends on #62. This is a feature PR, not a release PR.