### PR TITLE
Browser Card 14: validate and polish foundation

### DIFF
--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -2,7 +2,7 @@
 
 use iced::Task;
 
-use vibez_dropbox::{load_app_key_with_env_override, DropboxEntry};
+use vibez_dropbox::{load_app_key_with_env_override, DropboxClient, DropboxEntry};
 
 use crate::message::{BrowserImportTarget, Message};
 
@@ -10,6 +10,7 @@ use super::*;
 
 pub(super) const REMOTE_SELECTION_DEBOUNCE: std::time::Duration =
     std::time::Duration::from_millis(200);
+pub(super) const REMOTE_CATALOG_SAVE_PAGE_INTERVAL: usize = 10;
 
 fn queue_latest_remote_audition(slot: &mut Option<DropboxEntry>, entry: DropboxEntry) {
     *slot = Some(entry);
@@ -17,6 +18,24 @@ fn queue_latest_remote_audition(slot: &mut Option<DropboxEntry>, entry: DropboxE
 
 pub(super) fn remote_import_result_is_current(current: u64, result: u64) -> bool {
     current == result
+}
+
+pub(super) fn remote_catalog_page_task(
+    client: Arc<DropboxClient>,
+    checkpoint: Option<String>,
+    completed_pages: usize,
+) -> Task<Message> {
+    Task::perform(
+        async move {
+            let provider = crate::remote_provider::DropboxRemoteProvider::new((*client).clone());
+            crate::remote_provider::fetch_remote_catalog_page(&provider, checkpoint.as_deref())
+                .await
+        },
+        move |result| Message::RemoteCatalogPageFetched {
+            completed_pages,
+            result,
+        },
+    )
 }
 
 impl App {
@@ -90,6 +109,9 @@ impl App {
     }
 
     pub(super) fn handle_remote_catalog_refresh(&mut self) -> Task<Message> {
+        if self.state.browser.remote.catalog_state == crate::state::RemoteCatalogState::Refreshing {
+            return Task::none();
+        }
         let Some(client) = self.dropbox_client.clone() else {
             self.state.browser.remote.catalog_state =
                 crate::state::RemoteCatalogState::AuthenticationRequired {
@@ -98,16 +120,11 @@ impl App {
             return Task::none();
         };
         self.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Refreshing;
+        self.state.browser.remote.refresh_pages = 0;
+        self.state.browser.remote.refresh_items = self.state.browser.remote.catalog.entries.len();
+        self.state.status_text = "Refreshing Remote catalog…".into();
         let checkpoint = self.state.browser.remote.catalog.checkpoint.clone();
-        Task::perform(
-            async move {
-                let provider =
-                    crate::remote_provider::DropboxRemoteProvider::new((*client).clone());
-                crate::remote_provider::refresh_remote_catalog(&provider, checkpoint.as_deref())
-                    .await
-            },
-            Message::RemoteCatalogRefreshed,
-        )
+        remote_catalog_page_task(client, checkpoint, 0)
     }
 
     pub(super) fn start_remote_audition(

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -36,6 +36,20 @@ pub(crate) fn global_key_handler(
         return Some(Message::EscapePressed);
     }
 
+    // Plain Up/Down moves the Active Source Entry through Browser Results.
+    // Text inputs consume these before the global ignored-event subscription.
+    if modifiers.is_empty() {
+        match key {
+            iced::keyboard::Key::Named(Named::ArrowUp) => {
+                return Some(Message::SelectAdjacentBrowserResult(-1));
+            }
+            iced::keyboard::Key::Named(Named::ArrowDown) => {
+                return Some(Message::SelectAdjacentBrowserResult(1));
+            }
+            _ => {}
+        }
+    }
+
     // Enter: the focused Browser selection always means Arrangement Import.
     // Text inputs capture Enter before this global ignored-event subscription.
     if !modifiers.control()
@@ -212,6 +226,24 @@ mod tests {
             Some(Message::ImportSelectedBrowserSampleToArrangement)
         ));
         assert!(global_key_handler(Key::Named(Named::Enter), Modifiers::SHIFT).is_none());
+    }
+
+    #[test]
+    fn plain_arrows_navigate_browser_results_without_stealing_track_reorder() {
+        use iced::keyboard::{key::Named, Key, Modifiers};
+
+        assert!(matches!(
+            global_key_handler(Key::Named(Named::ArrowUp), Modifiers::empty()),
+            Some(Message::SelectAdjacentBrowserResult(-1))
+        ));
+        assert!(matches!(
+            global_key_handler(Key::Named(Named::ArrowDown), Modifiers::empty()),
+            Some(Message::SelectAdjacentBrowserResult(1))
+        ));
+        assert!(matches!(
+            global_key_handler(Key::Named(Named::ArrowUp), Modifiers::CTRL),
+            Some(Message::Arrangement(ArrangementMsg::MoveSelectedTrackUp))
+        ));
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -17,7 +17,176 @@ use crate::state::{AuditionMode, SampleBrowserEntry, UiClip, UiDrumPad, UiTrack}
 
 use super::*;
 
+fn adjacent_result_index(length: usize, current: Option<usize>, direction: i8) -> Option<usize> {
+    if length == 0 || direction == 0 {
+        return None;
+    }
+    Some(if direction < 0 {
+        current.unwrap_or(length).saturating_sub(1)
+    } else {
+        current
+            .map(|index| (index + 1).min(length - 1))
+            .unwrap_or(0)
+    })
+}
+
+#[cfg(test)]
+mod browser_keyboard_navigation_tests {
+    use super::adjacent_result_index;
+
+    #[test]
+    fn adjacent_result_navigation_selects_edges_and_clamps() {
+        assert_eq!(adjacent_result_index(0, None, 1), None);
+        assert_eq!(adjacent_result_index(3, None, 1), Some(0));
+        assert_eq!(adjacent_result_index(3, None, -1), Some(2));
+        assert_eq!(adjacent_result_index(3, Some(1), 1), Some(2));
+        assert_eq!(adjacent_result_index(3, Some(2), 1), Some(2));
+        assert_eq!(adjacent_result_index(3, Some(0), -1), Some(0));
+    }
+}
+
 impl App {
+    pub(super) fn select_adjacent_browser_result(&mut self, direction: i8) -> Task<Message> {
+        if !self.state.browser.open || direction == 0 {
+            return Task::none();
+        }
+        let browser = &self.state.browser;
+        let query = browser.search.trim().to_ascii_lowercase();
+        let searching = !query.is_empty();
+        let results: Vec<(
+            MediaSourceRef,
+            Option<crate::remote_provider::RemoteCatalogEntry>,
+        )> = match browser.mode {
+            crate::state::SampleBrowserMode::Local => {
+                let root_results = if !searching && browser.current_folder.is_none() {
+                    browser.roots.len()
+                } else if searching && browser.search_scope_path().is_none() {
+                    browser
+                        .roots
+                        .iter()
+                        .filter(|root| root.display().to_string().to_lowercase().contains(&query))
+                        .count()
+                } else {
+                    0
+                };
+                let folder_results = browser
+                    .folders
+                    .iter()
+                    .filter(|folder| browser.local_folder_is_result(folder, &query))
+                    .count();
+                let media_limit = browser
+                    .results_visible_limit
+                    .saturating_sub(root_results + folder_results);
+                let mut entries: Vec<_> = browser
+                    .entries
+                    .iter()
+                    .filter(|entry| browser.local_entry_is_result(entry, &query))
+                    .collect();
+                entries.sort_by(|left, right| {
+                    (left.name.to_lowercase(), &left.relative_path)
+                        .cmp(&(right.name.to_lowercase(), &right.relative_path))
+                });
+                entries
+                    .into_iter()
+                    .take(media_limit)
+                    .map(|entry| (entry.source.clone(), None))
+                    .collect()
+            }
+            crate::state::SampleBrowserMode::Remote => {
+                let current = browser.remote.current_path.as_str();
+                let in_current_tree = |entry: &crate::remote_provider::RemoteCatalogEntry| {
+                    current.is_empty()
+                        || entry.provider_item_id == current
+                        || entry
+                            .provider_item_id
+                            .strip_prefix(current)
+                            .is_some_and(|rest| rest.starts_with('/'))
+                };
+                let mut remote: Vec<_> = browser
+                    .remote
+                    .catalog
+                    .entries
+                    .iter()
+                    .filter(|entry| entry.is_folder || entry.is_supported_audio())
+                    .filter(|entry| {
+                        if searching {
+                            let in_scope = match browser.search_scope {
+                                crate::state::BrowserSearchScope::SelectedFolder => {
+                                    in_current_tree(entry)
+                                }
+                                crate::state::BrowserSearchScope::Root
+                                | crate::state::BrowserSearchScope::Everywhere => true,
+                            };
+                            in_scope
+                                && (entry.name.to_ascii_lowercase().contains(&query)
+                                    || entry.path.to_ascii_lowercase().contains(&query))
+                        } else {
+                            entry.parent_path == current
+                        }
+                    })
+                    .cloned()
+                    .collect();
+                remote.sort_by(|left, right| {
+                    (!left.is_folder, left.name.to_ascii_lowercase())
+                        .cmp(&(!right.is_folder, right.name.to_ascii_lowercase()))
+                });
+                let remote_visible = remote.len().min(browser.results_visible_limit);
+                let mut combined: Vec<_> = remote
+                    .into_iter()
+                    .take(remote_visible)
+                    .filter(|entry| !entry.is_folder)
+                    .map(|entry| {
+                        (
+                            MediaSourceRef::DropboxFile {
+                                path_lower: entry.provider_item_id.clone(),
+                                display_path: entry.path.clone(),
+                                rev: entry.revision.clone(),
+                            },
+                            Some(entry),
+                        )
+                    })
+                    .collect();
+                if searching && browser.search_scope == crate::state::BrowserSearchScope::Everywhere
+                {
+                    let mut local: Vec<_> = browser
+                        .entries
+                        .iter()
+                        .filter(|entry| {
+                            entry.name.to_ascii_lowercase().contains(&query)
+                                || entry
+                                    .relative_path
+                                    .to_string_lossy()
+                                    .to_ascii_lowercase()
+                                    .contains(&query)
+                        })
+                        .collect();
+                    local.sort_by_key(|entry| entry.name.to_ascii_lowercase());
+                    combined.extend(
+                        local
+                            .into_iter()
+                            .take(browser.results_visible_limit - remote_visible)
+                            .map(|entry| (entry.source.clone(), None)),
+                    );
+                }
+                combined
+            }
+        };
+        if results.is_empty() {
+            self.state.status_text = "No media result to select".into();
+            return Task::none();
+        }
+        let current = browser
+            .selected_source
+            .as_ref()
+            .and_then(|selected| results.iter().position(|(source, _)| source == selected));
+        let index = adjacent_result_index(results.len(), current, direction).unwrap();
+        let (source, remote) = results.into_iter().nth(index).unwrap();
+        match remote {
+            Some(entry) => self.update(Message::ClickRemoteBrowserEntry(entry)),
+            None => self.update(Message::ClickLocalBrowserEntry(source)),
+        }
+    }
+
     pub(super) fn stop_browser_audition(&mut self) {
         self.send_command(EngineCommand::StopAudition);
         self.state.browser.stop_audition_state();

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use iced::widget::scrollable;
 use iced::Task;
 
 use vibez_core::audio_buffer::DecodedAudio;
@@ -30,9 +31,32 @@ fn adjacent_result_index(length: usize, current: Option<usize>, direction: i8) -
     })
 }
 
+fn browser_results_scroll_offset(row_index: usize, visible_rows: usize) -> f32 {
+    if visible_rows <= 1 {
+        0.0
+    } else {
+        row_index.min(visible_rows - 1) as f32 / (visible_rows - 1) as f32
+    }
+}
+
+pub(super) fn browser_results_scroll_id(mode: crate::state::SampleBrowserMode) -> scrollable::Id {
+    let id = match mode {
+        crate::state::SampleBrowserMode::Local => "browser-local-results",
+        crate::state::SampleBrowserMode::Remote => "browser-remote-results",
+    };
+    scrollable::Id::new(id)
+}
+
+struct BrowserNavigableResult {
+    source: MediaSourceRef,
+    remote: Option<crate::remote_provider::RemoteCatalogEntry>,
+    row_index: usize,
+    visible_rows: usize,
+}
+
 #[cfg(test)]
 mod browser_keyboard_navigation_tests {
-    use super::adjacent_result_index;
+    use super::{adjacent_result_index, browser_results_scroll_offset};
 
     #[test]
     fn adjacent_result_navigation_selects_edges_and_clamps() {
@@ -42,6 +66,14 @@ mod browser_keyboard_navigation_tests {
         assert_eq!(adjacent_result_index(3, Some(1), 1), Some(2));
         assert_eq!(adjacent_result_index(3, Some(2), 1), Some(2));
         assert_eq!(adjacent_result_index(3, Some(0), -1), Some(0));
+    }
+
+    #[test]
+    fn keyboard_selection_maps_to_the_results_scroll_range() {
+        assert_eq!(browser_results_scroll_offset(0, 1), 0.0);
+        assert_eq!(browser_results_scroll_offset(0, 100), 0.0);
+        assert!((browser_results_scroll_offset(50, 100) - 0.505).abs() < 0.001);
+        assert_eq!(browser_results_scroll_offset(99, 100), 1.0);
     }
 }
 
@@ -53,10 +85,8 @@ impl App {
         let browser = &self.state.browser;
         let query = browser.search.trim().to_ascii_lowercase();
         let searching = !query.is_empty();
-        let results: Vec<(
-            MediaSourceRef,
-            Option<crate::remote_provider::RemoteCatalogEntry>,
-        )> = match browser.mode {
+        let mode = browser.mode;
+        let results: Vec<BrowserNavigableResult> = match mode {
             crate::state::SampleBrowserMode::Local => {
                 let root_results = if !searching && browser.current_folder.is_none() {
                     browser.roots.len()
@@ -86,10 +116,19 @@ impl App {
                     (left.name.to_lowercase(), &left.relative_path)
                         .cmp(&(right.name.to_lowercase(), &right.relative_path))
                 });
+                let prefix_rows =
+                    (root_results + folder_results).min(browser.results_visible_limit);
+                let entries: Vec<_> = entries.into_iter().take(media_limit).collect();
+                let visible_rows = prefix_rows + entries.len();
                 entries
                     .into_iter()
-                    .take(media_limit)
-                    .map(|entry| (entry.source.clone(), None))
+                    .enumerate()
+                    .map(|(index, entry)| BrowserNavigableResult {
+                        source: entry.source.clone(),
+                        remote: None,
+                        row_index: prefix_rows + index,
+                        visible_rows,
+                    })
                     .collect()
             }
             crate::state::SampleBrowserMode::Remote => {
@@ -134,18 +173,20 @@ impl App {
                 let mut combined: Vec<_> = remote
                     .into_iter()
                     .take(remote_visible)
-                    .filter(|entry| !entry.is_folder)
-                    .map(|entry| {
-                        (
-                            MediaSourceRef::DropboxFile {
-                                path_lower: entry.provider_item_id.clone(),
-                                display_path: entry.path.clone(),
-                                rev: entry.revision.clone(),
-                            },
-                            Some(entry),
-                        )
+                    .enumerate()
+                    .filter(|(_, entry)| !entry.is_folder)
+                    .map(|(row_index, entry)| BrowserNavigableResult {
+                        source: MediaSourceRef::DropboxFile {
+                            path_lower: entry.provider_item_id.clone(),
+                            display_path: entry.path.clone(),
+                            rev: entry.revision.clone(),
+                        },
+                        remote: Some(entry),
+                        row_index,
+                        visible_rows: 0,
                     })
                     .collect();
+                let mut local_visible = 0;
                 if searching && browser.search_scope == crate::state::BrowserSearchScope::Everywhere
                 {
                     let mut local: Vec<_> = browser
@@ -161,13 +202,24 @@ impl App {
                         })
                         .collect();
                     local.sort_by_key(|entry| entry.name.to_ascii_lowercase());
-                    combined.extend(
-                        local
-                            .into_iter()
-                            .take(browser.results_visible_limit - remote_visible)
-                            .map(|entry| (entry.source.clone(), None)),
-                    );
+                    let local: Vec<_> = local
+                        .into_iter()
+                        .take(browser.results_visible_limit - remote_visible)
+                        .collect();
+                    local_visible = local.len();
+                    combined.extend(local.into_iter().enumerate().map(|(index, entry)| {
+                        BrowserNavigableResult {
+                            source: entry.source.clone(),
+                            remote: None,
+                            row_index: remote_visible + index,
+                            visible_rows: 0,
+                        }
+                    }));
                 }
+                let visible_rows = remote_visible + local_visible;
+                combined
+                    .iter_mut()
+                    .for_each(|entry| entry.visible_rows = visible_rows);
                 combined
             }
         };
@@ -178,13 +230,21 @@ impl App {
         let current = browser
             .selected_source
             .as_ref()
-            .and_then(|selected| results.iter().position(|(source, _)| source == selected));
+            .and_then(|selected| results.iter().position(|entry| &entry.source == selected));
         let index = adjacent_result_index(results.len(), current, direction).unwrap();
-        let (source, remote) = results.into_iter().nth(index).unwrap();
-        match remote {
+        let result = results.into_iter().nth(index).unwrap();
+        let selection = match result.remote {
             Some(entry) => self.update(Message::ClickRemoteBrowserEntry(entry)),
-            None => self.update(Message::ClickLocalBrowserEntry(source)),
-        }
+            None => self.update(Message::ClickLocalBrowserEntry(result.source)),
+        };
+        let scroll = scrollable::snap_to(
+            browser_results_scroll_id(mode),
+            scrollable::RelativeOffset {
+                x: 0.0,
+                y: browser_results_scroll_offset(result.row_index, result.visible_rows),
+            },
+        );
+        Task::batch([selection, scroll])
     }
 
     pub(super) fn stop_browser_audition(&mut self) {

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -141,14 +141,14 @@ impl App {
                             .strip_prefix(current)
                             .is_some_and(|rest| rest.starts_with('/'))
                 };
-                let mut remote: Vec<_> = browser
-                    .remote
-                    .catalog
-                    .entries
-                    .iter()
-                    .filter(|entry| entry.is_folder || entry.is_supported_audio())
-                    .filter(|entry| {
-                        if searching {
+                let mut remote: Vec<_> = if searching {
+                    browser
+                        .remote
+                        .catalog
+                        .entries
+                        .iter()
+                        .filter(|entry| entry.is_folder || entry.is_supported_audio())
+                        .filter(|entry| {
                             let in_scope = match browser.search_scope {
                                 crate::state::BrowserSearchScope::SelectedFolder => {
                                     in_current_tree(entry)
@@ -159,16 +159,25 @@ impl App {
                             in_scope
                                 && (entry.name.to_ascii_lowercase().contains(&query)
                                     || entry.path.to_ascii_lowercase().contains(&query))
-                        } else {
-                            entry.parent_path == current
-                        }
-                    })
-                    .cloned()
-                    .collect();
-                remote.sort_by(|left, right| {
-                    (!left.is_folder, left.name.to_ascii_lowercase())
-                        .cmp(&(!right.is_folder, right.name.to_ascii_lowercase()))
-                });
+                        })
+                        .cloned()
+                        .collect()
+                } else {
+                    browser
+                        .remote
+                        .catalog_child_indices(current)
+                        .iter()
+                        .filter_map(|&index| browser.remote.catalog.entries.get(index))
+                        .filter(|entry| entry.is_folder || entry.is_supported_audio())
+                        .cloned()
+                        .collect()
+                };
+                if searching {
+                    remote.sort_by(|left, right| {
+                        (!left.is_folder, left.name.to_ascii_lowercase())
+                            .cmp(&(!right.is_folder, right.name.to_ascii_lowercase()))
+                    });
+                }
                 let remote_visible = remote.len().min(browser.results_visible_limit);
                 let mut combined: Vec<_> = remote
                     .into_iter()

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -308,7 +308,6 @@ impl App {
             })
         }));
         let remote_startup_task = if app.dropbox_client.is_some() {
-            app.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Refreshing;
             Task::done(Message::RefreshRemoteConnection)
         } else {
             Task::none()

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -182,7 +182,7 @@ impl App {
                 error: "Sign in to refresh; showing the last saved Remote catalog".into(),
             };
         }
-        let remote_ui_state = crate::state::RemoteUiState {
+        let mut remote_ui_state = crate::state::RemoteUiState {
             connected: dropbox_client.is_some(),
             account_email: dropbox_settings.account_email.clone(),
             app_key_input: dropbox_settings.app_key.clone().unwrap_or_default(),
@@ -195,6 +195,7 @@ impl App {
             cache_automatic_eviction: ui_settings.media_cache_automatic_eviction,
             ..Default::default()
         };
+        remote_ui_state.rebuild_catalog_children();
 
         let mut state = AppState {
             transport: crate::state::TransportState {

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -1472,6 +1472,7 @@ impl App {
                             error: None,
                         },
                     );
+                    self.state.browser.remote.rebuild_catalog_children();
                     self.state.browser.remote.refresh_pages = pages;
                     self.state.browser.remote.refresh_items =
                         self.state.browser.remote.catalog.entries.len();

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -837,23 +837,39 @@ impl App {
                 self.state.browser.fail_waveform_load(&source, err);
             }
             Message::BrowserBpmDetected(source, estimate) => {
-                if self.state.browser.install_bpm_suggestion(source, estimate)
-                    && self.state.browser.audition_mode == crate::state::AuditionMode::Warp
-                    && self.state.browser.audition_bpm_confirmed.is_none()
+                let source_for_warp = source.clone();
+                if self.state.browser.install_bpm_suggestion(
+                    source,
+                    estimate,
+                    self.state.warp_confidence_threshold,
+                ) && self.state.browser.audition_mode == crate::state::AuditionMode::Warp
                 {
-                    self.state.status_text = match estimate {
-                        Some((bpm, confidence))
-                            if confidence < self.state.warp_confidence_threshold =>
-                        {
-                            format!(
+                    if let Some(source_bpm) = self.state.browser.audition_bpm_confirmed {
+                        let project_bpm = self.state.transport.bpm;
+                        self.state.status_text = format!(
+                            "Detected {source_bpm:.1} source BPM; WARP targets project {project_bpm:.1} BPM"
+                        );
+                        if self.state.browser.audition_enabled {
+                            if let Some(raw) = self.state.browser.waveform_audio.clone() {
+                                self.stop_browser_audition();
+                                return self.prepare_browser_warp(source_for_warp, raw, source_bpm);
+                            }
+                        }
+                    } else {
+                        self.state.status_text = match estimate {
+                            Some((bpm, confidence))
+                                if confidence < self.state.warp_confidence_threshold =>
+                            {
+                                format!(
                                 "Low-confidence suggestion {bpm:.1} BPM; confirm or edit for WARP"
                             )
-                        }
-                        Some((bpm, _)) => {
-                            format!("Suggested {bpm:.1} BPM; confirm for WARP")
-                        }
-                        None => "No BPM detected; enter a positive source BPM for WARP".into(),
-                    };
+                            }
+                            Some((bpm, _)) => {
+                                format!("Suggested {bpm:.1} BPM; confirm for WARP")
+                            }
+                            None => "No BPM detected; enter a positive source BPM for WARP".into(),
+                        };
+                    }
                 }
             }
             Message::BrowserAuditionWarpReady {
@@ -1439,47 +1455,93 @@ impl App {
             Message::RefreshRemoteConnection => {
                 return self.handle_remote_catalog_refresh();
             }
-            Message::RemoteCatalogRefreshed(result) => {
-                crate::remote_provider::reconcile_remote_catalog(
-                    &mut self.state.browser.remote.catalog,
-                    &result,
-                );
-                let save_error = crate::remote_provider::RemoteCatalogStore::for_dropbox()
-                    .save(&self.state.browser.remote.catalog)
-                    .err();
-                self.state.browser.remote.catalog_state = match (&result.error, save_error) {
-                    (Some(error), _)
-                        if error.kind
-                            == crate::remote_provider::RemoteProviderErrorKind::Authentication =>
+            Message::RemoteCatalogPageFetched {
+                completed_pages,
+                result,
+            } => match result {
+                Ok(page) => {
+                    let pages = completed_pages.saturating_add(1);
+                    let has_more = page.has_more;
+                    let next_checkpoint = page.checkpoint.clone();
+                    crate::remote_provider::reconcile_remote_catalog(
+                        &mut self.state.browser.remote.catalog,
+                        &crate::remote_provider::RemoteRefreshResult {
+                            pages: 1,
+                            changes: page.changes,
+                            checkpoint: (!has_more).then_some(page.checkpoint),
+                            error: None,
+                        },
+                    );
+                    self.state.browser.remote.refresh_pages = pages;
+                    self.state.browser.remote.refresh_items =
+                        self.state.browser.remote.catalog.entries.len();
+                    if !has_more
+                        || pages % super::dropbox_io::REMOTE_CATALOG_SAVE_PAGE_INTERVAL == 0
+                    {
+                        if let Err(error) =
+                            crate::remote_provider::RemoteCatalogStore::for_dropbox()
+                                .save(&self.state.browser.remote.catalog)
+                        {
+                            self.state.browser.remote.catalog_state =
+                                crate::state::RemoteCatalogState::Stale {
+                                    error: error.clone(),
+                                };
+                            self.state.status_text =
+                                format!("Remote catalog save failed after page {pages}: {error}");
+                            return Task::none();
+                        }
+                    }
+                    if has_more {
+                        self.state.status_text = format!(
+                            "Remote catalog: {} items available · fetching page {}…",
+                            self.state.browser.remote.refresh_items,
+                            pages.saturating_add(1)
+                        );
+                        if let Some(client) = self.dropbox_client.clone() {
+                            return super::dropbox_io::remote_catalog_page_task(
+                                client,
+                                Some(next_checkpoint),
+                                pages,
+                            );
+                        }
+                        self.state.browser.remote.catalog_state =
+                            crate::state::RemoteCatalogState::AuthenticationRequired {
+                                error: "Disconnected during refresh; showing fetched metadata"
+                                    .into(),
+                            };
+                    } else {
+                        self.state.browser.remote.catalog_state =
+                            crate::state::RemoteCatalogState::Ready;
+                        self.state.status_text = format!(
+                            "Remote catalog refreshed: {} items across {pages} page(s)",
+                            self.state.browser.remote.refresh_items
+                        );
+                    }
+                }
+                Err(error) => {
+                    self.state.browser.remote.catalog_state = if error.kind
+                        == crate::remote_provider::RemoteProviderErrorKind::Authentication
                     {
                         crate::state::RemoteCatalogState::AuthenticationRequired {
                             error: error.message.clone(),
                         }
-                    }
-                    (Some(error), _) if result.pages > 0 => {
+                    } else if completed_pages > 0 {
                         crate::state::RemoteCatalogState::Partial {
-                            pages: result.pages,
+                            pages: completed_pages,
                             error: error.message.clone(),
                         }
-                    }
-                    (Some(error), _) => crate::state::RemoteCatalogState::Stale {
-                        error: error.message.clone(),
-                    },
-                    (None, Some(error)) => crate::state::RemoteCatalogState::Stale { error },
-                    (None, None) => crate::state::RemoteCatalogState::Ready,
-                };
-                let item_count = self.state.browser.remote.catalog.entries.len();
-                self.state.status_text = match result.error {
-                    None => format!(
-                        "Remote catalog refreshed: {item_count} items across {} page(s)",
-                        result.pages
-                    ),
-                    Some(error) => format!(
-                        "Remote catalog kept {} items after refresh error: {}",
-                        item_count, error.message
-                    ),
-                };
-            }
+                    } else {
+                        crate::state::RemoteCatalogState::Stale {
+                            error: error.message.clone(),
+                        }
+                    };
+                    self.state.status_text = format!(
+                        "Remote catalog kept {} available items after refresh error: {}",
+                        self.state.browser.remote.catalog.entries.len(),
+                        error.message
+                    );
+                }
+            },
             Message::SetMediaCacheBudgetGiB(gib) => {
                 let gib = gib.clamp(1.0, 500.0);
                 let bytes = (gib as f64 * 1024.0 * 1024.0 * 1024.0) as u64;

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -881,6 +881,9 @@ impl App {
             Message::ImportSelectedBrowserSampleToArrangement => {
                 return self.handle_import_selected_browser_sample_to_arrangement();
             }
+            Message::SelectAdjacentBrowserResult(direction) => {
+                return self.select_adjacent_browser_result(direction);
+            }
             Message::LoadSelectedBrowserSampleToDevice => {
                 return self.handle_load_selected_browser_sample_to_device();
             }

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -646,14 +646,36 @@ impl App {
             .padding([3, 5])
             .width(Length::Fixed(if compact { 54.0 } else { 62.0 }))
             .style(browser_compact_input_style);
-        let confirm_bpm = button(text(if compact { "SET" } else { "CONFIRM" }).size(9))
+        let confirm_bpm = button(text(if compact { "USE" } else { "USE SOURCE" }).size(9))
             .on_press(Message::ConfirmAuditionBpm)
             .padding([3, 5])
             .style(browser_utility_action_style);
+        let automatic_bpm = self
+            .state
+            .browser
+            .audition_bpm_suggestion
+            .zip(self.state.browser.audition_bpm_confidence)
+            .is_some_and(|(suggestion, confidence)| {
+                confidence >= self.state.warp_confidence_threshold
+                    && self.state.browser.audition_bpm_confirmed == Some(suggestion)
+            });
+        let bpm_controls: Element<'_, Message> = if automatic_bpm {
+            text("AUTO").size(9).color(th::accent()).into()
+        } else {
+            row![bpm_input, confirm_bpm]
+                .spacing(4)
+                .align_y(iced::Alignment::Center)
+                .into()
+        };
+        let project_bpm = self.state.transport.bpm;
         let bpm_state = if self.state.browser.audition_bpm_detecting {
-            "DETECTING".to_string()
+            format!("DETECTING SOURCE → {project_bpm:.0}")
         } else if let Some(confirmed) = self.state.browser.audition_bpm_confirmed {
-            format!("CONFIRMED {confirmed:.1}")
+            if compact {
+                format!("{confirmed:.1} → {project_bpm:.0}")
+            } else {
+                format!("SOURCE {confirmed:.1} → PROJECT {project_bpm:.0}")
+            }
         } else if let Some(suggestion) = self.state.browser.audition_bpm_suggestion {
             let low = self
                 .state
@@ -661,12 +683,12 @@ impl App {
                 .audition_bpm_confidence
                 .is_some_and(|confidence| confidence < self.state.warp_confidence_threshold);
             if low {
-                format!("SUGGEST {suggestion:.1} · LOW")
+                format!("LOW {suggestion:.1} → PROJECT {project_bpm:.0}")
             } else {
-                format!("SUGGEST {suggestion:.1}")
+                format!("SOURCE {suggestion:.1} → PROJECT {project_bpm:.0}")
             }
         } else {
-            "MANUAL FOR WARP".to_string()
+            format!("SOURCE NEEDED → PROJECT {project_bpm:.0}")
         };
 
         let waveform: Element<'_, Message> = container(
@@ -779,9 +801,10 @@ impl App {
             .spacing(3)
             .align_y(iced::Alignment::Center),
             row![
-                text("BPM").size(9).color(th::text_muted()),
-                bpm_input,
-                confirm_bpm,
+                text(if compact { "SRC" } else { "SOURCE BPM" })
+                    .size(9)
+                    .color(th::text_muted()),
+                bpm_controls,
                 text(bpm_state)
                     .size(9)
                     .color(if self.state.browser.audition_bpm_confirmed.is_some() {
@@ -1196,6 +1219,9 @@ impl App {
                             ..Default::default()
                         })
                 )
+                .id(super::media::browser_results_scroll_id(
+                    SampleBrowserMode::Local,
+                ))
                 .height(Length::Fill)
                 .direction(scrollable::Direction::Vertical(
                     scrollable::Scrollbar::default()
@@ -1338,6 +1364,16 @@ impl App {
         results.truncate(remote_visible);
         local_everywhere.truncate(visible_results.saturating_sub(remote_visible));
         let wide_columns = browser.results_use_wide_columns(self.state.view.window_width);
+        let catalog_label = if remote.catalog_state == crate::state::RemoteCatalogState::Refreshing
+        {
+            if browser.effective_dock_width(self.state.view.window_width) < 360.0 {
+                format!("REF {}P", remote.refresh_pages)
+            } else {
+                format!("REFRESHING {}P", remote.refresh_pages)
+            }
+        } else {
+            remote.catalog_state.label().to_string()
+        };
         let table_header: Element<'_, Message> = if wide_columns {
             row![
                 text("NAME")
@@ -1675,7 +1711,7 @@ impl App {
                     horizontal_space(),
                     text(format!(
                         "{} · {visible_results}/{total_results}",
-                        remote.catalog_state.label()
+                        catalog_label
                     ))
                     .size(9)
                     .color(state_color),
@@ -1692,6 +1728,9 @@ impl App {
                             ..Default::default()
                         })
                 )
+                .id(super::media::browser_results_scroll_id(
+                    SampleBrowserMode::Remote,
+                ))
                 .height(Length::Fill)
                 .direction(scrollable::Direction::Vertical(
                     scrollable::Scrollbar::default()

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -561,6 +561,11 @@ impl App {
     }
 
     fn view_browser_audition_footer(&self) -> Element<'_, Message> {
+        let compact = self
+            .state
+            .browser
+            .effective_dock_width(self.state.view.window_width)
+            < 360.0;
         let selected_local = self.selected_sample_browser_entry();
         let selected_dropbox = self.selected_dropbox_entry();
         let selected_label = match self.state.browser.mode {
@@ -639,9 +644,9 @@ impl App {
             .on_submit(Message::ConfirmAuditionBpm)
             .size(10)
             .padding([3, 5])
-            .width(Length::Fixed(62.0))
+            .width(Length::Fixed(if compact { 54.0 } else { 62.0 }))
             .style(browser_compact_input_style);
-        let confirm_bpm = button(text("CONFIRM").size(9))
+        let confirm_bpm = button(text(if compact { "SET" } else { "CONFIRM" }).size(9))
             .on_press(Message::ConfirmAuditionBpm)
             .padding([3, 5])
             .style(browser_utility_action_style);
@@ -1039,6 +1044,13 @@ impl App {
                 .duration_seconds
                 .map(format_browser_duration)
                 .unwrap_or_else(|| "—".into());
+            let source_detail = browser_folder_context(
+                &entry.root_path,
+                &entry.relative_path,
+                &metadata_detail,
+                entry.file_size,
+            );
+            let compact_detail = format!("BPM {bpm} · {length} · {source_detail}");
             // mouse_area returns early if its child captures the event, so
             // iced Button underneath would swallow press events. Use a
             // plain container as the click target instead.
@@ -1049,12 +1061,11 @@ impl App {
                     .width(Length::Fill)
                     .height(Length::Fixed(14.0))
                     .wrapping(iced::widget::text::Wrapping::None),
-                text(browser_folder_context(
-                    &entry.root_path,
-                    &entry.relative_path,
-                    &metadata_detail,
-                    entry.file_size,
-                ))
+                text(if wide_columns {
+                    source_detail
+                } else {
+                    compact_detail
+                })
                 .size(9)
                 .color(cell_color)
                 .width(Length::Fill)
@@ -1441,6 +1452,9 @@ impl App {
             let length = metadata
                 .map(|metadata| format_browser_duration(metadata.duration_seconds))
                 .unwrap_or_else(|| "—".into());
+            if !wide_columns && !entry.is_folder {
+                context = format!("BPM {bpm} · {length} · {context}");
+            }
             let name_cell = column![
                 text(if entry.is_folder {
                     format!("› {}", entry.name)
@@ -1639,7 +1653,7 @@ impl App {
                     .style(browser_utility_action_style),
             );
         }
-        let refresh = button(text("REFRESH").size(9).color(th::text_dim()))
+        let refresh = button(text("REF").size(9).color(th::text_dim()))
             .on_press(Message::RefreshRemoteConnection)
             .padding([3, 5])
             .style(browser_utility_action_style);

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -333,44 +333,92 @@ impl App {
             places = places.push(local_row);
         }
 
-        places = places.push(place_button(
-            "Remote",
-            remote_active,
-            SampleBrowserMode::Remote,
-        ));
-        let connection_active = remote_active && self.state.browser.remote.current_path.is_empty();
-        let connection = button(
-            text(self.state.browser.remote.catalog.connection_name.as_str())
+        let remote = &self.state.browser.remote;
+        let remote_toggle = button(
+            text(if remote.place_expanded { "▾" } else { "▸" })
                 .size(10)
-                .color(if connection_active {
-                    th::accent()
-                } else {
-                    th::text_dim()
-                })
-                .wrapping(iced::widget::text::Wrapping::None),
+                .color(th::text_muted()),
         )
-        .on_press(Message::Browser(BrowserMsg::SelectRemoteFolder(
-            String::new(),
+        .on_press(Message::Browser(BrowserMsg::ToggleRemotePlace))
+        .padding([3, 2])
+        .style(browser_utility_action_style);
+        let remote_select = button(
+            row![
+                container(text("")).width(Length::Fixed(1.0)),
+                text("Remote")
+                    .size(10)
+                    .color(if remote_active {
+                        th::accent()
+                    } else {
+                        th::text_dim()
+                    })
+                    .wrapping(iced::widget::text::Wrapping::None)
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::Browser(BrowserMsg::SetSampleBrowserMode(
+            SampleBrowserMode::Remote,
         )))
         .padding([4, 2])
         .width(Length::Fill)
-        .style(move |_theme: &Theme, status| browser_place_button_style(connection_active, status));
+        .style(move |_theme: &Theme, status| browser_place_button_style(remote_active, status));
         places = places.push(
-            row![
-                horizontal_space().width(Length::Fixed(REMOTE_CONNECTION_INDENT)),
-                text("▾").size(10).color(th::text_muted()),
-                connection,
-                text(self.state.browser.remote.catalog_state.label())
-                    .size(8)
-                    .color(th::text_muted())
-            ]
-            .spacing(2)
-            .align_y(iced::Alignment::Center),
+            row![remote_toggle, remote_select]
+                .spacing(1)
+                .align_y(iced::Alignment::Center),
         );
-        let mut remote_rows = Vec::new();
-        self.render_remote_places_tree("", 0, &mut remote_rows);
-        for remote_row in remote_rows {
-            places = places.push(remote_row);
+        if remote.place_expanded {
+            let connection_active = remote_active && remote.current_path.is_empty();
+            let connection_toggle = button(
+                text(if remote.connection_expanded {
+                    "▾"
+                } else {
+                    "▸"
+                })
+                .size(10)
+                .color(th::text_muted()),
+            )
+            .on_press(Message::Browser(BrowserMsg::ToggleRemoteConnection))
+            .padding([3, 2])
+            .style(browser_utility_action_style);
+            let connection = button(
+                text(remote.catalog.connection_name.as_str())
+                    .size(10)
+                    .color(if connection_active {
+                        th::accent()
+                    } else {
+                        th::text_dim()
+                    })
+                    .wrapping(iced::widget::text::Wrapping::None),
+            )
+            .on_press(Message::Browser(BrowserMsg::SelectRemoteFolder(
+                String::new(),
+            )))
+            .padding([4, 2])
+            .width(Length::Fill)
+            .style(move |_theme: &Theme, status| {
+                browser_place_button_style(connection_active, status)
+            });
+            places = places.push(
+                row![
+                    horizontal_space().width(Length::Fixed(REMOTE_CONNECTION_INDENT)),
+                    connection_toggle,
+                    connection,
+                    text(remote.catalog_state.label())
+                        .size(8)
+                        .color(th::text_muted())
+                ]
+                .spacing(2)
+                .align_y(iced::Alignment::Center),
+            );
+            if remote.connection_expanded {
+                let mut remote_rows = Vec::new();
+                self.render_remote_places_tree("", 0, &mut remote_rows);
+                for remote_row in remote_rows {
+                    places = places.push(remote_row);
+                }
+            }
         }
 
         let add = button(
@@ -496,17 +544,12 @@ impl App {
         depth: usize,
         rows: &mut Vec<Element<'a, Message>>,
     ) {
-        let mut children: Vec<_> = self
-            .state
-            .browser
-            .remote
-            .catalog
-            .entries
-            .iter()
-            .filter(|entry| entry.is_folder && entry.parent_path == parent)
-            .collect();
-        children.sort_by_key(|entry| entry.name.to_ascii_lowercase());
-        for folder in children {
+        let remote = &self.state.browser.remote;
+        for &index in remote.catalog_child_indices(parent) {
+            let folder = &remote.catalog.entries[index];
+            if !folder.is_folder {
+                continue;
+            }
             let expanded = self
                 .state
                 .browser
@@ -515,14 +558,10 @@ impl App {
                 .contains(&folder.provider_item_id);
             let active = self.state.browser.mode == SampleBrowserMode::Remote
                 && self.state.browser.remote.current_path == folder.provider_item_id;
-            let has_children = self
-                .state
-                .browser
-                .remote
-                .catalog
-                .entries
+            let has_children = remote
+                .catalog_child_indices(&folder.provider_item_id)
                 .iter()
-                .any(|entry| entry.is_folder && entry.parent_path == folder.provider_item_id);
+                .any(|&child| remote.catalog.entries[child].is_folder);
             let toggle: Element<'a, Message> = if has_children {
                 button(
                     text(if expanded { "▾" } else { "▸" })
@@ -1325,13 +1364,13 @@ impl App {
                     .strip_prefix(current)
                     .is_some_and(|rest| rest.starts_with('/'))
         };
-        let mut results: Vec<&crate::remote_provider::RemoteCatalogEntry> = remote
-            .catalog
-            .entries
-            .iter()
-            .filter(|entry| entry.is_folder || entry.is_supported_audio())
-            .filter(|entry| {
-                if searching {
+        let mut results: Vec<&crate::remote_provider::RemoteCatalogEntry> = if searching {
+            remote
+                .catalog
+                .entries
+                .iter()
+                .filter(|entry| entry.is_folder || entry.is_supported_audio())
+                .filter(|entry| {
                     let in_scope = match browser.search_scope {
                         crate::state::BrowserSearchScope::SelectedFolder => in_current_tree(entry),
                         crate::state::BrowserSearchScope::Root
@@ -1340,15 +1379,22 @@ impl App {
                     in_scope
                         && (entry.name.to_ascii_lowercase().contains(&query)
                             || entry.path.to_ascii_lowercase().contains(&query))
-                } else {
-                    entry.parent_path == current
-                }
-            })
-            .collect();
-        results.sort_by(|left, right| {
-            (!left.is_folder, left.name.to_ascii_lowercase())
-                .cmp(&(!right.is_folder, right.name.to_ascii_lowercase()))
-        });
+                })
+                .collect()
+        } else {
+            remote
+                .catalog_child_indices(current)
+                .iter()
+                .filter_map(|&index| remote.catalog.entries.get(index))
+                .filter(|entry| entry.is_folder || entry.is_supported_audio())
+                .collect()
+        };
+        if searching {
+            results.sort_by(|left, right| {
+                (!left.is_folder, left.name.to_ascii_lowercase())
+                    .cmp(&(!right.is_folder, right.name.to_ascii_lowercase()))
+            });
+        }
         let mut local_everywhere: Vec<&SampleBrowserEntry> =
             if searching && browser.search_scope == crate::state::BrowserSearchScope::Everywhere {
                 browser

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -18,6 +18,15 @@ use vibez_engine::commands::AuditionSync;
 
 use super::*;
 
+const REMOTE_CONNECTION_INDENT: f32 = 14.0;
+const BROWSER_TREE_INDENT_STEP: f32 = 8.0;
+const BROWSER_TREE_MAX_DEPTH: f32 = 5.0;
+
+fn remote_places_indent(depth: usize) -> f32 {
+    REMOTE_CONNECTION_INDENT
+        + ((depth as f32 + 1.0).min(BROWSER_TREE_MAX_DEPTH) * BROWSER_TREE_INDENT_STEP)
+}
+
 impl App {
     pub(super) fn view_sample_browser_panel(&self) -> Element<'_, Message> {
         let width = self
@@ -348,7 +357,7 @@ impl App {
         .style(move |_theme: &Theme, status| browser_place_button_style(connection_active, status));
         places = places.push(
             row![
-                horizontal_space().width(Length::Fixed(14.0)),
+                horizontal_space().width(Length::Fixed(REMOTE_CONNECTION_INDENT)),
                 text("▾").size(10).color(th::text_muted()),
                 connection,
                 text(self.state.browser.remote.catalog_state.label())
@@ -359,7 +368,7 @@ impl App {
             .align_y(iced::Alignment::Center),
         );
         let mut remote_rows = Vec::new();
-        self.render_remote_places_tree("", 1, &mut remote_rows);
+        self.render_remote_places_tree("", 0, &mut remote_rows);
         for remote_row in remote_rows {
             places = places.push(remote_row);
         }
@@ -546,7 +555,7 @@ impl App {
             .style(move |_theme: &Theme, status| browser_place_button_style(active, status));
             rows.push(
                 row![
-                    horizontal_space().width(Length::Fixed((depth as f32 * 8.0).min(40.0))),
+                    horizontal_space().width(Length::Fixed(remote_places_indent(depth))),
                     toggle,
                     select
                 ]
@@ -2034,6 +2043,19 @@ mod browser_table_tests {
         assert_eq!(
             format_browser_duration(entry.duration_seconds.unwrap()),
             "2:00"
+        );
+    }
+
+    #[test]
+    fn remote_folders_begin_beyond_the_connection_and_nest_by_depth() {
+        assert!(remote_places_indent(0) > REMOTE_CONNECTION_INDENT);
+        assert_eq!(
+            remote_places_indent(1) - remote_places_indent(0),
+            BROWSER_TREE_INDENT_STEP
+        );
+        assert_eq!(
+            remote_places_indent(8),
+            REMOTE_CONNECTION_INDENT + BROWSER_TREE_MAX_DEPTH * BROWSER_TREE_INDENT_STEP
         );
     }
 }

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -526,8 +526,9 @@ mod tests {
         browser.audition_mode = crate::state::AuditionMode::Warp;
         assert!(browser.audition_import_input().is_none());
 
-        assert!(browser.install_bpm_suggestion(first, Some((127.8, 0.42))));
+        assert!(browser.install_bpm_suggestion(first, Some((127.8, 0.42)), 0.6));
         assert_eq!(browser.audition_bpm_edit, "127.8");
+        assert!(browser.audition_bpm_confirmed.is_none());
         assert_eq!(browser.confirm_audition_bpm().unwrap(), 127.8);
         let input = browser.audition_import_input().unwrap();
         assert_eq!(input.mode, crate::state::AuditionMode::Warp);
@@ -538,6 +539,23 @@ mod tests {
         assert!(browser.audition_import_input().is_none());
         browser.audition_bpm_edit = "0".into();
         assert!(browser.confirm_audition_bpm().is_err());
+    }
+
+    #[test]
+    fn trustworthy_detected_source_bpm_is_ready_without_manual_entry() {
+        let source = MediaSourceRef::LocalFile {
+            path: PathBuf::from("/samples/loop.wav"),
+        };
+        let mut browser = BrowserState::default();
+        browser.select_source(source.clone());
+        browser.audition_mode = crate::state::AuditionMode::Warp;
+
+        assert!(browser.install_bpm_suggestion(source, Some((124.0, 0.91)), 0.6));
+        assert_eq!(browser.audition_bpm_confirmed, Some(124.0));
+        assert_eq!(
+            browser.audition_import_input().unwrap().source_bpm,
+            Some(124.0)
+        );
     }
 
     #[test]

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -67,6 +67,8 @@ pub enum BrowserMsg {
         result: Result<SampleLibraryScanResult, String>,
     },
     RemoveSampleLibraryRoot(PathBuf),
+    ToggleRemotePlace,
+    ToggleRemoteConnection,
     SelectRemoteFolder(String),
     ToggleRemoteFolder(String),
     SelectRemoteEntry(RemoteCatalogEntry),
@@ -361,6 +363,12 @@ impl BrowserState {
                 }
                 action.persist_settings = true;
                 action.status = Some("Removed sample root".to_string());
+            }
+            BrowserMsg::ToggleRemotePlace => {
+                self.remote.place_expanded = !self.remote.place_expanded;
+            }
+            BrowserMsg::ToggleRemoteConnection => {
+                self.remote.connection_expanded = !self.remote.connection_expanded;
             }
             BrowserMsg::SelectRemoteFolder(path) => {
                 self.remote.current_path = path;
@@ -684,6 +692,59 @@ mod tests {
             browser.search_scope,
             crate::state::BrowserSearchScope::SelectedFolder
         );
+    }
+
+    #[test]
+    fn remote_place_and_connection_collapse_without_losing_navigation_state() {
+        let mut browser = BrowserState::default();
+        browser.remote.current_path = "/megalodon/drums".into();
+        browser.remote.expanded.insert("/megalodon".into());
+
+        browser.update(BrowserMsg::ToggleRemoteConnection);
+        browser.update(BrowserMsg::ToggleRemotePlace);
+
+        assert!(!browser.remote.connection_expanded);
+        assert!(!browser.remote.place_expanded);
+        assert_eq!(browser.remote.current_path, "/megalodon/drums");
+        assert!(browser.remote.expanded.contains("/megalodon"));
+
+        browser.update(BrowserMsg::ToggleRemotePlace);
+        browser.update(BrowserMsg::ToggleRemoteConnection);
+        assert!(browser.remote.place_expanded);
+        assert!(browser.remote.connection_expanded);
+    }
+
+    #[test]
+    fn remote_catalog_children_are_indexed_folder_first_per_parent() {
+        let entry = |id: &str, parent: &str, name: &str, is_folder: bool| RemoteCatalogEntry {
+            provider_item_id: id.into(),
+            path: id.into(),
+            parent_path: parent.into(),
+            name: name.into(),
+            is_folder,
+            revision: None,
+            size: None,
+            derived_metadata: None,
+        };
+        let mut browser = BrowserState::default();
+        browser.remote.catalog.entries = vec![
+            entry("/z.wav", "", "z.wav", false),
+            entry("/beats", "", "Beats", true),
+            entry("/a.wav", "", "a.wav", false),
+            entry("/beats/kick.wav", "/beats", "kick.wav", false),
+        ];
+
+        browser.remote.rebuild_catalog_children();
+
+        let root_names: Vec<_> = browser
+            .remote
+            .catalog_child_indices("")
+            .iter()
+            .map(|&index| browser.remote.catalog.entries[index].name.as_str())
+            .collect();
+        assert_eq!(root_names, ["Beats", "a.wav", "z.wav"]);
+        assert_eq!(browser.remote.catalog_child_indices("/beats").len(), 1);
+        assert!(browser.remote.catalog_child_indices("/missing").is_empty());
     }
 
     #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -445,7 +445,11 @@ pub enum Message {
     DropboxConnected(Result<DropboxConnectOutcome, String>),
     DisconnectDropbox,
     RefreshRemoteConnection,
-    RemoteCatalogRefreshed(crate::remote_provider::RemoteRefreshResult),
+    RemoteCatalogPageFetched {
+        completed_pages: usize,
+        result:
+            Result<crate::remote_provider::RemotePage, crate::remote_provider::RemoteProviderError>,
+    },
     SetMediaCacheBudgetGiB(f32),
     ToggleMediaCacheAutomaticEviction,
     ClearMediaCache,

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -327,6 +327,7 @@ pub enum Message {
         track_id: TrackId,
     },
     ImportSelectedBrowserSampleToArrangement,
+    SelectAdjacentBrowserResult(i8),
     LoadSelectedBrowserSampleToDevice,
     BrowserSampleDecoded(
         BrowserImportTarget,

--- a/crates/vibez-ui/src/remote_provider.rs
+++ b/crates/vibez-ui/src/remote_provider.rs
@@ -9,6 +9,7 @@ use std::future::Future;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use vibez_dropbox::{DerivedMetadata, DropboxClient, DropboxError, DropboxListItem};
@@ -16,6 +17,7 @@ use vibez_dropbox::{DerivedMetadata, DropboxClient, DropboxError, DropboxListIte
 pub const DROPBOX_PROVIDER_ID: &str = "dropbox";
 pub const DROPBOX_CONNECTION_ID: &str = "dropbox-primary";
 pub const DROPBOX_CONNECTION_NAME: &str = "Alex's Dropbox";
+const REMOTE_CATALOG_PAGE_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RemoteCatalogEntry {
@@ -187,9 +189,46 @@ pub struct RemoteRefreshResult {
     pub error: Option<RemoteProviderError>,
 }
 
+#[cfg(test)]
 pub async fn refresh_remote_catalog<P: RemoteProvider>(
     provider: &P,
     checkpoint: Option<&str>,
+) -> RemoteRefreshResult {
+    refresh_remote_catalog_with_page_timeout(provider, checkpoint, REMOTE_CATALOG_PAGE_TIMEOUT)
+        .await
+}
+
+pub async fn fetch_remote_catalog_page<P: RemoteProvider>(
+    provider: &P,
+    checkpoint: Option<&str>,
+) -> Result<RemotePage, RemoteProviderError> {
+    debug_assert_eq!(provider.provider_id(), DROPBOX_PROVIDER_ID);
+    debug_assert_eq!(provider.connection_id(), DROPBOX_CONNECTION_ID);
+    fetch_remote_catalog_page_with_timeout(provider, checkpoint, REMOTE_CATALOG_PAGE_TIMEOUT).await
+}
+
+async fn fetch_remote_catalog_page_with_timeout<P: RemoteProvider>(
+    provider: &P,
+    checkpoint: Option<&str>,
+    page_timeout: Duration,
+) -> Result<RemotePage, RemoteProviderError> {
+    match tokio::time::timeout(page_timeout, provider.fetch_metadata_page(checkpoint)).await {
+        Ok(result) => result,
+        Err(_) => Err(RemoteProviderError {
+            kind: RemoteProviderErrorKind::Unavailable,
+            message: format!(
+                "Remote catalog page timed out after {} second(s); retry Refresh",
+                page_timeout.as_secs_f32()
+            ),
+        }),
+    }
+}
+
+#[cfg(test)]
+async fn refresh_remote_catalog_with_page_timeout<P: RemoteProvider>(
+    provider: &P,
+    checkpoint: Option<&str>,
+    page_timeout: Duration,
 ) -> RemoteRefreshResult {
     debug_assert_eq!(provider.provider_id(), DROPBOX_PROVIDER_ID);
     debug_assert_eq!(provider.connection_id(), DROPBOX_CONNECTION_ID);
@@ -197,7 +236,9 @@ pub async fn refresh_remote_catalog<P: RemoteProvider>(
     let mut pages = 0;
     let mut changes = Vec::new();
     loop {
-        match provider.fetch_metadata_page(cursor.as_deref()).await {
+        match fetch_remote_catalog_page_with_timeout(provider, cursor.as_deref(), page_timeout)
+            .await
+        {
             Ok(page) => {
                 pages += 1;
                 changes.extend(page.changes);
@@ -227,6 +268,8 @@ pub fn reconcile_remote_catalog(
     snapshot: &mut RemoteCatalogSnapshot,
     result: &RemoteRefreshResult,
 ) {
+    debug_assert!(result.pages > 0 || result.changes.is_empty());
+    debug_assert!(result.error.is_none() || result.checkpoint.is_none());
     let mut entries: HashMap<String, RemoteCatalogEntry> = snapshot
         .entries
         .drain(..)
@@ -324,6 +367,25 @@ mod tests {
         pages: Mutex<VecDeque<Result<RemotePage, RemoteProviderError>>>,
     }
 
+    struct HangingProvider;
+
+    impl RemoteProvider for HangingProvider {
+        fn provider_id(&self) -> &'static str {
+            DROPBOX_PROVIDER_ID
+        }
+
+        fn connection_id(&self) -> &str {
+            DROPBOX_CONNECTION_ID
+        }
+
+        fn fetch_metadata_page<'a>(
+            &'a self,
+            _checkpoint: Option<&'a str>,
+        ) -> RemoteProviderFuture<'a> {
+            Box::pin(std::future::pending())
+        }
+    }
+
     impl RemoteProvider for FakeProvider {
         fn provider_id(&self) -> &'static str {
             DROPBOX_PROVIDER_ID
@@ -377,6 +439,20 @@ mod tests {
         assert_eq!(result.changes.len(), 2);
         assert_eq!(result.checkpoint.as_deref(), Some("complete"));
         assert!(result.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_hung_provider_page_becomes_a_recoverable_refresh_failure() {
+        let result = refresh_remote_catalog_with_page_timeout(
+            &HangingProvider,
+            None,
+            std::time::Duration::from_millis(10),
+        )
+        .await;
+        assert_eq!(result.pages, 0);
+        let error = result.error.expect("hung refresh should fail visibly");
+        assert_eq!(error.kind, RemoteProviderErrorKind::Unavailable);
+        assert!(error.message.contains("timed out"));
     }
 
     #[tokio::test]

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -979,8 +979,15 @@ pub struct RemoteUiState {
     pub refresh_items: usize,
     /// Current provider folder (`""` means the connection root).
     pub current_path: String,
+    /// Whether the Remote place reveals its configured connections.
+    pub place_expanded: bool,
+    /// Whether the Dropbox connection reveals its folder tree.
+    pub connection_expanded: bool,
     /// Paths expanded beneath the connection in Places.
     pub expanded: HashSet<String>,
+    /// Derived catalog lookup used by Places and ordinary folder navigation.
+    /// Values are indexes into `catalog.entries`, sorted folder-first by name.
+    pub catalog_children: HashMap<String, Vec<usize>>,
     /// Provider item identity of the current Remote selection.
     pub selected_path: Option<String>,
     /// A preview fetch / playback is in flight.
@@ -1007,7 +1014,10 @@ impl Default for RemoteUiState {
             refresh_pages: 0,
             refresh_items: 0,
             current_path: String::new(),
+            place_expanded: true,
+            connection_expanded: true,
             expanded: HashSet::new(),
+            catalog_children: HashMap::new(),
             selected_path: None,
             preview_in_progress: false,
             availability: HashMap::new(),
@@ -1017,6 +1027,45 @@ impl Default for RemoteUiState {
             cache_automatic_eviction: true,
             cache_error: None,
         }
+    }
+}
+
+impl RemoteUiState {
+    /// Rebuild the parent/children lookup after the catalog is loaded or
+    /// reconciled. UI redraws can then navigate one folder without rescanning
+    /// the complete provider catalog.
+    pub fn rebuild_catalog_children(&mut self) {
+        let mut children: HashMap<String, Vec<usize>> = HashMap::new();
+        for (index, entry) in self.catalog.entries.iter().enumerate() {
+            children
+                .entry(entry.parent_path.clone())
+                .or_default()
+                .push(index);
+        }
+        for indexes in children.values_mut() {
+            indexes.sort_by(|left, right| {
+                let left = &self.catalog.entries[*left];
+                let right = &self.catalog.entries[*right];
+                (
+                    !left.is_folder,
+                    left.name.to_ascii_lowercase(),
+                    &left.provider_item_id,
+                )
+                    .cmp(&(
+                        !right.is_folder,
+                        right.name.to_ascii_lowercase(),
+                        &right.provider_item_id,
+                    ))
+            });
+        }
+        self.catalog_children = children;
+    }
+
+    pub fn catalog_child_indices(&self, parent: &str) -> &[usize] {
+        self.catalog_children
+            .get(parent)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
     }
 }
 

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -679,6 +679,7 @@ impl BrowserState {
         &mut self,
         source: MediaSourceRef,
         estimate: Option<(f64, f32)>,
+        auto_confirm_threshold: f32,
     ) -> bool {
         if self.selected_source.as_ref() != Some(&source) {
             return false;
@@ -687,6 +688,13 @@ impl BrowserState {
         self.audition_bpm_detecting = false;
         self.audition_bpm_suggestion = estimate.map(|value| value.0);
         self.audition_bpm_confidence = estimate.map(|value| value.1);
+        self.audition_bpm_confirmed = estimate
+            .filter(|(bpm, confidence)| {
+                bpm.is_finite()
+                    && *bpm > 0.0
+                    && *confidence >= auto_confirm_threshold.clamp(0.0, 1.0)
+            })
+            .map(|(bpm, _)| bpm);
         if self.audition_bpm_edit.is_empty() {
             self.audition_bpm_edit = estimate
                 .map(|value| format!("{:.1}", value.0))
@@ -966,6 +974,9 @@ pub struct RemoteUiState {
     pub last_error: Option<String>,
     pub catalog: RemoteCatalogSnapshot,
     pub catalog_state: RemoteCatalogState,
+    /// Pages and entries applied during the current progressive Catalog Refresh.
+    pub refresh_pages: usize,
+    pub refresh_items: usize,
     /// Current provider folder (`""` means the connection root).
     pub current_path: String,
     /// Paths expanded beneath the connection in Places.
@@ -993,6 +1004,8 @@ impl Default for RemoteUiState {
             last_error: None,
             catalog: RemoteCatalogSnapshot::default(),
             catalog_state: RemoteCatalogState::default(),
+            refresh_pages: 0,
+            refresh_items: 0,
             current_path: String::new(),
             expanded: HashSet::new(),
             selected_path: None,


### PR DESCRIPTION
## Outcome

Completes the Browser foundation validation cutoff with keyboard result navigation and final responsive polish. This is a chained feature PR based on Card 13 (#63), not a release PR.

## Changes

- add plain Up/Down navigation across visible actionable Browser results while preserving Ctrl+Up/Down track reorder
- route keyboard selection through the same Local/Remote selection and Audition paths as pointer input
- keep compact selected-row BPM and length metadata visible
- prevent narrow Remote refresh/BPM controls from wrapping
- mirror table ordering/window limits so keyboard navigation cannot select hidden results

## Verification

- `cargo test --workspace` (UI: 176 passed; workspace green)
- `cargo clippy -p vibez-ui --lib -- -D warnings`
- `cargo build --release -p vibez --bin vibez`
- `cargo fmt --all -- --check`
- native Xvfb release-binary smoke in High Contrast narrow, Solarized Light standard, and custom `.vzt` wide states
- native Remote keyboard-selection/Audition proof plus prior Card 13 import/save/reopen proof

## Scope

No Favorites, Recents, Crates, Offline Pins, ISO/CUE, marketplace, additional provider, Perform, MIDI-import, or unrelated architecture work.