### PR TITLE
Card 03: map computer keys to pad gestures

### DIFF
--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -12,6 +12,149 @@ use crate::domains::view::ViewMsg;
 
 use crate::message::Message;
 
+pub(crate) fn keyboard_input_message(
+    event: iced::keyboard::Event,
+    status: iced::event::Status,
+) -> Option<Message> {
+    let should_forward = match &event {
+        iced::keyboard::Event::KeyPressed { .. } => status == iced::event::Status::Ignored,
+        // A release must clear a press that began before focus moved into a
+        // text field. Unpaired releases are harmless in the adapter.
+        iced::keyboard::Event::KeyReleased { .. } => true,
+        iced::keyboard::Event::ModifiersChanged(_) => false,
+    };
+    should_forward.then(|| Message::KeyboardInput {
+        event,
+        occurred_at: std::time::Instant::now(),
+    })
+}
+
+fn computer_key_from_physical(
+    physical: iced::keyboard::key::Physical,
+) -> Option<crate::domains::perform::ComputerKey> {
+    use crate::domains::perform::ComputerKey;
+    use iced::keyboard::key::Code;
+
+    let iced::keyboard::key::Physical::Code(code) = physical else {
+        return None;
+    };
+    Some(match code {
+        Code::Digit0 => ComputerKey::Digit0,
+        Code::Digit1 => ComputerKey::Digit1,
+        Code::Digit2 => ComputerKey::Digit2,
+        Code::Digit3 => ComputerKey::Digit3,
+        Code::Digit4 => ComputerKey::Digit4,
+        Code::Digit5 => ComputerKey::Digit5,
+        Code::Digit6 => ComputerKey::Digit6,
+        Code::Digit7 => ComputerKey::Digit7,
+        Code::Digit8 => ComputerKey::Digit8,
+        Code::Digit9 => ComputerKey::Digit9,
+        Code::KeyA => ComputerKey::A,
+        Code::KeyB => ComputerKey::B,
+        Code::KeyC => ComputerKey::C,
+        Code::KeyD => ComputerKey::D,
+        Code::KeyE => ComputerKey::E,
+        Code::KeyF => ComputerKey::F,
+        Code::KeyG => ComputerKey::G,
+        Code::KeyH => ComputerKey::H,
+        Code::KeyI => ComputerKey::I,
+        Code::KeyJ => ComputerKey::J,
+        Code::KeyK => ComputerKey::K,
+        Code::KeyL => ComputerKey::L,
+        Code::KeyM => ComputerKey::M,
+        Code::KeyN => ComputerKey::N,
+        Code::KeyO => ComputerKey::O,
+        Code::KeyP => ComputerKey::P,
+        Code::KeyQ => ComputerKey::Q,
+        Code::KeyR => ComputerKey::R,
+        Code::KeyS => ComputerKey::S,
+        Code::KeyT => ComputerKey::T,
+        Code::KeyU => ComputerKey::U,
+        Code::KeyV => ComputerKey::V,
+        Code::KeyW => ComputerKey::W,
+        Code::KeyX => ComputerKey::X,
+        Code::KeyY => ComputerKey::Y,
+        Code::KeyZ => ComputerKey::Z,
+        _ => return None,
+    })
+}
+
+fn runtime_key_id(key: &iced::keyboard::Key) -> String {
+    format!("{key:?}")
+}
+
+impl super::App {
+    pub(super) fn handle_keyboard_input(
+        &mut self,
+        event: iced::keyboard::Event,
+        occurred_at: std::time::Instant,
+    ) -> iced::Task<Message> {
+        use iced::keyboard::key::Named;
+
+        let (perform_msg, fallback) = match event {
+            iced::keyboard::Event::KeyPressed {
+                key,
+                physical_key,
+                modifiers,
+                ..
+            } => {
+                if self.state.perform.key_rebind_target.is_some()
+                    && matches!(key, iced::keyboard::Key::Named(Named::Escape))
+                {
+                    (Some(PerformMsg::CancelKeyRebind), None)
+                } else if let Some(computer_key) = computer_key_from_physical(physical_key) {
+                    if modifiers.is_empty() || self.state.perform.key_rebind_target.is_some() {
+                        (
+                            Some(PerformMsg::ComputerKeyPressed {
+                                key: computer_key,
+                                key_id: runtime_key_id(&key),
+                                occurred_at,
+                            }),
+                            Some((key, modifiers)),
+                        )
+                    } else {
+                        (None, Some((key, modifiers)))
+                    }
+                } else if self.state.perform.key_rebind_target.is_some() {
+                    self.state.status_text = "Perform keys must be letters or numbers".into();
+                    return iced::Task::none();
+                } else {
+                    (None, Some((key, modifiers)))
+                }
+            }
+            iced::keyboard::Event::KeyReleased { key, .. } => (
+                Some(PerformMsg::ComputerKeyReleased {
+                    key_id: runtime_key_id(&key),
+                    occurred_at,
+                }),
+                None,
+            ),
+            iced::keyboard::Event::ModifiersChanged(_) => return iced::Task::none(),
+        };
+
+        if let Some(msg) = perform_msg {
+            let ctx = crate::domains::perform::PerformCtx {
+                workspace_visible: self.state.view.workspace == crate::state::Workspace::Perform,
+            };
+            let action = {
+                let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+                self.state.perform.update(msg, &mut engine, ctx)
+            };
+            if action.persist_settings {
+                self.persist_ui_settings();
+                self.state.status_text = "Perform key mapping saved".into();
+            }
+            if action.keyboard_consumed {
+                return iced::Task::none();
+            }
+        }
+
+        fallback
+            .and_then(|(key, modifiers)| global_key_handler(key, modifiers))
+            .map_or_else(iced::Task::none, iced::Task::done)
+    }
+}
+
 pub(crate) fn truncate_end(text: &str, max_chars: usize) -> String {
     if text.chars().count() <= max_chars {
         text.to_string()
@@ -290,5 +433,26 @@ mod tests {
         }
 
         assert!(global_key_handler(Key::Named(Named::F1), Modifiers::SHIFT).is_none());
+    }
+
+    #[test]
+    fn text_field_capture_suppresses_computer_pad_presses() {
+        use iced::keyboard::key::{Code, Physical};
+        use iced::keyboard::{Event, Key, Location, Modifiers};
+
+        let event = Event::KeyPressed {
+            key: Key::Character("q".into()),
+            modified_key: Key::Character("q".into()),
+            physical_key: Physical::Code(Code::KeyQ),
+            location: Location::Standard,
+            modifiers: Modifiers::empty(),
+            text: Some("q".into()),
+        };
+
+        assert!(keyboard_input_message(event.clone(), iced::event::Status::Captured).is_none());
+        assert!(matches!(
+            keyboard_input_message(event, iced::event::Status::Ignored),
+            Some(Message::KeyboardInput { .. })
+        ));
     }
 }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -158,6 +158,7 @@ mod views_mixer;
 mod views_overlays;
 mod views_perform;
 mod views_settings;
+mod views_settings_perform;
 mod views_shell;
 mod views_transport;
 
@@ -253,6 +254,7 @@ impl App {
             },
             ..Default::default()
         };
+        state.perform.input_mapping = ui_settings.perform_input_mapping.clone();
 
         // Themes: scan the user's .vzt collection, then restore the
         // saved selection (built-in name or user theme name).
@@ -469,8 +471,8 @@ impl App {
         Subscription::batch([
             iced::time::every(std::time::Duration::from_millis(UI_TICK_MS)).map(|_| Message::Tick),
             local_watcher::subscription(self.state.browser.roots.clone()),
-            iced::keyboard::on_key_press(global_key_handler),
             iced::event::listen_with(|event, _status, _id| match event {
+                iced::Event::Keyboard(event) => keyboard_input_message(event, _status),
                 iced::Event::Mouse(iced::mouse::Event::CursorMoved { position }) => {
                     Some(Message::View(ViewMsg::CursorMoved(position.x, position.y)))
                 }

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -216,6 +216,7 @@ impl App {
 
     pub(super) fn persist_ui_settings(&mut self) {
         let settings = UiSettings {
+            perform_input_mapping: self.state.perform.input_mapping.clone(),
             sample_library_roots: self.state.browser.roots.clone(),
             sample_browser_open: self.state.browser.open,
             sample_browser_width: self.state.browser.dock_width,

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -125,6 +125,9 @@ impl App {
             Message::UndoGesture { .. } => {
                 unreachable!("undo gesture wrappers are removed before routing")
             }
+            Message::KeyboardInput { event, occurred_at } => {
+                return self.handle_keyboard_input(event, occurred_at);
+            }
             // The transport domain owns its logic entirely; app.rs
             // only computes the cross-domain context, routes the
             // message, and applies the returned action.
@@ -233,8 +236,8 @@ impl App {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
                     self.state.perform.update(msg, &mut engine, ctx)
                 };
-                match action {
-                    crate::domains::perform::PerformAction::None => {}
+                if action.persist_settings {
+                    self.persist_ui_settings();
                 }
             }
             Message::View(msg) => {
@@ -408,6 +411,7 @@ impl App {
             }
             Message::CloseSettings => {
                 self.state.settings_open = false;
+                self.state.perform.key_rebind_target = None;
                 let _ = self.state.plugin_settings.save();
             }
             Message::SelectSettingsTab(tab) => {

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -236,6 +236,7 @@ impl App {
         let ordinal = u16::from(position.ordinal(mode))
             + u16::from(self.state.perform.banks.for_mode(mode)) * 16;
         let selected = self.state.perform.selected_pad == Some(position);
+        let pressed = self.state.perform.is_pad_pressed(position);
         let (title, detail, color) = match mode {
             PerformMode::Sections => (
                 "+ SECTION".to_string(),
@@ -309,7 +310,9 @@ impl App {
                 iced::gradient::Linear::new(2.35)
                     .add_stop(
                         0.0,
-                        if selected {
+                        if pressed {
+                            th::blend(th::accent_dim(), color, 0.35)
+                        } else if selected {
                             th::bg_hover()
                         } else {
                             th::perform_pad_highlight()
@@ -319,7 +322,7 @@ impl App {
                     .into(),
             ),
             border: iced::Border {
-                color: if selected {
+                color: if pressed || selected {
                     th::accent()
                 } else {
                     th::blend(th::border_light(), color, 0.38)
@@ -335,7 +338,14 @@ impl App {
             .height(Length::Fill)
             .padding(3)
             .style(move |_theme: &Theme| container::Style {
-                background: Some(th::bg_dark().into()),
+                background: Some(
+                    if pressed {
+                        th::blend(th::bg_dark(), color, 0.28)
+                    } else {
+                        th::bg_dark()
+                    }
+                    .into(),
+                ),
                 border: iced::Border {
                     color: th::blend(th::border(), color, 0.3),
                     width: 1.0,
@@ -343,8 +353,8 @@ impl App {
                 },
                 shadow: Shadow {
                     color: th::perform_shadow(),
-                    offset: Vector::new(0.0, 3.0),
-                    blur_radius: 7.0,
+                    offset: Vector::new(0.0, if pressed { 1.0 } else { 3.0 }),
+                    blur_radius: if pressed { 3.0 } else { 7.0 },
                 },
                 ..Default::default()
             })

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -47,7 +47,7 @@ impl App {
             };
             button(text(label).size(13).color(color))
                 .on_press(Message::SelectSettingsTab(tab))
-                .padding([6, 16])
+                .padding([6, 10])
                 .style(move |_theme: &Theme, status| {
                     let bg = if is_active {
                         None
@@ -95,6 +95,11 @@ impl App {
                 active == SettingsTab::Warping
             ),
             make_tab_btn(
+                "Perform",
+                SettingsTab::Perform,
+                active == SettingsTab::Perform
+            ),
+            make_tab_btn(
                 "Appearance",
                 SettingsTab::Appearance,
                 active == SettingsTab::Appearance
@@ -108,6 +113,7 @@ impl App {
             SettingsTab::Plugins => self.view_settings_plugins_tab(),
             SettingsTab::Dropbox => self.view_settings_dropbox_tab(),
             SettingsTab::Warping => self.view_settings_warping_tab(),
+            SettingsTab::Perform => self.view_settings_perform_tab(),
             SettingsTab::Appearance => self.view_settings_appearance_tab(),
         };
 

--- a/crates/vibez-ui/src/app/views_settings_perform.rs
+++ b/crates/vibez-ui/src/app/views_settings_perform.rs
@@ -1,0 +1,95 @@
+//! Global Perform input preferences.
+
+use iced::widget::{button, column, container, row, text};
+use iced::{Element, Length, Theme};
+
+use crate::domains::perform::{PadPosition, PerformMsg};
+use crate::message::Message;
+use crate::theme as th;
+
+use super::*;
+
+impl App {
+    pub(super) fn view_settings_perform_tab(&self) -> Element<'_, Message> {
+        let title = text("Computer Keys").size(14).color(th::text());
+        let hint = text(
+            "Select a Pad Position, then press a letter or number key. The mapping is global and applies to every project.",
+        )
+        .size(11)
+        .color(th::text_dim());
+
+        let mut grid = column![].spacing(6);
+        for row_index in 0..4 {
+            let mut key_row = row![].spacing(6).width(Length::Fill);
+            for position in PadPosition::ALL
+                .iter()
+                .copied()
+                .filter(|position| position.row == row_index)
+            {
+                let waiting = self.state.perform.key_rebind_target == Some(position);
+                let key = self.state.perform.input_mapping.key_for(position);
+                let label = if waiting {
+                    "PRESS KEY".to_string()
+                } else {
+                    key.label().to_string()
+                };
+                let content = column![
+                    text(format!("R{} · C{}", position.row + 1, position.column + 1))
+                        .size(9)
+                        .color(th::text_dim()),
+                    text(label)
+                        .size(if waiting { 10 } else { 15 })
+                        .color(if waiting { th::accent() } else { th::text() })
+                ]
+                .spacing(3)
+                .align_x(iced::Alignment::Center);
+                let key_button = button(content)
+                    .on_press(Message::Perform(PerformMsg::BeginKeyRebind(position)))
+                    .width(Length::FillPortion(1))
+                    .height(Length::Fixed(58.0))
+                    .style(move |_theme: &Theme, status| {
+                        let hovered =
+                            matches!(status, button::Status::Hovered | button::Status::Pressed);
+                        button::Style {
+                            background: Some(
+                                if waiting || hovered {
+                                    th::bg_hover()
+                                } else {
+                                    th::bg_elevated()
+                                }
+                                .into(),
+                            ),
+                            text_color: th::text(),
+                            border: iced::Border {
+                                color: if waiting { th::accent() } else { th::border() },
+                                width: if waiting { 2.0 } else { 1.0 },
+                                radius: 5.0.into(),
+                            },
+                            ..Default::default()
+                        }
+                    });
+                key_row = key_row.push(key_button);
+            }
+            grid = grid.push(key_row);
+        }
+
+        let status = if let Some(position) = self.state.perform.key_rebind_target {
+            format!(
+                "Waiting for R{} · C{} — press Esc to cancel",
+                position.row + 1,
+                position.column + 1
+            )
+        } else {
+            "Default physical layout: 1234 / QWER / ASDF / ZXCV".to_string()
+        };
+
+        column![
+            title,
+            hint,
+            container(grid).width(Length::Fill).padding([6, 0]),
+            text(status).size(10).color(th::text_dim())
+        ]
+        .spacing(8)
+        .into()
+    }
+}

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -1,8 +1,12 @@
 //! Perform workspace interaction state.
 //!
-//! Card 02 intentionally owns UI state only. Playback truth and Pad Gestures
-//! arrive in later slices; changing Perform Mode must therefore be silent at
-//! the engine boundary.
+//! Computer keyboards and later hardware adapters converge on [`PadGesture`]
+//! before the active Perform Mode assigns musical meaning.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
 
 use super::EngineHandle;
 
@@ -67,6 +71,10 @@ impl PadPosition {
         Self { row, column }
     }
 
+    const fn index(self) -> usize {
+        self.row as usize * 4 + self.column as usize
+    }
+
     /// One-based mode order for this stable position. Sections and Track
     /// Mutes begin at the top-left; Instrument begins at the bottom-left.
     pub const fn ordinal(self, mode: PerformMode) -> u8 {
@@ -75,6 +83,175 @@ impl PadPosition {
             PerformMode::Instrument => (3 - self.row) * 4 + self.column + 1,
         }
     }
+}
+
+/// A portable physical computer-key position supported by Perform rebinding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ComputerKey {
+    Digit0,
+    Digit1,
+    Digit2,
+    Digit3,
+    Digit4,
+    Digit5,
+    Digit6,
+    Digit7,
+    Digit8,
+    Digit9,
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W,
+    X,
+    Y,
+    Z,
+}
+
+impl ComputerKey {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Digit0 => "0",
+            Self::Digit1 => "1",
+            Self::Digit2 => "2",
+            Self::Digit3 => "3",
+            Self::Digit4 => "4",
+            Self::Digit5 => "5",
+            Self::Digit6 => "6",
+            Self::Digit7 => "7",
+            Self::Digit8 => "8",
+            Self::Digit9 => "9",
+            Self::A => "A",
+            Self::B => "B",
+            Self::C => "C",
+            Self::D => "D",
+            Self::E => "E",
+            Self::F => "F",
+            Self::G => "G",
+            Self::H => "H",
+            Self::I => "I",
+            Self::J => "J",
+            Self::K => "K",
+            Self::L => "L",
+            Self::M => "M",
+            Self::N => "N",
+            Self::O => "O",
+            Self::P => "P",
+            Self::Q => "Q",
+            Self::R => "R",
+            Self::S => "S",
+            Self::T => "T",
+            Self::U => "U",
+            Self::V => "V",
+            Self::W => "W",
+            Self::X => "X",
+            Self::Y => "Y",
+            Self::Z => "Z",
+        }
+    }
+}
+
+const DEFAULT_COMPUTER_KEYS: [ComputerKey; 16] = [
+    ComputerKey::Digit1,
+    ComputerKey::Digit2,
+    ComputerKey::Digit3,
+    ComputerKey::Digit4,
+    ComputerKey::Q,
+    ComputerKey::W,
+    ComputerKey::E,
+    ComputerKey::R,
+    ComputerKey::A,
+    ComputerKey::S,
+    ComputerKey::D,
+    ComputerKey::F,
+    ComputerKey::Z,
+    ComputerKey::X,
+    ComputerKey::C,
+    ComputerKey::V,
+];
+
+/// Global producer preference assigning physical computer keys to Pad Positions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PerformInputMapping {
+    #[serde(default = "default_computer_keys")]
+    computer_keys: [ComputerKey; 16],
+}
+
+const fn default_computer_keys() -> [ComputerKey; 16] {
+    DEFAULT_COMPUTER_KEYS
+}
+
+impl Default for PerformInputMapping {
+    fn default() -> Self {
+        Self {
+            computer_keys: DEFAULT_COMPUTER_KEYS,
+        }
+    }
+}
+
+impl PerformInputMapping {
+    pub fn key_for(&self, position: PadPosition) -> ComputerKey {
+        self.computer_keys[position.index()]
+    }
+
+    pub fn position_for(&self, key: ComputerKey) -> Option<PadPosition> {
+        self.computer_keys
+            .iter()
+            .position(|candidate| *candidate == key)
+            .map(|index| PadPosition::ALL[index])
+    }
+
+    pub fn rebind(&mut self, position: PadPosition, key: ComputerKey) {
+        let target = position.index();
+        if let Some(existing) = self
+            .computer_keys
+            .iter()
+            .position(|candidate| *candidate == key)
+        {
+            self.computer_keys.swap(target, existing);
+        } else {
+            self.computer_keys[target] = key;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PadGestureKind {
+    Press,
+    Release,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PadGestureSource {
+    ComputerKeyboard { key: ComputerKey },
+}
+
+/// Controller-independent input delivered synchronously from an input event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PadGesture {
+    pub position: PadPosition,
+    pub kind: PadGestureKind,
+    pub velocity: Option<u8>,
+    pub source: PadGestureSource,
+    pub occurred_at: Instant,
 }
 
 /// Which part of Perform owns keyboard/editor focus. This remains runtime UI
@@ -105,20 +282,34 @@ impl PerformBanks {
     }
 }
 
-/// Perform's runtime interaction slice. It is not part of project persistence
-/// or undo because changing the workspace presentation does not edit music.
-#[derive(Debug, Default)]
+/// Perform's interaction slice. Its input mapping is a global user preference;
+/// no field here belongs to project persistence or undo.
+#[derive(Default)]
 pub struct PerformState {
     pub mode: PerformMode,
     pub banks: PerformBanks,
     pub selected_pad: Option<PadPosition>,
     pub editor_focus: PerformEditorFocus,
+    pub input_mapping: PerformInputMapping,
+    pub key_rebind_target: Option<PadPosition>,
+    active_computer_keys: HashMap<String, (PadPosition, PadGestureSource)>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PerformMsg {
     SelectMode(PerformMode),
     FocusEditor(PerformEditorFocus),
+    BeginKeyRebind(PadPosition),
+    CancelKeyRebind,
+    ComputerKeyPressed {
+        key: ComputerKey,
+        key_id: String,
+        occurred_at: Instant,
+    },
+    ComputerKeyReleased {
+        key_id: String,
+        occurred_at: Instant,
+    },
 }
 
 impl PerformMsg {
@@ -134,12 +325,13 @@ pub struct PerformCtx {
     pub workspace_visible: bool,
 }
 
-/// Cross-domain effects requested by Perform. The shell currently needs none,
-/// but the explicit action boundary keeps later slices out of the router.
+/// Cross-domain effects requested by Perform. Pad Gestures leave the adapter
+/// through this boundary so later musical consumers do not observe UI state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum PerformAction {
-    #[default]
-    None,
+pub struct PerformAction {
+    pub keyboard_consumed: bool,
+    pub persist_settings: bool,
+    pub gesture: Option<PadGesture>,
 }
 
 impl PerformState {
@@ -149,19 +341,89 @@ impl PerformState {
         _engine: &mut impl EngineHandle,
         ctx: PerformCtx,
     ) -> PerformAction {
-        if !ctx.workspace_visible {
-            return PerformAction::None;
-        }
-
         match msg {
             PerformMsg::SelectMode(mode) => {
-                self.mode = mode;
+                if ctx.workspace_visible {
+                    self.mode = mode;
+                }
             }
             PerformMsg::FocusEditor(focus) => {
-                self.editor_focus = focus;
+                if ctx.workspace_visible {
+                    self.editor_focus = focus;
+                }
+            }
+            PerformMsg::BeginKeyRebind(position) => {
+                self.key_rebind_target = Some(position);
+            }
+            PerformMsg::CancelKeyRebind => {
+                self.key_rebind_target = None;
+            }
+            PerformMsg::ComputerKeyPressed {
+                key,
+                key_id,
+                occurred_at,
+            } => {
+                if let Some(position) = self.key_rebind_target.take() {
+                    self.input_mapping.rebind(position, key);
+                    return PerformAction {
+                        keyboard_consumed: true,
+                        persist_settings: true,
+                        gesture: None,
+                    };
+                }
+                if !ctx.workspace_visible {
+                    return PerformAction::default();
+                }
+                if self.active_computer_keys.contains_key(&key_id) {
+                    return PerformAction {
+                        keyboard_consumed: true,
+                        ..PerformAction::default()
+                    };
+                }
+                let Some(position) = self.input_mapping.position_for(key) else {
+                    return PerformAction::default();
+                };
+                let source = PadGestureSource::ComputerKeyboard { key };
+                self.active_computer_keys.insert(key_id, (position, source));
+                return PerformAction {
+                    keyboard_consumed: true,
+                    persist_settings: false,
+                    gesture: Some(PadGesture {
+                        position,
+                        kind: PadGestureKind::Press,
+                        velocity: None,
+                        source,
+                        occurred_at,
+                    }),
+                };
+            }
+            PerformMsg::ComputerKeyReleased {
+                key_id,
+                occurred_at,
+            } => {
+                let Some((position, source)) = self.active_computer_keys.remove(&key_id) else {
+                    return PerformAction::default();
+                };
+                return PerformAction {
+                    keyboard_consumed: true,
+                    persist_settings: false,
+                    gesture: Some(PadGesture {
+                        position,
+                        kind: PadGestureKind::Release,
+                        velocity: None,
+                        source,
+                        occurred_at,
+                    }),
+                };
             }
         }
-        PerformAction::None
+        PerformAction::default()
+    }
+
+    pub fn is_pad_pressed(&self, position: PadPosition) -> bool {
+        self.active_computer_keys
+            .values()
+            .any(|(pressed, _)| *pressed == position)
     }
 }
 
@@ -196,7 +458,7 @@ mod tests {
         );
 
         assert_eq!(state.mode, PerformMode::Instrument);
-        assert_eq!(action, PerformAction::None);
+        assert_eq!(action, PerformAction::default());
         assert!(engine.0.is_empty());
         assert!(!PerformMsg::SelectMode(PerformMode::Sections).marks_dirty());
     }
@@ -254,5 +516,183 @@ mod tests {
         );
         assert_eq!(state.editor_focus, PerformEditorFocus::SectionConstruction);
         assert!(engine.0.is_empty());
+    }
+
+    #[test]
+    fn default_mapping_uses_the_settled_physical_layout() {
+        let mapping = PerformInputMapping::default();
+        assert_eq!(
+            PadPosition::ALL.map(|position| mapping.key_for(position).label()),
+            ["1", "2", "3", "4", "Q", "W", "E", "R", "A", "S", "D", "F", "Z", "X", "C", "V"]
+        );
+    }
+
+    #[test]
+    fn one_hold_produces_exactly_one_press_and_release() {
+        let mut state = PerformState::default();
+        let mut engine = RecordingEngine::default();
+        let pressed_at = Instant::now();
+        let released_at = pressed_at + std::time::Duration::from_millis(23);
+        let ctx = PerformCtx {
+            workspace_visible: true,
+        };
+
+        let press = state.update(
+            PerformMsg::ComputerKeyPressed {
+                key: ComputerKey::Q,
+                key_id: "q".into(),
+                occurred_at: pressed_at,
+            },
+            &mut engine,
+            ctx,
+        );
+        let repeat = state.update(
+            PerformMsg::ComputerKeyPressed {
+                key: ComputerKey::Q,
+                key_id: "q".into(),
+                occurred_at: pressed_at,
+            },
+            &mut engine,
+            ctx,
+        );
+        let release = state.update(
+            PerformMsg::ComputerKeyReleased {
+                key_id: "q".into(),
+                occurred_at: released_at,
+            },
+            &mut engine,
+            ctx,
+        );
+        let extra_release = state.update(
+            PerformMsg::ComputerKeyReleased {
+                key_id: "q".into(),
+                occurred_at: released_at,
+            },
+            &mut engine,
+            ctx,
+        );
+
+        let position = PadPosition { row: 1, column: 0 };
+        assert_eq!(
+            press.gesture,
+            Some(PadGesture {
+                position,
+                kind: PadGestureKind::Press,
+                velocity: None,
+                source: PadGestureSource::ComputerKeyboard {
+                    key: ComputerKey::Q
+                },
+                occurred_at: pressed_at,
+            })
+        );
+        assert!(repeat.keyboard_consumed);
+        assert!(repeat.gesture.is_none());
+        assert_eq!(release.gesture.unwrap().kind, PadGestureKind::Release);
+        assert_eq!(release.gesture.unwrap().occurred_at, released_at);
+        assert!(extra_release.gesture.is_none());
+        assert!(!state.is_pad_pressed(position));
+        assert!(engine.0.is_empty());
+    }
+
+    #[test]
+    fn mapping_changes_do_not_change_gesture_structure_between_modes() {
+        let at = Instant::now();
+        let mut engine = RecordingEngine::default();
+        let mut sections = PerformState::default();
+        let mut instrument = PerformState {
+            mode: PerformMode::Instrument,
+            ..PerformState::default()
+        };
+        sections
+            .input_mapping
+            .rebind(PadPosition::ALL[0], ComputerKey::Y);
+        instrument.input_mapping = sections.input_mapping.clone();
+
+        let mut press = |state: &mut PerformState, key_id: &str| {
+            state
+                .update(
+                    PerformMsg::ComputerKeyPressed {
+                        key: ComputerKey::Y,
+                        key_id: key_id.into(),
+                        occurred_at: at,
+                    },
+                    &mut engine,
+                    PerformCtx {
+                        workspace_visible: true,
+                    },
+                )
+                .gesture
+                .unwrap()
+        };
+
+        assert_eq!(
+            press(&mut sections, "sections"),
+            press(&mut instrument, "instrument")
+        );
+    }
+
+    #[test]
+    fn release_keeps_the_original_pair_when_mapping_changes_mid_hold() {
+        let mut state = PerformState::default();
+        let mut engine = RecordingEngine::default();
+        let ctx = PerformCtx {
+            workspace_visible: true,
+        };
+        let at = Instant::now();
+        let press = state.update(
+            PerformMsg::ComputerKeyPressed {
+                key: ComputerKey::Q,
+                key_id: "q".into(),
+                occurred_at: at,
+            },
+            &mut engine,
+            ctx,
+        );
+        state
+            .input_mapping
+            .rebind(PadPosition::ALL[0], ComputerKey::Q);
+        let release = state.update(
+            PerformMsg::ComputerKeyReleased {
+                key_id: "q".into(),
+                occurred_at: at,
+            },
+            &mut engine,
+            ctx,
+        );
+
+        assert_eq!(press.gesture.unwrap().position, PadPosition::ALL[4]);
+        assert_eq!(release.gesture.unwrap().position, PadPosition::ALL[4]);
+    }
+
+    #[test]
+    fn rebinding_swaps_an_existing_key_and_requests_global_persistence() {
+        let mut state = PerformState::default();
+        let mut engine = RecordingEngine::default();
+        state.update(
+            PerformMsg::BeginKeyRebind(PadPosition::ALL[0]),
+            &mut engine,
+            PerformCtx::default(),
+        );
+        let action = state.update(
+            PerformMsg::ComputerKeyPressed {
+                key: ComputerKey::Q,
+                key_id: "q".into(),
+                occurred_at: Instant::now(),
+            },
+            &mut engine,
+            PerformCtx::default(),
+        );
+
+        assert_eq!(
+            state.input_mapping.key_for(PadPosition::ALL[0]),
+            ComputerKey::Q
+        );
+        assert_eq!(
+            state.input_mapping.key_for(PadPosition::ALL[4]),
+            ComputerKey::Digit1
+        );
+        assert!(action.keyboard_consumed);
+        assert!(action.persist_settings);
+        assert!(action.gesture.is_none());
     }
 }

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -209,6 +209,10 @@ pub enum Message {
     Project(crate::domains::project::ProjectMsg),
     Automation(crate::domains::automation::AutomationMsg),
     Perform(crate::domains::perform::PerformMsg),
+    KeyboardInput {
+        event: iced::keyboard::Event,
+        occurred_at: std::time::Instant,
+    },
     View(crate::domains::view::ViewMsg),
 
     // Workspace

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -185,6 +185,7 @@ pub enum SettingsTab {
     Plugins,
     Dropbox,
     Warping,
+    Perform,
     Appearance,
 }
 

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiSettings {
     #[serde(default)]
+    pub perform_input_mapping: crate::domains::perform::PerformInputMapping,
+    #[serde(default)]
     pub sample_library_roots: Vec<PathBuf>,
     #[serde(default = "default_sample_browser_open")]
     pub sample_browser_open: bool,
@@ -44,6 +46,7 @@ pub struct UiSettings {
 impl Default for UiSettings {
     fn default() -> Self {
         Self {
+            perform_input_mapping: crate::domains::perform::PerformInputMapping::default(),
             sample_library_roots: Vec::new(),
             sample_browser_open: default_sample_browser_open(),
             sample_browser_width: default_sample_browser_width(),
@@ -189,5 +192,67 @@ mod tests {
         let loaded: UiSettings = serde_json::from_str(&json).unwrap();
 
         assert_eq!(loaded.sample_library_roots, roots);
+    }
+
+    #[test]
+    fn old_settings_receive_the_default_perform_input_mapping() {
+        use crate::domains::perform::{ComputerKey, PadPosition};
+
+        let loaded: UiSettings = serde_json::from_str(r#"{"sample_library_roots":[]}"#).unwrap();
+
+        assert_eq!(
+            loaded.input_mapping_key(PadPosition::ALL[0]),
+            ComputerKey::Digit1
+        );
+        assert_eq!(
+            loaded.input_mapping_key(PadPosition::ALL[15]),
+            ComputerKey::V
+        );
+    }
+
+    #[test]
+    fn perform_input_mapping_roundtrips_in_global_settings() {
+        use crate::domains::perform::{ComputerKey, PadPosition};
+
+        let mut settings = UiSettings::default();
+        settings
+            .perform_input_mapping
+            .rebind(PadPosition::ALL[0], ComputerKey::Y);
+        let loaded: UiSettings =
+            serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
+
+        assert_eq!(
+            loaded.input_mapping_key(PadPosition::ALL[0]),
+            ComputerKey::Y
+        );
+    }
+
+    #[test]
+    fn rebinding_global_input_does_not_change_project_bytes() {
+        use crate::domains::perform::{ComputerKey, PadPosition};
+
+        let project = vibez_project::Project::default();
+        let before = serde_json::to_vec(&project).unwrap();
+        let mut settings = UiSettings::default();
+        settings
+            .perform_input_mapping
+            .rebind(PadPosition::ALL[0], ComputerKey::Y);
+        let after = serde_json::to_vec(&project).unwrap();
+
+        assert_eq!(before, after);
+        assert_ne!(
+            settings.perform_input_mapping,
+            crate::domains::perform::PerformInputMapping::default()
+        );
+    }
+}
+
+#[cfg(test)]
+impl UiSettings {
+    fn input_mapping_key(
+        &self,
+        position: crate::domains::perform::PadPosition,
+    ) -> crate::domains::perform::ComputerKey {
+        self.perform_input_mapping.key_for(position)
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,9 +39,11 @@ flowchart LR
     ENG --> OUT(("audio out"))
 ```
 
-The UI polls the event ring at 60 fps (an iced subscription tick) and pumps
-every background service in the same tick: engine events, finished plugin
-loads, plugin GUI run loops, and MIDI input.
+The UI polls the engine event ring at 60 fps (an iced subscription tick) and
+pumps background services in the same tick: finished plugin loads, plugin GUI
+run loops, and the legacy MIDI input. Computer-key Perform input instead enters
+through iced's keyboard event subscription and is timestamped and dispatched
+without waiting for that tick.
 
 ## Crate map
 
@@ -106,6 +108,17 @@ router and `EngineHandle`. The initial workspace shell sends no engine commands
 when its mode changes. Perform is a sibling of Arrange and Mix in the shared
 shell, and all three retain their interaction state when producers switch
 between them.
+
+Perform input adapters resolve physical controls before mode semantics. The
+computer-key adapter maps physical key codes through the global
+`PerformInputMapping`, suppresses auto-repeat, pairs releases with the original
+press, and emits a timestamped `PadGesture` containing Pad Position, state,
+optional velocity, and source identity. The domain consumes the gesture
+synchronously to mirror pressed state in the Pad Surface; later musical slices
+consume the same gesture action without deriving input from rendered state or
+the 60 fps engine-event pump. Widget-captured presses are not forwarded, so
+text fields suppress pad input. The mapping persists in the user's `ui.json`
+settings and is absent from the project document and undo snapshots.
 
 ## Project Tracks and timeline content
 


### PR DESCRIPTION
## Summary

- add controller-independent, timestamped Pad Gestures with physical Pad Position, press/release state, optional velocity, and source identity
- route physical computer-key events directly from iced input, pair releases, suppress repeat, and ignore widget-captured typing
- persist the configurable 4x4 key mapping in global UI settings and add a dedicated Perform settings pane
- mirror held gestures across the Pad Surface in Sections, Track Mutes, and Instrument without adding musical behavior

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -j 4 -- -D warnings`
- `cargo test --workspace -j 4`
- focused Perform, keyboard focus-suppression, global-settings, and project-byte-equivalence tests
- `git diff --check`

Native dogfood covered the default `1234` / `QWER` / `ASDF` / `ZXCV` layout, rebinding R1 · C1 to `Y`, restart persistence, text-field suppression, visible held feedback in all three Perform Modes, and Arrange Ctrl+T / Space / Ctrl+Z regression checks. Local evidence is under `target/card03-dogfood/`, including `card03-pad-mapping.mp4`.

## Scope

Card 03 only. This PR assigns no musical meaning to Pad Gestures and does not begin Card 04, MIDI/VDC input, Instrument velocity, Sections, or launching.
