### PR TITLE
fix(ui): group continuous edits into one undo step

### DIFF
--- a/crates/vibez-ui/src/app/project_replay.rs
+++ b/crates/vibez-ui/src/app/project_replay.rs
@@ -27,9 +27,9 @@ impl App {
         }
     }
 
-    pub(super) fn push_undo_snapshot(&mut self) {
+    pub(super) fn push_undo_snapshot(&mut self, gesture: Option<crate::state::UndoGestureId>) {
         let snapshot = self.take_snapshot();
-        self.state.project.history.push_undo(snapshot);
+        self.state.project.history.push_edit(snapshot, gesture);
     }
 
     pub(super) fn apply_snapshot(&mut self, mut snapshot: crate::state::ProjectSnapshot) {

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -19,6 +19,10 @@ use super::*;
 
 impl App {
     pub(super) fn update(&mut self, message: Message) -> Task<Message> {
+        let (message, undo_gesture) = match message {
+            Message::UndoGesture { id, edit } => (*edit, Some(id)),
+            message => (message, None),
+        };
         if self.state.view.edit_menu_open {
             let keep_menu = matches!(
                 &message,
@@ -113,11 +117,14 @@ impl App {
             || matches!(&message, Message::PianoRoll(m) if m.marks_dirty())
             || matches!(&message, Message::Automation(m) if m.marks_dirty());
         if should_mark_dirty {
-            self.push_undo_snapshot();
+            self.push_undo_snapshot(undo_gesture);
             self.mark_project_dirty();
         }
 
         match message {
+            Message::UndoGesture { .. } => {
+                unreachable!("undo gesture wrappers are removed before routing")
+            }
             // The transport domain owns its logic entirely; app.rs
             // only computes the cross-domain context, routes the
             // message, and applies the returned action.

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -14,6 +14,7 @@ use vibez_project::Project;
 
 use crate::state::{
     AuditionImportInput, AuditionMode, SampleBrowserEntry, SampleBrowserFolder, SettingsTab,
+    UndoGestureId,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -191,6 +192,12 @@ pub struct ProjectSaveResult {
 
 #[derive(Debug, Clone)]
 pub enum Message {
+    /// One incremental update within a continuous pointer edit. Messages from
+    /// the same gesture share one pre-edit undo snapshot.
+    UndoGesture {
+        id: UndoGestureId,
+        edit: Box<Message>,
+    },
     /// Transport domain (playback, tempo, arrangement loop).
     Transport(crate::domains::transport::TransportMsg),
     /// Devices domain (effect chain, instruments, drum pads, menu).
@@ -497,6 +504,13 @@ pub enum Message {
 /// Arity-preserving constructor helpers so call sites read cleanly
 /// and mechanical migrations stay parenthesis-balanced.
 impl Message {
+    pub fn in_undo_gesture(self, id: UndoGestureId) -> Self {
+        Self::UndoGesture {
+            id,
+            edit: Box::new(self),
+        }
+    }
+
     pub fn add_effect(t: TrackId, e: EffectType) -> Self {
         Self::Devices(crate::domains::devices::DevicesMsg::AddEffect(t, e))
     }

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 mod browser_results;
@@ -205,6 +206,19 @@ pub struct ProjectSnapshot {
     pub selected_note_clip: Option<(TrackId, ClipId)>,
 }
 
+/// Runtime identity for one continuous pointer gesture. Every incremental
+/// project edit emitted while the pointer remains held carries the same id so
+/// undo history can retain the pre-gesture snapshot only once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UndoGestureId(u64);
+
+impl UndoGestureId {
+    pub fn new() -> Self {
+        static NEXT_GESTURE_ID: AtomicU64 = AtomicU64::new(1);
+        Self(NEXT_GESTURE_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
 /// Project domain slice: file-menu visibility, the current file,
 /// the dirty flag, and the undo/redo history.
 #[derive(Debug, Default)]
@@ -223,12 +237,18 @@ pub struct ProjectState {
 pub struct UndoHistory {
     pub undo: VecDeque<ProjectSnapshot>,
     pub redo: VecDeque<ProjectSnapshot>,
+    last_gesture: Option<UndoGestureId>,
 }
 
 impl UndoHistory {
     pub const CAPACITY: usize = 100;
 
     pub fn push_undo(&mut self, snapshot: ProjectSnapshot) {
+        self.last_gesture = None;
+        self.push_snapshot(snapshot);
+    }
+
+    fn push_snapshot(&mut self, snapshot: ProjectSnapshot) {
         self.undo.push_back(snapshot);
         if self.undo.len() > Self::CAPACITY {
             self.undo.pop_front();
@@ -236,7 +256,16 @@ impl UndoHistory {
         self.redo.clear();
     }
 
+    pub fn push_edit(&mut self, snapshot: ProjectSnapshot, gesture: Option<UndoGestureId>) {
+        if gesture.is_some() && self.last_gesture == gesture {
+            return;
+        }
+        self.push_snapshot(snapshot);
+        self.last_gesture = gesture;
+    }
+
     pub fn pop_undo(&mut self) -> Option<ProjectSnapshot> {
+        self.last_gesture = None;
         self.undo.pop_back()
     }
 
@@ -248,6 +277,7 @@ impl UndoHistory {
     }
 
     pub fn pop_redo(&mut self) -> Option<ProjectSnapshot> {
+        self.last_gesture = None;
         self.redo.pop_back()
     }
 
@@ -264,8 +294,12 @@ impl UndoHistory {
     pub fn clear(&mut self) {
         self.undo.clear();
         self.redo.clear();
+        self.last_gesture = None;
     }
 }
+
+#[cfg(test)]
+mod undo_tests;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeviceMenuCategory {

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -1,0 +1,130 @@
+use std::sync::Arc;
+
+use vibez_core::automation::{AutomationLane, AutomationTarget};
+use vibez_core::effect::EffectType;
+use vibez_core::id::{ClipId, EffectId, TrackId};
+
+use super::{
+    AppState, ArrangementTimeline, ProjectSnapshot, ProjectTrack, TrackTimelineContent, UiEffect,
+    UiNoteClip, UndoGestureId,
+};
+
+fn snapshot(state: &AppState) -> ProjectSnapshot {
+    ProjectSnapshot {
+        project_tracks: Arc::clone(&state.project_tracks),
+        arrange_timeline: Arc::clone(&state.arrangement.timeline),
+        bpm: state.transport.bpm,
+        bpm_text: state.transport.bpm_text.clone(),
+        loop_enabled: state.transport.loop_enabled,
+        loop_start_beats: state.transport.loop_start_beats,
+        loop_end_beats: state.transport.loop_end_beats,
+        selected_track: state.arrangement.selected_track,
+        selected_clips: state.arrangement.selected_clips.clone(),
+        selected_note_clip: state.arrangement.selected_note_clip,
+    }
+}
+
+fn apply_snapshot(state: &mut AppState, snapshot: ProjectSnapshot) {
+    state.project_tracks = snapshot.project_tracks;
+    state.arrangement.timeline = snapshot.arrange_timeline;
+}
+
+#[test]
+fn one_eq_drag_is_one_undo_step() {
+    let mut state = AppState::default();
+    let track_id = TrackId::new();
+    let effect_id = EffectId::new();
+    let mut track = ProjectTrack::new(track_id, "Audio".into(), 0);
+    track.effects.push(UiEffect {
+        id: effect_id,
+        effect_type: EffectType::Eq,
+        bypass: false,
+        params: vec![0.0],
+        descriptors: &[],
+        plugin_name: None,
+        has_plugin_gui: false,
+        plugin_ref: None,
+    });
+    Arc::make_mut(&mut state.project_tracks).tracks.push(track);
+
+    let gesture = UndoGestureId::new();
+    for gain in [1.0, 2.0, 3.0] {
+        state
+            .project
+            .history
+            .push_edit(snapshot(&state), Some(gesture));
+        Arc::make_mut(&mut state.project_tracks).tracks[0].effects[0].params[0] = gain;
+    }
+
+    assert_eq!(state.project.history.undo.len(), 1);
+    let before_drag = state.project.history.pop_undo().unwrap();
+    apply_snapshot(&mut state, before_drag);
+    assert_eq!(state.project_tracks.tracks[0].effects[0].params[0], 0.0);
+}
+
+#[test]
+fn clip_resize_does_not_hide_the_preceding_automation_undo_step() {
+    let mut state = AppState::default();
+    let track_id = TrackId::new();
+    let clip_id = ClipId::new();
+    Arc::make_mut(&mut state.project_tracks)
+        .tracks
+        .push(ProjectTrack::new(track_id, "MIDI".into(), 0));
+    state.arrangement.timeline = Arc::new(ArrangementTimeline {
+        by_track: [(
+            track_id,
+            TrackTimelineContent {
+                note_clips: vec![UiNoteClip {
+                    id: clip_id,
+                    name: "Pattern".into(),
+                    position_beats: 0.0,
+                    duration_beats: 4.0,
+                    notes: Vec::new(),
+                    selected_notes: Default::default(),
+                    loop_enabled: false,
+                    loop_start_beats: 0.0,
+                    loop_end_beats: 0.0,
+                }],
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect(),
+    });
+
+    state.project.history.push_edit(snapshot(&state), None);
+    Arc::make_mut(&mut state.arrangement.timeline)
+        .get_mut(track_id)
+        .unwrap()
+        .automation
+        .push(AutomationLane::new(AutomationTarget::TrackGain));
+
+    let resize = UndoGestureId::new();
+    for duration in [5.0, 6.0, 8.0] {
+        state
+            .project
+            .history
+            .push_edit(snapshot(&state), Some(resize));
+        Arc::make_mut(&mut state.arrangement.timeline)
+            .get_mut(track_id)
+            .unwrap()
+            .note_clips[0]
+            .duration_beats = duration;
+    }
+
+    let before_resize = state.project.history.pop_undo().unwrap();
+    apply_snapshot(&mut state, before_resize);
+    let content = state.arrangement.timeline.get(track_id).unwrap();
+    assert_eq!(content.note_clips[0].duration_beats, 4.0);
+    assert_eq!(content.automation.len(), 1);
+
+    let before_automation = state.project.history.pop_undo().unwrap();
+    apply_snapshot(&mut state, before_automation);
+    assert!(state
+        .arrangement
+        .timeline
+        .get(track_id)
+        .unwrap()
+        .automation
+        .is_empty());
+}

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -63,6 +63,32 @@ fn one_eq_drag_is_one_undo_step() {
 }
 
 #[test]
+fn separate_drags_are_separate_undo_steps() {
+    let mut state = AppState::default();
+    let first_drag = UndoGestureId::new();
+    let second_drag = UndoGestureId::new();
+
+    state
+        .project
+        .history
+        .push_edit(snapshot(&state), Some(first_drag));
+    state
+        .project
+        .history
+        .push_edit(snapshot(&state), Some(first_drag));
+    state
+        .project
+        .history
+        .push_edit(snapshot(&state), Some(second_drag));
+    state
+        .project
+        .history
+        .push_edit(snapshot(&state), Some(second_drag));
+
+    assert_eq!(state.project.history.undo.len(), 2);
+}
+
+#[test]
 fn clip_resize_does_not_hide_the_preceding_automation_undo_step() {
     let mut state = AppState::default();
     let track_id = TrackId::new();

--- a/crates/vibez-ui/src/widgets/effect_knob.rs
+++ b/crates/vibez-ui/src/widgets/effect_knob.rs
@@ -394,7 +394,9 @@ impl canvas::Program<Message> for EffectKnobWidget {
                         canvas::event::Status::Captured,
                         Some(
                             self.set_value_message(self.denormalize(norm))
-                                .in_undo_gesture(state.undo_gesture.unwrap()),
+                                .in_undo_gesture(
+                                    *state.undo_gesture.get_or_insert_with(UndoGestureId::new),
+                                ),
                         ),
                     );
                 }

--- a/crates/vibez-ui/src/widgets/effect_knob.rs
+++ b/crates/vibez-ui/src/widgets/effect_knob.rs
@@ -6,6 +6,7 @@ use iced::widget::{canvas, column, text};
 use iced::{Color, Element, Length, Rectangle, Renderer, Theme};
 
 use crate::message::{DrumPadParam, Message};
+use crate::state::UndoGestureId;
 use crate::theme;
 use crate::widgets::double_click::DoubleClick;
 use crate::widgets::drag::ValueDrag;
@@ -221,6 +222,7 @@ pub fn format_value(value: f32, unit: &str) -> String {
 #[derive(Debug, Default)]
 pub struct EffectKnobState {
     drag: ValueDrag,
+    undo_gesture: Option<UndoGestureId>,
     shift_held: bool,
     double_click: DoubleClick,
 }
@@ -365,7 +367,9 @@ impl canvas::Program<Message> for EffectKnobWidget {
                         }
                     }
 
-                    state.drag.grab(cursor, bounds, self.normalized());
+                    if state.drag.grab(cursor, bounds, self.normalized()) {
+                        state.undo_gesture = Some(UndoGestureId::new());
+                    }
                     return (canvas::event::Status::Captured, None);
                 }
             }
@@ -373,6 +377,7 @@ impl canvas::Program<Message> for EffectKnobWidget {
             // Release
             canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 if state.drag.release() {
+                    state.undo_gesture = None;
                     return (canvas::event::Status::Captured, None);
                 }
             }
@@ -387,7 +392,10 @@ impl canvas::Program<Message> for EffectKnobWidget {
                 if let Some(norm) = state.drag.drag_to(cursor, 0.0, -sensitivity, 0.0..=1.0) {
                     return (
                         canvas::event::Status::Captured,
-                        Some(self.set_value_message(self.denormalize(norm))),
+                        Some(
+                            self.set_value_message(self.denormalize(norm))
+                                .in_undo_gesture(state.undo_gesture.unwrap()),
+                        ),
                     );
                 }
             }

--- a/crates/vibez-ui/src/widgets/eq_display.rs
+++ b/crates/vibez-ui/src/widgets/eq_display.rs
@@ -11,6 +11,7 @@ use iced::{Color, Point, Rectangle, Renderer, Theme};
 
 use crate::message::Message;
 use crate::spectrum::{freq_to_norm, norm_to_freq, DISPLAY_BINS, FLOOR_DB};
+use crate::state::UndoGestureId;
 use crate::theme as th;
 use crate::widgets::double_click::DoubleClick;
 use vibez_core::effect::ParamDescriptor;
@@ -81,6 +82,7 @@ pub struct EqDisplayWidget {
 #[derive(Debug, Default)]
 pub struct EqDisplayState {
     drag: Option<usize>,
+    undo_gesture: Option<UndoGestureId>,
     hover: Option<usize>,
     double_click: DoubleClick,
 }
@@ -399,12 +401,14 @@ impl canvas::Program<Message> for EqDisplayWidget {
                             );
                         }
                         state.drag = Some(band_idx);
+                        state.undo_gesture = Some(UndoGestureId::new());
                         return (canvas::event::Status::Captured, None);
                     }
                 }
             }
             canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 if state.drag.take().is_some() {
+                    state.undo_gesture = None;
                     return (canvas::event::Status::Captured, None);
                 }
             }
@@ -415,7 +419,10 @@ impl canvas::Program<Message> for EqDisplayWidget {
                         let pos = Point::new(abs.x - bounds.x, abs.y - bounds.y);
                         return (
                             canvas::event::Status::Captured,
-                            Some(self.drag_message(band_idx, pos, bounds)),
+                            Some(
+                                self.drag_message(band_idx, pos, bounds)
+                                    .in_undo_gesture(state.undo_gesture.unwrap()),
+                            ),
                         );
                     }
                 }

--- a/crates/vibez-ui/src/widgets/eq_display.rs
+++ b/crates/vibez-ui/src/widgets/eq_display.rs
@@ -419,10 +419,9 @@ impl canvas::Program<Message> for EqDisplayWidget {
                         let pos = Point::new(abs.x - bounds.x, abs.y - bounds.y);
                         return (
                             canvas::event::Status::Captured,
-                            Some(
-                                self.drag_message(band_idx, pos, bounds)
-                                    .in_undo_gesture(state.undo_gesture.unwrap()),
-                            ),
+                            Some(self.drag_message(band_idx, pos, bounds).in_undo_gesture(
+                                *state.undo_gesture.get_or_insert_with(UndoGestureId::new),
+                            )),
                         );
                     }
                 }

--- a/crates/vibez-ui/src/widgets/fader.rs
+++ b/crates/vibez-ui/src/widgets/fader.rs
@@ -3,6 +3,7 @@ use iced::widget::canvas;
 use iced::{Color, Rectangle, Renderer, Theme};
 
 use crate::message::Message;
+use crate::state::UndoGestureId;
 use crate::theme;
 use crate::widgets::drag::ValueDrag;
 use vibez_core::id::TrackId;
@@ -30,6 +31,7 @@ impl HorizontalFaderWidget {
 #[derive(Debug, Default)]
 pub struct HorizontalFaderState {
     drag: ValueDrag,
+    undo_gesture: Option<UndoGestureId>,
 }
 
 impl canvas::Program<Message> for HorizontalFaderWidget {
@@ -122,11 +124,13 @@ impl canvas::Program<Message> for HorizontalFaderWidget {
         match event {
             canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
                 if state.drag.grab(cursor, bounds, self.value) {
+                    state.undo_gesture = Some(UndoGestureId::new());
                     return (canvas::event::Status::Captured, None);
                 }
             }
             canvas::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
                 if state.drag.release() {
+                    state.undo_gesture = None;
                     return (canvas::event::Status::Captured, None);
                 }
             }
@@ -135,7 +139,10 @@ impl canvas::Program<Message> for HorizontalFaderWidget {
                 if let Some(gain) = state.drag.drag_to(cursor, 2.0 / track_w, 0.0, 0.0..=2.0) {
                     return (
                         canvas::event::Status::Captured,
-                        Some(Message::set_track_gain(self.track_id, gain)),
+                        Some(
+                            Message::set_track_gain(self.track_id, gain)
+                                .in_undo_gesture(state.undo_gesture.unwrap()),
+                        ),
                     );
                 }
             }
@@ -171,6 +178,7 @@ mod tests {
 
     fn gain_of(message: Option<Message>) -> Option<f32> {
         match message {
+            Some(Message::UndoGesture { edit, .. }) => gain_of(Some(*edit)),
             Some(Message::Arrangement(ArrangementMsg::SetTrackGain(_, gain))) => Some(gain),
             _ => None,
         }
@@ -260,6 +268,7 @@ impl FaderWidget {
 #[derive(Debug, Default)]
 pub struct FaderState {
     drag: ValueDrag,
+    undo_gesture: Option<UndoGestureId>,
 }
 
 impl canvas::Program<Message> for FaderWidget {
@@ -352,11 +361,13 @@ impl canvas::Program<Message> for FaderWidget {
         match event {
             canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
                 if state.drag.grab(cursor, bounds, self.value) {
+                    state.undo_gesture = Some(UndoGestureId::new());
                     return (canvas::event::Status::Captured, None);
                 }
             }
             canvas::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
                 if state.drag.release() {
+                    state.undo_gesture = None;
                     return (canvas::event::Status::Captured, None);
                 }
             }
@@ -365,7 +376,10 @@ impl canvas::Program<Message> for FaderWidget {
                 if let Some(gain) = state.drag.drag_to(cursor, 0.0, -2.0 / track_h, 0.0..=2.0) {
                     return (
                         canvas::event::Status::Captured,
-                        Some(Message::set_track_gain(self.track_id, gain)),
+                        Some(
+                            Message::set_track_gain(self.track_id, gain)
+                                .in_undo_gesture(state.undo_gesture.unwrap()),
+                        ),
                     );
                 }
             }

--- a/crates/vibez-ui/src/widgets/fader.rs
+++ b/crates/vibez-ui/src/widgets/fader.rs
@@ -140,8 +140,9 @@ impl canvas::Program<Message> for HorizontalFaderWidget {
                     return (
                         canvas::event::Status::Captured,
                         Some(
-                            Message::set_track_gain(self.track_id, gain)
-                                .in_undo_gesture(state.undo_gesture.unwrap()),
+                            Message::set_track_gain(self.track_id, gain).in_undo_gesture(
+                                *state.undo_gesture.get_or_insert_with(UndoGestureId::new),
+                            ),
                         ),
                     );
                 }
@@ -174,6 +175,20 @@ mod tests {
             }),
             mouse::Cursor::Available(cursor_at),
         )
+    }
+
+    fn release(cursor_at: Point) -> (canvas::Event, mouse::Cursor) {
+        (
+            canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)),
+            mouse::Cursor::Available(cursor_at),
+        )
+    }
+
+    fn gesture_of(message: Option<Message>) -> Option<UndoGestureId> {
+        match message {
+            Some(Message::UndoGesture { id, .. }) => Some(id),
+            _ => None,
+        }
     }
 
     fn gain_of(message: Option<Message>) -> Option<f32> {
@@ -242,6 +257,29 @@ mod tests {
         let (_, message) = widget.update(&mut state, event, bounds, cursor);
         let gain = gain_of(message).expect("drag outside bounds must keep tracking");
         assert!(gain > 1.0, "rightward drag should raise gain, got {gain}");
+    }
+
+    #[test]
+    fn separate_fader_drags_get_distinct_undo_gestures() {
+        let widget = FaderWidget::new(TrackId::MASTER, 1.0, Color::WHITE);
+        let bounds = Rectangle::new(Point::new(100.0, 100.0), Size::new(24.0, 108.0));
+        let mut state = FaderState::default();
+
+        let (event, cursor) = press(Point::new(112.0, 150.0));
+        widget.update(&mut state, event, bounds, cursor);
+        let (event, cursor) = drag(Point::new(112.0, 140.0));
+        let (_, first) = widget.update(&mut state, event, bounds, cursor);
+        let first = gesture_of(first).expect("first drag emits a grouped edit");
+
+        let (event, cursor) = release(Point::new(112.0, 140.0));
+        widget.update(&mut state, event, bounds, cursor);
+        let (event, cursor) = press(Point::new(112.0, 150.0));
+        widget.update(&mut state, event, bounds, cursor);
+        let (event, cursor) = drag(Point::new(112.0, 130.0));
+        let (_, second) = widget.update(&mut state, event, bounds, cursor);
+        let second = gesture_of(second).expect("second drag emits a grouped edit");
+
+        assert_ne!(first, second);
     }
 }
 
@@ -377,8 +415,9 @@ impl canvas::Program<Message> for FaderWidget {
                     return (
                         canvas::event::Status::Captured,
                         Some(
-                            Message::set_track_gain(self.track_id, gain)
-                                .in_undo_gesture(state.undo_gesture.unwrap()),
+                            Message::set_track_gain(self.track_id, gain).in_undo_gesture(
+                                *state.undo_gesture.get_or_insert_with(UndoGestureId::new),
+                            ),
                         ),
                     );
                 }

--- a/crates/vibez-ui/src/widgets/knob.rs
+++ b/crates/vibez-ui/src/widgets/knob.rs
@@ -6,6 +6,7 @@ use iced::widget::canvas;
 use iced::{Color, Rectangle, Renderer, Theme};
 
 use crate::message::Message;
+use crate::state::UndoGestureId;
 use crate::theme;
 use crate::widgets::double_click::DoubleClick;
 use crate::widgets::drag::ValueDrag;
@@ -49,6 +50,7 @@ impl KnobWidget {
 #[derive(Debug, Default)]
 pub struct KnobState {
     drag: ValueDrag,
+    undo_gesture: Option<UndoGestureId>,
     shift_held: bool,
     double_click: DoubleClick,
 }
@@ -187,7 +189,9 @@ impl canvas::Program<Message> for KnobWidget {
                         }
                     }
 
-                    state.drag.grab(cursor, bounds, self.value);
+                    if state.drag.grab(cursor, bounds, self.value) {
+                        state.undo_gesture = Some(UndoGestureId::new());
+                    }
                     return (canvas::event::Status::Captured, None);
                 }
             }
@@ -195,6 +199,7 @@ impl canvas::Program<Message> for KnobWidget {
             // Release
             canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 if state.drag.release() {
+                    state.undo_gesture = None;
                     return (canvas::event::Status::Captured, None);
                 }
             }
@@ -209,7 +214,10 @@ impl canvas::Program<Message> for KnobWidget {
                 if let Some(pan) = state.drag.drag_to(cursor, 0.0, -sensitivity, 0.0..=1.0) {
                     return (
                         canvas::event::Status::Captured,
-                        Some(Message::set_track_pan(self.track_id, pan)),
+                        Some(
+                            Message::set_track_pan(self.track_id, pan)
+                                .in_undo_gesture(state.undo_gesture.unwrap()),
+                        ),
                     );
                 }
             }

--- a/crates/vibez-ui/src/widgets/knob.rs
+++ b/crates/vibez-ui/src/widgets/knob.rs
@@ -214,10 +214,9 @@ impl canvas::Program<Message> for KnobWidget {
                 if let Some(pan) = state.drag.drag_to(cursor, 0.0, -sensitivity, 0.0..=1.0) {
                     return (
                         canvas::event::Status::Captured,
-                        Some(
-                            Message::set_track_pan(self.track_id, pan)
-                                .in_undo_gesture(state.undo_gesture.unwrap()),
-                        ),
+                        Some(Message::set_track_pan(self.track_id, pan).in_undo_gesture(
+                            *state.undo_gesture.get_or_insert_with(UndoGestureId::new),
+                        )),
                     );
                 }
             }

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -14,6 +14,7 @@ use crate::domains::view::ViewMsg;
 use crate::message::Message;
 use crate::state::{
     ArrangementSelection, ContextMenuTarget, GridConfig, ProjectTrack, TrackTimelineContent,
+    UndoGestureId,
 };
 use crate::widgets::local_drag::LocalDrag;
 use vibez_core::id::{ClipId, TrackId};
@@ -24,6 +25,7 @@ use super::*;
 #[derive(Debug, Clone)]
 pub enum ClipDragAction {
     MoveClip {
+        undo_gesture: UndoGestureId,
         clip_id: ClipId,
         is_note_clip: bool,
         /// Initial local x pixel where the drag started.
@@ -32,6 +34,7 @@ pub enum ClipDragAction {
         start_y: f32,
     },
     ResizeClip {
+        undo_gesture: UndoGestureId,
         clip_id: ClipId,
         is_note_clip: bool,
         clip_start_beat: f64,
@@ -342,6 +345,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                         if near_right && in_title_bar {
                             // Right edge of title bar → resize
                             state.drag = Some(ClipDragAction::ResizeClip {
+                                undo_gesture: UndoGestureId::new(),
                                 clip_id,
                                 is_note_clip,
                                 clip_start_beat: pos_beats,
@@ -349,6 +353,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                         } else if in_title_bar {
                             // Title bar → move clip
                             state.drag = Some(ClipDragAction::MoveClip {
+                                undo_gesture: UndoGestureId::new(),
                                 clip_id,
                                 is_note_clip,
                                 start_local_x: pos.x,
@@ -515,6 +520,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 return (canvas::event::Status::Captured, None);
                             }
                             ClipDragAction::MoveClip {
+                                undo_gesture,
                                 clip_id,
                                 is_note_clip,
                                 start_local_x,
@@ -547,46 +553,45 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                         // Type compatibility: note clips to instrument tracks,
                                         // audio clips to audio tracks
                                         if *is_note_clip == target_is_instrument {
-                                            return (
-                                                canvas::event::Status::Captured,
-                                                Some(Message::Arrangement(
-                                                    ArrangementMsg::MoveClipToTrack {
-                                                        source_track: track_id,
-                                                        target_track,
-                                                        clip_id: *clip_id,
-                                                        is_note_clip: *is_note_clip,
-                                                    },
-                                                )),
-                                            );
+                                            let edit = Message::Arrangement(
+                                                ArrangementMsg::MoveClipToTrack {
+                                                    source_track: track_id,
+                                                    target_track,
+                                                    clip_id: *clip_id,
+                                                    is_note_clip: *is_note_clip,
+                                                },
+                                            )
+                                            .in_undo_gesture(*undo_gesture);
+                                            return (canvas::event::Status::Captured, Some(edit));
                                         }
                                     }
                                 }
 
                                 if *is_note_clip {
-                                    return (
-                                        canvas::event::Status::Captured,
-                                        Some(Message::Arrangement(
-                                            ArrangementMsg::MoveNoteClipPosition {
-                                                track_id,
-                                                clip_id: *clip_id,
-                                                new_position_beats: snapped,
-                                            },
-                                        )),
-                                    );
+                                    let edit = Message::Arrangement(
+                                        ArrangementMsg::MoveNoteClipPosition {
+                                            track_id,
+                                            clip_id: *clip_id,
+                                            new_position_beats: snapped,
+                                        },
+                                    )
+                                    .in_undo_gesture(*undo_gesture);
+                                    return (canvas::event::Status::Captured, Some(edit));
                                 } else {
                                     let spb = self.spb();
                                     let new_sample_pos = (snapped * spb) as u64;
-                                    return (
-                                        canvas::event::Status::Captured,
-                                        Some(Message::Arrangement(ArrangementMsg::MoveAudioClip {
+                                    let edit =
+                                        Message::Arrangement(ArrangementMsg::MoveAudioClip {
                                             track_id,
                                             clip_id: *clip_id,
                                             new_position: new_sample_pos,
-                                        })),
-                                    );
+                                        })
+                                        .in_undo_gesture(*undo_gesture);
+                                    return (canvas::event::Status::Captured, Some(edit));
                                 }
                             }
                             ClipDragAction::ResizeClip {
+                                undo_gesture,
                                 clip_id,
                                 is_note_clip,
                                 clip_start_beat,
@@ -601,31 +606,27 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 let snapped = self.snapped_beat(new_dur).max(min_duration);
 
                                 if *is_note_clip {
-                                    return (
-                                        canvas::event::Status::Captured,
-                                        Some(Message::Arrangement(
-                                            ArrangementMsg::ResizeSelectedClips {
-                                                anchor: ArrangementSelection::NoteClip {
-                                                    track_id,
-                                                    clip_id: *clip_id,
-                                                },
-                                                new_duration_beats: snapped,
+                                    let edit =
+                                        Message::Arrangement(ArrangementMsg::ResizeSelectedClips {
+                                            anchor: ArrangementSelection::NoteClip {
+                                                track_id,
+                                                clip_id: *clip_id,
                                             },
-                                        )),
-                                    );
+                                            new_duration_beats: snapped,
+                                        })
+                                        .in_undo_gesture(*undo_gesture);
+                                    return (canvas::event::Status::Captured, Some(edit));
                                 } else {
-                                    return (
-                                        canvas::event::Status::Captured,
-                                        Some(Message::Arrangement(
-                                            ArrangementMsg::ResizeSelectedClips {
-                                                anchor: ArrangementSelection::AudioClip {
-                                                    track_id,
-                                                    clip_id: *clip_id,
-                                                },
-                                                new_duration_beats: snapped,
+                                    let edit =
+                                        Message::Arrangement(ArrangementMsg::ResizeSelectedClips {
+                                            anchor: ArrangementSelection::AudioClip {
+                                                track_id,
+                                                clip_id: *clip_id,
                                             },
-                                        )),
-                                    );
+                                            new_duration_beats: snapped,
+                                        })
+                                        .in_undo_gesture(*undo_gesture);
+                                    return (canvas::event::Status::Captured, Some(edit));
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

- assign a runtime gesture id to continuous EQ, knob, fader, and timeline clip drag/resize edits
- retain only the first pre-edit snapshot for all incremental messages in one pointer gesture
- keep discrete edits and separate pointer gestures as independent undo steps

## Confirmed cause

The affected widgets emit a project-edit message on every cursor-move event, and the router previously pushed an undo snapshot for every emitted message. A single EQ or clip drag therefore produced several nearly identical history entries. One Undo reverted only the last few pixels, while repeated resize entries hid an earlier automation edit. This cadence already exists on `dev`; Card 01 exposed the pre-existing history granularity defect rather than introducing split-store corruption.

## Regression coverage

- `one_eq_drag_is_one_undo_step`
- `clip_resize_does_not_hide_the_preceding_automation_undo_step`
- existing fader drag tests updated to assert through the gesture wrapper

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -j 4 -- -D warnings`
- `cargo test --workspace -j 4`
- release build launched for native retest

Stacked on #68; base is `refactor/separate-project-tracks-timeline-content`. Card 02 is untouched.