### PR TITLE
refactor(ui): separate project tracks from timeline content

### DIFF
--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -257,6 +257,47 @@ mod tests {
     }
 
     #[test]
+    fn existing_project_document_roundtrips_semantically_unchanged() {
+        let track = TrackInfo::new("Legacy Track");
+        let project = Project {
+            name: "Legacy Layout".into(),
+            bpm: 123.0,
+            sample_rate: 44_100,
+            tracks: vec![track.clone()],
+            clips: vec![ClipInfo {
+                id: ClipId::new(),
+                track_id: track.id,
+                name: "legacy.wav".into(),
+                position: 128,
+                source_offset: 32,
+                duration: 2_048,
+                source: Some(MediaSourceRef::LocalFile {
+                    path: PathBuf::from("audio/legacy.wav"),
+                }),
+                file_path: Some(PathBuf::from("audio/legacy.wav")),
+                loop_enabled: true,
+                loop_start: 32,
+                loop_end: 2_080,
+                original_bpm: Some(123.0),
+                warped: false,
+                warped_to_bpm: None,
+            }],
+            note_clips: Vec::new(),
+            master: None,
+            buses: Vec::new(),
+        };
+        let legacy_bytes = serde_json::to_vec_pretty(&project).unwrap();
+
+        let loaded: Project = serde_json::from_slice(&legacy_bytes).unwrap();
+        let rewritten = serde_json::to_vec_pretty(&loaded).unwrap();
+
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&legacy_bytes).unwrap(),
+            serde_json::from_slice::<serde_json::Value>(&rewritten).unwrap()
+        );
+    }
+
+    #[test]
     fn load_bad_path() {
         let result = Project::load_from_file(Path::new("/nonexistent/path.vibez"));
         assert!(result.is_err());

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -404,8 +404,9 @@ impl App {
                         self.state.peak_l = peak_l.max(self.state.peak_l * 0.85);
                         self.state.peak_r = peak_r.max(self.state.peak_r * 0.85);
                         // The master strip meters the same summed mix.
-                        self.state.arrangement.master.peak_l = self.state.peak_l;
-                        self.state.arrangement.master.peak_r = self.state.peak_r;
+                        let project_tracks = Arc::make_mut(&mut self.state.project_tracks);
+                        project_tracks.master.peak_l = self.state.peak_l;
+                        project_tracks.master.peak_r = self.state.peak_r;
                     }
                     EngineEvent::PlaybackStopped => {
                         self.state.transport.playing = false;

--- a/crates/vibez-ui/src/app/bounce.rs
+++ b/crates/vibez-ui/src/app/bounce.rs
@@ -12,7 +12,7 @@ use vibez_core::id::{ClipId, TrackId};
 use vibez_engine::commands::EngineCommand;
 
 use crate::message::Message;
-use crate::state::{ArrangementSelection, UiClip, UiTrack};
+use crate::state::{ArrangementSelection, ProjectTrack, UiClip};
 
 use super::*;
 
@@ -32,9 +32,11 @@ impl App {
         let mut clips = std::collections::HashMap::new();
         let mut samplers = std::collections::HashMap::new();
         let mut pads = std::collections::HashMap::new();
-        for track in &self.state.arrangement.tracks {
-            for clip in &track.clips {
-                clips.insert(clip.id, Arc::clone(&clip.audio));
+        for track in &self.state.project_tracks.tracks {
+            if let Some(content) = self.state.arrange_content(track.id) {
+                for clip in &content.clips {
+                    clips.insert(clip.id, Arc::clone(&clip.audio));
+                }
             }
             if let Some(audio) = &track.sample_audio {
                 samplers.insert(
@@ -118,16 +120,15 @@ impl App {
 
     pub(super) fn finalize_bounce(&mut self, outcome: crate::message::BounceOutcome) {
         let track_num = self.next_unique_track_number("Bounce");
-        self.state.arrangement.next_track_number = track_num + 1;
+        Arc::make_mut(&mut self.state.project_tracks).next_track_number = track_num + 1;
         let color_index = (track_num.wrapping_sub(1) % 8) as u8;
         let track_id = TrackId::new();
         let track_name = format!("Bounce {track_num}");
 
         self.send_command(EngineCommand::AddTrack(track_id, track_name.clone()));
-        self.state
-            .arrangement
+        Arc::make_mut(&mut self.state.project_tracks)
             .tracks
-            .push(UiTrack::new(track_id, track_name, color_index));
+            .push(ProjectTrack::new(track_id, track_name, color_index));
 
         let clip_id = ClipId::new();
         let duration = outcome.audio.num_frames() as u64;
@@ -143,8 +144,8 @@ impl App {
             loop_end: 0,
         });
 
-        if let Some(track) = self.state.find_track_mut(track_id) {
-            track.clips.push(UiClip {
+        if self.state.find_track(track_id).is_some() {
+            self.state.arrange_content_mut(track_id).clips.push(UiClip {
                 id: clip_id,
                 name: outcome.clip_name.clone(),
                 audio: Arc::clone(&outcome.audio),
@@ -192,8 +193,10 @@ impl App {
         self.state.view.context_menu = None;
         let (range, insert_pos, name) = if is_note_clip {
             let spb = self.state.transport.sample_rate as f64 * 60.0 / self.state.transport.bpm;
-            let track_opt = self.state.find_track(track_id);
-            let nc = track_opt.and_then(|t| t.note_clips.iter().find(|c| c.id == clip_id));
+            let nc = self
+                .state
+                .arrange_content(track_id)
+                .and_then(|content| content.note_clips.iter().find(|c| c.id == clip_id));
             match nc {
                 Some(nc) => {
                     let start = (nc.position_beats * spb) as u64;
@@ -203,8 +206,10 @@ impl App {
                 None => (None, 0, String::new()),
             }
         } else {
-            let track_opt = self.state.find_track(track_id);
-            let ac = track_opt.and_then(|t| t.clips.iter().find(|c| c.id == clip_id));
+            let ac = self
+                .state
+                .arrange_content(track_id)
+                .and_then(|content| content.clips.iter().find(|c| c.id == clip_id));
             match ac {
                 Some(ac) => (
                     Some((ac.position, ac.position + ac.duration)),

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -12,7 +12,7 @@ use vibez_core::track::MediaSourceRef;
 use vibez_engine::commands::{AuditionSync, EngineCommand};
 
 use crate::message::{BrowserImportTarget, Message, PreparedBrowserImport};
-use crate::state::{AuditionMode, SampleBrowserEntry, UiClip, UiDrumPad, UiTrack};
+use crate::state::{AuditionMode, ProjectTrack, SampleBrowserEntry, UiClip, UiDrumPad};
 
 use super::*;
 
@@ -438,16 +438,16 @@ impl App {
         }
 
         let track_num = self.next_unique_track_number("Audio");
-        self.state.arrangement.next_track_number = track_num + 1;
+        Arc::make_mut(&mut self.state.project_tracks).next_track_number = track_num + 1;
         let id = TrackId::new();
         let color_index = ((track_num - 1) % 8) as u8;
         let name = format!("Audio {track_num}");
 
         self.send_command(EngineCommand::AddTrack(id, name.clone()));
-        self.state
-            .arrangement
+        Arc::make_mut(&mut self.state.project_tracks)
             .tracks
-            .push(UiTrack::new(id, name, color_index));
+            .push(ProjectTrack::new(id, name, color_index));
+        self.state.arrange_content_mut(id);
         self.state.arrangement.selected_track = Some(id);
         id
     }
@@ -600,8 +600,8 @@ impl App {
             loop_start: 0,
             loop_end: 0,
         });
-        if let Some(track) = self.state.find_track_mut(track_id) {
-            track.clips.push(UiClip {
+        if self.state.find_track(track_id).is_some() {
+            self.state.arrange_content_mut(track_id).clips.push(UiClip {
                 id: clip_id,
                 name: name.clone(),
                 audio: Arc::clone(&audio),

--- a/crates/vibez-ui/src/app/media_import.rs
+++ b/crates/vibez-ui/src/app/media_import.rs
@@ -181,11 +181,11 @@ impl App {
         clip_id: ClipId,
         grid: crate::state::SnapGrid,
     ) -> Task<Message> {
-        let Some(track) = self.state.find_track(track_id) else {
+        let Some(content) = self.state.arrange_content(track_id) else {
             self.state.status_text = "Track not found".to_string();
             return Task::none();
         };
-        let Some(clip) = track.clips.iter().find(|c| c.id == clip_id) else {
+        let Some(clip) = content.clips.iter().find(|c| c.id == clip_id) else {
             self.state.status_text = "Clip not found".to_string();
             return Task::none();
         };
@@ -221,11 +221,11 @@ impl App {
         track_id: TrackId,
         clip_id: ClipId,
     ) -> Task<Message> {
-        let Some(track) = self.state.find_track(track_id) else {
+        let Some(content) = self.state.arrange_content(track_id) else {
             self.state.status_text = "Track not found".to_string();
             return Task::none();
         };
-        let Some(clip) = track.clips.iter().find(|c| c.id == clip_id) else {
+        let Some(clip) = content.clips.iter().find(|c| c.id == clip_id) else {
             self.state.status_text = "Clip not found".to_string();
             return Task::none();
         };
@@ -258,17 +258,18 @@ impl App {
         let mut warped: Vec<(TrackId, ClipId)> = Vec::new();
         let mut moves: Vec<(TrackId, ClipId, u64)> = Vec::new();
 
-        for track in &mut self.state.arrangement.tracks {
-            for clip in &mut track.clips {
+        for (track_id, content) in &mut Arc::make_mut(&mut self.state.arrangement.timeline).by_track
+        {
+            for clip in &mut content.clips {
                 if !clip.warped {
                     continue;
                 }
                 let new_position = (clip.position as f64 * position_ratio).round() as u64;
                 if new_position != clip.position {
                     clip.position = new_position;
-                    moves.push((track.id, clip.id, new_position));
+                    moves.push((*track_id, clip.id, new_position));
                 }
-                warped.push((track.id, clip.id));
+                warped.push((*track_id, clip.id));
             }
         }
         for (track_id, clip_id, new_position) in moves {
@@ -303,11 +304,11 @@ impl App {
             self.state.status_text = "Cannot warp at zero BPM".to_string();
             return Task::none();
         }
-        let Some(track) = self.state.find_track(track_id) else {
+        let Some(content) = self.state.arrange_content(track_id) else {
             self.state.status_text = "Track not found".to_string();
             return Task::none();
         };
-        let Some(clip) = track.clips.iter().find(|c| c.id == clip_id) else {
+        let Some(clip) = content.clips.iter().find(|c| c.id == clip_id) else {
             self.state.status_text = "Clip not found".to_string();
             return Task::none();
         };
@@ -465,7 +466,7 @@ impl App {
     ) -> Task<Message> {
         let existing_end = self
             .state
-            .find_track(track_id)
+            .arrange_content(track_id)
             .map(|t| {
                 t.clips
                     .iter()
@@ -489,8 +490,8 @@ impl App {
             loop_end: 0,
         });
 
-        if let Some(track) = self.state.find_track_mut(track_id) {
-            track.clips.push(UiClip {
+        if self.state.find_track(track_id).is_some() {
+            self.state.arrange_content_mut(track_id).clips.push(UiClip {
                 id: clip_id,
                 name: name.clone(),
                 audio: Arc::clone(&audio),
@@ -556,15 +557,20 @@ impl App {
         // Collect targets first so we don't hold a borrow across dispatch.
         let targets: Vec<(TrackId, ClipId)> = self
             .state
-            .arrangement
+            .project_tracks
             .tracks
             .iter()
             .flat_map(|track| {
-                track
-                    .clips
-                    .iter()
-                    .filter(|c| c.warped && c.original_bpm.is_some())
-                    .map(move |c| (track.id, c.id))
+                self.state
+                    .arrange_content(track.id)
+                    .into_iter()
+                    .flat_map(move |content| {
+                        content
+                            .clips
+                            .iter()
+                            .filter(|c| c.warped && c.original_bpm.is_some())
+                            .map(move |c| (track.id, c.id))
+                    })
             })
             .collect();
         if targets.is_empty() {

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -396,8 +396,8 @@ impl App {
 
     pub(super) fn active_editor_pixels_per_beat(&self) -> f32 {
         if let Some((track_id, clip_id)) = self.state.arrangement.selected_note_clip {
-            if let Some(duration) = self.state.find_track(track_id).and_then(|track| {
-                track
+            if let Some(duration) = self.state.arrange_content(track_id).and_then(|content| {
+                content
                     .note_clips
                     .iter()
                     .find(|clip| clip.id == clip_id)
@@ -415,13 +415,18 @@ impl App {
     /// deletes, or undo chains.
     fn next_unique_track_number(&mut self, prefix: &str) -> u32 {
         loop {
-            let candidate = self.state.arrangement.next_track_number;
+            let candidate = self.state.project_tracks.next_track_number;
             let name = format!("{prefix} {candidate}");
-            let clash = self.state.arrangement.tracks.iter().any(|t| t.name == name);
+            let clash = self
+                .state
+                .project_tracks
+                .tracks
+                .iter()
+                .any(|t| t.name == name);
             if !clash {
                 return candidate;
             }
-            self.state.arrangement.next_track_number += 1;
+            Arc::make_mut(&mut self.state.project_tracks).next_track_number += 1;
         }
     }
 

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -16,7 +16,7 @@ use vibez_plugin_host::gui::PluginGuiKey;
 use vibez_project::Project;
 
 use crate::message::{Message, ProjectLoadResult};
-use crate::state::{UiClip, UiDrumPad, UiEffect, UiNoteClip, UiTrack};
+use crate::state::{ProjectTrack, UiClip, UiDrumPad, UiEffect, UiNoteClip};
 use crate::ui_settings::UiSettings;
 
 use super::*;
@@ -32,18 +32,30 @@ impl App {
         self.send_command(EngineCommand::Stop);
         self.send_command(EngineCommand::Seek(0));
 
-        let existing_track_ids: Vec<TrackId> =
-            self.state.arrangement.tracks.iter().map(|t| t.id).collect();
+        let existing_track_ids: Vec<TrackId> = self
+            .state
+            .project_tracks
+            .tracks
+            .iter()
+            .map(|t| t.id)
+            .collect();
         for track_id in existing_track_ids {
             self.send_command(EngineCommand::RemoveTrack(track_id));
         }
 
-        self.state.arrangement.tracks.clear();
-        let bus_ids: Vec<TrackId> = self.state.arrangement.buses.iter().map(|b| b.id).collect();
+        Arc::make_mut(&mut self.state.project_tracks).tracks.clear();
+        let bus_ids: Vec<TrackId> = self
+            .state
+            .project_tracks
+            .buses
+            .iter()
+            .map(|b| b.id)
+            .collect();
         for bus_id in bus_ids {
             self.send_command(EngineCommand::RemoveBus(bus_id));
         }
-        self.state.arrangement.buses.clear();
+        Arc::make_mut(&mut self.state.project_tracks).buses.clear();
+        self.state.arrangement.timeline = Arc::new(crate::state::ArrangementTimeline::default());
         self.reset_master_channel();
         // The engine drops all plugin instances with their tracks;
         // their GUI windows and stale raw pointers must go with them
@@ -54,7 +66,7 @@ impl App {
         self.plugin_gui_raw_ptrs.clear();
         self.plugin_state_ptrs.clear();
         self.state.arrangement.selected_track = None;
-        self.state.arrangement.next_track_number = 1;
+        Arc::make_mut(&mut self.state.project_tracks).next_track_number = 1;
         self.state.arrangement.selected_note_clip = None;
         self.state.arrangement.selected_clips.clear();
         self.state.transport.loop_enabled = false;
@@ -79,7 +91,7 @@ impl App {
     pub(super) fn reset_master_channel(&mut self) {
         let effect_ids: Vec<EffectId> = self
             .state
-            .arrangement
+            .project_tracks
             .master
             .effects
             .iter()
@@ -88,7 +100,7 @@ impl App {
         for effect_id in effect_ids {
             self.send_command(EngineCommand::RemoveEffect(TrackId::MASTER, effect_id));
         }
-        self.state.arrangement.master = crate::state::new_master_track();
+        Arc::make_mut(&mut self.state.project_tracks).master = crate::state::new_master_track();
         self.send_command(EngineCommand::SetTrackGain(TrackId::MASTER, 1.0));
     }
 
@@ -112,16 +124,8 @@ impl App {
             // find_track_mut borrows state; re-resolve inside the
             // engine-handle scope.
             let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
-            if let Some(channel) = if chan_id.is_master() {
-                Some(&mut self.state.arrangement.master)
-            } else {
-                self.state
-                    .arrangement
-                    .tracks
-                    .iter_mut()
-                    .chain(self.state.arrangement.buses.iter_mut())
-                    .find(|t| t.id == chan_id)
-            } {
+            let project_tracks = Arc::make_mut(&mut self.state.project_tracks);
+            if let Some(channel) = project_tracks.find_mut(chan_id) {
                 crate::domains::arrangement::attach_channel_eq(&mut engine, channel);
             }
         }
@@ -230,7 +234,7 @@ impl App {
         }
     }
 
-    pub(super) fn track_info_from_ui(&self, track: &UiTrack) -> TrackInfo {
+    pub(super) fn track_info_from_ui(&self, track: &ProjectTrack) -> TrackInfo {
         let effects = track
             .effects
             .iter()
@@ -291,7 +295,11 @@ impl App {
             instrument: track.instrument_kind,
             native_instrument,
             plugin_instrument,
-            automation: track.automation.clone(),
+            automation: self
+                .state
+                .arrange_content(track.id)
+                .map(|content| content.automation.clone())
+                .unwrap_or_default(),
             sends: track.sends.clone(),
         }
     }
@@ -308,7 +316,7 @@ impl App {
     pub(super) fn project_from_state(&self) -> Project {
         let tracks = self
             .state
-            .arrangement
+            .project_tracks
             .tracks
             .iter()
             .map(|track| self.track_info_from_ui(track))
@@ -316,57 +324,66 @@ impl App {
 
         let clips = self
             .state
-            .arrangement
+            .project_tracks
             .tracks
             .iter()
             .flat_map(|track| {
-                track.clips.iter().map(|clip| ClipInfo {
-                    id: clip.id,
-                    track_id: track.id,
-                    name: clip.name.clone(),
-                    position: clip.position,
-                    source_offset: clip.source_offset,
-                    duration: clip.duration,
-                    source: clip.source.clone(),
-                    file_path: clip.source.as_ref().and_then(|source| match source {
-                        MediaSourceRef::LocalFile { path } => Some(path.clone()),
-                        MediaSourceRef::StagedProjectMedia { .. }
-                        | MediaSourceRef::StagedRemoteProjectMedia { .. }
-                        | MediaSourceRef::ProjectMedia { .. }
-                        | MediaSourceRef::DropboxFile { .. } => None,
-                    }),
-                    loop_enabled: clip.loop_enabled,
-                    loop_start: clip.loop_start,
-                    loop_end: clip.loop_end,
-                    original_bpm: clip.original_bpm,
-                    warped: clip.warped,
-                    warped_to_bpm: clip.warped_to_bpm,
-                })
-            })
-            .collect();
-
-        let note_clips = self
-            .state
-            .arrangement
-            .tracks
-            .iter()
-            .flat_map(|track| {
-                track
-                    .note_clips
-                    .iter()
-                    .map(|clip| vibez_core::midi::NoteClipInfo {
-                        id: clip.id,
-                        track_id: track.id,
-                        name: clip.name.clone(),
-                        position_beats: clip.position_beats,
-                        duration_beats: clip.duration_beats,
-                        notes: clip.notes.clone(),
-                        loop_enabled: clip.loop_enabled,
-                        loop_start_beats: clip.loop_start_beats,
-                        loop_end_beats: clip.loop_end_beats,
+                self.state
+                    .arrange_content(track.id)
+                    .into_iter()
+                    .flat_map(move |content| {
+                        content.clips.iter().map(move |clip| ClipInfo {
+                            id: clip.id,
+                            track_id: track.id,
+                            name: clip.name.clone(),
+                            position: clip.position,
+                            source_offset: clip.source_offset,
+                            duration: clip.duration,
+                            source: clip.source.clone(),
+                            file_path: clip.source.as_ref().and_then(|source| match source {
+                                MediaSourceRef::LocalFile { path } => Some(path.clone()),
+                                MediaSourceRef::StagedProjectMedia { .. }
+                                | MediaSourceRef::StagedRemoteProjectMedia { .. }
+                                | MediaSourceRef::ProjectMedia { .. }
+                                | MediaSourceRef::DropboxFile { .. } => None,
+                            }),
+                            loop_enabled: clip.loop_enabled,
+                            loop_start: clip.loop_start,
+                            loop_end: clip.loop_end,
+                            original_bpm: clip.original_bpm,
+                            warped: clip.warped,
+                            warped_to_bpm: clip.warped_to_bpm,
+                        })
                     })
             })
             .collect();
+
+        let note_clips =
+            self.state
+                .project_tracks
+                .tracks
+                .iter()
+                .flat_map(|track| {
+                    self.state
+                        .arrange_content(track.id)
+                        .into_iter()
+                        .flat_map(move |content| {
+                            content.note_clips.iter().map(move |clip| {
+                                vibez_core::midi::NoteClipInfo {
+                                    id: clip.id,
+                                    track_id: track.id,
+                                    name: clip.name.clone(),
+                                    position_beats: clip.position_beats,
+                                    duration_beats: clip.duration_beats,
+                                    notes: clip.notes.clone(),
+                                    loop_enabled: clip.loop_enabled,
+                                    loop_start_beats: clip.loop_start_beats,
+                                    loop_end_beats: clip.loop_end_beats,
+                                }
+                            })
+                        })
+                })
+                .collect();
 
         Project {
             name: self
@@ -382,10 +399,10 @@ impl App {
             tracks,
             clips,
             note_clips,
-            master: Some(self.track_info_from_ui(&self.state.arrangement.master)),
+            master: Some(self.track_info_from_ui(&self.state.project_tracks.master)),
             buses: self
                 .state
-                .arrangement
+                .project_tracks
                 .buses
                 .iter()
                 .map(|bus| self.track_info_from_ui(bus))
@@ -407,10 +424,14 @@ impl App {
 
     pub(super) fn apply_saved_project_sources(&mut self, project: &Project) {
         for saved_clip in &project.clips {
-            if let Some(track) = self.state.find_track_mut(saved_clip.track_id) {
-                if let Some(clip) = track.clips.iter_mut().find(|clip| clip.id == saved_clip.id) {
-                    clip.source = saved_clip.source.clone();
-                }
+            if let Some(clip) = self
+                .state
+                .arrange_content_mut(saved_clip.track_id)
+                .clips
+                .iter_mut()
+                .find(|clip| clip.id == saved_clip.id)
+            {
+                clip.source = saved_clip.source.clone();
             }
         }
         for saved_track in &project.tracks {
@@ -477,7 +498,7 @@ impl App {
         self.send_command(EngineCommand::SetBpm(loaded.project.bpm));
 
         for track_info in &loaded.project.tracks {
-            let mut track = UiTrack::new_instrument(
+            let mut track = ProjectTrack::new_instrument(
                 track_info.id,
                 track_info.name.clone(),
                 track_info.kind,
@@ -487,7 +508,8 @@ impl App {
             track.pan = track_info.pan;
             track.mute = track_info.mute;
             track.solo = track_info.solo;
-            track.automation = track_info.automation.clone();
+            self.state.arrange_content_mut(track_info.id).automation =
+                track_info.automation.clone();
             track.instrument_kind = track_info.instrument;
             track.has_instrument = track_info.instrument.is_some();
             if let Some(dev) = &track_info.plugin_instrument {
@@ -650,19 +672,18 @@ impl App {
                 });
             }
 
-            self.state.arrangement.next_track_number = self
-                .state
-                .arrangement
+            let project_tracks = Arc::make_mut(&mut self.state.project_tracks);
+            project_tracks.next_track_number = project_tracks
                 .next_track_number
-                .max(self.state.arrangement.tracks.len() as u32 + 1);
-            self.state.arrangement.tracks.push(track);
+                .max(project_tracks.tracks.len() as u32 + 2);
+            project_tracks.tracks.push(track);
         }
 
         // Master bus: gain + effect chain from the file, then the
         // channel-EQ backfill for projects saved before the master
         // was a real channel. clear_project_runtime left it bare.
         if let Some(master_info) = &loaded.project.master {
-            self.state.arrangement.master.gain = master_info.gain;
+            Arc::make_mut(&mut self.state.project_tracks).master.gain = master_info.gain;
             self.send_command(EngineCommand::SetTrackGain(
                 TrackId::MASTER,
                 master_info.gain,
@@ -672,8 +693,9 @@ impl App {
                 TrackId::MASTER,
                 &mut plugin_effect_requests,
             );
-            self.state.arrangement.master.effects = effects;
-            self.state.arrangement.master.automation = master_info.automation.clone();
+            Arc::make_mut(&mut self.state.project_tracks).master.effects = effects;
+            self.state.arrange_content_mut(TrackId::MASTER).automation =
+                master_info.automation.clone();
             for lane in &master_info.automation {
                 self.send_command(EngineCommand::SetAutomationLane {
                     track_id: TrackId::MASTER,
@@ -687,7 +709,8 @@ impl App {
         // were restored with their tracks above.
         for bus_info in &loaded.project.buses {
             self.send_command(EngineCommand::AddBus(bus_info.id, bus_info.name.clone()));
-            let mut bus = UiTrack::new(bus_info.id, bus_info.name.clone(), bus_info.color_index);
+            let mut bus =
+                ProjectTrack::new(bus_info.id, bus_info.name.clone(), bus_info.color_index);
             bus.gain = bus_info.gain;
             bus.pan = bus_info.pan;
             bus.mute = bus_info.mute;
@@ -701,14 +724,16 @@ impl App {
                 bus_info.id,
                 &mut plugin_effect_requests,
             );
-            bus.automation = bus_info.automation.clone();
+            self.state.arrange_content_mut(bus_info.id).automation = bus_info.automation.clone();
             for lane in &bus_info.automation {
                 self.send_command(EngineCommand::SetAutomationLane {
                     track_id: bus_info.id,
                     lane: lane.clone(),
                 });
             }
-            self.state.arrangement.buses.push(bus);
+            Arc::make_mut(&mut self.state.project_tracks)
+                .buses
+                .push(bus);
             self.ensure_channel_eq(bus_info.id);
         }
 
@@ -725,23 +750,26 @@ impl App {
                 loop_end: loaded_clip.info.loop_end,
             });
 
-            if let Some(track) = self.state.find_track_mut(loaded_clip.info.track_id) {
-                track.clips.push(UiClip {
-                    id: loaded_clip.info.id,
-                    name: loaded_clip.info.name,
-                    audio: loaded_clip.audio,
-                    source: loaded_clip.info.source.clone(),
-                    position: loaded_clip.info.position,
-                    source_offset: loaded_clip.info.source_offset,
-                    duration: loaded_clip.info.duration,
-                    loop_enabled: loaded_clip.info.loop_enabled,
-                    loop_start: loaded_clip.info.loop_start,
-                    loop_end: loaded_clip.info.loop_end,
-                    original_bpm: loaded_clip.info.original_bpm,
-                    warped: loaded_clip.info.warped,
-                    warped_to_bpm: loaded_clip.info.warped_to_bpm,
-                    original_audio: loaded_clip.original_audio,
-                });
+            if self.state.find_track(loaded_clip.info.track_id).is_some() {
+                self.state
+                    .arrange_content_mut(loaded_clip.info.track_id)
+                    .clips
+                    .push(UiClip {
+                        id: loaded_clip.info.id,
+                        name: loaded_clip.info.name,
+                        audio: loaded_clip.audio,
+                        source: loaded_clip.info.source.clone(),
+                        position: loaded_clip.info.position,
+                        source_offset: loaded_clip.info.source_offset,
+                        duration: loaded_clip.info.duration,
+                        loop_enabled: loaded_clip.info.loop_enabled,
+                        loop_start: loaded_clip.info.loop_start,
+                        loop_end: loaded_clip.info.loop_end,
+                        original_bpm: loaded_clip.info.original_bpm,
+                        warped: loaded_clip.info.warped,
+                        warped_to_bpm: loaded_clip.info.warped_to_bpm,
+                        original_audio: loaded_clip.original_audio,
+                    });
             }
         }
 
@@ -762,18 +790,21 @@ impl App {
                     note: *note,
                 });
             }
-            if let Some(track) = self.state.find_track_mut(note_clip.track_id) {
-                track.note_clips.push(UiNoteClip {
-                    id: note_clip.id,
-                    name: note_clip.name.clone(),
-                    position_beats: note_clip.position_beats,
-                    duration_beats: note_clip.duration_beats,
-                    notes: note_clip.notes.clone(),
-                    selected_notes: HashSet::new(),
-                    loop_enabled: note_clip.loop_enabled,
-                    loop_start_beats: note_clip.loop_start_beats,
-                    loop_end_beats: note_clip.loop_end_beats,
-                });
+            if self.state.find_track(note_clip.track_id).is_some() {
+                self.state
+                    .arrange_content_mut(note_clip.track_id)
+                    .note_clips
+                    .push(UiNoteClip {
+                        id: note_clip.id,
+                        name: note_clip.name.clone(),
+                        position_beats: note_clip.position_beats,
+                        duration_beats: note_clip.duration_beats,
+                        notes: note_clip.notes.clone(),
+                        selected_notes: HashSet::new(),
+                        loop_enabled: note_clip.loop_enabled,
+                        loop_start_beats: note_clip.loop_start_beats,
+                        loop_end_beats: note_clip.loop_end_beats,
+                    });
             }
         }
 
@@ -811,8 +842,12 @@ impl App {
             });
         }
 
-        self.state.arrangement.selected_track =
-            self.state.arrangement.tracks.first().map(|track| track.id);
+        self.state.arrangement.selected_track = self
+            .state
+            .project_tracks
+            .tracks
+            .first()
+            .map(|track| track.id);
         self.state.project.current_path = Some(loaded.path.clone());
         self.state.project.dirty = false;
         let provenance_suffix = remote_provenance

--- a/crates/vibez-ui/src/app/project_replay.rs
+++ b/crates/vibez-ui/src/app/project_replay.rs
@@ -7,16 +7,15 @@ use vibez_core::id::{EffectId, TrackId};
 use vibez_core::midi::{InstrumentKind, TrackKind};
 use vibez_engine::commands::EngineCommand;
 
-use crate::state::UiTrack;
+use crate::state::ProjectTrack;
 
 use super::*;
 
 impl App {
     pub(super) fn take_snapshot(&self) -> crate::state::ProjectSnapshot {
         crate::state::ProjectSnapshot {
-            tracks: self.state.arrangement.tracks.clone(),
-            master: self.state.arrangement.master.clone(),
-            buses: self.state.arrangement.buses.clone(),
+            project_tracks: Arc::clone(&self.state.project_tracks),
+            arrange_timeline: Arc::clone(&self.state.arrangement.timeline),
             bpm: self.state.transport.bpm,
             bpm_text: self.state.transport.bpm_text.clone(),
             loop_enabled: self.state.transport.loop_enabled,
@@ -25,7 +24,6 @@ impl App {
             selected_track: self.state.arrangement.selected_track,
             selected_clips: self.state.arrangement.selected_clips.clone(),
             selected_note_clip: self.state.arrangement.selected_note_clip,
-            next_track_number: self.state.arrangement.next_track_number,
         }
     }
 
@@ -57,8 +55,13 @@ impl App {
         self.plugin_state_ptrs.clear();
 
         // Tear down the engine side.
-        let existing_track_ids: Vec<TrackId> =
-            self.state.arrangement.tracks.iter().map(|t| t.id).collect();
+        let existing_track_ids: Vec<TrackId> = self
+            .state
+            .project_tracks
+            .tracks
+            .iter()
+            .map(|t| t.id)
+            .collect();
         for track_id in existing_track_ids {
             self.send_command(EngineCommand::RemoveTrack(track_id));
         }
@@ -66,7 +69,7 @@ impl App {
         // explicitly so the snapshot replay starts from bare.
         let master_effect_ids: Vec<EffectId> = self
             .state
-            .arrangement
+            .project_tracks
             .master
             .effects
             .iter()
@@ -76,14 +79,19 @@ impl App {
             self.send_command(EngineCommand::RemoveEffect(TrackId::MASTER, effect_id));
         }
 
-        let bus_ids: Vec<TrackId> = self.state.arrangement.buses.iter().map(|b| b.id).collect();
+        let bus_ids: Vec<TrackId> = self
+            .state
+            .project_tracks
+            .buses
+            .iter()
+            .map(|b| b.id)
+            .collect();
         for bus_id in bus_ids {
             self.send_command(EngineCommand::RemoveBus(bus_id));
         }
 
-        self.state.arrangement.master = snapshot.master;
-        self.state.arrangement.buses = snapshot.buses;
-        self.state.arrangement.tracks = snapshot.tracks;
+        self.state.project_tracks = snapshot.project_tracks;
+        self.state.arrangement.timeline = snapshot.arrange_timeline;
         self.state.transport.bpm = snapshot.bpm;
         self.state.transport.bpm_text = snapshot.bpm_text;
         self.state.transport.loop_enabled = snapshot.loop_enabled;
@@ -92,7 +100,6 @@ impl App {
         self.state.arrangement.selected_track = snapshot.selected_track;
         self.state.arrangement.selected_clips = snapshot.selected_clips;
         self.state.arrangement.selected_note_clip = snapshot.selected_note_clip;
-        self.state.arrangement.next_track_number = snapshot.next_track_number;
 
         self.send_command(EngineCommand::SetBpm(self.state.transport.bpm));
         self.send_command(EngineCommand::SetArrangementLoop(
@@ -108,13 +115,13 @@ impl App {
             self.send_command(EngineCommand::SetArrangementLoopRegion { start, end });
         }
 
-        let tracks = self.state.arrangement.tracks.clone();
+        let tracks = self.state.project_tracks.tracks.clone();
         for track in &tracks {
             self.replay_track_to_engine(track);
         }
-        let master = self.state.arrangement.master.clone();
+        let master = self.state.project_tracks.master.clone();
         self.replay_track_to_engine(&master);
-        let buses = self.state.arrangement.buses.clone();
+        let buses = self.state.project_tracks.buses.clone();
         for bus in &buses {
             self.replay_bus_to_engine(bus);
         }
@@ -124,13 +131,18 @@ impl App {
         self.spawn_project_plugin_loads(reloads.effects, reloads.instruments);
     }
 
-    pub(super) fn replay_track_to_engine(&mut self, track: &UiTrack) {
+    pub(super) fn replay_track_to_engine(&mut self, track: &ProjectTrack) {
+        let content = self
+            .state
+            .arrange_content(track.id)
+            .cloned()
+            .unwrap_or_default();
         if track.id.is_master() {
             // The master bus always exists in the engine: replay only
             // its gain and effect chain.
             self.send_command(EngineCommand::SetTrackGain(track.id, track.gain));
             self.replay_effects_to_engine(track);
-            for lane in &track.automation {
+            for lane in &content.automation {
                 self.send_command(EngineCommand::SetAutomationLane {
                     track_id: track.id,
                     lane: lane.clone(),
@@ -191,7 +203,7 @@ impl App {
             }
         }
 
-        for lane in &track.automation {
+        for lane in &content.automation {
             self.send_command(EngineCommand::SetAutomationLane {
                 track_id: track.id,
                 lane: lane.clone(),
@@ -208,7 +220,7 @@ impl App {
             });
         }
 
-        for clip in &track.clips {
+        for clip in &content.clips {
             self.send_command(EngineCommand::AddClip {
                 track_id: track.id,
                 clip_id: clip.id,
@@ -222,7 +234,7 @@ impl App {
             });
         }
 
-        for clip in &track.note_clips {
+        for clip in &content.note_clips {
             self.send_command(EngineCommand::AddNoteClip {
                 track_id: track.id,
                 clip_id: clip.id,
@@ -244,14 +256,19 @@ impl App {
 
     /// Recreate a bus in the engine from its UI model: the channel
     /// itself, then gain/pan/mute and the effect chain.
-    fn replay_bus_to_engine(&mut self, bus: &UiTrack) {
+    fn replay_bus_to_engine(&mut self, bus: &ProjectTrack) {
+        let automation = self
+            .state
+            .arrange_content(bus.id)
+            .map(|content| content.automation.clone())
+            .unwrap_or_default();
         self.send_command(EngineCommand::AddBus(bus.id, bus.name.clone()));
         self.send_command(EngineCommand::SetTrackGain(bus.id, bus.gain));
         self.send_command(EngineCommand::SetTrackPan(bus.id, bus.pan));
         self.send_command(EngineCommand::SetTrackMute(bus.id, bus.mute));
         self.send_command(EngineCommand::SetTrackSolo(bus.id, bus.solo));
         self.replay_effects_to_engine(bus);
-        for lane in &bus.automation {
+        for lane in &automation {
             self.send_command(EngineCommand::SetAutomationLane {
                 track_id: bus.id,
                 lane: lane.clone(),
@@ -262,7 +279,7 @@ impl App {
     /// Replay a channel's built-in effect chain to the engine
     /// (add, params, bypass). Plugin devices reload through the
     /// async pipeline instead.
-    fn replay_effects_to_engine(&mut self, track: &UiTrack) {
+    fn replay_effects_to_engine(&mut self, track: &ProjectTrack) {
         for effect in &track.effects {
             self.send_command(EngineCommand::AddEffect {
                 track_id: track.id,

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -146,12 +146,13 @@ impl App {
                 let sample_rate = self.state.transport.sample_rate;
                 let action = {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+                    let project_tracks = Arc::make_mut(&mut self.state.project_tracks);
                     self.state.devices.update(
                         msg,
                         &mut engine,
-                        &mut self.state.arrangement.tracks,
-                        &mut self.state.arrangement.master,
-                        &mut self.state.arrangement.buses,
+                        &mut project_tracks.tracks,
+                        &mut project_tracks.master,
+                        &mut project_tracks.buses,
                         sample_rate,
                     )
                 };
@@ -169,7 +170,12 @@ impl App {
                 };
                 let action = {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
-                    self.state.arrangement.update(msg, &mut engine, ctx)
+                    self.state.arrangement.update(
+                        Arc::make_mut(&mut self.state.project_tracks),
+                        msg,
+                        &mut engine,
+                        ctx,
+                    )
                 };
                 return self.apply_arrangement_action(action);
             }
@@ -186,7 +192,7 @@ impl App {
                     self.state.piano_roll.update(
                         msg,
                         &mut engine,
-                        &mut self.state.arrangement.tracks,
+                        Arc::make_mut(&mut self.state.arrangement.timeline),
                         ctx,
                     )
                 };
@@ -199,12 +205,12 @@ impl App {
             Message::Automation(msg) => {
                 let action = {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+                    let project_tracks = Arc::make_mut(&mut self.state.project_tracks);
                     self.state.automation_ui.update(
                         msg,
                         &mut engine,
-                        &mut self.state.arrangement.tracks,
-                        &mut self.state.arrangement.master,
-                        &mut self.state.arrangement.buses,
+                        project_tracks,
+                        Arc::make_mut(&mut self.state.arrangement.timeline),
                     )
                 };
                 if let Some(status) = action.status {
@@ -258,7 +264,7 @@ impl App {
                 let action = self
                     .state
                     .view
-                    .update(msg, &self.state.arrangement.tracks, ctx);
+                    .update(msg, &self.state.arrangement.timeline, ctx);
                 return self.apply_view_action(action);
             }
             Message::Project(msg) => {
@@ -442,7 +448,7 @@ impl App {
 
                     let is_bus = self
                         .state
-                        .arrangement
+                        .project_tracks
                         .buses
                         .iter()
                         .any(|b| b.id == track_id);

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -37,8 +37,8 @@ impl App {
         if let Some((track_id, clip_id)) = self.state.arrangement.selected_note_clip {
             let has_selection = self
                 .state
-                .find_track(track_id)
-                .and_then(|t| t.note_clips.iter().find(|c| c.id == clip_id))
+                .arrange_content(track_id)
+                .and_then(|content| content.note_clips.iter().find(|c| c.id == clip_id))
                 .is_some_and(|c| !c.selected_notes.is_empty());
             if has_selection {
                 return self.update(Message::PianoRoll(PianoRollMsg::RemoveSelectedNotes(

--- a/crates/vibez-ui/src/app/views_arrangement.rs
+++ b/crates/vibez-ui/src/app/views_arrangement.rs
@@ -15,7 +15,7 @@ use vibez_core::id::{ClipId, TrackId};
 
 use crate::icons;
 use crate::message::Message;
-use crate::state::{ArrangementSelection, ContextMenuTarget};
+use crate::state::{ArrangementSelection, ContextMenuTarget, TrackTimelineContent};
 use crate::theme as th;
 use crate::widgets::timeline::{ArrangementMinimap, MinimapTrack, RulerWidget, TrackClipCanvas};
 use crate::widgets::track_header::{view_editable_channel_name, view_track_header};
@@ -208,12 +208,13 @@ impl App {
 
         // Track rows: header widgets + clip canvas
         let mut track_rows = column![].spacing(0);
+        let empty_content = TrackTimelineContent::default();
 
         for (track_index, track) in self.state.project_tracks.tracks.iter().enumerate() {
             let content = self
                 .state
                 .arrange_content(track.id)
-                .expect("every Project Track has Arrange Timeline Content");
+                .unwrap_or(&empty_content);
             let selected = self.state.arrangement.selected_track == Some(track.id);
             let track_color = th::track_color(track.color_index);
 

--- a/crates/vibez-ui/src/app/views_arrangement.rs
+++ b/crates/vibez-ui/src/app/views_arrangement.rs
@@ -24,7 +24,7 @@ use super::*;
 
 impl App {
     pub(super) fn view_arrangement(&self) -> Element<'_, Message> {
-        if self.state.arrangement.tracks.is_empty() {
+        if self.state.project_tracks.tracks.is_empty() {
             let browser_drag_active = self.state.browser.drag_source.is_some();
             let empty_beat = match self.state.browser.drag_target {
                 Some(crate::state::BrowserDropTarget::EmptyArrangement { beat }) => Some(beat),
@@ -135,21 +135,27 @@ impl App {
             loop_end_beats: self.state.transport.loop_end_beats,
             tracks: self
                 .state
-                .arrangement
+                .project_tracks
                 .tracks
                 .iter()
                 .map(|t| {
                     let color = th::track_color(t.color_index);
-                    let mut clips: Vec<(f64, f64)> = t
-                        .clips
-                        .iter()
-                        .map(|c| (c.position as f64 / spb, c.duration as f64 / spb))
+                    let content = self.state.arrange_content(t.id);
+                    let mut clips: Vec<(f64, f64)> = content
+                        .into_iter()
+                        .flat_map(|content| {
+                            content
+                                .clips
+                                .iter()
+                                .map(|c| (c.position as f64 / spb, c.duration as f64 / spb))
+                        })
                         .collect();
-                    clips.extend(
-                        t.note_clips
+                    clips.extend(content.into_iter().flat_map(|content| {
+                        content
+                            .note_clips
                             .iter()
-                            .map(|c| (c.position_beats, c.duration_beats)),
-                    );
+                            .map(|c| (c.position_beats, c.duration_beats))
+                    }));
                     MinimapTrack { color, clips }
                 })
                 .collect(),
@@ -170,15 +176,21 @@ impl App {
         let minimap_row = row![minimap_spacer, minimap_canvas];
 
         // Collect track IDs and kinds for cross-track drag
-        let track_ids: Vec<TrackId> = self.state.arrangement.tracks.iter().map(|t| t.id).collect();
+        let track_ids: Vec<TrackId> = self
+            .state
+            .project_tracks
+            .tracks
+            .iter()
+            .map(|t| t.id)
+            .collect();
         let track_kinds: Vec<bool> = self
             .state
-            .arrangement
+            .project_tracks
             .tracks
             .iter()
             .map(|t| t.kind.is_midi())
             .collect();
-        let total_track_count = self.state.arrangement.tracks.len();
+        let total_track_count = self.state.project_tracks.tracks.len();
         let browser_drag_duration = self
             .state
             .browser
@@ -197,7 +209,11 @@ impl App {
         // Track rows: header widgets + clip canvas
         let mut track_rows = column![].spacing(0);
 
-        for (track_index, track) in self.state.arrangement.tracks.iter().enumerate() {
+        for (track_index, track) in self.state.project_tracks.tracks.iter().enumerate() {
+            let content = self
+                .state
+                .arrange_content(track.id)
+                .expect("every Project Track has Arrange Timeline Content");
             let selected = self.state.arrangement.selected_track == Some(track.id);
             let track_color = th::track_color(track.color_index);
 
@@ -236,6 +252,7 @@ impl App {
             // Clip canvas for this track
             let clip_canvas_widget = TrackClipCanvas::from_track(
                 track,
+                content,
                 playhead_beats,
                 zoom_level,
                 self.state.view.grid_config(),
@@ -355,10 +372,10 @@ impl App {
         // Clipless lanes at the bottom, Ableton-style: a slim header
         // (select, expand, delete for returns) and their automation
         // lanes when expanded.
-        let master_ref = &self.state.arrangement.master;
-        let channel_refs: Vec<&crate::state::UiTrack> = self
+        let master_ref = &self.state.project_tracks.master;
+        let channel_refs: Vec<&crate::state::ProjectTrack> = self
             .state
-            .arrangement
+            .project_tracks
             .buses
             .iter()
             .chain(std::iter::once(master_ref))
@@ -507,14 +524,20 @@ impl App {
     pub(super) fn push_automation_lanes<'a>(
         &'a self,
         mut rows: iced::widget::Column<'a, Message>,
-        track: &'a crate::state::UiTrack,
+        track: &'a crate::state::ProjectTrack,
         track_color: iced::Color,
     ) -> iced::widget::Column<'a, Message> {
         use crate::domains::automation::{target_label_with_buses, AutomationMsg};
         use crate::widgets::automation_lane::{AutomationLaneWidget, LANE_HEIGHT};
 
-        for lane in &track.automation {
-            let label = target_label_with_buses(&lane.target, track, &self.state.arrangement.buses);
+        let automation = self
+            .state
+            .arrange_content(track.id)
+            .map(|content| content.automation.as_slice())
+            .unwrap_or(&[]);
+        for lane in automation {
+            let label =
+                target_label_with_buses(&lane.target, track, &self.state.project_tracks.buses);
             let remove = button(icons::icon(icons::TRASH_2).size(9).color(th::text_dim()))
                 .on_press(Message::Automation(AutomationMsg::RemoveLane {
                     track_id: track.id,
@@ -642,19 +665,19 @@ impl App {
             let is_channel = track.id.is_master()
                 || self
                     .state
-                    .arrangement
+                    .project_tracks
                     .buses
                     .iter()
                     .any(|b| b.id == track.id);
             if !is_channel {
-                for bus in &self.state.arrangement.buses {
+                for bus in &self.state.project_tracks.buses {
                     choices.push(LaneChoice {
                         label: format!("Send: {}", bus.name),
                         target: vibez_core::automation::AutomationTarget::Send { bus_id: bus.id },
                     });
                 }
             }
-            choices.retain(|c| !track.automation.iter().any(|l| l.target == c.target));
+            choices.retain(|c| !automation.iter().any(|l| l.target == c.target));
 
             let needle = query.to_lowercase();
             let total_before = choices.len();
@@ -815,7 +838,7 @@ const MAX_PICKER_RESULTS: usize = 40;
 
 /// Reference value plus scale labels for a lane's target.
 fn lane_scale(
-    track: &crate::state::UiTrack,
+    track: &crate::state::ProjectTrack,
     target: &vibez_core::automation::AutomationTarget,
 ) -> (Option<f32>, String, String, String) {
     use crate::domains::automation::{normalized_target_value, target_descriptor};

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -122,7 +122,11 @@ impl App {
                                     _ => None,
                                 });
                         if let Some(sel_cid) = audio_sel {
-                            if let Some(clip) = track.clips.iter().find(|c| c.id == sel_cid) {
+                            if let Some(clip) = self
+                                .state
+                                .arrange_content(track_id)
+                                .and_then(|content| content.clips.iter().find(|c| c.id == sel_cid))
+                            {
                                 self.view_audio_clip_panel(track_id, clip, track_color)
                             } else {
                                 self.view_clip_placeholder()
@@ -196,11 +200,8 @@ impl App {
             if let Some((tid, cid)) = self.state.arrangement.selected_note_clip {
                 if tid == track_id {
                     self.state
-                        .arrangement
-                        .tracks
-                        .iter()
-                        .find(|t| t.id == track_id)
-                        .and_then(|t| t.note_clips.iter().find(|c| c.id == cid))
+                        .arrange_content(track_id)
+                        .and_then(|content| content.note_clips.iter().find(|c| c.id == cid))
                         .map(|c| {
                             (
                                 c.name.clone(),
@@ -219,8 +220,8 @@ impl App {
             };
 
         let piano_widget = if let Some(ref cd) = clip_data {
-            if let Some(track) = self.state.find_track(track_id) {
-                if let Some(clip) = track.note_clips.iter().find(|c| c.id == cd.5) {
+            if let Some(content) = self.state.arrange_content(track_id) {
+                if let Some(clip) = content.note_clips.iter().find(|c| c.id == cd.5) {
                     let clip_relative_playhead = playhead_beats - clip.position_beats;
                     PianoRollWidget::from_clip(
                         track_id,

--- a/crates/vibez-ui/src/app/views_mixer.rs
+++ b/crates/vibez-ui/src/app/views_mixer.rs
@@ -10,13 +10,13 @@ use crate::icons;
 use crate::message::Message;
 use crate::state::ContextMenuTarget;
 use crate::theme as th;
-use crate::widgets::mixer_strip::{view_mixer_strip, StripRole};
+use crate::widgets::mixer_strip::{view_mixer_strip, MixerStripView, StripRole};
 
 use super::*;
 
 impl App {
     pub(super) fn view_mixer(&self) -> Element<'_, Message> {
-        if self.state.arrangement.tracks.is_empty() {
+        if self.state.project_tracks.tracks.is_empty() {
             let prompt = text("Add a track to get started")
                 .size(16)
                 .color(th::text_dim());
@@ -35,19 +35,26 @@ impl App {
 
         // ── Channel strips, buses, pinned master ──
         let playhead_beat = self.state.position_beats();
-        let buses = &self.state.arrangement.buses;
+        let buses = &self.state.project_tracks.buses;
         let mut strips = row![].spacing(4).padding(8).height(Length::Fill);
 
-        for track in &self.state.arrangement.tracks {
+        for track in &self.state.project_tracks.tracks {
             let selected = self.state.arrangement.selected_track == Some(track.id);
             let strip = view_mixer_strip(
                 track,
-                selected,
                 StripRole::Track,
                 buses,
-                self.state.view.editing_track_name == Some(track.id),
-                &self.state.view.edit_name_text,
-                playhead_beat,
+                MixerStripView {
+                    selected,
+                    editing_name: self.state.view.editing_track_name == Some(track.id),
+                    edit_text: &self.state.view.edit_name_text,
+                    playhead_beat,
+                    automation: self
+                        .state
+                        .arrange_content(track.id)
+                        .map(|content| content.automation.as_slice())
+                        .unwrap_or(&[]),
+                },
             );
             strips = strips.push(strip);
         }
@@ -59,12 +66,19 @@ impl App {
             let selected = self.state.arrangement.selected_track == Some(bus.id);
             right_group = right_group.push(view_mixer_strip(
                 bus,
-                selected,
                 StripRole::Bus,
                 buses,
-                self.state.view.editing_track_name == Some(bus.id),
-                &self.state.view.edit_name_text,
-                playhead_beat,
+                MixerStripView {
+                    selected,
+                    editing_name: self.state.view.editing_track_name == Some(bus.id),
+                    edit_text: &self.state.view.edit_name_text,
+                    playhead_beat,
+                    automation: self
+                        .state
+                        .arrange_content(bus.id)
+                        .map(|content| content.automation.as_slice())
+                        .unwrap_or(&[]),
+                },
             ));
         }
 
@@ -105,13 +119,20 @@ impl App {
         let master_selected =
             self.state.arrangement.selected_track == Some(vibez_core::id::TrackId::MASTER);
         let master_strip = container(view_mixer_strip(
-            &self.state.arrangement.master,
-            master_selected,
+            &self.state.project_tracks.master,
             StripRole::Master,
             buses,
-            false,
-            &self.state.view.edit_name_text,
-            playhead_beat,
+            MixerStripView {
+                selected: master_selected,
+                editing_name: false,
+                edit_text: &self.state.view.edit_name_text,
+                playhead_beat,
+                automation: self
+                    .state
+                    .arrange_content(vibez_core::id::TrackId::MASTER)
+                    .map(|content| content.automation.as_slice())
+                    .unwrap_or(&[]),
+            },
         ))
         .padding(8)
         .height(Length::Fill);

--- a/crates/vibez-ui/src/domains/arrangement/media_ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/media_ops.rs
@@ -1,0 +1,661 @@
+//! Heavier arrangement operations: warp/quantize result
+//! application and clip joining (audio-buffer merges).
+
+use std::collections::HashSet;
+
+use crate::message::{AudioQuantizeSuccess, AutoWarpOutcome, ClipWarpSuccess};
+use std::sync::Arc;
+
+use vibez_core::id::{ClipId, TrackId};
+use vibez_core::midi::MidiNote;
+use vibez_engine::commands::EngineCommand;
+
+use super::EngineHandle;
+use crate::state::{ArrangementSelection, ArrangementState, UiClip, UiNoteClip};
+
+use super::*;
+
+fn audio_source_frame(clip: &UiClip, local_frame: u64) -> usize {
+    let raw = clip.source_offset.saturating_add(local_frame);
+    if clip.loop_enabled && clip.loop_end > clip.loop_start && raw >= clip.loop_end {
+        let loop_len = clip.loop_end - clip.loop_start;
+        (clip.loop_start + (raw - clip.loop_start) % loop_len) as usize
+    } else {
+        raw as usize
+    }
+}
+
+fn visible_notes(clip: &UiNoteClip, local_start: f64, local_end: f64) -> Vec<MidiNote> {
+    let looping = clip.loop_enabled && clip.loop_end_beats > clip.loop_start_beats;
+    let mut visible = Vec::new();
+    for note in &clip.notes {
+        let mut occurrence = note.start_beat;
+        loop {
+            let note_end = occurrence + note.duration_beats;
+            let kept_start = occurrence.max(local_start);
+            let kept_end = note_end.min(local_end);
+            if kept_end > kept_start {
+                visible.push(MidiNote {
+                    start_beat: kept_start - local_start,
+                    duration_beats: kept_end - kept_start,
+                    ..*note
+                });
+            }
+            if !looping
+                || note.start_beat < clip.loop_start_beats
+                || note.start_beat >= clip.loop_end_beats
+            {
+                break;
+            }
+            occurrence += clip.loop_end_beats - clip.loop_start_beats;
+            if occurrence >= local_end {
+                break;
+            }
+        }
+    }
+    visible.sort_by(|a, b| {
+        a.start_beat
+            .partial_cmp(&b.start_beat)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    visible
+}
+
+impl ArrangementState {
+    /// A background warp finished: swap in the stretched audio and
+    /// record the warp geometry on the clip.
+    pub fn apply_clip_warp_success(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        track_id: TrackId,
+        clip_id: ClipId,
+        success: ClipWarpSuccess,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        engine.send(EngineCommand::ReplaceClipAudio {
+            track_id,
+            clip_id,
+            audio: Arc::clone(&success.audio),
+            duration: success.new_duration,
+            source_offset: success.new_source_offset,
+            loop_start: success.new_loop_start,
+            loop_end: success.new_loop_end,
+        });
+        if let Some(track) = self.find_content_mut(track_id) {
+            if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
+                clip.audio = Arc::clone(&success.audio);
+                clip.duration = success.new_duration;
+                clip.source_offset = success.new_source_offset;
+                clip.loop_start = success.new_loop_start;
+                clip.loop_end = success.new_loop_end;
+                clip.original_bpm = Some(success.detected_bpm);
+                clip.warped = true;
+                clip.warped_to_bpm = Some(success.warped_to_bpm);
+                clip.original_audio = Some(Arc::clone(&success.original_audio));
+            }
+        }
+        action.status = Some(format!("Warped to {:.0} BPM", success.warped_to_bpm));
+        action.mark_dirty = true;
+        action
+    }
+
+    /// An auto-warp-on-import attempt finished.
+    pub fn apply_auto_warp_outcome(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        track_id: TrackId,
+        clip_id: ClipId,
+        outcome: AutoWarpOutcome,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        match outcome {
+            AutoWarpOutcome::NotDetected => {
+                // Nothing to apply. Point the user at the manual
+                // workflow in the clip detail panel.
+                action.status = Some(
+                    "Auto-warp: could not detect BPM. Select the clip and type the source \
+                     BPM in the Warp row, then press Enter and click Warp."
+                        .to_string(),
+                );
+            }
+            AutoWarpOutcome::DetectedOnly { bpm, confidence } => {
+                if let Some(track) = self.find_content_mut(track_id) {
+                    if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
+                        clip.original_bpm = Some(bpm);
+                    }
+                }
+                action.status = Some(format!(
+                    "Auto-warp skipped: detected {:.1} BPM at low confidence {:.2}. \
+                     Use the clip's Warp button to apply it manually.",
+                    bpm, confidence
+                ));
+                action.mark_dirty = true;
+            }
+            AutoWarpOutcome::Warped { success, .. } => {
+                return self.apply_clip_warp_success(engine, track_id, clip_id, success);
+            }
+        }
+        action
+    }
+
+    /// Restore a warped clip's original audio (or just drop the warp
+    /// flags when the original is gone).
+    pub fn apply_clear_clip_warp(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        track_id: TrackId,
+        clip_id: ClipId,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        let restore = self
+            .find_content(track_id)
+            .and_then(|track| track.clips.iter().find(|c| c.id == clip_id))
+            .and_then(|clip| clip.original_audio.as_ref().map(Arc::clone));
+        if let Some(original) = restore {
+            let original_frames = original.num_frames() as u64;
+            engine.send(EngineCommand::ReplaceClipAudio {
+                track_id,
+                clip_id,
+                audio: Arc::clone(&original),
+                duration: original_frames,
+                source_offset: 0,
+                loop_start: 0,
+                loop_end: 0,
+            });
+            if let Some(track) = self.find_content_mut(track_id) {
+                if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
+                    clip.audio = original;
+                    clip.duration = original_frames;
+                    clip.source_offset = 0;
+                    clip.loop_start = 0;
+                    clip.loop_end = 0;
+                    clip.warped = false;
+                    clip.warped_to_bpm = None;
+                    clip.original_audio = None;
+                }
+            }
+        } else if let Some(track) = self.find_content_mut(track_id) {
+            if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
+                clip.warped = false;
+                clip.warped_to_bpm = None;
+            }
+        }
+        action.status = Some("Cleared clip warp".to_string());
+        action.mark_dirty = true;
+        action
+    }
+
+    /// A background audio quantize finished: replace the source clip
+    /// with the newly rendered one and select it.
+    pub fn apply_audio_quantize_success(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        track_id: TrackId,
+        old_clip_id: ClipId,
+        success: AudioQuantizeSuccess,
+        sample_rate: u32,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        engine.send(EngineCommand::RemoveClip(track_id, old_clip_id));
+        if let Some(track) = self.find_content_mut(track_id) {
+            track.clips.retain(|c| c.id != old_clip_id);
+        }
+        self.selected_clips.retain(|sel| match sel {
+            ArrangementSelection::AudioClip {
+                clip_id: cid,
+                track_id: tid,
+            } => !(*tid == track_id && *cid == old_clip_id),
+            _ => true,
+        });
+
+        engine.send(EngineCommand::AddClip {
+            track_id,
+            clip_id: success.new_clip_id,
+            audio: Arc::clone(&success.new_audio),
+            position: success.new_position,
+            source_offset: 0,
+            duration: success.new_duration,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        });
+        if let Some(track) = self.find_content_mut(track_id) {
+            track.clips.push(UiClip {
+                id: success.new_clip_id,
+                name: success.new_name,
+                audio: Arc::clone(&success.new_audio),
+                source: None,
+                position: success.new_position,
+                source_offset: 0,
+                duration: success.new_duration,
+                loop_enabled: false,
+                loop_start: 0,
+                loop_end: 0,
+                original_bpm: None,
+                warped: false,
+                warped_to_bpm: None,
+                original_audio: None,
+            });
+        }
+        self.selected_clips.insert(ArrangementSelection::AudioClip {
+            track_id,
+            clip_id: success.new_clip_id,
+        });
+
+        let duration_seconds = success.new_duration as f64 / sample_rate.max(1) as f64;
+        action.status = Some(format!(
+            "Quantized {} slice(s) to {} ({:.1}s)",
+            success.slice_count, success.grid_label, duration_seconds
+        ));
+        action
+    }
+
+    /// A background BPM detection finished.
+    pub fn apply_clip_bpm_detected(
+        &mut self,
+        track_id: TrackId,
+        clip_id: ClipId,
+        bpm: Option<f64>,
+        confidence: f32,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        match bpm {
+            Some(b) => {
+                if let Some(track) = self.find_content_mut(track_id) {
+                    if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
+                        clip.original_bpm = Some(b);
+                    }
+                }
+                self.clip_bpm_edit.remove(&clip_id);
+                action.status = Some(format!(
+                    "Detected {:.1} BPM (confidence {:.2})",
+                    b, confidence
+                ));
+                action.mark_dirty = true;
+            }
+            None => {
+                action.status = Some(
+                    "Could not detect BPM. Type the source BPM in the Warp row and \
+                     press Enter, then click Warp."
+                        .to_string(),
+                );
+            }
+        }
+        action
+    }
+
+    pub(super) fn join_audio_clips(
+        &mut self,
+        track_id: TrackId,
+        selections: &[ArrangementSelection],
+        engine: &mut impl EngineHandle,
+    ) -> Option<String> {
+        // Collect clip data sorted by position
+        let clip_ids: Vec<ClipId> = selections
+            .iter()
+            .filter_map(|s| match s {
+                ArrangementSelection::AudioClip { clip_id, .. } => Some(*clip_id),
+                _ => None,
+            })
+            .collect();
+
+        let mut clip_data: Vec<UiClip> = Vec::new();
+        if let Some(track) = self.find_content(track_id) {
+            for cid in &clip_ids {
+                if let Some(clip) = track.clips.iter().find(|c| c.id == *cid) {
+                    clip_data.push(clip.clone());
+                }
+            }
+        }
+
+        if clip_data.len() < 2 {
+            return None;
+        }
+
+        // Sort by position
+        clip_data.sort_by_key(|clip| clip.position);
+
+        let start_pos = clip_data[0].position;
+        let end_pos = clip_data
+            .iter()
+            .map(|clip| clip.position.saturating_add(clip.duration))
+            .max()
+            .unwrap_or(start_pos);
+        let total_duration = end_pos - start_pos;
+        let joined_loop_enabled = clip_data.iter().any(|clip| clip.loop_enabled);
+
+        // Determine channel count from first clip
+        let channels = clip_data[0].audio.num_channels();
+        let sr = clip_data[0].audio.sample_rate;
+
+        // Create joined buffer filled with silence
+        let mut joined_channels: Vec<Vec<f32>> = (0..channels)
+            .map(|_| vec![0.0f32; total_duration as usize])
+            .collect();
+
+        // Consolidate the audible arrangement result, including source
+        // wrapping for clips whose visible duration exceeds their loop.
+        for clip in &clip_data {
+            let offset_in_joined = (clip.position - start_pos) as usize;
+            let dur = clip.duration as usize;
+            let ch_count = channels.min(clip.audio.num_channels());
+            for (ch, dst) in joined_channels.iter_mut().enumerate().take(ch_count) {
+                for local in 0..dur {
+                    let dst_frame = offset_in_joined + local;
+                    if dst_frame >= dst.len() {
+                        break;
+                    }
+                    let source_frame = audio_source_frame(clip, local as u64);
+                    if let Some(sample) = clip.audio.channels[ch].get(source_frame) {
+                        dst[dst_frame] = *sample;
+                    }
+                }
+            }
+        }
+
+        // Create DecodedAudio
+        let joined_audio = Arc::new(vibez_core::audio_buffer::DecodedAudio {
+            channels: joined_channels,
+            sample_rate: sr,
+        });
+
+        // Remove all originals
+        for cid in &clip_ids {
+            engine.send(EngineCommand::RemoveClip(track_id, *cid));
+            if let Some(track) = self.find_content_mut(track_id) {
+                track.clips.retain(|c| c.id != *cid);
+            }
+        }
+
+        // Add joined clip
+        let new_id = ClipId::new();
+        engine.send(EngineCommand::AddClip {
+            track_id,
+            clip_id: new_id,
+            audio: Arc::clone(&joined_audio),
+            position: start_pos,
+            source_offset: 0,
+            duration: total_duration,
+            loop_enabled: joined_loop_enabled,
+            loop_start: 0,
+            loop_end: total_duration,
+        });
+        if let Some(track) = self.find_content_mut(track_id) {
+            track.clips.push(UiClip {
+                id: new_id,
+                name: "Joined".to_string(),
+                audio: joined_audio,
+                source: None,
+                position: start_pos,
+                source_offset: 0,
+                duration: total_duration,
+                loop_enabled: joined_loop_enabled,
+                loop_start: 0,
+                loop_end: total_duration,
+                original_bpm: None,
+                warped: false,
+                warped_to_bpm: None,
+                original_audio: None,
+            });
+        }
+
+        self.selected_clips.clear();
+        self.selected_clips.insert(ArrangementSelection::AudioClip {
+            track_id,
+            clip_id: new_id,
+        });
+        Some("Joined audio clips".to_string())
+    }
+
+    pub(super) fn join_note_clips(
+        &mut self,
+        track_id: TrackId,
+        selections: &[ArrangementSelection],
+        engine: &mut impl EngineHandle,
+    ) -> Option<String> {
+        let clip_ids: Vec<ClipId> = selections
+            .iter()
+            .filter_map(|s| match s {
+                ArrangementSelection::NoteClip { clip_id, .. } => Some(*clip_id),
+                _ => None,
+            })
+            .collect();
+
+        let mut clip_data: Vec<UiNoteClip> = Vec::new();
+        if let Some(track) = self.find_content(track_id) {
+            for cid in &clip_ids {
+                if let Some(clip) = track.note_clips.iter().find(|c| c.id == *cid) {
+                    clip_data.push(clip.clone());
+                }
+            }
+        }
+
+        if clip_data.len() < 2 {
+            return None;
+        }
+
+        // Sort by position
+        clip_data.sort_by(|a, b| {
+            a.position_beats
+                .partial_cmp(&b.position_beats)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let start_pos = clip_data[0].position_beats;
+        let end_pos = clip_data
+            .iter()
+            .map(|clip| clip.position_beats + clip.duration_beats)
+            .fold(0.0_f64, f64::max);
+        let total_duration = end_pos - start_pos;
+        let joined_loop_enabled = clip_data.iter().any(|clip| clip.loop_enabled);
+
+        // Merge the audible notes, expanding repeated loop occurrences.
+        let mut merged_notes: Vec<MidiNote> = Vec::new();
+        for clip in &clip_data {
+            let offset = clip.position_beats - start_pos;
+            for note in visible_notes(clip, 0.0, clip.duration_beats) {
+                merged_notes.push(MidiNote {
+                    start_beat: note.start_beat + offset,
+                    ..note
+                });
+            }
+        }
+
+        // Remove all originals
+        for cid in &clip_ids {
+            engine.send(EngineCommand::RemoveNoteClip(track_id, *cid));
+            if let Some(track) = self.find_content_mut(track_id) {
+                track.note_clips.retain(|c| c.id != *cid);
+            }
+        }
+
+        // Add joined clip
+        let new_id = ClipId::new();
+        engine.send(EngineCommand::AddNoteClip {
+            track_id,
+            clip_id: new_id,
+            position_beats: start_pos,
+            duration_beats: total_duration,
+            loop_enabled: joined_loop_enabled,
+            loop_start_beats: 0.0,
+            loop_end_beats: total_duration,
+        });
+        for note in &merged_notes {
+            engine.send(EngineCommand::AddNote {
+                track_id,
+                clip_id: new_id,
+                note: *note,
+            });
+        }
+        if let Some(track) = self.find_content_mut(track_id) {
+            track.note_clips.push(UiNoteClip {
+                id: new_id,
+                name: "Joined".to_string(),
+                position_beats: start_pos,
+                duration_beats: total_duration,
+                notes: merged_notes,
+                selected_notes: HashSet::new(),
+                loop_enabled: joined_loop_enabled,
+                loop_start_beats: 0.0,
+                loop_end_beats: total_duration,
+            });
+        }
+
+        self.selected_clips.clear();
+        self.selected_clips.insert(ArrangementSelection::NoteClip {
+            track_id,
+            clip_id: new_id,
+        });
+        self.selected_note_clip = Some((track_id, new_id));
+        Some("Joined note clips".to_string())
+    }
+
+    pub(super) fn op_split_audio_clip(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        _ctx: ArrangementCtx,
+        track_id: TrackId,
+        clip_id: ClipId,
+        split_position: u64,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        let split = self
+            .find_content(track_id)
+            .and_then(|track| track.clips.iter().find(|clip| clip.id == clip_id))
+            .filter(|clip| {
+                split_position > clip.position
+                    && split_position < clip.position.saturating_add(clip.duration)
+            })
+            .map(|clip| {
+                let left_duration = split_position - clip.position;
+                let mut left = clip.clone();
+                left.id = ClipId::new();
+                left.name = format!("{} L", clip.name);
+                left.duration = left_duration;
+
+                let mut right = clip.clone();
+                right.id = ClipId::new();
+                right.name = format!("{} R", clip.name);
+                right.position = split_position;
+                right.duration = clip.duration - left_duration;
+                right.source_offset = audio_source_frame(clip, left_duration) as u64;
+                (left, right)
+            });
+        if let Some((left, right)) = split {
+            let left_id = left.id;
+
+            engine.send(EngineCommand::RemoveClip(track_id, clip_id));
+            if let Some(track) = self.find_content_mut(track_id) {
+                track.clips.retain(|c| c.id != clip_id);
+            }
+
+            for clip in [&left, &right] {
+                engine.send(EngineCommand::AddClip {
+                    track_id,
+                    clip_id: clip.id,
+                    audio: Arc::clone(&clip.audio),
+                    position: clip.position,
+                    source_offset: clip.source_offset,
+                    duration: clip.duration,
+                    loop_enabled: clip.loop_enabled,
+                    loop_start: clip.loop_start,
+                    loop_end: clip.loop_end,
+                });
+            }
+            if let Some(track) = self.find_content_mut(track_id) {
+                track.clips.extend([left, right]);
+            }
+
+            self.selected_clips
+                .remove(&ArrangementSelection::AudioClip { track_id, clip_id });
+            self.selected_clips.insert(ArrangementSelection::AudioClip {
+                track_id,
+                clip_id: left_id,
+            });
+            action.status = Some("Split audio clip".to_string());
+        }
+        action
+    }
+
+    pub(super) fn op_split_note_clip(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        _ctx: ArrangementCtx,
+        track_id: TrackId,
+        clip_id: ClipId,
+        split_beat: f64,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        let split = self
+            .find_content(track_id)
+            .and_then(|track| track.note_clips.iter().find(|clip| clip.id == clip_id))
+            .filter(|clip| {
+                split_beat > clip.position_beats
+                    && split_beat < clip.position_beats + clip.duration_beats
+            })
+            .map(|clip| {
+                let local_split = split_beat - clip.position_beats;
+                let mut left = clip.clone();
+                left.id = ClipId::new();
+                left.name = format!("{} L", clip.name);
+                left.duration_beats = local_split;
+                left.notes = visible_notes(clip, 0.0, local_split);
+                left.selected_notes.clear();
+
+                let mut right = clip.clone();
+                right.id = ClipId::new();
+                right.name = format!("{} R", clip.name);
+                right.position_beats = split_beat;
+                right.duration_beats = clip.duration_beats - local_split;
+                right.notes = visible_notes(clip, local_split, clip.duration_beats);
+                right.selected_notes.clear();
+
+                if clip.loop_enabled {
+                    left.loop_start_beats = 0.0;
+                    left.loop_end_beats = left.duration_beats;
+                    right.loop_start_beats = 0.0;
+                    right.loop_end_beats = right.duration_beats;
+                }
+                (left, right)
+            });
+        if let Some((left, right)) = split {
+            let left_id = left.id;
+            engine.send(EngineCommand::RemoveNoteClip(track_id, clip_id));
+            if let Some(track) = self.find_content_mut(track_id) {
+                track.note_clips.retain(|c| c.id != clip_id);
+            }
+
+            for clip in [&left, &right] {
+                engine.send(EngineCommand::AddNoteClip {
+                    track_id,
+                    clip_id: clip.id,
+                    position_beats: clip.position_beats,
+                    duration_beats: clip.duration_beats,
+                    loop_enabled: clip.loop_enabled,
+                    loop_start_beats: clip.loop_start_beats,
+                    loop_end_beats: clip.loop_end_beats,
+                });
+                for note in &clip.notes {
+                    engine.send(EngineCommand::AddNote {
+                        track_id,
+                        clip_id: clip.id,
+                        note: *note,
+                    });
+                }
+            }
+            if let Some(track) = self.find_content_mut(track_id) {
+                track.note_clips.extend([left, right]);
+            }
+
+            self.selected_clips
+                .remove(&ArrangementSelection::NoteClip { track_id, clip_id });
+            self.selected_clips.insert(ArrangementSelection::NoteClip {
+                track_id,
+                clip_id: left_id,
+            });
+            self.selected_note_clip = Some((track_id, left_id));
+            action.status = Some("Split note clip".to_string());
+        }
+        action
+    }
+}

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -1,0 +1,182 @@
+//! Arrange messages, cross-domain actions, and read-only update context.
+
+use vibez_core::id::{ClipId, TrackId};
+
+use crate::state::ArrangementSelection;
+
+/// Messages the arrangement domain handles (track tranche).
+#[derive(Debug, Clone)]
+pub enum ArrangementMsg {
+    AddTrack,
+    AddMidiTrack,
+    AddInstrumentTrack,
+    RemoveTrack(TrackId),
+    SelectTrack(TrackId),
+    RenameTrack(TrackId, String),
+    RenameClip(TrackId, ClipId, String),
+    MoveTrackUp(TrackId),
+    MoveTrackDown(TrackId),
+    MoveSelectedTrackUp,
+    MoveSelectedTrackDown,
+    SetTrackGain(TrackId, f32),
+    SetTrackPan(TrackId, f32),
+    SetTrackMute(TrackId),
+    SetTrackSolo(TrackId),
+    /// Add a return bus (mixer-only channel).
+    AddBus,
+    /// Remove a bus and every send pointing at it.
+    RemoveBus(TrackId),
+    /// Set a track's post-fader send amount into a bus.
+    SetSend {
+        track_id: TrackId,
+        bus_id: TrackId,
+        amount: f32,
+    },
+    EngineTrackMeter {
+        track_id: TrackId,
+        peak_l: f32,
+        peak_r: f32,
+    },
+    // ── Clip tranche ──
+    RemoveClip(TrackId, ClipId),
+    SelectArrangementClip {
+        selection: ArrangementSelection,
+        shift_held: bool,
+    },
+    MoveAudioClip {
+        track_id: TrackId,
+        clip_id: ClipId,
+        new_position: u64,
+    },
+    MoveNoteClipPosition {
+        track_id: TrackId,
+        clip_id: ClipId,
+        new_position_beats: f64,
+    },
+    ResizeAudioClip {
+        track_id: TrackId,
+        clip_id: ClipId,
+        new_duration: u64,
+    },
+    MoveClipToTrack {
+        source_track: TrackId,
+        target_track: TrackId,
+        clip_id: ClipId,
+        is_note_clip: bool,
+    },
+    ToggleClipLoop(TrackId, ClipId),
+    SetClipLoopRegion {
+        track_id: TrackId,
+        clip_id: ClipId,
+        loop_start: u64,
+        loop_end: u64,
+    },
+    SetTimeSelection {
+        start_beats: f64,
+        end_beats: f64,
+        track_id: Option<TrackId>,
+    },
+    SetTimeSelectionActive(bool),
+    SetSelectionAsLoop,
+    DeleteSelectedClip,
+    DuplicateSelectedClip,
+    CopySelectedClips,
+    CutSelectedClips,
+    PasteClipsAtPlayhead,
+    ToggleSelectedClipLoop,
+    ResizeSelectedClips {
+        anchor: ArrangementSelection,
+        new_duration_beats: f64,
+    },
+    DuplicateNoteClip(TrackId, ClipId),
+    SplitAudioClip {
+        track_id: TrackId,
+        clip_id: ClipId,
+        split_position: u64,
+    },
+    SplitNoteClip {
+        track_id: TrackId,
+        clip_id: ClipId,
+        split_beat: f64,
+    },
+    SplitSelectedAtPlayhead,
+    JoinSelectedClips,
+    DeleteClipsInRegion {
+        start_beats: f64,
+        end_beats: f64,
+        track_id: Option<TrackId>,
+    },
+    SplitClipsAtRegion {
+        start_beats: f64,
+        end_beats: f64,
+        track_id: Option<TrackId>,
+    },
+    CreateClipFromSelection,
+    CreateNoteClipFromSelection(TrackId),
+    ClipBpmInputChanged {
+        track_id: TrackId,
+        clip_id: ClipId,
+        text: String,
+    },
+    SubmitClipBpm {
+        track_id: TrackId,
+        clip_id: ClipId,
+    },
+    SetClipNominalBpm {
+        track_id: TrackId,
+        clip_id: ClipId,
+        bpm: f64,
+    },
+    ClearClipWarp {
+        track_id: TrackId,
+        clip_id: ClipId,
+    },
+}
+
+impl ArrangementMsg {
+    /// Whether this message edits the project (drives the dirty flag).
+    pub fn marks_dirty(&self) -> bool {
+        !matches!(
+            self,
+            ArrangementMsg::SelectTrack(_)
+                | ArrangementMsg::EngineTrackMeter { .. }
+                | ArrangementMsg::SelectArrangementClip { .. }
+                | ArrangementMsg::SetTimeSelection { .. }
+                | ArrangementMsg::SetTimeSelectionActive(_)
+                | ArrangementMsg::SetSelectionAsLoop
+                | ArrangementMsg::CopySelectedClips
+                | ArrangementMsg::ClipBpmInputChanged { .. }
+        )
+    }
+}
+
+/// Cross-domain effects requested by an arrangement update.
+#[derive(Debug, Default, PartialEq)]
+pub struct ArrangementAction {
+    /// All plugin GUI windows and raw pointers of this track must go
+    /// (the track's devices are being destroyed).
+    pub close_track_guis: Option<TrackId>,
+    /// Status bar text.
+    pub status: Option<String>,
+    /// Selecting a clip focuses the detail panel's Clip tab.
+    pub focus_clip_tab: bool,
+    /// A time selection was promoted to the transport loop region.
+    pub loop_from_selection: Option<(f64, f64)>,
+    /// A drag moved a clip near the view edge; auto-scroll to it.
+    pub scroll_to_beat: Option<f64>,
+    /// Dismiss the arrangement context menu.
+    pub close_context_menu: bool,
+    /// The project content changed outside the undo-snapshot path.
+    pub mark_dirty: bool,
+}
+
+/// Read-only cross-domain facts for arrangement updates.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ArrangementCtx {
+    /// Samples per beat at the current tempo (clip drag snapping).
+    pub samples_per_beat: f64,
+    /// Playhead position in samples (split-at-playhead).
+    pub playhead_samples: u64,
+    /// Playhead position in beats.
+    pub playhead_beats: f64,
+}

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -1,9 +1,9 @@
-//! Arrangement domain, tranche one: track lifecycle and mixing
-//! basics. Owns the track list (the shared model other domains
-//! receive explicitly), selection, and track numbering.
+//! Arrange editing domain.
 //!
-//! Clip operations (moves, splits, warp orchestration) are the next
-//! tranche; they follow this same pattern.
+//! Project Tracks are supplied explicitly from their project-wide store;
+//! Arrange owns only timeline content and editor selection. Track lifecycle
+//! and mixing messages originate here today because Arrange exposes those
+//! controls, but they mutate the separate `ProjectTracksState`.
 
 use std::collections::HashSet;
 
@@ -14,189 +14,17 @@ use vibez_core::midi::TrackKind;
 use vibez_engine::commands::EngineCommand;
 
 use super::EngineHandle;
-use crate::state::{ArrangementSelection, ArrangementState, UiNoteClip, UiTrack};
+use crate::state::{
+    ArrangementSelection, ArrangementState, ProjectTrack, ProjectTracksState, TrackTimelineContent,
+    UiNoteClip,
+};
 
-/// Messages the arrangement domain handles (track tranche).
-#[derive(Debug, Clone)]
-pub enum ArrangementMsg {
-    AddTrack,
-    AddMidiTrack,
-    AddInstrumentTrack,
-    RemoveTrack(TrackId),
-    SelectTrack(TrackId),
-    RenameTrack(TrackId, String),
-    RenameClip(TrackId, ClipId, String),
-    MoveTrackUp(TrackId),
-    MoveTrackDown(TrackId),
-    MoveSelectedTrackUp,
-    MoveSelectedTrackDown,
-    SetTrackGain(TrackId, f32),
-    SetTrackPan(TrackId, f32),
-    SetTrackMute(TrackId),
-    SetTrackSolo(TrackId),
-    /// Add a return bus (mixer-only channel).
-    AddBus,
-    /// Remove a bus and every send pointing at it.
-    RemoveBus(TrackId),
-    /// Set a track's post-fader send amount into a bus.
-    SetSend {
-        track_id: TrackId,
-        bus_id: TrackId,
-        amount: f32,
-    },
-    EngineTrackMeter {
-        track_id: TrackId,
-        peak_l: f32,
-        peak_r: f32,
-    },
-    // ── Clip tranche ──
-    RemoveClip(TrackId, ClipId),
-    SelectArrangementClip {
-        selection: ArrangementSelection,
-        shift_held: bool,
-    },
-    MoveAudioClip {
-        track_id: TrackId,
-        clip_id: ClipId,
-        new_position: u64,
-    },
-    MoveNoteClipPosition {
-        track_id: TrackId,
-        clip_id: ClipId,
-        new_position_beats: f64,
-    },
-    ResizeAudioClip {
-        track_id: TrackId,
-        clip_id: ClipId,
-        new_duration: u64,
-    },
-    MoveClipToTrack {
-        source_track: TrackId,
-        target_track: TrackId,
-        clip_id: ClipId,
-        is_note_clip: bool,
-    },
-    ToggleClipLoop(TrackId, ClipId),
-    SetClipLoopRegion {
-        track_id: TrackId,
-        clip_id: ClipId,
-        loop_start: u64,
-        loop_end: u64,
-    },
-    SetTimeSelection {
-        start_beats: f64,
-        end_beats: f64,
-        track_id: Option<TrackId>,
-    },
-    SetTimeSelectionActive(bool),
-    SetSelectionAsLoop,
-    DeleteSelectedClip,
-    DuplicateSelectedClip,
-    CopySelectedClips,
-    CutSelectedClips,
-    PasteClipsAtPlayhead,
-    ToggleSelectedClipLoop,
-    ResizeSelectedClips {
-        anchor: ArrangementSelection,
-        new_duration_beats: f64,
-    },
-    DuplicateNoteClip(TrackId, ClipId),
-    SplitAudioClip {
-        track_id: TrackId,
-        clip_id: ClipId,
-        split_position: u64,
-    },
-    SplitNoteClip {
-        track_id: TrackId,
-        clip_id: ClipId,
-        split_beat: f64,
-    },
-    SplitSelectedAtPlayhead,
-    JoinSelectedClips,
-    DeleteClipsInRegion {
-        start_beats: f64,
-        end_beats: f64,
-        track_id: Option<TrackId>,
-    },
-    SplitClipsAtRegion {
-        start_beats: f64,
-        end_beats: f64,
-        track_id: Option<TrackId>,
-    },
-    CreateClipFromSelection,
-    CreateNoteClipFromSelection(TrackId),
-    ClipBpmInputChanged {
-        track_id: TrackId,
-        clip_id: ClipId,
-        text: String,
-    },
-    SubmitClipBpm {
-        track_id: TrackId,
-        clip_id: ClipId,
-    },
-    SetClipNominalBpm {
-        track_id: TrackId,
-        clip_id: ClipId,
-        bpm: f64,
-    },
-    ClearClipWarp {
-        track_id: TrackId,
-        clip_id: ClipId,
-    },
-}
+mod messages;
+pub use messages::{ArrangementAction, ArrangementCtx, ArrangementMsg};
 
-impl ArrangementMsg {
-    /// Whether this message edits the project (drives the dirty flag).
-    pub fn marks_dirty(&self) -> bool {
-        !matches!(
-            self,
-            ArrangementMsg::SelectTrack(_)
-                | ArrangementMsg::EngineTrackMeter { .. }
-                | ArrangementMsg::SelectArrangementClip { .. }
-                | ArrangementMsg::SetTimeSelection { .. }
-                | ArrangementMsg::SetTimeSelectionActive(_)
-                | ArrangementMsg::SetSelectionAsLoop
-                | ArrangementMsg::CopySelectedClips
-                | ArrangementMsg::ClipBpmInputChanged { .. }
-        )
-    }
-}
-
-/// Cross-domain effects requested by an arrangement update.
-#[derive(Debug, Default, PartialEq)]
-pub struct ArrangementAction {
-    /// All plugin GUI windows and raw pointers of this track must go
-    /// (the track's devices are being destroyed).
-    pub close_track_guis: Option<TrackId>,
-    /// Status bar text.
-    pub status: Option<String>,
-    /// Selecting a clip focuses the detail panel's Clip tab.
-    pub focus_clip_tab: bool,
-    /// A time selection was promoted to the transport loop region.
-    pub loop_from_selection: Option<(f64, f64)>,
-    /// A drag moved a clip near the view edge; auto-scroll to it.
-    pub scroll_to_beat: Option<f64>,
-    /// Dismiss the arrangement context menu.
-    pub close_context_menu: bool,
-    /// The project content changed outside the undo-snapshot path.
-    pub mark_dirty: bool,
-}
-
-/// Read-only cross-domain facts for arrangement updates.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct ArrangementCtx {
-    /// Samples per beat at the current tempo (clip drag snapping).
-    pub samples_per_beat: f64,
-    /// Playhead position in samples (split-at-playhead).
-    pub playhead_samples: u64,
-    /// Playhead position in beats.
-    pub playhead_beats: f64,
-}
-
-/// Every channel carries an SSL-style EQ, console style: create it
-/// flat (passthrough) alongside the track. Also used for the master
+/// Every channel carries a flat SSL-style EQ. Also used for the master
 /// bus, which is why it is crate-visible.
-pub(crate) fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut UiTrack) {
+pub(crate) fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut ProjectTrack) {
     let effect_id = vibez_core::id::EffectId::new();
     let effect_type = vibez_core::effect::EffectType::Eq;
     let descriptors = vibez_dsp::factory::create_effect(effect_type, 48_000.0).param_descriptors();
@@ -219,17 +47,7 @@ pub(crate) fn attach_channel_eq(engine: &mut impl EngineHandle, track: &mut UiTr
     });
 }
 
-impl ArrangementState {
-    fn find_track(&self, track_id: TrackId) -> Option<&UiTrack> {
-        if track_id.is_master() {
-            return Some(&self.master);
-        }
-        self.tracks
-            .iter()
-            .chain(self.buses.iter())
-            .find(|t| t.id == track_id)
-    }
-
+impl ProjectTracksState {
     /// First track number with no name clash for the given prefix.
     pub fn next_unique_track_number(&mut self, prefix: &str) -> u32 {
         loop {
@@ -240,16 +58,6 @@ impl ArrangementState {
             }
             self.next_track_number += 1;
         }
-    }
-
-    fn find_track_mut(&mut self, track_id: TrackId) -> Option<&mut UiTrack> {
-        if track_id.is_master() {
-            return Some(&mut self.master);
-        }
-        self.tracks
-            .iter_mut()
-            .chain(self.buses.iter_mut())
-            .find(|t| t.id == track_id)
     }
 
     fn move_track(&mut self, track_id: TrackId, up: bool, engine: &mut impl EngineHandle) {
@@ -268,9 +76,20 @@ impl ArrangementState {
             }
         }
     }
+}
+
+impl ArrangementState {
+    fn find_content(&self, track_id: TrackId) -> Option<&TrackTimelineContent> {
+        self.timeline.get(track_id)
+    }
+
+    fn find_content_mut(&mut self, track_id: TrackId) -> Option<&mut TrackTimelineContent> {
+        Arc::make_mut(&mut self.timeline).get_mut(track_id)
+    }
 
     pub fn update(
         &mut self,
+        project_tracks: &mut ProjectTracksState,
         msg: ArrangementMsg,
         engine: &mut impl EngineHandle,
         ctx: ArrangementCtx,
@@ -279,38 +98,41 @@ impl ArrangementState {
         let mut action = ArrangementAction::default();
         match msg {
             ArrangementMsg::AddTrack => {
-                let track_num = self.next_unique_track_number("Track");
+                let track_num = project_tracks.next_unique_track_number("Track");
                 let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-                self.next_track_number = track_num + 1;
+                project_tracks.next_track_number = track_num + 1;
                 let id = TrackId::new();
                 let name = format!("Track {track_num}");
                 engine.send(EngineCommand::AddTrack(id, name.clone()));
-                let mut track = UiTrack::new(id, name, color_index);
+                let mut track = ProjectTrack::new(id, name, color_index);
                 attach_channel_eq(engine, &mut track);
-                self.tracks.push(track);
+                project_tracks.tracks.push(track);
+                Arc::make_mut(&mut self.timeline).ensure(id);
                 self.selected_track = Some(id);
-                action.status = Some(format!("{} tracks", self.tracks.len()));
+                action.status = Some(format!("{} tracks", project_tracks.tracks.len()));
             }
             ArrangementMsg::AddMidiTrack | ArrangementMsg::AddInstrumentTrack => {
-                let track_num = self.next_unique_track_number("MIDI");
+                let track_num = project_tracks.next_unique_track_number("MIDI");
                 let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-                self.next_track_number = track_num + 1;
+                project_tracks.next_track_number = track_num + 1;
                 let id = TrackId::new();
                 let name = format!("MIDI {track_num}");
                 engine.send(EngineCommand::AddMidiTrack(id, name.clone()));
-                let mut track = UiTrack::new_instrument(id, name, TrackKind::Midi, color_index);
+                let mut track =
+                    ProjectTrack::new_instrument(id, name, TrackKind::Midi, color_index);
                 track.has_instrument = false;
                 attach_channel_eq(engine, &mut track);
-                self.tracks.push(track);
+                project_tracks.tracks.push(track);
+                Arc::make_mut(&mut self.timeline).ensure(id);
                 self.selected_track = Some(id);
-                action.status = Some(format!("{} tracks", self.tracks.len()));
+                action.status = Some(format!("{} tracks", project_tracks.tracks.len()));
             }
             ArrangementMsg::RemoveTrack(track_id) => {
                 if track_id.is_master() {
                     // The master bus cannot be deleted.
                     return action;
                 }
-                let removed_name = self
+                let removed_name = project_tracks
                     .tracks
                     .iter()
                     .find(|t| t.id == track_id)
@@ -318,9 +140,10 @@ impl ArrangementState {
                     .unwrap_or_else(|| format!("{track_id}"));
 
                 engine.send(EngineCommand::RemoveTrack(track_id));
-                self.tracks.retain(|t| t.id != track_id);
+                project_tracks.tracks.retain(|t| t.id != track_id);
+                Arc::make_mut(&mut self.timeline).remove(track_id);
                 if self.selected_track == Some(track_id) {
-                    self.selected_track = self.tracks.first().map(|t| t.id);
+                    self.selected_track = project_tracks.tracks.first().map(|t| t.id);
                 }
                 if let Some((tid, _)) = self.selected_note_clip {
                     if tid == track_id {
@@ -337,19 +160,19 @@ impl ArrangementState {
                 action.close_track_guis = Some(track_id);
                 action.status = Some(format!(
                     "Removed {removed_name}. {} track(s) remain.",
-                    self.tracks.len()
+                    project_tracks.tracks.len()
                 ));
             }
             ArrangementMsg::SelectTrack(track_id) => {
                 self.selected_track = Some(track_id);
             }
             ArrangementMsg::RenameTrack(track_id, new_name) => {
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = project_tracks.find_mut(track_id) {
                     track.name = new_name;
                 }
             }
             ArrangementMsg::RenameClip(track_id, clip_id, new_name) => {
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = self.find_content_mut(track_id) {
                     if let Some(c) = track.clips.iter_mut().find(|c| c.id == clip_id) {
                         c.name = new_name.clone();
                     }
@@ -358,71 +181,79 @@ impl ArrangementState {
                     }
                 }
             }
-            ArrangementMsg::MoveTrackUp(track_id) => self.move_track(track_id, true, engine),
-            ArrangementMsg::MoveTrackDown(track_id) => self.move_track(track_id, false, engine),
+            ArrangementMsg::MoveTrackUp(track_id) => {
+                project_tracks.move_track(track_id, true, engine)
+            }
+            ArrangementMsg::MoveTrackDown(track_id) => {
+                project_tracks.move_track(track_id, false, engine)
+            }
             ArrangementMsg::MoveSelectedTrackUp => {
                 if let Some(tid) = self.selected_track {
-                    self.move_track(tid, true, engine);
+                    project_tracks.move_track(tid, true, engine);
                 }
             }
             ArrangementMsg::MoveSelectedTrackDown => {
                 if let Some(tid) = self.selected_track {
-                    self.move_track(tid, false, engine);
+                    project_tracks.move_track(tid, false, engine);
                 }
             }
             ArrangementMsg::SetTrackGain(track_id, gain) => {
                 let gain = gain.clamp(0.0, 2.0);
                 engine.send(EngineCommand::SetTrackGain(track_id, gain));
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = project_tracks.find_mut(track_id) {
                     track.gain = gain;
                 }
             }
             ArrangementMsg::SetTrackPan(track_id, pan) => {
                 let pan = pan.clamp(0.0, 1.0);
                 engine.send(EngineCommand::SetTrackPan(track_id, pan));
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = project_tracks.find_mut(track_id) {
                     track.pan = pan;
                 }
             }
             ArrangementMsg::SetTrackMute(track_id) => {
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = project_tracks.find_mut(track_id) {
                     track.mute = !track.mute;
                     let mute = track.mute;
                     engine.send(EngineCommand::SetTrackMute(track_id, mute));
                 }
             }
             ArrangementMsg::SetTrackSolo(track_id) => {
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = project_tracks.find_mut(track_id) {
                     track.solo = !track.solo;
                     let solo = track.solo;
                     engine.send(EngineCommand::SetTrackSolo(track_id, solo));
                 }
             }
             ArrangementMsg::AddBus => {
-                let letter = (b'A' + (self.buses.len() % 26) as u8) as char;
+                let letter = (b'A' + (project_tracks.buses.len() % 26) as u8) as char;
                 let id = TrackId::new();
                 let name = format!("{letter} Return");
                 engine.send(EngineCommand::AddBus(id, name.clone()));
                 // Offset into the palette so the first buses don't
                 // mirror the first tracks' colors.
-                let color_index = ((self.buses.len() + 4) % 8) as u8;
-                let mut bus = UiTrack::new(id, name.clone(), color_index);
+                let color_index = ((project_tracks.buses.len() + 4) % 8) as u8;
+                let mut bus = ProjectTrack::new(id, name.clone(), color_index);
                 attach_channel_eq(engine, &mut bus);
-                self.buses.push(bus);
+                project_tracks.buses.push(bus);
+                Arc::make_mut(&mut self.timeline).ensure(id);
                 self.selected_track = Some(id);
                 action.status = Some(format!("Added {name}"));
             }
             ArrangementMsg::RemoveBus(bus_id) => {
                 engine.send(EngineCommand::RemoveBus(bus_id));
-                self.buses.retain(|b| b.id != bus_id);
-                for track in &mut self.tracks {
+                project_tracks.buses.retain(|b| b.id != bus_id);
+                Arc::make_mut(&mut self.timeline).remove(bus_id);
+                for track in &mut project_tracks.tracks {
                     track.sends.retain(|(b, _)| *b != bus_id);
-                    track.automation.retain(|lane| {
+                }
+                for content in Arc::make_mut(&mut self.timeline).by_track.values_mut() {
+                    content.automation.retain(|lane| {
                         lane.target != vibez_core::automation::AutomationTarget::Send { bus_id }
                     });
                 }
                 if self.selected_track == Some(bus_id) {
-                    self.selected_track = self.tracks.first().map(|t| t.id);
+                    self.selected_track = project_tracks.tracks.first().map(|t| t.id);
                 }
                 // Plugin GUIs on the bus die with its devices.
                 action.close_track_guis = Some(bus_id);
@@ -434,7 +265,7 @@ impl ArrangementState {
                 amount,
             } => {
                 let amount = amount.clamp(0.0, 1.0);
-                if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+                if let Some(track) = project_tracks.tracks.iter_mut().find(|t| t.id == track_id) {
                     match track.sends.iter_mut().find(|(b, _)| *b == bus_id) {
                         Some(send) => send.1 = amount,
                         None => track.sends.push((bus_id, amount)),
@@ -451,14 +282,14 @@ impl ArrangementState {
                 peak_l,
                 peak_r,
             } => {
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = project_tracks.find_mut(track_id) {
                     track.peak_l = peak_l.max(track.peak_l * 0.85);
                     track.peak_r = peak_r.max(track.peak_r * 0.85);
                 }
             }
             ArrangementMsg::RemoveClip(track_id, clip_id) => {
                 engine.send(EngineCommand::RemoveClip(track_id, clip_id));
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = self.find_content_mut(track_id) {
                     track.clips.retain(|c| c.id != clip_id);
                 }
                 // Clear from multi-selection if this clip was selected
@@ -467,7 +298,7 @@ impl ArrangementState {
             }
             ArrangementMsg::ToggleClipLoop(track_id, clip_id) => {
                 let mut cmd_data = None;
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = self.find_content_mut(track_id) {
                     if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
                         clip.loop_enabled = !clip.loop_enabled;
                         if clip.loop_enabled && clip.loop_end == 0 {
@@ -494,7 +325,7 @@ impl ArrangementState {
                 loop_end,
             } => {
                 let mut enabled = false;
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = self.find_content_mut(track_id) {
                     if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
                         clip.loop_start = loop_start;
                         clip.loop_end = loop_end;
@@ -542,7 +373,7 @@ impl ArrangementState {
                 clip_id,
                 new_position,
             } => {
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = self.find_content_mut(track_id) {
                     if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
                         clip.position = new_position;
                     }
@@ -559,7 +390,7 @@ impl ArrangementState {
                 clip_id,
                 new_position_beats,
             } => {
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = self.find_content_mut(track_id) {
                     if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
                         clip.position_beats = new_position_beats;
                     }
@@ -580,7 +411,7 @@ impl ArrangementState {
                 let spb = ctx.samples_per_beat;
                 let mut sync_data = None;
                 let mut clip_end_beat = None;
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = self.find_content_mut(track_id) {
                     if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
                         let source_len = clip.audio.num_frames() as u64 - clip.source_offset;
                         if new_duration > source_len {
@@ -644,7 +475,7 @@ impl ArrangementState {
                 if is_note_clip {
                     // Move note clip between instrument tracks
                     let mut clip_data = None;
-                    if let Some(track) = self.find_track_mut(source_track) {
+                    if let Some(track) = self.find_content_mut(source_track) {
                         if let Some(idx) = track.note_clips.iter().position(|c| c.id == clip_id) {
                             clip_data = Some(track.note_clips.remove(idx));
                         }
@@ -670,7 +501,7 @@ impl ArrangementState {
                             });
                         }
                         // Add to UI target track
-                        if let Some(track) = self.find_track_mut(target_track) {
+                        if let Some(track) = self.find_content_mut(target_track) {
                             track.note_clips.push(clip);
                         }
                         // Update selection
@@ -688,7 +519,7 @@ impl ArrangementState {
                 } else {
                     // Move audio clip between audio tracks
                     let mut clip_data = None;
-                    if let Some(track) = self.find_track_mut(source_track) {
+                    if let Some(track) = self.find_content_mut(source_track) {
                         if let Some(idx) = track.clips.iter().position(|c| c.id == clip_id) {
                             clip_data = Some(track.clips.remove(idx));
                         }
@@ -709,7 +540,7 @@ impl ArrangementState {
                             loop_end: clip.loop_end,
                         });
                         // Add to UI target track
-                        if let Some(track) = self.find_track_mut(target_track) {
+                        if let Some(track) = self.find_content_mut(target_track) {
                             track.clips.push(clip);
                         }
                         // Update selection
@@ -733,13 +564,13 @@ impl ArrangementState {
                         match selection {
                             ArrangementSelection::AudioClip { track_id, clip_id } => {
                                 engine.send(EngineCommand::RemoveClip(*track_id, *clip_id));
-                                if let Some(track) = self.find_track_mut(*track_id) {
+                                if let Some(track) = self.find_content_mut(*track_id) {
                                     track.clips.retain(|c| c.id != *clip_id);
                                 }
                             }
                             ArrangementSelection::NoteClip { track_id, clip_id } => {
                                 engine.send(EngineCommand::RemoveNoteClip(*track_id, *clip_id));
-                                if let Some(track) = self.find_track_mut(*track_id) {
+                                if let Some(track) = self.find_content_mut(*track_id) {
                                     track.note_clips.retain(|c| c.id != *clip_id);
                                 }
                                 if self
@@ -766,7 +597,7 @@ impl ArrangementState {
                     for selection in &selections {
                         match selection {
                             ArrangementSelection::AudioClip { track_id, clip_id } => {
-                                let duplicate = self.find_track(*track_id).and_then(|track| {
+                                let duplicate = self.find_content(*track_id).and_then(|track| {
                                     track.clips.iter().find(|c| c.id == *clip_id).map(|clip| {
                                         let mut duplicate = clip.clone();
                                         duplicate.id = ClipId::new();
@@ -789,7 +620,7 @@ impl ArrangementState {
                                         loop_end: duplicate.loop_end,
                                     });
                                     let new_id = duplicate.id;
-                                    if let Some(track) = self.find_track_mut(*track_id) {
+                                    if let Some(track) = self.find_content_mut(*track_id) {
                                         track.clips.push(duplicate);
                                     }
                                     new_selections.insert(ArrangementSelection::AudioClip {
@@ -800,7 +631,7 @@ impl ArrangementState {
                             }
                             ArrangementSelection::NoteClip { track_id, clip_id } => {
                                 let duplicate =
-                                    self.find_track(*track_id).and_then(|track| {
+                                    self.find_content(*track_id).and_then(|track| {
                                         track.note_clips.iter().find(|c| c.id == *clip_id).map(
                                             |clip| {
                                                 let mut duplicate = clip.clone();
@@ -831,7 +662,7 @@ impl ArrangementState {
                                         });
                                     }
                                     let new_id = duplicate.id;
-                                    if let Some(track) = self.find_track_mut(*track_id) {
+                                    if let Some(track) = self.find_content_mut(*track_id) {
                                         track.note_clips.push(duplicate);
                                     }
                                     new_selections.insert(ArrangementSelection::NoteClip {
@@ -867,7 +698,12 @@ impl ArrangementState {
                 let mut result = if ranged {
                     self.op_delete_clips_in_region(engine, ctx, start, end, track_id)
                 } else {
-                    self.update(ArrangementMsg::DeleteSelectedClip, engine, ctx)
+                    self.update(
+                        project_tracks,
+                        ArrangementMsg::DeleteSelectedClip,
+                        engine,
+                        ctx,
+                    )
                 };
                 result.status = Some("Cut to clipboard".to_string());
                 return result;
@@ -882,7 +718,13 @@ impl ArrangementState {
                 anchor,
                 new_duration_beats,
             } => {
-                return self.op_resize_selected_clips(engine, ctx, anchor, new_duration_beats);
+                return self.op_resize_selected_clips(
+                    project_tracks,
+                    engine,
+                    ctx,
+                    anchor,
+                    new_duration_beats,
+                );
             }
             ArrangementMsg::SetTimeSelection {
                 start_beats,
@@ -916,7 +758,7 @@ impl ArrangementState {
                 let new_clip_id = ClipId::new();
                 let mut new_clip_data = None;
 
-                if let Some(track) = self.find_track(track_id) {
+                if let Some(track) = self.find_content(track_id) {
                     if let Some(clip) = track.note_clips.iter().find(|c| c.id == clip_id) {
                         let new_pos = clip.position_beats + clip.duration_beats;
                         new_clip_data = Some((
@@ -944,7 +786,7 @@ impl ArrangementState {
                 if let Some((new_clip, pos, dur, notes, loop_enabled, loop_start, loop_end)) =
                     new_clip_data
                 {
-                    if let Some(track) = self.find_track_mut(track_id) {
+                    if let Some(track) = self.find_content_mut(track_id) {
                         track.note_clips.push(new_clip);
                     }
                     engine.send(EngineCommand::AddNoteClip {
@@ -986,6 +828,7 @@ impl ArrangementState {
                     && self.selection_end_beats > self.selection_start_beats
                 {
                     return self.update(
+                        project_tracks,
                         ArrangementMsg::SplitClipsAtRegion {
                             start_beats: self.selection_start_beats,
                             end_beats: self.selection_end_beats,
@@ -1001,6 +844,7 @@ impl ArrangementState {
                     match selection {
                         ArrangementSelection::AudioClip { track_id, clip_id } => {
                             let _ = self.update(
+                                project_tracks,
                                 ArrangementMsg::SplitAudioClip {
                                     track_id,
                                     clip_id,
@@ -1012,6 +856,7 @@ impl ArrangementState {
                         }
                         ArrangementSelection::NoteClip { track_id, clip_id } => {
                             let _ = self.update(
+                                project_tracks,
                                 ArrangementMsg::SplitNoteClip {
                                     track_id,
                                     clip_id,
@@ -1054,10 +899,15 @@ impl ArrangementState {
                 );
             }
             ArrangementMsg::CreateClipFromSelection => {
-                return self.op_create_clip_from_selection(engine, ctx);
+                return self.op_create_clip_from_selection(project_tracks, engine, ctx);
             }
             ArrangementMsg::CreateNoteClipFromSelection(track_id) => {
-                return self.op_create_note_clip_from_selection(engine, ctx, track_id);
+                return self.op_create_note_clip_from_selection(
+                    project_tracks,
+                    engine,
+                    ctx,
+                    track_id,
+                );
             }
             ArrangementMsg::ClipBpmInputChanged {
                 track_id: _,
@@ -1073,7 +923,7 @@ impl ArrangementState {
                     .and_then(|t| t.parse::<f64>().ok())
                     .filter(|b| *b > 0.0 && *b < 1_000.0);
                 if let Some(bpm) = parsed {
-                    if let Some(track) = self.find_track_mut(track_id) {
+                    if let Some(track) = self.find_content_mut(track_id) {
                         if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
                             clip.original_bpm = Some(bpm);
                         }
@@ -1087,7 +937,7 @@ impl ArrangementState {
                 clip_id,
                 bpm,
             } => {
-                if let Some(track) = self.find_track_mut(track_id) {
+                if let Some(track) = self.find_content_mut(track_id) {
                     if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
                         clip.original_bpm = Some(bpm);
                     }
@@ -1103,7 +953,10 @@ impl ArrangementState {
     }
 }
 
+mod media_ops;
 mod ops;
 
+#[cfg(test)]
+mod test_support;
 #[cfg(test)]
 mod tests;

--- a/crates/vibez-ui/src/domains/arrangement/ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/ops.rs
@@ -1,666 +1,19 @@
-//! Heavier arrangement operations: warp/quantize result
-//! application and clip joining (audio-buffer merges).
+//! Multi-clip and range operations for Arrange Timeline Content.
 
 use std::collections::HashSet;
-
-use crate::message::{AudioQuantizeSuccess, AutoWarpOutcome, ClipWarpSuccess};
 use std::sync::Arc;
 
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::MidiNote;
 use vibez_engine::commands::EngineCommand;
 
-use super::EngineHandle;
+use super::{ArrangementAction, ArrangementCtx, ArrangementMsg, EngineHandle};
 use crate::state::{
-    ArrangementSelection, ArrangementState, ClipClipboard, ClipboardClip, UiClip, UiNoteClip,
+    ArrangementSelection, ArrangementState, ClipClipboard, ClipboardClip, ProjectTracksState,
+    UiNoteClip,
 };
 
-use super::*;
-
-fn audio_source_frame(clip: &UiClip, local_frame: u64) -> usize {
-    let raw = clip.source_offset.saturating_add(local_frame);
-    if clip.loop_enabled && clip.loop_end > clip.loop_start && raw >= clip.loop_end {
-        let loop_len = clip.loop_end - clip.loop_start;
-        (clip.loop_start + (raw - clip.loop_start) % loop_len) as usize
-    } else {
-        raw as usize
-    }
-}
-
-fn visible_notes(clip: &UiNoteClip, local_start: f64, local_end: f64) -> Vec<MidiNote> {
-    let looping = clip.loop_enabled && clip.loop_end_beats > clip.loop_start_beats;
-    let mut visible = Vec::new();
-    for note in &clip.notes {
-        let mut occurrence = note.start_beat;
-        loop {
-            let note_end = occurrence + note.duration_beats;
-            let kept_start = occurrence.max(local_start);
-            let kept_end = note_end.min(local_end);
-            if kept_end > kept_start {
-                visible.push(MidiNote {
-                    start_beat: kept_start - local_start,
-                    duration_beats: kept_end - kept_start,
-                    ..*note
-                });
-            }
-            if !looping
-                || note.start_beat < clip.loop_start_beats
-                || note.start_beat >= clip.loop_end_beats
-            {
-                break;
-            }
-            occurrence += clip.loop_end_beats - clip.loop_start_beats;
-            if occurrence >= local_end {
-                break;
-            }
-        }
-    }
-    visible.sort_by(|a, b| {
-        a.start_beat
-            .partial_cmp(&b.start_beat)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-    visible
-}
-
 impl ArrangementState {
-    /// A background warp finished: swap in the stretched audio and
-    /// record the warp geometry on the clip.
-    pub fn apply_clip_warp_success(
-        &mut self,
-        engine: &mut impl EngineHandle,
-        track_id: TrackId,
-        clip_id: ClipId,
-        success: ClipWarpSuccess,
-    ) -> ArrangementAction {
-        let mut action = ArrangementAction::default();
-        engine.send(EngineCommand::ReplaceClipAudio {
-            track_id,
-            clip_id,
-            audio: Arc::clone(&success.audio),
-            duration: success.new_duration,
-            source_offset: success.new_source_offset,
-            loop_start: success.new_loop_start,
-            loop_end: success.new_loop_end,
-        });
-        if let Some(track) = self.find_track_mut(track_id) {
-            if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
-                clip.audio = Arc::clone(&success.audio);
-                clip.duration = success.new_duration;
-                clip.source_offset = success.new_source_offset;
-                clip.loop_start = success.new_loop_start;
-                clip.loop_end = success.new_loop_end;
-                clip.original_bpm = Some(success.detected_bpm);
-                clip.warped = true;
-                clip.warped_to_bpm = Some(success.warped_to_bpm);
-                clip.original_audio = Some(Arc::clone(&success.original_audio));
-            }
-        }
-        action.status = Some(format!("Warped to {:.0} BPM", success.warped_to_bpm));
-        action.mark_dirty = true;
-        action
-    }
-
-    /// An auto-warp-on-import attempt finished.
-    pub fn apply_auto_warp_outcome(
-        &mut self,
-        engine: &mut impl EngineHandle,
-        track_id: TrackId,
-        clip_id: ClipId,
-        outcome: AutoWarpOutcome,
-    ) -> ArrangementAction {
-        let mut action = ArrangementAction::default();
-        match outcome {
-            AutoWarpOutcome::NotDetected => {
-                // Nothing to apply. Point the user at the manual
-                // workflow in the clip detail panel.
-                action.status = Some(
-                    "Auto-warp: could not detect BPM. Select the clip and type the source \
-                     BPM in the Warp row, then press Enter and click Warp."
-                        .to_string(),
-                );
-            }
-            AutoWarpOutcome::DetectedOnly { bpm, confidence } => {
-                if let Some(track) = self.find_track_mut(track_id) {
-                    if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
-                        clip.original_bpm = Some(bpm);
-                    }
-                }
-                action.status = Some(format!(
-                    "Auto-warp skipped: detected {:.1} BPM at low confidence {:.2}. \
-                     Use the clip's Warp button to apply it manually.",
-                    bpm, confidence
-                ));
-                action.mark_dirty = true;
-            }
-            AutoWarpOutcome::Warped { success, .. } => {
-                return self.apply_clip_warp_success(engine, track_id, clip_id, success);
-            }
-        }
-        action
-    }
-
-    /// Restore a warped clip's original audio (or just drop the warp
-    /// flags when the original is gone).
-    pub fn apply_clear_clip_warp(
-        &mut self,
-        engine: &mut impl EngineHandle,
-        track_id: TrackId,
-        clip_id: ClipId,
-    ) -> ArrangementAction {
-        let mut action = ArrangementAction::default();
-        let restore = self
-            .find_track(track_id)
-            .and_then(|track| track.clips.iter().find(|c| c.id == clip_id))
-            .and_then(|clip| clip.original_audio.as_ref().map(Arc::clone));
-        if let Some(original) = restore {
-            let original_frames = original.num_frames() as u64;
-            engine.send(EngineCommand::ReplaceClipAudio {
-                track_id,
-                clip_id,
-                audio: Arc::clone(&original),
-                duration: original_frames,
-                source_offset: 0,
-                loop_start: 0,
-                loop_end: 0,
-            });
-            if let Some(track) = self.find_track_mut(track_id) {
-                if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
-                    clip.audio = original;
-                    clip.duration = original_frames;
-                    clip.source_offset = 0;
-                    clip.loop_start = 0;
-                    clip.loop_end = 0;
-                    clip.warped = false;
-                    clip.warped_to_bpm = None;
-                    clip.original_audio = None;
-                }
-            }
-        } else if let Some(track) = self.find_track_mut(track_id) {
-            if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
-                clip.warped = false;
-                clip.warped_to_bpm = None;
-            }
-        }
-        action.status = Some("Cleared clip warp".to_string());
-        action.mark_dirty = true;
-        action
-    }
-
-    /// A background audio quantize finished: replace the source clip
-    /// with the newly rendered one and select it.
-    pub fn apply_audio_quantize_success(
-        &mut self,
-        engine: &mut impl EngineHandle,
-        track_id: TrackId,
-        old_clip_id: ClipId,
-        success: AudioQuantizeSuccess,
-        sample_rate: u32,
-    ) -> ArrangementAction {
-        let mut action = ArrangementAction::default();
-        engine.send(EngineCommand::RemoveClip(track_id, old_clip_id));
-        if let Some(track) = self.find_track_mut(track_id) {
-            track.clips.retain(|c| c.id != old_clip_id);
-        }
-        self.selected_clips.retain(|sel| match sel {
-            ArrangementSelection::AudioClip {
-                clip_id: cid,
-                track_id: tid,
-            } => !(*tid == track_id && *cid == old_clip_id),
-            _ => true,
-        });
-
-        engine.send(EngineCommand::AddClip {
-            track_id,
-            clip_id: success.new_clip_id,
-            audio: Arc::clone(&success.new_audio),
-            position: success.new_position,
-            source_offset: 0,
-            duration: success.new_duration,
-            loop_enabled: false,
-            loop_start: 0,
-            loop_end: 0,
-        });
-        if let Some(track) = self.find_track_mut(track_id) {
-            track.clips.push(UiClip {
-                id: success.new_clip_id,
-                name: success.new_name,
-                audio: Arc::clone(&success.new_audio),
-                source: None,
-                position: success.new_position,
-                source_offset: 0,
-                duration: success.new_duration,
-                loop_enabled: false,
-                loop_start: 0,
-                loop_end: 0,
-                original_bpm: None,
-                warped: false,
-                warped_to_bpm: None,
-                original_audio: None,
-            });
-        }
-        self.selected_clips.insert(ArrangementSelection::AudioClip {
-            track_id,
-            clip_id: success.new_clip_id,
-        });
-
-        let duration_seconds = success.new_duration as f64 / sample_rate.max(1) as f64;
-        action.status = Some(format!(
-            "Quantized {} slice(s) to {} ({:.1}s)",
-            success.slice_count, success.grid_label, duration_seconds
-        ));
-        action
-    }
-
-    /// A background BPM detection finished.
-    pub fn apply_clip_bpm_detected(
-        &mut self,
-        track_id: TrackId,
-        clip_id: ClipId,
-        bpm: Option<f64>,
-        confidence: f32,
-    ) -> ArrangementAction {
-        let mut action = ArrangementAction::default();
-        match bpm {
-            Some(b) => {
-                if let Some(track) = self.find_track_mut(track_id) {
-                    if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
-                        clip.original_bpm = Some(b);
-                    }
-                }
-                self.clip_bpm_edit.remove(&clip_id);
-                action.status = Some(format!(
-                    "Detected {:.1} BPM (confidence {:.2})",
-                    b, confidence
-                ));
-                action.mark_dirty = true;
-            }
-            None => {
-                action.status = Some(
-                    "Could not detect BPM. Type the source BPM in the Warp row and \
-                     press Enter, then click Warp."
-                        .to_string(),
-                );
-            }
-        }
-        action
-    }
-
-    pub(super) fn join_audio_clips(
-        &mut self,
-        track_id: TrackId,
-        selections: &[ArrangementSelection],
-        engine: &mut impl EngineHandle,
-    ) -> Option<String> {
-        // Collect clip data sorted by position
-        let clip_ids: Vec<ClipId> = selections
-            .iter()
-            .filter_map(|s| match s {
-                ArrangementSelection::AudioClip { clip_id, .. } => Some(*clip_id),
-                _ => None,
-            })
-            .collect();
-
-        let mut clip_data: Vec<UiClip> = Vec::new();
-        if let Some(track) = self.find_track(track_id) {
-            for cid in &clip_ids {
-                if let Some(clip) = track.clips.iter().find(|c| c.id == *cid) {
-                    clip_data.push(clip.clone());
-                }
-            }
-        }
-
-        if clip_data.len() < 2 {
-            return None;
-        }
-
-        // Sort by position
-        clip_data.sort_by_key(|clip| clip.position);
-
-        let start_pos = clip_data[0].position;
-        let end_pos = clip_data
-            .iter()
-            .map(|clip| clip.position.saturating_add(clip.duration))
-            .max()
-            .unwrap_or(start_pos);
-        let total_duration = end_pos - start_pos;
-        let joined_loop_enabled = clip_data.iter().any(|clip| clip.loop_enabled);
-
-        // Determine channel count from first clip
-        let channels = clip_data[0].audio.num_channels();
-        let sr = clip_data[0].audio.sample_rate;
-
-        // Create joined buffer filled with silence
-        let mut joined_channels: Vec<Vec<f32>> = (0..channels)
-            .map(|_| vec![0.0f32; total_duration as usize])
-            .collect();
-
-        // Consolidate the audible arrangement result, including source
-        // wrapping for clips whose visible duration exceeds their loop.
-        for clip in &clip_data {
-            let offset_in_joined = (clip.position - start_pos) as usize;
-            let dur = clip.duration as usize;
-            let ch_count = channels.min(clip.audio.num_channels());
-            for (ch, dst) in joined_channels.iter_mut().enumerate().take(ch_count) {
-                for local in 0..dur {
-                    let dst_frame = offset_in_joined + local;
-                    if dst_frame >= dst.len() {
-                        break;
-                    }
-                    let source_frame = audio_source_frame(clip, local as u64);
-                    if let Some(sample) = clip.audio.channels[ch].get(source_frame) {
-                        dst[dst_frame] = *sample;
-                    }
-                }
-            }
-        }
-
-        // Create DecodedAudio
-        let joined_audio = Arc::new(vibez_core::audio_buffer::DecodedAudio {
-            channels: joined_channels,
-            sample_rate: sr,
-        });
-
-        // Remove all originals
-        for cid in &clip_ids {
-            engine.send(EngineCommand::RemoveClip(track_id, *cid));
-            if let Some(track) = self.find_track_mut(track_id) {
-                track.clips.retain(|c| c.id != *cid);
-            }
-        }
-
-        // Add joined clip
-        let new_id = ClipId::new();
-        engine.send(EngineCommand::AddClip {
-            track_id,
-            clip_id: new_id,
-            audio: Arc::clone(&joined_audio),
-            position: start_pos,
-            source_offset: 0,
-            duration: total_duration,
-            loop_enabled: joined_loop_enabled,
-            loop_start: 0,
-            loop_end: total_duration,
-        });
-        if let Some(track) = self.find_track_mut(track_id) {
-            track.clips.push(UiClip {
-                id: new_id,
-                name: "Joined".to_string(),
-                audio: joined_audio,
-                source: None,
-                position: start_pos,
-                source_offset: 0,
-                duration: total_duration,
-                loop_enabled: joined_loop_enabled,
-                loop_start: 0,
-                loop_end: total_duration,
-                original_bpm: None,
-                warped: false,
-                warped_to_bpm: None,
-                original_audio: None,
-            });
-        }
-
-        self.selected_clips.clear();
-        self.selected_clips.insert(ArrangementSelection::AudioClip {
-            track_id,
-            clip_id: new_id,
-        });
-        Some("Joined audio clips".to_string())
-    }
-
-    pub(super) fn join_note_clips(
-        &mut self,
-        track_id: TrackId,
-        selections: &[ArrangementSelection],
-        engine: &mut impl EngineHandle,
-    ) -> Option<String> {
-        let clip_ids: Vec<ClipId> = selections
-            .iter()
-            .filter_map(|s| match s {
-                ArrangementSelection::NoteClip { clip_id, .. } => Some(*clip_id),
-                _ => None,
-            })
-            .collect();
-
-        let mut clip_data: Vec<UiNoteClip> = Vec::new();
-        if let Some(track) = self.find_track(track_id) {
-            for cid in &clip_ids {
-                if let Some(clip) = track.note_clips.iter().find(|c| c.id == *cid) {
-                    clip_data.push(clip.clone());
-                }
-            }
-        }
-
-        if clip_data.len() < 2 {
-            return None;
-        }
-
-        // Sort by position
-        clip_data.sort_by(|a, b| {
-            a.position_beats
-                .partial_cmp(&b.position_beats)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        let start_pos = clip_data[0].position_beats;
-        let end_pos = clip_data
-            .iter()
-            .map(|clip| clip.position_beats + clip.duration_beats)
-            .fold(0.0_f64, f64::max);
-        let total_duration = end_pos - start_pos;
-        let joined_loop_enabled = clip_data.iter().any(|clip| clip.loop_enabled);
-
-        // Merge the audible notes, expanding repeated loop occurrences.
-        let mut merged_notes: Vec<MidiNote> = Vec::new();
-        for clip in &clip_data {
-            let offset = clip.position_beats - start_pos;
-            for note in visible_notes(clip, 0.0, clip.duration_beats) {
-                merged_notes.push(MidiNote {
-                    start_beat: note.start_beat + offset,
-                    ..note
-                });
-            }
-        }
-
-        // Remove all originals
-        for cid in &clip_ids {
-            engine.send(EngineCommand::RemoveNoteClip(track_id, *cid));
-            if let Some(track) = self.find_track_mut(track_id) {
-                track.note_clips.retain(|c| c.id != *cid);
-            }
-        }
-
-        // Add joined clip
-        let new_id = ClipId::new();
-        engine.send(EngineCommand::AddNoteClip {
-            track_id,
-            clip_id: new_id,
-            position_beats: start_pos,
-            duration_beats: total_duration,
-            loop_enabled: joined_loop_enabled,
-            loop_start_beats: 0.0,
-            loop_end_beats: total_duration,
-        });
-        for note in &merged_notes {
-            engine.send(EngineCommand::AddNote {
-                track_id,
-                clip_id: new_id,
-                note: *note,
-            });
-        }
-        if let Some(track) = self.find_track_mut(track_id) {
-            track.note_clips.push(UiNoteClip {
-                id: new_id,
-                name: "Joined".to_string(),
-                position_beats: start_pos,
-                duration_beats: total_duration,
-                notes: merged_notes,
-                selected_notes: HashSet::new(),
-                loop_enabled: joined_loop_enabled,
-                loop_start_beats: 0.0,
-                loop_end_beats: total_duration,
-            });
-        }
-
-        self.selected_clips.clear();
-        self.selected_clips.insert(ArrangementSelection::NoteClip {
-            track_id,
-            clip_id: new_id,
-        });
-        self.selected_note_clip = Some((track_id, new_id));
-        Some("Joined note clips".to_string())
-    }
-
-    pub(super) fn op_split_audio_clip(
-        &mut self,
-        engine: &mut impl EngineHandle,
-        _ctx: ArrangementCtx,
-        track_id: TrackId,
-        clip_id: ClipId,
-        split_position: u64,
-    ) -> ArrangementAction {
-        let mut action = ArrangementAction::default();
-        let split = self
-            .find_track(track_id)
-            .and_then(|track| track.clips.iter().find(|clip| clip.id == clip_id))
-            .filter(|clip| {
-                split_position > clip.position
-                    && split_position < clip.position.saturating_add(clip.duration)
-            })
-            .map(|clip| {
-                let left_duration = split_position - clip.position;
-                let mut left = clip.clone();
-                left.id = ClipId::new();
-                left.name = format!("{} L", clip.name);
-                left.duration = left_duration;
-
-                let mut right = clip.clone();
-                right.id = ClipId::new();
-                right.name = format!("{} R", clip.name);
-                right.position = split_position;
-                right.duration = clip.duration - left_duration;
-                right.source_offset = audio_source_frame(clip, left_duration) as u64;
-                (left, right)
-            });
-        if let Some((left, right)) = split {
-            let left_id = left.id;
-
-            engine.send(EngineCommand::RemoveClip(track_id, clip_id));
-            if let Some(track) = self.find_track_mut(track_id) {
-                track.clips.retain(|c| c.id != clip_id);
-            }
-
-            for clip in [&left, &right] {
-                engine.send(EngineCommand::AddClip {
-                    track_id,
-                    clip_id: clip.id,
-                    audio: Arc::clone(&clip.audio),
-                    position: clip.position,
-                    source_offset: clip.source_offset,
-                    duration: clip.duration,
-                    loop_enabled: clip.loop_enabled,
-                    loop_start: clip.loop_start,
-                    loop_end: clip.loop_end,
-                });
-            }
-            if let Some(track) = self.find_track_mut(track_id) {
-                track.clips.extend([left, right]);
-            }
-
-            self.selected_clips
-                .remove(&ArrangementSelection::AudioClip { track_id, clip_id });
-            self.selected_clips.insert(ArrangementSelection::AudioClip {
-                track_id,
-                clip_id: left_id,
-            });
-            action.status = Some("Split audio clip".to_string());
-        }
-        action
-    }
-
-    pub(super) fn op_split_note_clip(
-        &mut self,
-        engine: &mut impl EngineHandle,
-        _ctx: ArrangementCtx,
-        track_id: TrackId,
-        clip_id: ClipId,
-        split_beat: f64,
-    ) -> ArrangementAction {
-        let mut action = ArrangementAction::default();
-        let split = self
-            .find_track(track_id)
-            .and_then(|track| track.note_clips.iter().find(|clip| clip.id == clip_id))
-            .filter(|clip| {
-                split_beat > clip.position_beats
-                    && split_beat < clip.position_beats + clip.duration_beats
-            })
-            .map(|clip| {
-                let local_split = split_beat - clip.position_beats;
-                let mut left = clip.clone();
-                left.id = ClipId::new();
-                left.name = format!("{} L", clip.name);
-                left.duration_beats = local_split;
-                left.notes = visible_notes(clip, 0.0, local_split);
-                left.selected_notes.clear();
-
-                let mut right = clip.clone();
-                right.id = ClipId::new();
-                right.name = format!("{} R", clip.name);
-                right.position_beats = split_beat;
-                right.duration_beats = clip.duration_beats - local_split;
-                right.notes = visible_notes(clip, local_split, clip.duration_beats);
-                right.selected_notes.clear();
-
-                if clip.loop_enabled {
-                    left.loop_start_beats = 0.0;
-                    left.loop_end_beats = left.duration_beats;
-                    right.loop_start_beats = 0.0;
-                    right.loop_end_beats = right.duration_beats;
-                }
-                (left, right)
-            });
-        if let Some((left, right)) = split {
-            let left_id = left.id;
-            engine.send(EngineCommand::RemoveNoteClip(track_id, clip_id));
-            if let Some(track) = self.find_track_mut(track_id) {
-                track.note_clips.retain(|c| c.id != clip_id);
-            }
-
-            for clip in [&left, &right] {
-                engine.send(EngineCommand::AddNoteClip {
-                    track_id,
-                    clip_id: clip.id,
-                    position_beats: clip.position_beats,
-                    duration_beats: clip.duration_beats,
-                    loop_enabled: clip.loop_enabled,
-                    loop_start_beats: clip.loop_start_beats,
-                    loop_end_beats: clip.loop_end_beats,
-                });
-                for note in &clip.notes {
-                    engine.send(EngineCommand::AddNote {
-                        track_id,
-                        clip_id: clip.id,
-                        note: *note,
-                    });
-                }
-            }
-            if let Some(track) = self.find_track_mut(track_id) {
-                track.note_clips.extend([left, right]);
-            }
-
-            self.selected_clips
-                .remove(&ArrangementSelection::NoteClip { track_id, clip_id });
-            self.selected_clips.insert(ArrangementSelection::NoteClip {
-                track_id,
-                clip_id: left_id,
-            });
-            self.selected_note_clip = Some((track_id, left_id));
-            action.status = Some("Split note clip".to_string());
-        }
-        action
-    }
-
     pub(super) fn op_delete_clips_in_region(
         &mut self,
         engine: &mut impl EngineHandle,
@@ -681,9 +34,9 @@ impl ArrangementState {
         // Collect clip IDs to remove
         let mut audio_removals: Vec<(TrackId, ClipId)> = Vec::new();
         let mut note_removals: Vec<(TrackId, ClipId)> = Vec::new();
-        for track in &self.tracks {
+        for (content_track_id, track) in &self.timeline.by_track {
             if let Some(tid) = target_track {
-                if track.id != tid {
+                if *content_track_id != tid {
                     continue;
                 }
             }
@@ -692,26 +45,26 @@ impl ArrangementState {
                     let clip_start = clip.position as f64 / spb;
                     let clip_end = (clip.position + clip.duration) as f64 / spb;
                     if clip_start >= start_beats - 1e-9 && clip_end <= end_beats + 1e-9 {
-                        audio_removals.push((track.id, clip.id));
+                        audio_removals.push((*content_track_id, clip.id));
                     }
                 }
             }
             for nc in &track.note_clips {
                 let clip_end = nc.position_beats + nc.duration_beats;
                 if nc.position_beats >= start_beats - 1e-9 && clip_end <= end_beats + 1e-9 {
-                    note_removals.push((track.id, nc.id));
+                    note_removals.push((*content_track_id, nc.id));
                 }
             }
         }
         for (tid, cid) in &audio_removals {
             engine.send(EngineCommand::RemoveClip(*tid, *cid));
-            if let Some(track) = self.find_track_mut(*tid) {
+            if let Some(track) = self.find_content_mut(*tid) {
                 track.clips.retain(|c| c.id != *cid);
             }
         }
         for (tid, cid) in &note_removals {
             engine.send(EngineCommand::RemoveNoteClip(*tid, *cid));
-            if let Some(track) = self.find_track_mut(*tid) {
+            if let Some(track) = self.find_content_mut(*tid) {
                 track.note_clips.retain(|c| c.id != *cid);
             }
         }
@@ -749,15 +102,16 @@ impl ArrangementState {
             // the originating track when the selection was drawn
             // on a single lane.
             let audio_hits: Vec<(TrackId, ClipId)> = if spb > 0.0 {
-                self.tracks
+                self.timeline
+                    .by_track
                     .iter()
-                    .filter(|t| target_track.is_none_or(|tid| t.id == tid))
-                    .flat_map(|t| {
-                        t.clips.iter().filter_map(|c| {
+                    .filter(|(tid, _)| target_track.is_none_or(|target| **tid == target))
+                    .flat_map(|(tid, content)| {
+                        content.clips.iter().filter_map(|c| {
                             let cs = c.position as f64 / spb;
                             let ce = (c.position + c.duration) as f64 / spb;
                             if boundary_beats > cs && boundary_beats < ce {
-                                Some((t.id, c.id))
+                                Some((*tid, c.id))
                             } else {
                                 None
                             }
@@ -769,14 +123,15 @@ impl ArrangementState {
             };
 
             let note_hits: Vec<(TrackId, ClipId)> = self
-                .tracks
+                .timeline
+                .by_track
                 .iter()
-                .filter(|t| target_track.is_none_or(|tid| t.id == tid))
-                .flat_map(|t| {
-                    t.note_clips.iter().filter_map(|c| {
+                .filter(|(tid, _)| target_track.is_none_or(|target| **tid == target))
+                .flat_map(|(tid, content)| {
+                    content.note_clips.iter().filter_map(|c| {
                         let ce = c.position_beats + c.duration_beats;
                         if boundary_beats > c.position_beats && boundary_beats < ce {
-                            Some((t.id, c.id))
+                            Some((*tid, c.id))
                         } else {
                             None
                         }
@@ -785,27 +140,11 @@ impl ArrangementState {
                 .collect();
 
             for (tid, cid) in audio_hits {
-                let _ = self.update(
-                    ArrangementMsg::SplitAudioClip {
-                        track_id: tid,
-                        clip_id: cid,
-                        split_position: boundary_sample,
-                    },
-                    engine,
-                    ctx,
-                );
+                let _ = self.op_split_audio_clip(engine, ctx, tid, cid, boundary_sample);
                 split_count += 1;
             }
             for (tid, cid) in note_hits {
-                let _ = self.update(
-                    ArrangementMsg::SplitNoteClip {
-                        track_id: tid,
-                        clip_id: cid,
-                        split_beat: boundary_beats,
-                    },
-                    engine,
-                    ctx,
-                );
+                let _ = self.op_split_note_clip(engine, ctx, tid, cid, boundary_beats);
                 split_count += 1;
             }
         }
@@ -818,17 +157,19 @@ impl ArrangementState {
 
     pub(super) fn op_create_clip_from_selection(
         &mut self,
+        project_tracks: &ProjectTracksState,
         engine: &mut impl EngineHandle,
         ctx: ArrangementCtx,
     ) -> ArrangementAction {
         let mut action = ArrangementAction::default();
         if let Some(tid) = self.selected_track {
-            if let Some(track) = self.find_track(tid) {
+            if let Some(track) = project_tracks.find(tid) {
                 if track.kind.is_midi() {
-                    return self.update(
-                        ArrangementMsg::CreateNoteClipFromSelection(tid),
+                    return self.op_create_note_clip_from_selection(
+                        project_tracks,
                         engine,
                         ctx,
+                        tid,
                     );
                 } else {
                     action.status = Some("Select a time region on a MIDI track".to_string());
@@ -842,6 +183,7 @@ impl ArrangementState {
 
     pub(super) fn op_create_note_clip_from_selection(
         &mut self,
+        project_tracks: &ProjectTracksState,
         engine: &mut impl EngineHandle,
         _ctx: ArrangementCtx,
         track_id: TrackId,
@@ -854,7 +196,7 @@ impl ArrangementState {
             action.status = Some("No time selection active".to_string());
             return action;
         }
-        if let Some(track) = self.find_track(track_id) {
+        if let Some(track) = project_tracks.find(track_id) {
             if !track.kind.is_midi() {
                 action.status = Some("Can only create note clips on MIDI tracks".to_string());
                 return action;
@@ -863,7 +205,7 @@ impl ArrangementState {
         let clip_id = ClipId::new();
         let position_beats = self.selection_start_beats;
         let duration_beats = self.selection_end_beats - self.selection_start_beats;
-        if let Some(track) = self.find_track_mut(track_id) {
+        if let Some(track) = self.find_content_mut(track_id) {
             track.note_clips.push(UiNoteClip {
                 id: clip_id,
                 name: format!("Pattern {}", track.note_clips.len() + 1),
@@ -937,11 +279,10 @@ impl ArrangementState {
         {
             let start = self.selection_start_beats;
             let end = self.selection_end_beats;
-            for track in self
-                .tracks
-                .iter()
-                .filter(|t| self.time_selection_track.is_none_or(|tid| t.id == tid))
-            {
+            for (content_track_id, track) in self.timeline.by_track.iter().filter(|(tid, _)| {
+                self.time_selection_track
+                    .is_none_or(|target| **tid == target)
+            }) {
                 for clip in &track.clips {
                     let clip_start = clip.position as f64 / spb;
                     let clip_end = (clip.position + clip.duration) as f64 / spb;
@@ -968,7 +309,7 @@ impl ArrangementState {
                         raw_offset
                     };
                     copied.push(ClipboardClip::Audio {
-                        track_id: track.id,
+                        track_id: *content_track_id,
                         offset_beats: overlap_start - start,
                         clip: fragment,
                     });
@@ -1020,7 +361,7 @@ impl ArrangementState {
                     fragment.loop_start_beats = 0.0;
                     fragment.loop_end_beats = 0.0;
                     copied.push(ClipboardClip::Note {
-                        track_id: track.id,
+                        track_id: *content_track_id,
                         offset_beats: overlap_start - start,
                         clip: fragment,
                     });
@@ -1032,7 +373,7 @@ impl ArrangementState {
                 match selection {
                     ArrangementSelection::AudioClip { track_id, clip_id } if spb > 0.0 => {
                         if let Some(clip) = self
-                            .find_track(*track_id)
+                            .find_content(*track_id)
                             .and_then(|t| t.clips.iter().find(|c| c.id == *clip_id))
                         {
                             starts.push(clip.position as f64 / spb);
@@ -1040,7 +381,7 @@ impl ArrangementState {
                     }
                     ArrangementSelection::NoteClip { track_id, clip_id } => {
                         if let Some(clip) = self
-                            .find_track(*track_id)
+                            .find_content(*track_id)
                             .and_then(|t| t.note_clips.iter().find(|c| c.id == *clip_id))
                         {
                             starts.push(clip.position_beats);
@@ -1054,7 +395,7 @@ impl ArrangementState {
                 match selection {
                     ArrangementSelection::AudioClip { track_id, clip_id } if spb > 0.0 => {
                         if let Some(clip) = self
-                            .find_track(*track_id)
+                            .find_content(*track_id)
                             .and_then(|t| t.clips.iter().find(|c| c.id == *clip_id))
                         {
                             copied.push(ClipboardClip::Audio {
@@ -1066,7 +407,7 @@ impl ArrangementState {
                     }
                     ArrangementSelection::NoteClip { track_id, clip_id } => {
                         if let Some(clip) = self
-                            .find_track(*track_id)
+                            .find_content(*track_id)
                             .and_then(|t| t.note_clips.iter().find(|c| c.id == *clip_id))
                         {
                             copied.push(ClipboardClip::Note {
@@ -1117,7 +458,7 @@ impl ArrangementState {
                     offset_beats,
                     mut clip,
                 } => {
-                    if self.find_track(track_id).is_none() {
+                    if self.find_content(track_id).is_none() {
                         continue;
                     }
                     clip.id = ClipId::new();
@@ -1139,14 +480,14 @@ impl ArrangementState {
                         track_id,
                         clip_id: clip.id,
                     });
-                    self.find_track_mut(track_id).unwrap().clips.push(clip);
+                    self.find_content_mut(track_id).unwrap().clips.push(clip);
                 }
                 ClipboardClip::Note {
                     track_id,
                     offset_beats,
                     mut clip,
                 } => {
-                    if self.find_track(track_id).is_none() {
+                    if self.find_content(track_id).is_none() {
                         continue;
                     }
                     clip.id = ClipId::new();
@@ -1171,7 +512,10 @@ impl ArrangementState {
                         track_id,
                         clip_id: clip.id,
                     });
-                    self.find_track_mut(track_id).unwrap().note_clips.push(clip);
+                    self.find_content_mut(track_id)
+                        .unwrap()
+                        .note_clips
+                        .push(clip);
                 }
             }
         }
@@ -1195,11 +539,11 @@ impl ArrangementState {
         let selections: Vec<_> = self.selected_clips.iter().copied().collect();
         let enable = selections.iter().any(|selection| match selection {
             ArrangementSelection::AudioClip { track_id, clip_id } => self
-                .find_track(*track_id)
+                .find_content(*track_id)
                 .and_then(|t| t.clips.iter().find(|c| c.id == *clip_id))
                 .is_some_and(|c| !c.loop_enabled),
             ArrangementSelection::NoteClip { track_id, clip_id } => self
-                .find_track(*track_id)
+                .find_content(*track_id)
                 .and_then(|t| t.note_clips.iter().find(|c| c.id == *clip_id))
                 .is_some_and(|c| !c.loop_enabled),
         });
@@ -1209,7 +553,7 @@ impl ArrangementState {
                 ArrangementSelection::AudioClip { track_id, clip_id } => {
                     let mut command = None;
                     if let Some(clip) = self
-                        .find_track_mut(track_id)
+                        .find_content_mut(track_id)
                         .and_then(|t| t.clips.iter_mut().find(|c| c.id == clip_id))
                     {
                         clip.loop_enabled = enable;
@@ -1233,7 +577,7 @@ impl ArrangementState {
                 ArrangementSelection::NoteClip { track_id, clip_id } => {
                     let mut command = None;
                     if let Some(clip) = self
-                        .find_track_mut(track_id)
+                        .find_content_mut(track_id)
                         .and_then(|t| t.note_clips.iter_mut().find(|c| c.id == clip_id))
                     {
                         clip.loop_enabled = enable;
@@ -1270,6 +614,7 @@ impl ArrangementState {
 
     pub(super) fn op_resize_selected_clips(
         &mut self,
+        project_tracks: &mut ProjectTracksState,
         engine: &mut impl EngineHandle,
         ctx: ArrangementCtx,
         anchor: ArrangementSelection,
@@ -1280,11 +625,11 @@ impl ArrangementState {
         }
         let anchor_duration = match anchor {
             ArrangementSelection::AudioClip { track_id, clip_id } => self
-                .find_track(track_id)
+                .find_content(track_id)
                 .and_then(|t| t.clips.iter().find(|c| c.id == clip_id))
                 .map(|c| c.duration as f64 / ctx.samples_per_beat),
             ArrangementSelection::NoteClip { track_id, clip_id } => self
-                .find_track(track_id)
+                .find_content(track_id)
                 .and_then(|t| t.note_clips.iter().find(|c| c.id == clip_id))
                 .map(|c| c.duration_beats),
         };
@@ -1302,13 +647,14 @@ impl ArrangementState {
             match target {
                 ArrangementSelection::AudioClip { track_id, clip_id } => {
                     let old = self
-                        .find_track(track_id)
+                        .find_content(track_id)
                         .and_then(|t| t.clips.iter().find(|c| c.id == clip_id))
                         .map(|c| c.duration as f64 / ctx.samples_per_beat);
                     if let Some(old) = old {
                         let duration =
                             ((old + delta).max(0.25) * ctx.samples_per_beat).round() as u64;
                         let action = self.update(
+                            project_tracks,
                             ArrangementMsg::ResizeAudioClip {
                                 track_id,
                                 clip_id,
@@ -1326,7 +672,7 @@ impl ArrangementState {
                 ArrangementSelection::NoteClip { track_id, clip_id } => {
                     let mut sync = None;
                     if let Some(clip) = self
-                        .find_track_mut(track_id)
+                        .find_content_mut(track_id)
                         .and_then(|t| t.note_clips.iter_mut().find(|c| c.id == clip_id))
                     {
                         clip.duration_beats = (clip.duration_beats + delta).max(0.25);

--- a/crates/vibez-ui/src/domains/arrangement/test_support.rs
+++ b/crates/vibez-ui/src/domains/arrangement/test_support.rs
@@ -1,0 +1,178 @@
+//! Arrangement domain unit tests.
+
+use super::*;
+use crate::domains::test_support::RecordingEngine;
+use crate::state::{
+    new_master_track, ProjectTrack, ProjectTracksState, TrackTimelineContent, UiClip,
+};
+use vibez_core::automation::AutomationLane;
+
+pub(super) struct TestTrack {
+    project: ProjectTrack,
+    pub(super) clips: Vec<UiClip>,
+    pub(super) note_clips: Vec<UiNoteClip>,
+    pub(super) automation: Vec<AutomationLane>,
+}
+
+impl TestTrack {
+    fn from_parts(project: ProjectTrack, content: TrackTimelineContent) -> Self {
+        Self {
+            project,
+            clips: content.clips,
+            note_clips: content.note_clips,
+            automation: content.automation,
+        }
+    }
+
+    fn content(&self) -> TrackTimelineContent {
+        TrackTimelineContent {
+            clips: self.clips.clone(),
+            note_clips: self.note_clips.clone(),
+            automation: self.automation.clone(),
+        }
+    }
+}
+
+impl std::ops::Deref for TestTrack {
+    type Target = ProjectTrack;
+
+    fn deref(&self) -> &Self::Target {
+        &self.project
+    }
+}
+
+impl std::ops::DerefMut for TestTrack {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.project
+    }
+}
+
+pub(super) struct ArrangementFixture {
+    pub(super) arrangement: ArrangementState,
+    pub(super) tracks: Vec<TestTrack>,
+    pub(super) master: TestTrack,
+    pub(super) buses: Vec<TestTrack>,
+    next_track_number: u32,
+}
+
+impl Default for ArrangementFixture {
+    fn default() -> Self {
+        Self {
+            arrangement: ArrangementState::default(),
+            tracks: Vec::new(),
+            master: TestTrack::from_parts(new_master_track(), TrackTimelineContent::default()),
+            buses: Vec::new(),
+            next_track_number: 1,
+        }
+    }
+}
+
+impl std::ops::Deref for ArrangementFixture {
+    type Target = ArrangementState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.arrangement
+    }
+}
+
+impl std::ops::DerefMut for ArrangementFixture {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.arrangement
+    }
+}
+
+impl ArrangementFixture {
+    pub(super) fn update(
+        &mut self,
+        msg: ArrangementMsg,
+        engine: &mut impl EngineHandle,
+        ctx: ArrangementCtx,
+    ) -> ArrangementAction {
+        let mut project_tracks = ProjectTracksState {
+            tracks: self
+                .tracks
+                .iter()
+                .map(|track| track.project.clone())
+                .collect(),
+            master: self.master.project.clone(),
+            buses: self
+                .buses
+                .iter()
+                .map(|track| track.project.clone())
+                .collect(),
+            next_track_number: self.next_track_number,
+        };
+        let timeline = Arc::make_mut(&mut self.arrangement.timeline);
+        for track in self
+            .tracks
+            .iter()
+            .chain(self.buses.iter())
+            .chain(std::iter::once(&self.master))
+        {
+            timeline.by_track.insert(track.id, track.content());
+        }
+
+        let action = self
+            .arrangement
+            .update(&mut project_tracks, msg, engine, ctx);
+        self.next_track_number = project_tracks.next_track_number;
+        self.tracks = project_tracks
+            .tracks
+            .into_iter()
+            .map(|track| {
+                let content = self
+                    .arrangement
+                    .timeline
+                    .get(track.id)
+                    .cloned()
+                    .unwrap_or_default();
+                TestTrack::from_parts(track, content)
+            })
+            .collect();
+        self.master = TestTrack::from_parts(
+            project_tracks.master,
+            self.arrangement
+                .timeline
+                .get(TrackId::MASTER)
+                .cloned()
+                .unwrap_or_default(),
+        );
+        self.buses = project_tracks
+            .buses
+            .into_iter()
+            .map(|track| {
+                let content = self
+                    .arrangement
+                    .timeline
+                    .get(track.id)
+                    .cloned()
+                    .unwrap_or_default();
+                TestTrack::from_parts(track, content)
+            })
+            .collect();
+        action
+    }
+
+    pub(super) fn find_track(&self, track_id: TrackId) -> Option<&TestTrack> {
+        if track_id.is_master() {
+            return Some(&self.master);
+        }
+        self.tracks
+            .iter()
+            .chain(self.buses.iter())
+            .find(|track| track.id == track_id)
+    }
+}
+
+pub(super) fn arrangement_with_tracks(n: usize) -> ArrangementFixture {
+    let mut a = ArrangementFixture::default();
+    let mut engine = RecordingEngine::default();
+    for _ in 0..n {
+        a.update(
+            ArrangementMsg::AddTrack,
+            &mut engine,
+            ArrangementCtx::default(),
+        );
+    }
+    a
+}

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -1,26 +1,11 @@
 //! Arrangement domain unit tests.
 
+use super::test_support::*;
 use super::*;
 use crate::domains::test_support::RecordingEngine;
 use crate::state::UiClip;
 use vibez_core::automation::{AutomationLane, AutomationTarget};
 use vibez_core::midi::MidiNote;
-
-fn arrangement_with_tracks(n: usize) -> ArrangementState {
-    let mut a = ArrangementState {
-        next_track_number: 1,
-        ..Default::default()
-    };
-    let mut engine = RecordingEngine::default();
-    for _ in 0..n {
-        a.update(
-            ArrangementMsg::AddTrack,
-            &mut engine,
-            ArrangementCtx::default(),
-        );
-    }
-    a
-}
 
 #[test]
 fn add_track_selects_it_and_names_uniquely() {
@@ -46,6 +31,7 @@ fn remove_track_clears_its_selections_and_requests_gui_teardown() {
     assert_eq!(a.selected_track, Some(survivor));
     assert_eq!(a.selected_note_clip, None);
     assert_eq!(action.close_track_guis, Some(victim));
+    assert!(a.arrangement.timeline.get(victim).is_none());
 }
 
 #[test]
@@ -197,7 +183,7 @@ fn meter_decays_instead_of_snapping() {
 }
 
 fn add_audio_clip(
-    a: &mut ArrangementState,
+    a: &mut ArrangementFixture,
     track_idx: usize,
     position: u64,
     duration: u64,
@@ -208,7 +194,7 @@ fn add_audio_clip(
     });
     let id = ClipId::new();
     let tid = a.tracks[track_idx].id;
-    a.tracks[track_idx].clips.push(UiClip {
+    let clip = UiClip {
         id,
         name: "Clip".to_string(),
         audio,
@@ -223,7 +209,12 @@ fn add_audio_clip(
         warped: false,
         warped_to_bpm: None,
         original_audio: None,
-    });
+    };
+    a.tracks[track_idx].clips.push(clip.clone());
+    Arc::make_mut(&mut a.arrangement.timeline)
+        .ensure(tid)
+        .clips
+        .push(clip);
     (tid, id)
 }
 
@@ -395,7 +386,7 @@ fn warp_then_clear_roundtrips_clip_geometry() {
 
     let action =
         a.apply_clip_warp_success(&mut engine, tid, cid, warp_success(Arc::clone(&original)));
-    let clip = &a.tracks[0].clips[0];
+    let clip = &a.arrangement.timeline.get(tid).unwrap().clips[0];
     assert!(clip.warped);
     assert_eq!(clip.duration, 2000);
     assert_eq!(clip.warped_to_bpm, Some(120.0));
@@ -408,7 +399,7 @@ fn warp_then_clear_roundtrips_clip_geometry() {
     ));
 
     let action = a.apply_clear_clip_warp(&mut engine, tid, cid);
-    let clip = &a.tracks[0].clips[0];
+    let clip = &a.arrangement.timeline.get(tid).unwrap().clips[0];
     assert!(!clip.warped);
     assert_eq!(clip.duration, 1000);
     assert!(clip.original_audio.is_none());
@@ -422,7 +413,10 @@ fn bpm_detected_commits_and_clears_pending_edit() {
     let (tid, cid) = add_audio_clip(&mut a, 0, 0, 1000);
     a.clip_bpm_edit.insert(cid, "999".to_string());
     let action = a.apply_clip_bpm_detected(tid, cid, Some(174.0), 0.9);
-    assert_eq!(a.tracks[0].clips[0].original_bpm, Some(174.0));
+    assert_eq!(
+        a.arrangement.timeline.get(tid).unwrap().clips[0].original_bpm,
+        Some(174.0)
+    );
     assert!(a.clip_bpm_edit.is_empty());
     assert!(action.mark_dirty);
 

--- a/crates/vibez-ui/src/domains/automation.rs
+++ b/crates/vibez-ui/src/domains/automation.rs
@@ -1,6 +1,6 @@
 //! Automation domain: lane and point editing.
 //!
-//! Lanes live on [`UiTrack`] (the shared model) and mirror to the
+//! Lanes live in Arrange Timeline Content and mirror to the
 //! engine as whole-lane upserts: every edit clones the lane's points
 //! into a [`EngineCommand::SetAutomationLane`], so the allocation
 //! happens here on the UI thread and the audio thread only swaps
@@ -13,7 +13,7 @@ use vibez_core::id::{LaneId, TrackId};
 use vibez_engine::commands::EngineCommand;
 
 use super::EngineHandle;
-use crate::state::UiTrack;
+use crate::state::{ArrangementTimeline, ProjectTrack, ProjectTracksState};
 
 /// Messages the automation domain handles.
 #[derive(Debug, Clone)]
@@ -118,7 +118,7 @@ fn sync_lane(engine: &mut impl EngineHandle, track_id: TrackId, lane: &Automatio
 /// The target's CURRENT (un-automated) value, normalized 0..1.
 /// This seeds new lanes and draws the reference line. Track gain's
 /// native range is 0..2 (see the arrangement domain clamp).
-pub fn normalized_target_value(target: &AutomationTarget, track: &UiTrack) -> Option<f32> {
+pub fn normalized_target_value(target: &AutomationTarget, track: &ProjectTrack) -> Option<f32> {
     match target {
         AutomationTarget::TrackGain => Some((track.gain / 2.0).clamp(0.0, 1.0)),
         AutomationTarget::TrackPan => Some(track.pan.clamp(0.0, 1.0)),
@@ -178,7 +178,7 @@ pub static SEND_DESCRIPTOR: vibez_core::effect::ParamDescriptor =
 /// and instrument params). Gain/pan have implicit ranges.
 pub fn target_descriptor(
     target: &AutomationTarget,
-    track: &UiTrack,
+    track: &ProjectTrack,
 ) -> Option<&'static vibez_core::effect::ParamDescriptor> {
     match target {
         AutomationTarget::EffectParam {
@@ -204,7 +204,7 @@ pub fn target_descriptor(
 
 /// Human-readable name for a lane target, for lane headers and the
 /// add-lane picker.
-pub fn target_label(target: &AutomationTarget, track: &UiTrack) -> String {
+pub fn target_label(target: &AutomationTarget, track: &ProjectTrack) -> String {
     match target {
         AutomationTarget::TrackGain => "Volume".to_string(),
         AutomationTarget::TrackPan => "Pan".to_string(),
@@ -254,8 +254,8 @@ pub fn target_label(target: &AutomationTarget, track: &UiTrack) -> String {
 /// [`target_label`], with bus names resolved for send lanes.
 pub fn target_label_with_buses(
     target: &AutomationTarget,
-    track: &UiTrack,
-    buses: &[UiTrack],
+    track: &ProjectTrack,
+    buses: &[ProjectTrack],
 ) -> String {
     if let AutomationTarget::Send { bus_id } = target {
         if let Some(bus) = buses.iter().find(|b| b.id == *bus_id) {
@@ -271,25 +271,9 @@ impl AutomationState {
         &mut self,
         msg: AutomationMsg,
         engine: &mut impl EngineHandle,
-        tracks: &mut [UiTrack],
-        master: &mut UiTrack,
-        buses: &mut [UiTrack],
+        project_tracks: &mut ProjectTracksState,
+        timeline: &mut ArrangementTimeline,
     ) -> AutomationAction {
-        // One mutable view over every automatable channel.
-        fn chan_mut<'a>(
-            tracks: &'a mut [UiTrack],
-            master: &'a mut UiTrack,
-            buses: &'a mut [UiTrack],
-            id: TrackId,
-        ) -> Option<&'a mut UiTrack> {
-            if id.is_master() {
-                return Some(master);
-            }
-            tracks
-                .iter_mut()
-                .chain(buses.iter_mut())
-                .find(|t| t.id == id)
-        }
         let mut action = AutomationAction::default();
         match msg {
             AutomationMsg::ToggleTrackLanes(track_id) => {
@@ -298,7 +282,7 @@ impl AutomationState {
                 }
             }
             AutomationMsg::AddLane { track_id, target } => {
-                let Some(track) = chan_mut(tracks, master, buses, track_id) else {
+                let Some(track) = project_tracks.find(track_id) else {
                     return action;
                 };
                 // A send lane needs its engine-side send entry to
@@ -317,7 +301,8 @@ impl AutomationState {
                         amount,
                     });
                 }
-                if track.automation.iter().any(|l| l.target == target) {
+                let content = timeline.ensure(track_id);
+                if content.automation.iter().any(|l| l.target == target) {
                     action.status = Some("That parameter already has a lane".to_string());
                     return action;
                 }
@@ -332,14 +317,14 @@ impl AutomationState {
                 }
                 sync_lane(engine, track_id, &lane);
                 let label = target_label(&target, track);
-                track.automation.push(lane);
+                content.automation.push(lane);
                 self.expanded.insert(track_id);
                 self.picker = None;
                 action.status = Some(format!("Added automation lane: {label}"));
             }
             AutomationMsg::RemoveLane { track_id, lane_id } => {
-                if let Some(track) = chan_mut(tracks, master, buses, track_id) {
-                    track.automation.retain(|l| l.id != lane_id);
+                if let Some(content) = timeline.get_mut(track_id) {
+                    content.automation.retain(|l| l.id != lane_id);
                 }
                 engine.send(EngineCommand::RemoveAutomationLane { track_id, lane_id });
                 if matches!(self.selected, Some((t, l, _)) if t == track_id && l == lane_id) {
@@ -353,8 +338,9 @@ impl AutomationState {
                 beat,
                 value,
             } => {
-                let Some(lane) = chan_mut(tracks, master, buses, track_id)
-                    .and_then(|t| t.automation.iter_mut().find(|l| l.id == lane_id))
+                let Some(lane) = timeline
+                    .get_mut(track_id)
+                    .and_then(|content| content.automation.iter_mut().find(|l| l.id == lane_id))
                 else {
                     return action;
                 };
@@ -380,8 +366,9 @@ impl AutomationState {
                 beat,
                 value,
             } => {
-                let Some(lane) = chan_mut(tracks, master, buses, track_id)
-                    .and_then(|t| t.automation.iter_mut().find(|l| l.id == lane_id))
+                let Some(lane) = timeline
+                    .get_mut(track_id)
+                    .and_then(|content| content.automation.iter_mut().find(|l| l.id == lane_id))
                 else {
                     return action;
                 };
@@ -410,8 +397,9 @@ impl AutomationState {
                 lane_id,
                 index,
             } => {
-                let Some(lane) = chan_mut(tracks, master, buses, track_id)
-                    .and_then(|t| t.automation.iter_mut().find(|l| l.id == lane_id))
+                let Some(lane) = timeline
+                    .get_mut(track_id)
+                    .and_then(|content| content.automation.iter_mut().find(|l| l.id == lane_id))
                 else {
                     return action;
                 };
@@ -439,8 +427,9 @@ impl AutomationState {
                 index,
                 curve,
             } => {
-                let Some(lane) = chan_mut(tracks, master, buses, track_id)
-                    .and_then(|t| t.automation.iter_mut().find(|l| l.id == lane_id))
+                let Some(lane) = timeline
+                    .get_mut(track_id)
+                    .and_then(|content| content.automation.iter_mut().find(|l| l.id == lane_id))
                 else {
                     return action;
                 };
@@ -462,8 +451,9 @@ impl AutomationState {
                 } else {
                     (end_beat, start_beat)
                 };
-                let Some(lane) = chan_mut(tracks, master, buses, track_id)
-                    .and_then(|t| t.automation.iter_mut().find(|l| l.id == lane_id))
+                let Some(lane) = timeline
+                    .get_mut(track_id)
+                    .and_then(|content| content.automation.iter_mut().find(|l| l.id == lane_id))
                 else {
                     return action;
                 };
@@ -498,9 +488,8 @@ impl AutomationState {
                             index,
                         },
                         engine,
-                        tracks,
-                        master,
-                        buses,
+                        project_tracks,
+                        timeline,
                     );
                 }
             }
@@ -514,16 +503,21 @@ mod tests {
     use super::super::test_support::RecordingEngine;
     use super::*;
 
-    fn track() -> Vec<UiTrack> {
-        vec![UiTrack::new(TrackId::new(), "T1".to_string(), 0)]
+    fn track() -> (ProjectTracksState, ArrangementTimeline, TrackId) {
+        let track = ProjectTrack::new(TrackId::new(), "T1".to_string(), 0);
+        let track_id = track.id;
+        let mut project_tracks = ProjectTracksState::default();
+        project_tracks.tracks.push(track);
+        let mut timeline = ArrangementTimeline::default();
+        timeline.ensure(track_id);
+        (project_tracks, timeline, track_id)
     }
 
     #[test]
     fn add_lane_syncs_and_expands() {
         let mut a = AutomationState::default();
         let mut engine = RecordingEngine::default();
-        let mut tracks = track();
-        let tid = tracks[0].id;
+        let (mut tracks, mut timeline, tid) = track();
         a.update(
             AutomationMsg::AddLane {
                 track_id: tid,
@@ -531,10 +525,9 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
-        assert_eq!(tracks[0].automation.len(), 1);
+        assert_eq!(timeline.get(tid).unwrap().automation.len(), 1);
         assert!(a.expanded.contains(&tid));
         assert!(matches!(
             engine.0[0],
@@ -549,10 +542,9 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
-        assert_eq!(tracks[0].automation.len(), 1);
+        assert_eq!(timeline.get(tid).unwrap().automation.len(), 1);
         assert!(action.status.unwrap().contains("already"));
     }
 
@@ -560,8 +552,7 @@ mod tests {
     fn point_lifecycle_add_move_delete() {
         let mut a = AutomationState::default();
         let mut engine = RecordingEngine::default();
-        let mut tracks = track();
-        let tid = tracks[0].id;
+        let (mut tracks, mut timeline, tid) = track();
         a.update(
             AutomationMsg::AddLane {
                 track_id: tid,
@@ -569,10 +560,9 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
-        let lane_id = tracks[0].automation[0].id;
+        let lane_id = timeline.get(tid).unwrap().automation[0].id;
 
         a.update(
             AutomationMsg::AddPoint {
@@ -583,8 +573,7 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
         a.update(
             AutomationMsg::AddPoint {
@@ -595,10 +584,9 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
-        let beats: Vec<f64> = tracks[0].automation[0]
+        let beats: Vec<f64> = timeline.get(tid).unwrap().automation[0]
             .points
             .iter()
             .map(|p| p.beat)
@@ -617,10 +605,9 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
-        let beats: Vec<f64> = tracks[0].automation[0]
+        let beats: Vec<f64> = timeline.get(tid).unwrap().automation[0]
             .points
             .iter()
             .map(|p| p.beat)
@@ -633,10 +620,9 @@ mod tests {
             AutomationMsg::DeleteSelectedPoint,
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
-        assert_eq!(tracks[0].automation[0].points.len(), 1);
+        assert_eq!(timeline.get(tid).unwrap().automation[0].points.len(), 1);
         assert_eq!(a.selected, None);
     }
 
@@ -644,8 +630,7 @@ mod tests {
     fn remove_lane_clears_engine_and_selection() {
         let mut a = AutomationState::default();
         let mut engine = RecordingEngine::default();
-        let mut tracks = track();
-        let tid = tracks[0].id;
+        let (mut tracks, mut timeline, tid) = track();
         a.update(
             AutomationMsg::AddLane {
                 track_id: tid,
@@ -653,10 +638,9 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
-        let lane_id = tracks[0].automation[0].id;
+        let lane_id = timeline.get(tid).unwrap().automation[0].id;
         a.selected = Some((tid, lane_id, 0));
         a.update(
             AutomationMsg::RemoveLane {
@@ -665,10 +649,9 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
-        assert!(tracks[0].automation.is_empty());
+        assert!(timeline.get(tid).unwrap().automation.is_empty());
         assert_eq!(a.selected, None);
         assert!(matches!(
             engine.0.last(),
@@ -680,8 +663,7 @@ mod tests {
     fn values_clamp_to_unit_range() {
         let mut a = AutomationState::default();
         let mut engine = RecordingEngine::default();
-        let mut tracks = track();
-        let tid = tracks[0].id;
+        let (mut tracks, mut timeline, tid) = track();
         a.update(
             AutomationMsg::AddLane {
                 track_id: tid,
@@ -689,10 +671,9 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
-        let lane_id = tracks[0].automation[0].id;
+        let lane_id = timeline.get(tid).unwrap().automation[0].id;
         a.update(
             AutomationMsg::AddPoint {
                 track_id: tid,
@@ -702,10 +683,9 @@ mod tests {
             },
             &mut engine,
             &mut tracks,
-            &mut crate::state::new_master_track(),
-            &mut [],
+            &mut timeline,
         );
-        let p = tracks[0].automation[0].points[0];
+        let p = timeline.get(tid).unwrap().automation[0].points[0];
         assert_eq!(p.beat, 0.0);
         assert_eq!(p.value, 1.0);
     }

--- a/crates/vibez-ui/src/domains/devices.rs
+++ b/crates/vibez-ui/src/domains/devices.rs
@@ -5,10 +5,10 @@
 //!
 //! Follows the transport reference pattern with one addition: tracks
 //! are the shared model (like database entities), so `update`
-//! receives `&mut [UiTrack]` explicitly. The domain may touch the
+//! receives `&mut [ProjectTrack]` explicitly. The domain may touch the
 //! DEVICE fields of a track and nothing else; every dependency is
 //! visible in the signature, which is what keeps this testable with
-//! plain `Vec<UiTrack>` fixtures.
+//! plain `Vec<ProjectTrack>` fixtures.
 //!
 //! Deliberately NOT here (async/infrastructure, future services
 //! tranche): plugin scanning and loading pipelines, plugin GUI window
@@ -23,7 +23,7 @@ use vibez_plugin_host::gui::PluginGuiKey;
 
 use super::EngineHandle;
 use crate::message::DrumPadParam;
-use crate::state::{DeviceContextMenu, DeviceMenuCategory, UiDrumPad, UiEffect, UiTrack};
+use crate::state::{DeviceContextMenu, DeviceMenuCategory, ProjectTrack, UiDrumPad, UiEffect};
 
 /// Messages the devices domain handles.
 #[derive(Debug, Clone)]
@@ -119,11 +119,11 @@ pub fn default_instrument_params(kind: InstrumentKind, sample_rate: f32) -> Vec<
 }
 
 fn find_track_mut<'a>(
-    tracks: &'a mut [UiTrack],
-    master: &'a mut UiTrack,
-    buses: &'a mut [UiTrack],
+    tracks: &'a mut [ProjectTrack],
+    master: &'a mut ProjectTrack,
+    buses: &'a mut [ProjectTrack],
     track_id: TrackId,
-) -> Option<&'a mut UiTrack> {
+) -> Option<&'a mut ProjectTrack> {
     if track_id.is_master() {
         return Some(master);
     }
@@ -136,7 +136,7 @@ fn find_track_mut<'a>(
 /// Send the engine a pad's full state (single source of truth for
 /// pad edits).
 fn sync_pad(
-    tracks: &[UiTrack],
+    tracks: &[ProjectTrack],
     track_id: TrackId,
     pad_index: usize,
     engine: &mut impl EngineHandle,
@@ -160,9 +160,9 @@ impl DevicesState {
         &mut self,
         msg: DevicesMsg,
         engine: &mut impl EngineHandle,
-        tracks: &mut [UiTrack],
-        master: &mut UiTrack,
-        buses: &mut [UiTrack],
+        tracks: &mut [ProjectTrack],
+        master: &mut ProjectTrack,
+        buses: &mut [ProjectTrack],
         sample_rate: u32,
     ) -> DevicesAction {
         let mut action = DevicesAction::default();
@@ -487,9 +487,9 @@ mod tests {
     use super::super::test_support::RecordingEngine;
     use super::*;
 
-    fn midi_track_with_effect() -> (Vec<UiTrack>, TrackId, EffectId) {
+    fn midi_track_with_effect() -> (Vec<ProjectTrack>, TrackId, EffectId) {
         let track_id = TrackId::new();
-        let mut track = UiTrack::new_instrument(
+        let mut track = ProjectTrack::new_instrument(
             track_id,
             "MIDI 1".to_string(),
             vibez_core::midi::TrackKind::Midi,

--- a/crates/vibez-ui/src/domains/piano_roll.rs
+++ b/crates/vibez-ui/src/domains/piano_roll.rs
@@ -13,7 +13,9 @@ use vibez_core::midi::MidiNote;
 use vibez_engine::commands::EngineCommand;
 
 use super::EngineHandle;
-use crate::state::{PianoRollState, SnapGrid, UiNoteClip, UiTrack};
+use crate::state::{
+    ArrangementTimeline, PianoRollState, SnapGrid, TrackTimelineContent, UiNoteClip,
+};
 
 /// Messages the piano roll domain handles.
 #[derive(Debug, Clone)]
@@ -114,12 +116,15 @@ pub struct PianoRollAction {
     pub close_context_menu: bool,
 }
 
-fn find_track(tracks: &[UiTrack], track_id: TrackId) -> Option<&UiTrack> {
-    tracks.iter().find(|t| t.id == track_id)
+fn find_track(timeline: &ArrangementTimeline, track_id: TrackId) -> Option<&TrackTimelineContent> {
+    timeline.get(track_id)
 }
 
-fn find_track_mut(tracks: &mut [UiTrack], track_id: TrackId) -> Option<&mut UiTrack> {
-    tracks.iter_mut().find(|t| t.id == track_id)
+fn find_track_mut(
+    timeline: &mut ArrangementTimeline,
+    track_id: TrackId,
+) -> Option<&mut TrackTimelineContent> {
+    timeline.get_mut(track_id)
 }
 
 /// Loop region that covers the note content, rounded up to whole
@@ -140,7 +145,7 @@ pub fn default_loop_end(notes: &[MidiNote], duration_beats: f64) -> f64 {
 /// Snap every note start to the grid and sync changed notes to the
 /// engine.
 fn quantize_note_clip(
-    tracks: &mut [UiTrack],
+    tracks: &mut ArrangementTimeline,
     track_id: TrackId,
     clip_id: ClipId,
     grid: SnapGrid,
@@ -178,7 +183,7 @@ impl PianoRollState {
         &mut self,
         msg: PianoRollMsg,
         engine: &mut impl EngineHandle,
-        tracks: &mut [UiTrack],
+        tracks: &mut ArrangementTimeline,
         ctx: PianoRollCtx,
     ) -> PianoRollAction {
         let mut action = PianoRollAction::default();
@@ -695,13 +700,12 @@ mod tests {
     use super::super::test_support::RecordingEngine;
     use super::*;
     use crate::state::PianoRollEditMode;
-    use vibez_core::midi::TrackKind;
 
-    fn midi_track_with_clip() -> (Vec<UiTrack>, TrackId, ClipId) {
+    fn midi_track_with_clip() -> (ArrangementTimeline, TrackId, ClipId) {
         let track_id = TrackId::new();
         let clip_id = ClipId::new();
-        let mut track = UiTrack::new(track_id, "MIDI 1".to_string(), 0);
-        track.kind = TrackKind::Midi;
+        let mut timeline = ArrangementTimeline::default();
+        let track = timeline.ensure(track_id);
         track.note_clips.push(UiNoteClip {
             id: clip_id,
             name: "Pattern 1".to_string(),
@@ -726,7 +730,7 @@ mod tests {
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
         });
-        (vec![track], track_id, clip_id)
+        (timeline, track_id, clip_id)
     }
 
     #[test]
@@ -746,14 +750,14 @@ mod tests {
             &mut tracks,
             PianoRollCtx::default(),
         );
-        assert_eq!(tracks[0].note_clips[0].notes.len(), 3);
+        assert_eq!(tracks.get(tid).unwrap().note_clips[0].notes.len(), 3);
         assert!(matches!(engine.0[0], EngineCommand::AddNote { .. }));
     }
 
     #[test]
     fn remove_note_reindexes_selection() {
         let (mut tracks, tid, cid) = midi_track_with_clip();
-        tracks[0].note_clips[0].selected_notes = [0, 1].into_iter().collect();
+        tracks.get_mut(tid).unwrap().note_clips[0].selected_notes = [0, 1].into_iter().collect();
         let mut pr = PianoRollState::default();
         let mut engine = RecordingEngine::default();
         pr.update(
@@ -762,7 +766,7 @@ mod tests {
             &mut tracks,
             PianoRollCtx::default(),
         );
-        let clip = &tracks[0].note_clips[0];
+        let clip = &tracks.get(tid).unwrap().note_clips[0];
         assert_eq!(clip.notes.len(), 1);
         assert_eq!(
             clip.selected_notes.iter().copied().collect::<Vec<_>>(),
@@ -786,7 +790,7 @@ mod tests {
                 snap_grid: SnapGrid::QUARTER,
             },
         );
-        let clip = &tracks[0].note_clips[0];
+        let clip = &tracks.get(tid).unwrap().note_clips[0];
         assert_eq!(clip.notes[0].start_beat, 0.0);
         assert_eq!(clip.notes[1].start_beat, 2.0);
         assert!(action.close_context_menu);
@@ -804,7 +808,7 @@ mod tests {
             &mut tracks,
             PianoRollCtx::default(),
         );
-        let clip = &tracks[0].note_clips[0];
+        let clip = &tracks.get(tid).unwrap().note_clips[0];
         assert_eq!(clip.duration_beats, 8.0);
         assert_eq!(clip.notes.len(), 4);
         assert_eq!(clip.notes[2].start_beat, 4.1);
@@ -825,7 +829,7 @@ mod tests {
             &mut tracks,
             PianoRollCtx::default(),
         );
-        let clip = &tracks[0].note_clips[0];
+        let clip = &tracks.get(tid).unwrap().note_clips[0];
         assert!(clip.loop_enabled);
         assert_eq!(clip.loop_start_beats, 0.0);
         assert_eq!(clip.loop_end_beats, 4.0);
@@ -836,7 +840,7 @@ mod tests {
     fn toggle_edit_mode_flips_and_reports() {
         let mut pr = PianoRollState::default();
         let mut engine = RecordingEngine::default();
-        let mut tracks: Vec<UiTrack> = Vec::new();
+        let mut tracks = ArrangementTimeline::default();
         let action = pr.update(
             PianoRollMsg::ToggleEditMode,
             &mut engine,

--- a/crates/vibez-ui/src/domains/project.rs
+++ b/crates/vibez-ui/src/domains/project.rs
@@ -98,10 +98,11 @@ pub fn collect_plugin_reload_requests(
     mut capture_state: impl FnMut(PluginGuiKey) -> Option<String>,
 ) -> PluginReloadRequests {
     let mut requests = PluginReloadRequests::default();
+    let project_tracks = std::sync::Arc::make_mut(&mut snapshot.project_tracks);
     let (tracks, master, buses) = (
-        &mut snapshot.tracks,
-        &mut snapshot.master,
-        &mut snapshot.buses,
+        &mut project_tracks.tracks,
+        &mut project_tracks.master,
+        &mut project_tracks.buses,
     );
     for track in tracks
         .iter_mut()
@@ -136,7 +137,7 @@ pub fn collect_plugin_reload_requests(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{UiEffect, UiTrack};
+    use crate::state::{ArrangementTimeline, ProjectTrack, ProjectTracksState, UiEffect};
     use std::collections::HashSet;
     use vibez_core::effect::EffectType;
 
@@ -164,12 +165,16 @@ mod tests {
     }
 
     fn snapshot_with(effects: Vec<UiEffect>) -> ProjectSnapshot {
-        let mut track = UiTrack::new(TrackId::new(), "T1".to_string(), 0);
+        let mut track = ProjectTrack::new(TrackId::new(), "T1".to_string(), 0);
         track.effects = effects;
         ProjectSnapshot {
-            tracks: vec![track],
-            master: crate::state::new_master_track(),
-            buses: Vec::new(),
+            project_tracks: std::sync::Arc::new(ProjectTracksState {
+                tracks: vec![track],
+                master: crate::state::new_master_track(),
+                buses: Vec::new(),
+                next_track_number: 2,
+            }),
+            arrange_timeline: std::sync::Arc::new(ArrangementTimeline::default()),
             bpm: 120.0,
             bpm_text: "120".to_string(),
             loop_enabled: false,
@@ -178,7 +183,6 @@ mod tests {
             selected_track: None,
             selected_clips: HashSet::new(),
             selected_note_clip: None,
-            next_track_number: 2,
         }
     }
 
@@ -195,8 +199,8 @@ mod tests {
         assert_eq!(*chain_pos, 1);
         assert_eq!(dev.name, "comp");
         // Plugin slot stripped; builtins remain for direct replay.
-        assert_eq!(snap.tracks[0].effects.len(), 2);
-        assert!(snap.tracks[0]
+        assert_eq!(snap.project_tracks.tracks[0].effects.len(), 2);
+        assert!(snap.project_tracks.tracks[0]
             .effects
             .iter()
             .all(|e| e.plugin_ref.is_none()));
@@ -245,11 +249,14 @@ mod tests {
     #[test]
     fn plugin_instrument_is_requested_and_fields_kept() {
         let mut snap = snapshot_with(Vec::new());
-        snap.tracks[0].plugin_instrument_ref = Some(plugin_device("synth"));
-        snap.tracks[0].has_instrument = true;
+        let track = &mut std::sync::Arc::make_mut(&mut snap.project_tracks).tracks[0];
+        track.plugin_instrument_ref = Some(plugin_device("synth"));
+        track.has_instrument = true;
         let requests = collect_plugin_reload_requests(&mut snap, |_| None);
         assert_eq!(requests.instruments.len(), 1);
-        assert!(snap.tracks[0].plugin_instrument_ref.is_some());
-        assert!(snap.tracks[0].has_instrument);
+        assert!(snap.project_tracks.tracks[0]
+            .plugin_instrument_ref
+            .is_some());
+        assert!(snap.project_tracks.tracks[0].has_instrument);
     }
 }

--- a/crates/vibez-ui/src/domains/view.rs
+++ b/crates/vibez-ui/src/domains/view.rs
@@ -5,7 +5,9 @@
 
 use vibez_core::id::{ClipId, TrackId};
 
-use crate::state::{ContextMenuTarget, DetailPanelTab, SnapGrid, UiTrack, ViewState, Workspace};
+use crate::state::{
+    ArrangementTimeline, ContextMenuTarget, DetailPanelTab, SnapGrid, ViewState, Workspace,
+};
 
 /// Messages the view domain handles.
 #[derive(Debug, Clone)]
@@ -73,12 +75,13 @@ pub struct ViewAction {
     pub close_device_menu: bool,
 }
 
-fn find_track(tracks: &[UiTrack], track_id: TrackId) -> Option<&UiTrack> {
-    tracks.iter().find(|t| t.id == track_id)
-}
-
 impl ViewState {
-    pub fn update(&mut self, msg: ViewMsg, tracks: &[UiTrack], ctx: ViewCtx) -> ViewAction {
+    pub fn update(
+        &mut self,
+        msg: ViewMsg,
+        timeline: &ArrangementTimeline,
+        ctx: ViewCtx,
+    ) -> ViewAction {
         let mut action = ViewAction::default();
         match msg {
             ViewMsg::SwitchWorkspace(ws) => {
@@ -189,7 +192,7 @@ impl ViewState {
             }
             ViewMsg::StartEditingClipName(track_id, clip_id) => {
                 self.context_menu = None;
-                let name = find_track(tracks, track_id).and_then(|t| {
+                let name = timeline.get(track_id).and_then(|t| {
                     t.clips
                         .iter()
                         .find(|c| c.id == clip_id)
@@ -243,9 +246,17 @@ mod tests {
     #[test]
     fn zoom_clamps_both_directions() {
         let mut v = ViewState::default();
-        v.update(ViewMsg::SetZoom(99.0), &[], ViewCtx::default());
+        v.update(
+            ViewMsg::SetZoom(99.0),
+            &ArrangementTimeline::default(),
+            ViewCtx::default(),
+        );
         assert_eq!(v.zoom_level, 16.0);
-        v.update(ViewMsg::SetZoom(0.0), &[], ViewCtx::default());
+        v.update(
+            ViewMsg::SetZoom(0.0),
+            &ArrangementTimeline::default(),
+            ViewCtx::default(),
+        );
         assert_eq!(v.zoom_level, 0.01);
     }
 
@@ -253,9 +264,17 @@ mod tests {
     fn scroll_clamps_to_content() {
         let mut v = ViewState::default();
         let ctx = ViewCtx { total_beats: 32.0 };
-        v.update(ViewMsg::ScrollArrangement(100.0), &[], ctx);
+        v.update(
+            ViewMsg::ScrollArrangement(100.0),
+            &ArrangementTimeline::default(),
+            ctx,
+        );
         assert_eq!(v.scroll_offset_beats, 32.0);
-        v.update(ViewMsg::ScrollArrangement(-100.0), &[], ctx);
+        v.update(
+            ViewMsg::ScrollArrangement(-100.0),
+            &ArrangementTimeline::default(),
+            ctx,
+        );
         assert_eq!(v.scroll_offset_beats, 0.0);
     }
 
@@ -274,7 +293,7 @@ mod tests {
                     is_note_clip: false,
                 },
             },
-            &[],
+            &ArrangementTimeline::default(),
             ViewCtx::default(),
         );
         assert!(v.context_menu.is_some());
@@ -285,24 +304,22 @@ mod tests {
     fn finish_editing_track_name_emits_rename() {
         let mut v = ViewState::default();
         let tid = TrackId::new();
-        let mut track = UiTrack::new(tid, "Old".to_string(), 0);
-        track.name = "Old".to_string();
-        let tracks = vec![track];
+        let timeline = ArrangementTimeline::default();
         v.update(
             ViewMsg::StartEditingTrackName {
                 track_id: tid,
-                name: tracks[0].name.clone(),
+                name: "Old".to_string(),
             },
-            &tracks,
+            &timeline,
             ViewCtx::default(),
         );
         assert_eq!(v.edit_name_text, "Old");
         v.update(
             ViewMsg::EditNameText("New".to_string()),
-            &tracks,
+            &timeline,
             ViewCtx::default(),
         );
-        let action = v.update(ViewMsg::FinishEditing, &tracks, ViewCtx::default());
+        let action = v.update(ViewMsg::FinishEditing, &timeline, ViewCtx::default());
         assert_eq!(
             action.rename,
             Some(RenameRequest::Track(tid, "New".to_string()))
@@ -320,7 +337,7 @@ mod tests {
                 track_id: bus_id,
                 name: "A Return".to_string(),
             },
-            &[],
+            &ArrangementTimeline::default(),
             ViewCtx::default(),
         );
 
@@ -335,26 +352,54 @@ mod tests {
         assert!(v.snap_enabled);
         assert!(!v.adaptive_grid);
 
-        v.update(ViewMsg::NarrowGrid, &[], ViewCtx::default());
+        v.update(
+            ViewMsg::NarrowGrid,
+            &ArrangementTimeline::default(),
+            ViewCtx::default(),
+        );
         assert_eq!(v.snap_grid, SnapGrid::SIXTEENTH);
-        v.update(ViewMsg::WidenGrid, &[], ViewCtx::default());
+        v.update(
+            ViewMsg::WidenGrid,
+            &ArrangementTimeline::default(),
+            ViewCtx::default(),
+        );
         assert_eq!(v.snap_grid, SnapGrid::EIGHTH);
-        v.update(ViewMsg::ToggleTripletGrid, &[], ViewCtx::default());
+        v.update(
+            ViewMsg::ToggleTripletGrid,
+            &ArrangementTimeline::default(),
+            ViewCtx::default(),
+        );
         assert_eq!(v.snap_grid, SnapGrid::EIGHTH.triplet());
-        v.update(ViewMsg::ToggleSnapToGrid, &[], ViewCtx::default());
+        v.update(
+            ViewMsg::ToggleSnapToGrid,
+            &ArrangementTimeline::default(),
+            ViewCtx::default(),
+        );
         assert!(!v.snap_enabled);
-        v.update(ViewMsg::ToggleAdaptiveGrid, &[], ViewCtx::default());
+        v.update(
+            ViewMsg::ToggleAdaptiveGrid,
+            &ArrangementTimeline::default(),
+            ViewCtx::default(),
+        );
         assert!(v.adaptive_grid);
         assert_eq!(
             v.grid_config().effective_grid(20.0),
             SnapGrid::QUARTER.triplet()
         );
-        v.update(ViewMsg::NarrowGrid, &[], ViewCtx::default());
+        v.update(
+            ViewMsg::NarrowGrid,
+            &ArrangementTimeline::default(),
+            ViewCtx::default(),
+        );
         assert_eq!(
             v.grid_config().effective_grid(20.0),
             SnapGrid::EIGHTH.triplet()
         );
-        v.update(ViewMsg::WidenGrid, &[], ViewCtx::default());
+        v.update(
+            ViewMsg::WidenGrid,
+            &ArrangementTimeline::default(),
+            ViewCtx::default(),
+        );
         assert_eq!(
             v.grid_config().effective_grid(20.0),
             SnapGrid::QUARTER.triplet()
@@ -368,7 +413,11 @@ mod tests {
             edit_name_text: "x".to_string(),
             ..ViewState::default()
         };
-        let action = v.update(ViewMsg::CancelEditing, &[], ViewCtx::default());
+        let action = v.update(
+            ViewMsg::CancelEditing,
+            &ArrangementTimeline::default(),
+            ViewCtx::default(),
+        );
         assert_eq!(v.editing_track_name, None);
         assert!(v.edit_name_text.is_empty());
         assert!(action.close_device_menu);

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -187,14 +187,14 @@ pub enum SettingsTab {
     Appearance,
 }
 
-/// A point-in-time snapshot of the editable project state, used to
-/// implement undo / redo. `UiTrack` clones share audio via `Arc` so
-/// each snapshot is cheap on memory despite the full tree.
+/// A point-in-time snapshot of the editable project state, used to implement
+/// undo / redo. The two owned stores are independently shared so a timeline
+/// edit never clones Project Track instruments, effects, routing, or mixer
+/// state (and a mixer edit never clones Arrange clips).
 #[derive(Debug, Clone)]
 pub struct ProjectSnapshot {
-    pub tracks: Vec<UiTrack>,
-    pub master: UiTrack,
-    pub buses: Vec<UiTrack>,
+    pub project_tracks: Arc<ProjectTracksState>,
+    pub arrange_timeline: Arc<ArrangementTimeline>,
     pub bpm: f64,
     pub bpm_text: String,
     pub loop_enabled: bool,
@@ -203,7 +203,6 @@ pub struct ProjectSnapshot {
     pub selected_track: Option<TrackId>,
     pub selected_clips: HashSet<ArrangementSelection>,
     pub selected_note_clip: Option<(TrackId, ClipId)>,
-    pub next_track_number: u32,
 }
 
 /// Project domain slice: file-menu visibility, the current file,
@@ -319,23 +318,87 @@ impl Default for TransportState {
 /// chain, no clips or instrument. Lives outside `tracks` so the
 /// arrangement never shows it, but `find_track` resolves it, so the
 /// mixer strip, device chain, and effect commands all work on it.
-pub fn new_master_track() -> UiTrack {
-    let mut master = UiTrack::new(TrackId::MASTER, "Master".to_string(), 0);
+pub fn new_master_track() -> ProjectTrack {
+    let mut master = ProjectTrack::new(TrackId::MASTER, "Master".to_string(), 0);
     master.pan = 0.5;
     master
 }
 
-/// Arrangement domain state: the track list (the shared model other
-/// domains receive explicitly), selection, and track numbering.
+/// Project-owned tracks and channels shared by every musical timeline.
+#[derive(Debug, Clone)]
+pub struct ProjectTracksState {
+    pub tracks: Vec<ProjectTrack>,
+    /// The master bus channel (see [`new_master_track`]).
+    pub master: ProjectTrack,
+    /// Return channels: mixer-only tracks fed by per-track sends.
+    pub buses: Vec<ProjectTrack>,
+    pub next_track_number: u32,
+}
+
+impl Default for ProjectTracksState {
+    fn default() -> Self {
+        Self {
+            tracks: Vec::new(),
+            master: new_master_track(),
+            buses: Vec::new(),
+            next_track_number: 0,
+        }
+    }
+}
+
+impl ProjectTracksState {
+    pub fn find(&self, id: TrackId) -> Option<&ProjectTrack> {
+        if id.is_master() {
+            return Some(&self.master);
+        }
+        self.tracks
+            .iter()
+            .chain(self.buses.iter())
+            .find(|t| t.id == id)
+    }
+
+    pub fn find_mut(&mut self, id: TrackId) -> Option<&mut ProjectTrack> {
+        if id.is_master() {
+            return Some(&mut self.master);
+        }
+        self.tracks
+            .iter_mut()
+            .chain(self.buses.iter_mut())
+            .find(|t| t.id == id)
+    }
+}
+
+/// One musical timeline's content, associated with shared Project Tracks by
+/// stable identity. Hash-map storage prevents track reordering from moving or
+/// cloning timeline content.
+#[derive(Debug, Clone, Default)]
+pub struct ArrangementTimeline {
+    pub by_track: HashMap<TrackId, TrackTimelineContent>,
+}
+
+impl ArrangementTimeline {
+    pub fn get(&self, track_id: TrackId) -> Option<&TrackTimelineContent> {
+        self.by_track.get(&track_id)
+    }
+
+    pub fn get_mut(&mut self, track_id: TrackId) -> Option<&mut TrackTimelineContent> {
+        self.by_track.get_mut(&track_id)
+    }
+
+    pub fn ensure(&mut self, track_id: TrackId) -> &mut TrackTimelineContent {
+        self.by_track.entry(track_id).or_default()
+    }
+
+    pub fn remove(&mut self, track_id: TrackId) -> Option<TrackTimelineContent> {
+        self.by_track.remove(&track_id)
+    }
+}
+
+/// Arrange-owned timeline content and editor interaction state.
 #[derive(Debug)]
 pub struct ArrangementState {
-    pub tracks: Vec<UiTrack>,
-    /// The master bus channel (see [`new_master_track`]).
-    pub master: UiTrack,
-    /// Return channels: mixer-only tracks fed by per-track sends.
-    pub buses: Vec<UiTrack>,
+    pub timeline: Arc<ArrangementTimeline>,
     pub selected_track: Option<TrackId>,
-    pub next_track_number: u32,
     pub selected_clips: HashSet<ArrangementSelection>,
     pub selected_note_clip: Option<(TrackId, ClipId)>,
     pub clipboard: ClipClipboard,
@@ -356,11 +419,8 @@ pub struct ArrangementState {
 impl Default for ArrangementState {
     fn default() -> Self {
         Self {
-            tracks: Vec::new(),
-            master: new_master_track(),
-            buses: Vec::new(),
+            timeline: Arc::new(ArrangementTimeline::default()),
             selected_track: None,
-            next_track_number: 0,
             selected_clips: HashSet::new(),
             selected_note_clip: None,
             clipboard: ClipClipboard::default(),
@@ -392,7 +452,10 @@ pub struct AppState {
 
     pub piano_roll: PianoRollState,
 
-    // Arrangement domain slice (tracks, selection, numbering).
+    // Project Track domain slice (shared channels and devices).
+    pub project_tracks: Arc<ProjectTracksState>,
+
+    // Arrange-owned timeline content and editor state.
     pub arrangement: ArrangementState,
 
     /// In-progress manual BPM input text keyed by clip id. Only
@@ -443,10 +506,11 @@ impl Default for AppState {
             status_text: "Ready — Add a track to get started".to_string(),
             view: ViewState::default(),
             piano_roll: PianoRollState::default(),
-            arrangement: ArrangementState {
+            project_tracks: Arc::new(ProjectTracksState {
                 next_track_number: 1,
-                ..ArrangementState::default()
-            },
+                ..ProjectTracksState::default()
+            }),
+            arrangement: ArrangementState::default(),
             devices: crate::domains::devices::DevicesState::default(),
             settings_open: false,
             settings_tab: SettingsTab::default(),
@@ -570,35 +634,30 @@ impl AppState {
         }
     }
 
-    pub fn find_track(&self, id: TrackId) -> Option<&UiTrack> {
-        if id.is_master() {
-            return Some(&self.arrangement.master);
-        }
-        self.arrangement
-            .tracks
-            .iter()
-            .chain(self.arrangement.buses.iter())
-            .find(|t| t.id == id)
+    pub fn find_track(&self, id: TrackId) -> Option<&ProjectTrack> {
+        self.project_tracks.find(id)
     }
 
-    pub fn find_track_mut(&mut self, id: TrackId) -> Option<&mut UiTrack> {
-        if id.is_master() {
-            return Some(&mut self.arrangement.master);
-        }
-        self.arrangement
-            .tracks
-            .iter_mut()
-            .chain(self.arrangement.buses.iter_mut())
-            .find(|t| t.id == id)
+    pub fn find_track_mut(&mut self, id: TrackId) -> Option<&mut ProjectTrack> {
+        Arc::make_mut(&mut self.project_tracks).find_mut(id)
+    }
+
+    pub fn arrange_content(&self, id: TrackId) -> Option<&TrackTimelineContent> {
+        self.arrangement.timeline.get(id)
+    }
+
+    pub fn arrange_content_mut(&mut self, id: TrackId) -> &mut TrackTimelineContent {
+        Arc::make_mut(&mut self.arrangement.timeline).ensure(id)
     }
 
     /// Total duration in samples across all tracks (max clip end position).
     pub fn total_duration_samples(&self) -> u64 {
         let audio_max = self
             .arrangement
-            .tracks
-            .iter()
-            .flat_map(|t| t.clips.iter())
+            .timeline
+            .by_track
+            .values()
+            .flat_map(|content| content.clips.iter())
             .map(|c| c.position.saturating_add(c.duration))
             .max()
             .unwrap_or(0);
@@ -611,9 +670,10 @@ impl AppState {
         };
         let note_max = if spb > 0.0 {
             self.arrangement
-                .tracks
-                .iter()
-                .flat_map(|t| t.note_clips.iter())
+                .timeline
+                .by_track
+                .values()
+                .flat_map(|content| content.note_clips.iter())
                 .map(|c| ((c.position_beats + c.duration_beats) * spb) as u64)
                 .max()
                 .unwrap_or(0)
@@ -631,97 +691,109 @@ mod tests {
     use vibez_core::id::TrackId;
     use vibez_core::midi::TrackKind;
 
-    fn make_state_with(tracks: Vec<UiTrack>) -> AppState {
+    fn make_state_with(tracks: Vec<ProjectTrack>) -> AppState {
         let mut state = AppState::default();
-        state.arrangement.tracks = tracks;
+        Arc::make_mut(&mut state.project_tracks).tracks = tracks;
         state
     }
 
-    fn make_two_tracks() -> Vec<UiTrack> {
+    fn make_two_tracks() -> Vec<ProjectTrack> {
         vec![
-            UiTrack::new(TrackId::new(), "Track 1".into(), 0),
-            UiTrack::new(TrackId::new(), "Track 2".into(), 1),
+            ProjectTrack::new(TrackId::new(), "Track 1".into(), 0),
+            ProjectTrack::new(TrackId::new(), "Track 2".into(), 1),
         ]
     }
 
     #[test]
     fn move_track_up() {
         let mut state = make_state_with(make_two_tracks());
-        let id0 = state.arrangement.tracks[0].id;
-        let id1 = state.arrangement.tracks[1].id;
+        let id0 = state.project_tracks.tracks[0].id;
+        let id1 = state.project_tracks.tracks[1].id;
 
-        if let Some(idx) = state.arrangement.tracks.iter().position(|t| t.id == id1) {
+        if let Some(idx) = state.project_tracks.tracks.iter().position(|t| t.id == id1) {
             if idx > 0 {
-                state.arrangement.tracks.swap(idx, idx - 1);
+                Arc::make_mut(&mut state.project_tracks)
+                    .tracks
+                    .swap(idx, idx - 1);
             }
         }
-        assert_eq!(state.arrangement.tracks[0].id, id1);
-        assert_eq!(state.arrangement.tracks[1].id, id0);
+        assert_eq!(state.project_tracks.tracks[0].id, id1);
+        assert_eq!(state.project_tracks.tracks[1].id, id0);
     }
 
     #[test]
     fn move_track_down() {
         let mut state = make_state_with(make_two_tracks());
-        let id0 = state.arrangement.tracks[0].id;
-        let id1 = state.arrangement.tracks[1].id;
+        let id0 = state.project_tracks.tracks[0].id;
+        let id1 = state.project_tracks.tracks[1].id;
 
-        if let Some(idx) = state.arrangement.tracks.iter().position(|t| t.id == id0) {
-            if idx + 1 < state.arrangement.tracks.len() {
-                state.arrangement.tracks.swap(idx, idx + 1);
+        if let Some(idx) = state.project_tracks.tracks.iter().position(|t| t.id == id0) {
+            if idx + 1 < state.project_tracks.tracks.len() {
+                Arc::make_mut(&mut state.project_tracks)
+                    .tracks
+                    .swap(idx, idx + 1);
             }
         }
-        assert_eq!(state.arrangement.tracks[0].id, id1);
-        assert_eq!(state.arrangement.tracks[1].id, id0);
+        assert_eq!(state.project_tracks.tracks[0].id, id1);
+        assert_eq!(state.project_tracks.tracks[1].id, id0);
     }
 
     #[test]
     fn move_first_track_up_noop() {
-        let mut state = make_state_with(vec![UiTrack::new(TrackId::new(), "Track 1".into(), 0)]);
-        let id0 = state.arrangement.tracks[0].id;
+        let mut state =
+            make_state_with(vec![ProjectTrack::new(TrackId::new(), "Track 1".into(), 0)]);
+        let id0 = state.project_tracks.tracks[0].id;
 
-        if let Some(idx) = state.arrangement.tracks.iter().position(|t| t.id == id0) {
+        if let Some(idx) = state.project_tracks.tracks.iter().position(|t| t.id == id0) {
             if idx > 0 {
-                state.arrangement.tracks.swap(idx, idx - 1);
+                Arc::make_mut(&mut state.project_tracks)
+                    .tracks
+                    .swap(idx, idx - 1);
             }
         }
-        assert_eq!(state.arrangement.tracks[0].id, id0);
+        assert_eq!(state.project_tracks.tracks[0].id, id0);
     }
 
     #[test]
     fn move_last_track_down_noop() {
-        let mut state = make_state_with(vec![UiTrack::new(TrackId::new(), "Track 1".into(), 0)]);
-        let id0 = state.arrangement.tracks[0].id;
+        let mut state =
+            make_state_with(vec![ProjectTrack::new(TrackId::new(), "Track 1".into(), 0)]);
+        let id0 = state.project_tracks.tracks[0].id;
 
-        if let Some(idx) = state.arrangement.tracks.iter().position(|t| t.id == id0) {
-            if idx + 1 < state.arrangement.tracks.len() {
-                state.arrangement.tracks.swap(idx, idx + 1);
+        if let Some(idx) = state.project_tracks.tracks.iter().position(|t| t.id == id0) {
+            if idx + 1 < state.project_tracks.tracks.len() {
+                Arc::make_mut(&mut state.project_tracks)
+                    .tracks
+                    .swap(idx, idx + 1);
             }
         }
-        assert_eq!(state.arrangement.tracks[0].id, id0);
+        assert_eq!(state.project_tracks.tracks[0].id, id0);
     }
 
     #[test]
     fn rename_track() {
-        let mut state = make_state_with(vec![UiTrack::new(TrackId::new(), "Track 1".into(), 0)]);
-        let id = state.arrangement.tracks[0].id;
+        let mut state =
+            make_state_with(vec![ProjectTrack::new(TrackId::new(), "Track 1".into(), 0)]);
+        let id = state.project_tracks.tracks[0].id;
 
         if let Some(track) = state.find_track_mut(id) {
             track.name = "My Custom Track".into();
         }
-        assert_eq!(state.arrangement.tracks[0].name, "My Custom Track");
+        assert_eq!(state.project_tracks.tracks[0].name, "My Custom Track");
     }
 
     #[test]
     fn rename_note_clip() {
         let tid = TrackId::new();
         let cid = ClipId::new();
-        let mut track = UiTrack::new_instrument(
+        let track = ProjectTrack::new_instrument(
             tid,
             "Synth".into(),
             TrackKind::Instrument(vibez_core::midi::InstrumentKind::SubtractiveSynth),
             0,
         );
-        track.note_clips.push(UiNoteClip {
+        let mut state = make_state_with(vec![track]);
+        state.arrange_content_mut(tid).note_clips.push(UiNoteClip {
             id: cid,
             name: "Pattern 1".into(),
             position_beats: 0.0,
@@ -732,17 +804,38 @@ mod tests {
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
         });
-        let mut state = make_state_with(vec![track]);
-
-        if let Some(t) = state.find_track_mut(tid) {
+        if let Some(t) = Arc::make_mut(&mut state.arrangement.timeline).get_mut(tid) {
             if let Some(c) = t.note_clips.iter_mut().find(|c| c.id == cid) {
                 c.name = "Intro Pattern".into();
             }
         }
         assert_eq!(
-            state.arrangement.tracks[0].note_clips[0].name,
+            state.arrange_content(tid).unwrap().note_clips[0].name,
             "Intro Pattern"
         );
+    }
+
+    #[test]
+    fn timeline_edits_clone_only_timeline_content() {
+        let track_id = TrackId::new();
+        let mut state = make_state_with(vec![ProjectTrack::new(
+            track_id,
+            "Shared Project Track".into(),
+            0,
+        )]);
+        state.arrange_content_mut(track_id);
+
+        let project_tracks_before = Arc::clone(&state.project_tracks);
+        let timeline_before = Arc::clone(&state.arrangement.timeline);
+        state.arrange_content_mut(track_id).automation.push(
+            vibez_core::automation::AutomationLane::new(
+                vibez_core::automation::AutomationTarget::TrackGain,
+            ),
+        );
+
+        assert!(Arc::ptr_eq(&project_tracks_before, &state.project_tracks));
+        assert!(!Arc::ptr_eq(&timeline_before, &state.arrangement.timeline));
+        assert_eq!(state.project_tracks.tracks[0].name, "Shared Project Track");
     }
 
     #[test]
@@ -770,8 +863,9 @@ mod tests {
 
     #[test]
     fn rename_empty_rejected() {
-        let mut state = make_state_with(vec![UiTrack::new(TrackId::new(), "Track 1".into(), 0)]);
-        let id = state.arrangement.tracks[0].id;
+        let mut state =
+            make_state_with(vec![ProjectTrack::new(TrackId::new(), "Track 1".into(), 0)]);
+        let id = state.project_tracks.tracks[0].id;
 
         // Simulate the FinishEditing guard: empty name doesn't rename
         let new_name = "";
@@ -780,6 +874,6 @@ mod tests {
                 track.name = new_name.to_string();
             }
         }
-        assert_eq!(state.arrangement.tracks[0].name, "Track 1");
+        assert_eq!(state.project_tracks.tracks[0].name, "Track 1");
     }
 }

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -189,12 +189,15 @@ pub struct ClipClipboard {
     pub clips: Vec<ClipboardClip>,
 }
 
-/// A track as represented in the UI.
+/// A project-wide track/channel as represented in the UI.
+///
+/// Musical timeline content deliberately does not live here. Arrange (and,
+/// later, each Perform Section) associates its own [`TrackTimelineContent`]
+/// with this track's stable [`TrackId`].
 #[derive(Debug, Clone)]
-pub struct UiTrack {
+pub struct ProjectTrack {
     pub id: TrackId,
     pub name: String,
-    pub clips: Vec<UiClip>,
     pub gain: f32,
     pub pan: f32,
     pub mute: bool,
@@ -204,7 +207,6 @@ pub struct UiTrack {
     pub effects: Vec<UiEffect>,
     /// Post-fader send amounts into buses: `(bus id, 0..1)`.
     pub sends: Vec<(TrackId, f32)>,
-    pub note_clips: Vec<UiNoteClip>,
     pub kind: TrackKind,
     pub color_index: u8,
     pub has_instrument: bool,
@@ -216,8 +218,6 @@ pub struct UiTrack {
     pub sample_audio: Option<Arc<DecodedAudio>>,
     pub instrument_params: Vec<f32>,
     pub drum_rack_pads: Vec<UiDrumPad>,
-    /// Automation lanes (mirrored to the engine like note clips).
-    pub automation: Vec<vibez_core::automation::AutomationLane>,
     pub selected_drum_pad: usize,
     /// Display name for external plugin instruments (e.g. "Dexed", "Surge XT").
     pub plugin_instrument_name: Option<String>,
@@ -230,12 +230,15 @@ pub struct UiTrack {
     pub has_plugin_instrument_gui: bool,
 }
 
-impl UiTrack {
+/// Compatibility name used by older view-only modules. It resolves to the
+/// project-owned channel model and cannot carry Arrange Timeline Content.
+pub type UiTrack = ProjectTrack;
+
+impl ProjectTrack {
     pub fn new(id: TrackId, name: String, color_index: u8) -> Self {
         Self {
             id,
             name,
-            clips: Vec::new(),
             gain: 1.0,
             pan: 0.5,
             mute: false,
@@ -244,7 +247,6 @@ impl UiTrack {
             peak_r: 0.0,
             effects: Vec::new(),
             sends: Vec::new(),
-            note_clips: Vec::new(),
             kind: TrackKind::Audio,
             color_index,
             has_instrument: false,
@@ -254,7 +256,6 @@ impl UiTrack {
             sample_audio: None,
             instrument_params: Vec::new(),
             drum_rack_pads: default_drum_rack_pads(),
-            automation: Vec::new(),
             selected_drum_pad: 0,
             plugin_instrument_name: None,
             plugin_instrument_ref: None,
@@ -271,7 +272,6 @@ impl UiTrack {
         Self {
             id,
             name,
-            clips: Vec::new(),
             gain: 1.0,
             pan: 0.5,
             mute: false,
@@ -280,7 +280,6 @@ impl UiTrack {
             peak_r: 0.0,
             effects: Vec::new(),
             sends: Vec::new(),
-            note_clips: Vec::new(),
             kind,
             color_index,
             has_instrument,
@@ -290,7 +289,6 @@ impl UiTrack {
             sample_audio: None,
             instrument_params: Vec::new(),
             drum_rack_pads: default_drum_rack_pads(),
-            automation: Vec::new(),
             selected_drum_pad: 0,
             plugin_instrument_name: None,
             plugin_instrument_ref: None,
@@ -298,6 +296,18 @@ impl UiTrack {
             has_plugin_instrument_gui: false,
         }
     }
+}
+
+/// Arrange-owned musical content for one shared Project Track.
+///
+/// This type contains only timeline-editable state. Channel identity,
+/// devices, routing, sends, and mixer state stay on [`ProjectTrack`]. Runtime
+/// meters and device-media caches therefore cannot leak into timeline clones.
+#[derive(Debug, Clone, Default)]
+pub struct TrackTimelineContent {
+    pub clips: Vec<UiClip>,
+    pub note_clips: Vec<UiNoteClip>,
+    pub automation: Vec<vibez_core::automation::AutomationLane>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/vibez-ui/src/widgets/mixer_strip.rs
+++ b/crates/vibez-ui/src/widgets/mixer_strip.rs
@@ -5,7 +5,7 @@ use crate::icons;
 use crate::message::Message;
 use vibez_core::effect::EffectType;
 
-use crate::state::{UiEffect, UiTrack};
+use crate::state::{ProjectTrack, UiEffect};
 use crate::theme as th;
 use crate::widgets::effect_knob::EffectKnobWidget;
 use crate::widgets::fader::FaderWidget;
@@ -24,16 +24,22 @@ pub enum StripRole {
     Master,
 }
 
+/// Per-render inputs that are not part of the project-owned channel itself.
+pub struct MixerStripView<'a> {
+    pub selected: bool,
+    pub editing_name: bool,
+    pub edit_text: &'a str,
+    pub playhead_beat: f64,
+    pub automation: &'a [vibez_core::automation::AutomationLane],
+}
+
 /// Render a single mixer channel strip. `buses` drives the send
 /// knob section on regular track strips.
 pub fn view_mixer_strip<'a>(
-    track: &'a UiTrack,
-    selected: bool,
+    track: &'a ProjectTrack,
     role: StripRole,
-    buses: &'a [UiTrack],
-    editing_name: bool,
-    edit_text: &'a str,
-    playhead_beat: f64,
+    buses: &'a [ProjectTrack],
+    view: MixerStripView<'a>,
 ) -> Element<'a, Message> {
     let is_master = role == StripRole::Master;
     let track_color = if is_master {
@@ -63,7 +69,7 @@ pub fn view_mixer_strip<'a>(
             .width(Length::Fill)
             .into()
     } else {
-        view_editable_channel_name(track, editing_name, edit_text, 12, th::text())
+        view_editable_channel_name(track, view.editing_name, view.edit_text, 12, th::text())
     };
 
     // Tracks are deletable straight from the strip; the master is
@@ -261,7 +267,12 @@ pub fn view_mixer_strip<'a>(
     } else {
         let mut col = column![name_row, eq_section];
         if !buses.is_empty() {
-            col = col.push(view_sends(track, buses, playhead_beat));
+            col = col.push(view_sends(
+                track,
+                buses,
+                view.playhead_beat,
+                view.automation,
+            ));
         }
         col.push(knob_canvas)
             .push(pan_label)
@@ -280,7 +291,11 @@ pub fn view_mixer_strip<'a>(
         .style(move |_theme: &Theme| container::Style {
             background: Some(th::bg_surface().into()),
             border: iced::Border {
-                color: if selected { th::accent() } else { th::border() },
+                color: if view.selected {
+                    th::accent()
+                } else {
+                    th::border()
+                },
                 width: 1.0,
                 radius: 2.0.into(),
             },
@@ -299,9 +314,10 @@ pub fn view_mixer_strip<'a>(
 /// Send section on a track strip: one knob per bus, bus-colored,
 /// wrapped three to a row under a SENDS header.
 fn view_sends<'a>(
-    track: &'a UiTrack,
-    buses: &'a [UiTrack],
+    track: &'a ProjectTrack,
+    buses: &'a [ProjectTrack],
     playhead_beat: f64,
+    automation: &'a [vibez_core::automation::AutomationLane],
 ) -> Element<'a, Message> {
     let mut section = column![text("SENDS").size(7).color(th::text_muted())]
         .spacing(2)
@@ -309,7 +325,7 @@ fn view_sends<'a>(
     for chunk in buses.chunks(3) {
         let mut knobs = row![].spacing(4).align_y(iced::Alignment::Center);
         for bus in chunk {
-            let amount = effective_send_amount(track, bus.id, playhead_beat);
+            let amount = effective_send_amount(track, automation, bus.id, playhead_beat);
             let letter = bus.name.chars().next().unwrap_or('?');
             let knob = EffectKnobWidget::for_send(
                 track.id,
@@ -336,12 +352,12 @@ fn view_sends<'a>(
 }
 
 fn effective_send_amount(
-    track: &UiTrack,
+    track: &ProjectTrack,
+    automation: &[vibez_core::automation::AutomationLane],
     bus_id: vibez_core::id::TrackId,
     playhead_beat: f64,
 ) -> f32 {
-    track
-        .automation
+    automation
         .iter()
         .find_map(|lane| match lane.target {
             vibez_core::automation::AutomationTarget::Send { bus_id: target }
@@ -367,7 +383,7 @@ fn effective_send_amount(
 /// LMF blue, LF brown, like the console), with bell toggles on the
 /// outer bands and an IN (bypass) button. The EQ is an ordinary
 /// device on the chain, so automation and persistence come free.
-fn view_strip_eq(track: &UiTrack) -> Element<'_, Message> {
+fn view_strip_eq(track: &ProjectTrack) -> Element<'_, Message> {
     let eq = track
         .effects
         .iter()
@@ -627,7 +643,7 @@ mod tests {
     fn automated_send_value_overrides_the_manual_mixer_value() {
         let track_id = TrackId::new();
         let bus_id = TrackId::new();
-        let mut track = UiTrack::new(track_id, "Audio".to_string(), 0);
+        let mut track = ProjectTrack::new(track_id, "Audio".to_string(), 0);
         track.sends.push((bus_id, 0.25));
         let mut lane = AutomationLane::new(AutomationTarget::Send { bus_id });
         lane.insert_point(AutomationPoint {
@@ -640,9 +656,9 @@ mod tests {
             value: 0.9,
             curve: 0.0,
         });
-        track.automation.push(lane);
+        let automation = vec![lane];
 
-        let displayed = effective_send_amount(&track, bus_id, 2.0);
+        let displayed = effective_send_amount(&track, &automation, bus_id, 2.0);
 
         assert!((displayed - 0.5).abs() < 1e-6);
     }

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -12,7 +12,9 @@ use crate::domains::browser::BrowserMsg;
 use crate::domains::transport::TransportMsg;
 use crate::domains::view::ViewMsg;
 use crate::message::Message;
-use crate::state::{ArrangementSelection, ContextMenuTarget, GridConfig, UiTrack};
+use crate::state::{
+    ArrangementSelection, ContextMenuTarget, GridConfig, ProjectTrack, TrackTimelineContent,
+};
 use crate::widgets::local_drag::LocalDrag;
 use vibez_core::id::{ClipId, TrackId};
 
@@ -95,7 +97,8 @@ pub struct TrackClipCanvas {
 impl TrackClipCanvas {
     #[allow(clippy::too_many_arguments)]
     pub fn from_track(
-        track: &UiTrack,
+        track: &ProjectTrack,
+        content: &TrackTimelineContent,
         playhead_beats: f64,
         zoom_level: f32,
         grid: GridConfig,
@@ -122,7 +125,7 @@ impl TrackClipCanvas {
         sample_drop_duration_beats: Option<f64>,
         sample_drop_detail: Option<String>,
     ) -> Self {
-        let clips = track
+        let clips = content
             .clips
             .iter()
             .map(|c| TimelineClip {
@@ -140,7 +143,7 @@ impl TrackClipCanvas {
                         .unwrap_or(false),
             })
             .collect();
-        let note_clips = track
+        let note_clips = content
             .note_clips
             .iter()
             .map(|c| TimelineNoteClip {

--- a/crates/vibez-ui/src/widgets/track_header.rs
+++ b/crates/vibez-ui/src/widgets/track_header.rs
@@ -8,7 +8,7 @@ use crate::domains::piano_roll::PianoRollMsg;
 use crate::domains::view::ViewMsg;
 use crate::icons;
 use crate::message::Message;
-use crate::state::UiTrack;
+use crate::state::ProjectTrack;
 use crate::theme as th;
 use crate::widgets::fader::HorizontalFaderWidget;
 use crate::widgets::vu_meter::HorizontalVuMeterWidget;
@@ -23,7 +23,7 @@ pub const TRACK_HEADER_TOTAL_WIDTH: f32 = TRACK_HEADER_WIDTH + 3.0;
 /// Inline-editable channel name shared by arrangement headers and
 /// mixer strips. The caller decides which channel roles expose it.
 pub fn view_editable_channel_name<'a>(
-    track: &'a UiTrack,
+    track: &'a ProjectTrack,
     editing_name: bool,
     edit_text: &'a str,
     size: u16,
@@ -55,7 +55,7 @@ pub fn view_editable_channel_name<'a>(
 
 /// Render the track header for the arrangement view.
 pub fn view_track_header<'a>(
-    track: &'a UiTrack,
+    track: &'a ProjectTrack,
     selected: bool,
     editing_name: bool,
     edit_text: &'a str,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,8 +63,8 @@ The UI follows the Elm architecture (iced's native model) with one twist:
 instead of a single giant `update`, state and logic are split into **domain
 modules** under `crates/vibez-ui/src/domains/`. Each domain owns:
 
-- a **state slice** (for example `ArrangementState` holds the track list and
-  selection), stored on the app state
+- a **state slice** (for example `ArrangementState` holds Arrange Timeline
+  Content and editor selection), stored on the app state
 - a **message enum** (`ArrangementMsg`, `TransportMsg`, ...) describing
   everything that can happen to it
 - an **update function** that can only touch its own slice, plus three narrow
@@ -99,6 +99,32 @@ Anything asynchronous (file dialogs, decoding, saving, bounce renders) stays
 in the router layer as iced Tasks in topic modules under
 `crates/vibez-ui/src/app/`; the results come back as messages and the state
 math happens in the domains.
+
+## Project Tracks and timeline content
+
+Project Tracks exist once per project. `ProjectTracksState` owns their stable
+`TrackId`, channel name/type, instruments, effects, routing, sends, and mixer
+state. Arrange does not own or duplicate those channels.
+
+`ArrangementState` instead owns an `ArrangementTimeline`: a separate store
+keyed by the shared `TrackId`. Each `TrackTimelineContent` contains only the
+audio clips, note clips, and automation associated with that Project Track in
+Arrange. Track order is therefore independent from timeline storage, and a
+timeline edit cannot clone instruments, effects, routing, or mixer state.
+
+```mermaid
+flowchart LR
+    PT["ProjectTracksState<br/>TrackId + channel/devices/mixer"]
+    AT["ArrangementTimeline<br/>TrackId → TrackTimelineContent"]
+    UI["Arrange editor selection/view state"]
+    PT -- "shared TrackId" --> AT
+    AT --> UI
+```
+
+Undo snapshots retain the Project Track store and Arrange Timeline Content as
+separate `Arc` values. Copy-on-write happens only in the store being edited.
+Meters, decoded device media, waveform/runtime caches, and UI selection are UI
+runtime state; they are not fields of persisted timeline content.
 
 ## The audio engine
 
@@ -144,12 +170,15 @@ are handled in three stages:
 
 ## Projects, undo, and warping
 
-- Projects are JSON (`vibez-project`): tracks, clips, note data, device
-  chains, and plugin state as base64 blobs. Loading replays the whole
-  document into the engine as commands; plugin devices reload through the
-  same background pipeline as interactive loads.
-- Undo/redo keeps snapshots of the editable state (cheap: audio is shared via
-  `Arc`). Restoring a snapshot tears down the engine side and replays it.
+- Projects are JSON (`vibez-project`): Project Tracks remain in the existing
+  `tracks`/`master`/`buses` fields, while Arrange audio and note clips remain
+  in the existing `clips`/`note_clips` fields. Automation is projected between
+  Track Timeline Content and the compatible on-disk track record. Loading
+  rehydrates the two in-memory stores and replays them into the engine; legacy
+  project bytes remain loadable without a format migration.
+- Undo/redo keeps independently shared snapshots of Project Tracks and Arrange
+  Timeline Content (audio is also shared via `Arc`). Restoring a snapshot tears
+  down the engine side and replays both stores.
   Live plugin state is captured before teardown so undo does not reset
   plugin parameters.
 - Warping detects a clip's BPM, then time-stretches it to the project tempo


### PR DESCRIPTION
## Summary

- represent project-wide channels once in `ProjectTracksState`
- store Arrange clips, note clips, and automation separately in `ArrangementTimeline`, keyed by `TrackId`
- retain independent copy-on-write stores in undo snapshots so timeline edits do not clone devices, routing, or mixer state
- preserve the existing V1 project document shape while hydrating/projecting the new in-memory boundary
- document the ownership boundary in `docs/ARCHITECTURE.md`

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -j 4 -- -D warnings`
- `cargo test --workspace -j 4`
- legacy project semantic round-trip regression test
- `git diff --check`
- native dogfood: track create/delete, MIDI clip creation and note edit, mixer mute, Save As, New Project, reopen
- largest touched Rust source: 962 lines

## Scope

This delivers Perform Phase 0 / Card 01 only. It does not begin Card 02, Sections, Perform UI, the shared Timeline Editor extraction, or browser-import routing cleanup.
