### PR TITLE
Perform: toggle Project Track mutes from pads

### DIFF
--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -941,3 +941,7 @@ mod tests;
 #[cfg(test)]
 #[path = "engine_stuck_note_tests.rs"]
 mod stuck_note_tests;
+
+#[cfg(test)]
+#[path = "engine_mute_event_tests.rs"]
+mod mute_event_tests;

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -152,8 +152,19 @@ impl AudioEngine {
                     }
                 }
                 EngineCommand::SetTrackMute(id, mute) => {
-                    if let Some(track) = self.channel_mut(id) {
+                    let effective_at_samples = self.transport.position();
+                    let changed = if let Some(track) = self.channel_mut(id) {
                         track.mute = mute;
+                        true
+                    } else {
+                        false
+                    };
+                    if changed {
+                        let _ = self.event_tx.push(EngineEvent::TrackMuteChanged {
+                            track_id: id,
+                            muted: mute,
+                            effective_at_samples,
+                        });
                     }
                 }
 

--- a/crates/vibez-engine/src/engine_mute_event_tests.rs
+++ b/crates/vibez-engine/src/engine_mute_event_tests.rs
@@ -1,0 +1,32 @@
+use super::*;
+use vibez_core::id::TrackId;
+
+#[test]
+fn mute_change_reports_engine_effective_state_and_sample_time() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(track_id, "Track 1".into()))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut first_block = [0.0; 8];
+    engine.process(&mut first_block, 2);
+    while event_rx.pop().is_ok() {}
+    assert_eq!(engine.transport().position(), 4);
+
+    cmd_tx
+        .push(EngineCommand::SetTrackMute(track_id, true))
+        .unwrap();
+    let mut second_block = [0.0; 8];
+    engine.process(&mut second_block, 2);
+
+    assert!(matches!(
+        event_rx.pop(),
+        Ok(EngineEvent::TrackMuteChanged {
+            track_id: event_track,
+            muted: true,
+            effective_at_samples: 4,
+        }) if event_track == track_id
+    ));
+}

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -70,6 +70,15 @@ pub enum EngineEvent {
         peak_r: f32,
     },
 
+    /// A track mute command became effective in the audio engine at this
+    /// absolute transport sample. This is the authoritative event later
+    /// Capture work consumes.
+    TrackMuteChanged {
+        track_id: TrackId,
+        muted: bool,
+        effective_at_samples: u64,
+    },
+
     /// Playback has started (transport entered playing state).
     PlaybackStarted,
 
@@ -101,6 +110,11 @@ mod tests {
             track_id: TrackId::new(),
             peak_l: 0.5,
             peak_r: 0.4,
+        };
+        let _track_mute = EngineEvent::TrackMuteChanged {
+            track_id: TrackId::new(),
+            muted: true,
+            effective_at_samples: 44_100,
         };
         let _started = EngineEvent::PlaybackStarted;
         let _stopped = EngineEvent::PlaybackStopped;

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -14,11 +14,15 @@ use crate::state::{ArrangementSelection, AuditionMode, DetailPanelTab, UiEffect}
 use super::*;
 
 fn apply_track_mute_request(
-    project_tracks: &mut crate::state::ProjectTracksState,
+    project_tracks: &mut Arc<crate::state::ProjectTracksState>,
+    history: &mut crate::state::UndoHistory,
+    pre_edit_snapshot: crate::state::ProjectSnapshot,
     request: crate::domains::perform::TrackMuteRequest,
     engine: &mut impl crate::domains::EngineHandle,
 ) -> Option<String> {
-    let track = project_tracks.find_mut(request.track_id)?;
+    project_tracks.find(request.track_id)?;
+    history.push_edit(pre_edit_snapshot, None);
+    let track = Arc::make_mut(project_tracks).find_mut(request.track_id)?;
     track.mute = request.muted;
     let track_name = track.name.clone();
     engine.send(EngineCommand::SetTrackMute(request.track_id, request.muted));
@@ -34,10 +38,13 @@ impl App {
             self.state.status_text = "Perform key mapping saved".into();
         }
         if let Some(request) = action.track_mute_request {
+            let pre_edit_snapshot = self.take_snapshot();
             let changed = {
                 let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
                 apply_track_mute_request(
-                    Arc::make_mut(&mut self.state.project_tracks),
+                    &mut self.state.project_tracks,
+                    &mut self.state.project.history,
+                    pre_edit_snapshot,
                     request,
                     &mut engine,
                 )
@@ -585,20 +592,38 @@ impl App {
 mod perform_action_tests {
     use super::*;
     use crate::domains::test_support::RecordingEngine;
-    use crate::state::{ProjectTrack, ProjectTracksState};
+    use crate::state::{AppState, ProjectSnapshot, ProjectTrack};
     use vibez_core::id::TrackId;
+
+    fn snapshot(state: &AppState) -> ProjectSnapshot {
+        ProjectSnapshot {
+            project_tracks: Arc::clone(&state.project_tracks),
+            arrange_timeline: Arc::clone(&state.arrangement.timeline),
+            bpm: state.transport.bpm,
+            bpm_text: state.transport.bpm_text.clone(),
+            loop_enabled: state.transport.loop_enabled,
+            loop_start_beats: state.transport.loop_start_beats,
+            loop_end_beats: state.transport.loop_end_beats,
+            selected_track: state.arrangement.selected_track,
+            selected_clips: state.arrangement.selected_clips.clone(),
+            selected_note_clip: state.arrangement.selected_note_clip,
+        }
+    }
 
     #[test]
     fn perform_mute_request_updates_the_shared_track_and_engine_together() {
         let track_id = TrackId::new();
-        let mut project_tracks = ProjectTracksState::default();
-        project_tracks
+        let mut state = AppState::default();
+        Arc::make_mut(&mut state.project_tracks)
             .tracks
             .push(ProjectTrack::new(track_id, "Drums".into(), 0));
         let mut engine = RecordingEngine::default();
+        let pre_edit_snapshot = snapshot(&state);
 
         let name = apply_track_mute_request(
-            &mut project_tracks,
+            &mut state.project_tracks,
+            &mut state.project.history,
+            pre_edit_snapshot,
             crate::domains::perform::TrackMuteRequest {
                 track_id,
                 muted: true,
@@ -607,10 +632,35 @@ mod perform_action_tests {
         );
 
         assert_eq!(name.as_deref(), Some("Drums"));
-        assert!(project_tracks.tracks[0].mute);
+        assert!(state.project_tracks.tracks[0].mute);
         assert!(matches!(
             engine.0.as_slice(),
             [EngineCommand::SetTrackMute(event_track, true)] if *event_track == track_id
         ));
+        assert_eq!(state.project.history.undo.len(), 1);
+        let before_mute = state.project.history.pop_undo().expect("mute undo step");
+        assert!(!before_mute.project_tracks.tracks[0].mute);
+    }
+
+    #[test]
+    fn missing_track_mute_request_does_not_create_an_undo_step() {
+        let mut state = AppState::default();
+        let mut engine = RecordingEngine::default();
+        let pre_edit_snapshot = snapshot(&state);
+
+        let name = apply_track_mute_request(
+            &mut state.project_tracks,
+            &mut state.project.history,
+            pre_edit_snapshot,
+            crate::domains::perform::TrackMuteRequest {
+                track_id: TrackId::new(),
+                muted: true,
+            },
+            &mut engine,
+        );
+
+        assert_eq!(name, None);
+        assert!(state.project.history.undo.is_empty());
+        assert!(engine.0.is_empty());
     }
 }

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -13,7 +13,45 @@ use crate::state::{ArrangementSelection, AuditionMode, DetailPanelTab, UiEffect}
 
 use super::*;
 
+fn apply_track_mute_request(
+    project_tracks: &mut crate::state::ProjectTracksState,
+    request: crate::domains::perform::TrackMuteRequest,
+    engine: &mut impl crate::domains::EngineHandle,
+) -> Option<String> {
+    let track = project_tracks.find_mut(request.track_id)?;
+    track.mute = request.muted;
+    let track_name = track.name.clone();
+    engine.send(EngineCommand::SetTrackMute(request.track_id, request.muted));
+    Some(track_name)
+}
+
 impl App {
+    /// Apply cross-domain effects requested by Perform without giving the
+    /// Perform interaction slice ownership of Project Track state.
+    pub(super) fn apply_perform_action(&mut self, action: crate::domains::perform::PerformAction) {
+        if action.persist_settings {
+            self.persist_ui_settings();
+            self.state.status_text = "Perform key mapping saved".into();
+        }
+        if let Some(request) = action.track_mute_request {
+            let changed = {
+                let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+                apply_track_mute_request(
+                    Arc::make_mut(&mut self.state.project_tracks),
+                    request,
+                    &mut engine,
+                )
+            };
+            if let Some(track_name) = changed {
+                self.mark_project_dirty();
+                self.state.status_text = format!(
+                    "{} {track_name}",
+                    if request.muted { "Muted" } else { "Unmuted" }
+                );
+            }
+        }
+    }
+
     /// Route cross-domain effects requested by the arrangement domain.
     pub(super) fn apply_arrangement_action(
         &mut self,
@@ -447,6 +485,15 @@ impl App {
                             track.peak_r = peak_r.max(track.peak_r * 0.85);
                         }
                     }
+                    EngineEvent::TrackMuteChanged {
+                        track_id,
+                        muted,
+                        effective_at_samples: _,
+                    } => {
+                        if let Some(track) = self.state.find_track_mut(track_id) {
+                            track.mute = muted;
+                        }
+                    }
                 }
             }
         }
@@ -531,5 +578,39 @@ impl App {
             }
         }
         Task::none()
+    }
+}
+
+#[cfg(test)]
+mod perform_action_tests {
+    use super::*;
+    use crate::domains::test_support::RecordingEngine;
+    use crate::state::{ProjectTrack, ProjectTracksState};
+    use vibez_core::id::TrackId;
+
+    #[test]
+    fn perform_mute_request_updates_the_shared_track_and_engine_together() {
+        let track_id = TrackId::new();
+        let mut project_tracks = ProjectTracksState::default();
+        project_tracks
+            .tracks
+            .push(ProjectTrack::new(track_id, "Drums".into(), 0));
+        let mut engine = RecordingEngine::default();
+
+        let name = apply_track_mute_request(
+            &mut project_tracks,
+            crate::domains::perform::TrackMuteRequest {
+                track_id,
+                muted: true,
+            },
+            &mut engine,
+        );
+
+        assert_eq!(name.as_deref(), Some("Drums"));
+        assert!(project_tracks.tracks[0].mute);
+        assert!(matches!(
+            engine.0.as_slice(),
+            [EngineCommand::SetTrackMute(event_track, true)] if *event_track == track_id
+        ));
     }
 }

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -135,16 +135,15 @@ impl super::App {
         if let Some(msg) = perform_msg {
             let ctx = crate::domains::perform::PerformCtx {
                 workspace_visible: self.state.view.workspace == crate::state::Workspace::Perform,
+                project_tracks: &self.state.project_tracks.tracks,
             };
             let action = {
                 let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
                 self.state.perform.update(msg, &mut engine, ctx)
             };
-            if action.persist_settings {
-                self.persist_ui_settings();
-                self.state.status_text = "Perform key mapping saved".into();
-            }
-            if action.keyboard_consumed {
+            let keyboard_consumed = action.keyboard_consumed;
+            self.apply_perform_action(action);
+            if keyboard_consumed {
                 return iced::Task::none();
             }
         }
@@ -184,6 +183,16 @@ pub(crate) fn global_key_handler(
         };
         if let Some(mode) = mode {
             return Some(Message::Perform(PerformMsg::SelectMode(mode)));
+        }
+        if let iced::keyboard::Key::Character(ref character) = key {
+            let bank = match character.as_str() {
+                "[" => Some(PerformMsg::PreviousBank),
+                "]" => Some(PerformMsg::NextBank),
+                _ => None,
+            };
+            if let Some(bank) = bank {
+                return Some(Message::Perform(bank));
+            }
         }
     }
 
@@ -433,6 +442,21 @@ mod tests {
         }
 
         assert!(global_key_handler(Key::Named(Named::F1), Modifiers::SHIFT).is_none());
+    }
+
+    #[test]
+    fn brackets_navigate_the_active_perform_mode_bank() {
+        use iced::keyboard::{Key, Modifiers};
+
+        assert!(matches!(
+            global_key_handler(Key::Character("[".into()), Modifiers::empty()),
+            Some(Message::Perform(PerformMsg::PreviousBank))
+        ));
+        assert!(matches!(
+            global_key_handler(Key::Character("]".into()), Modifiers::empty()),
+            Some(Message::Perform(PerformMsg::NextBank))
+        ));
+        assert!(global_key_handler(Key::Character("]".into()), Modifiers::SHIFT).is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -204,6 +204,9 @@ impl App {
         self.remote_audition_cache_lease = None;
         let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
         self.clear_project_runtime();
+        self.state
+            .perform
+            .sync_project_tracks(&self.state.project_tracks.tracks);
         self.ensure_master_eq();
         self.state.transport.bpm = vibez_core::constants::DEFAULT_BPM;
         self.state.transport.bpm_text = format!("{:.0}", self.state.transport.bpm);
@@ -849,6 +852,9 @@ impl App {
             .tracks
             .first()
             .map(|track| track.id);
+        self.state
+            .perform
+            .sync_project_tracks(&self.state.project_tracks.tracks);
         self.state.project.current_path = Some(loaded.path.clone());
         self.state.project.dirty = false;
         let provenance_suffix = remote_provenance

--- a/crates/vibez-ui/src/app/project_replay.rs
+++ b/crates/vibez-ui/src/app/project_replay.rs
@@ -91,6 +91,9 @@ impl App {
         }
 
         self.state.project_tracks = snapshot.project_tracks;
+        self.state
+            .perform
+            .sync_project_tracks(&self.state.project_tracks.tracks);
         self.state.arrangement.timeline = snapshot.arrange_timeline;
         self.state.transport.bpm = snapshot.bpm;
         self.state.transport.bpm_text = snapshot.bpm_text;

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -187,6 +187,9 @@ impl App {
                         ctx,
                     )
                 };
+                self.state
+                    .perform
+                    .sync_project_tracks(&self.state.project_tracks.tracks);
                 return self.apply_arrangement_action(action);
             }
             Message::PianoRoll(msg) => {
@@ -231,14 +234,13 @@ impl App {
                 let ctx = crate::domains::perform::PerformCtx {
                     workspace_visible: self.state.view.workspace
                         == crate::state::Workspace::Perform,
+                    project_tracks: &self.state.project_tracks.tracks,
                 };
                 let action = {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
                     self.state.perform.update(msg, &mut engine, ctx)
                 };
-                if action.persist_settings {
-                    self.persist_ui_settings();
-                }
+                self.apply_perform_action(action);
             }
             Message::View(msg) => {
                 if matches!(&msg, ViewMsg::ToggleEditMenu) {

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -176,9 +176,12 @@ impl App {
         ]
         .spacing(5);
         let origin = match mode {
-            PerformMode::Sections => "ORDER · TOP-LEFT",
-            PerformMode::TrackMutes => "PROJECT TRACKS · TOP-LEFT",
-            PerformMode::Instrument => "ORDER · BOTTOM-LEFT",
+            PerformMode::Sections => "ORDER · TOP-LEFT".to_string(),
+            PerformMode::TrackMutes => format!(
+                "BANK {} · PROJECT TRACKS · [ ]",
+                self.state.perform.banks.track_mutes + 1
+            ),
+            PerformMode::Instrument => "ORDER · BOTTOM-LEFT".to_string(),
         };
         let header = row![
             heading,
@@ -237,36 +240,50 @@ impl App {
             + u16::from(self.state.perform.banks.for_mode(mode)) * 16;
         let selected = self.state.perform.selected_pad == Some(position);
         let pressed = self.state.perform.is_pad_pressed(position);
-        let (title, detail, color) = match mode {
+        let mute_track = (mode == PerformMode::TrackMutes)
+            .then(|| {
+                self.state
+                    .perform
+                    .track_for_mute_pad(position, &self.state.project_tracks.tracks)
+            })
+            .flatten();
+        let (title, detail, color, muted) = match mode {
             PerformMode::Sections => (
                 "+ SECTION".to_string(),
-                "EMPTY",
+                "EMPTY".to_string(),
                 th::track_color((ordinal - 1) as u8),
+                false,
             ),
             PerformMode::TrackMutes => {
-                if let Some(track) = self
-                    .state
-                    .project_tracks
-                    .tracks
-                    .get(usize::from(ordinal - 1))
-                {
+                if let Some(track) = mute_track {
                     (
                         track.name.clone(),
-                        if track.kind.is_midi() {
-                            "MIDI TRACK"
-                        } else {
-                            "AUDIO TRACK"
-                        },
+                        format!(
+                            "{} · {}",
+                            if track.kind.is_midi() {
+                                "MIDI"
+                            } else {
+                                "AUDIO"
+                            },
+                            if track.mute { "MUTED" } else { "LIVE" }
+                        ),
                         th::track_color(track.color_index),
+                        track.mute,
                     )
                 } else {
-                    ("—".to_string(), "NO PROJECT TRACK", th::text_muted())
+                    (
+                        "—".to_string(),
+                        "NO PROJECT TRACK".to_string(),
+                        th::text_muted(),
+                        false,
+                    )
                 }
             }
             PerformMode::Instrument => (
                 "SELECT MIDI".to_string(),
-                "NO INSTRUMENT TARGET",
+                "NO INSTRUMENT TARGET".to_string(),
                 th::track_color((ordinal - 1) as u8),
+                false,
             ),
         };
         let number_color = th::blend(color, th::text(), 0.3);
@@ -312,6 +329,8 @@ impl App {
                         0.0,
                         if pressed {
                             th::blend(th::accent_dim(), color, 0.35)
+                        } else if muted {
+                            th::blend(th::mute_active(), color, 0.28)
                         } else if selected {
                             th::bg_hover()
                         } else {
@@ -324,6 +343,8 @@ impl App {
             border: iced::Border {
                 color: if pressed || selected {
                     th::accent()
+                } else if muted {
+                    th::mute_active()
                 } else {
                     th::blend(th::border_light(), color, 0.38)
                 },
@@ -333,7 +354,7 @@ impl App {
             ..Default::default()
         });
 
-        container(pad_face)
+        let pad: Element<'_, Message> = container(pad_face)
             .width(Length::FillPortion(1))
             .height(Length::Fill)
             .padding(3)
@@ -358,7 +379,17 @@ impl App {
                 },
                 ..Default::default()
             })
-            .into()
+            .into();
+
+        if mute_track.is_some() {
+            mouse_area(pad)
+                .on_press(Message::Perform(PerformMsg::ToggleTrackMuteFromPad(
+                    position,
+                )))
+                .into()
+        } else {
+            pad
+        }
     }
 
     fn view_section_construction(&self) -> Element<'_, Message> {

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -7,8 +7,10 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
+use vibez_core::id::TrackId;
 
 use super::EngineHandle;
+use crate::state::ProjectTrack;
 
 /// The three Perform Modes exposed in V1. Macros stays absent until its
 /// behavior and Capture semantics are defined.
@@ -293,6 +295,7 @@ pub struct PerformState {
     pub input_mapping: PerformInputMapping,
     pub key_rebind_target: Option<PadPosition>,
     active_computer_keys: HashMap<String, (PadPosition, PadGestureSource)>,
+    track_mute_slots: Vec<Option<TrackId>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -301,6 +304,9 @@ pub enum PerformMsg {
     FocusEditor(PerformEditorFocus),
     BeginKeyRebind(PadPosition),
     CancelKeyRebind,
+    PreviousBank,
+    NextBank,
+    ToggleTrackMuteFromPad(PadPosition),
     ComputerKeyPressed {
         key: ComputerKey,
         key_id: String,
@@ -321,8 +327,17 @@ impl PerformMsg {
 
 /// Read-only facts supplied by the router.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct PerformCtx {
+pub struct PerformCtx<'a> {
     pub workspace_visible: bool,
+    pub project_tracks: &'a [ProjectTrack],
+}
+
+/// A semantic mute request resolved by Perform against a stable pad slot.
+/// The router applies it to the single shared Project Track state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrackMuteRequest {
+    pub track_id: TrackId,
+    pub muted: bool,
 }
 
 /// Cross-domain effects requested by Perform. Pad Gestures leave the adapter
@@ -332,15 +347,72 @@ pub struct PerformAction {
     pub keyboard_consumed: bool,
     pub persist_settings: bool,
     pub gesture: Option<PadGesture>,
+    pub track_mute_request: Option<TrackMuteRequest>,
 }
 
 impl PerformState {
+    fn sync_track_mute_slots(&mut self, tracks: &[ProjectTrack]) {
+        for slot in &mut self.track_mute_slots {
+            if slot.is_some_and(|track_id| !tracks.iter().any(|track| track.id == track_id)) {
+                *slot = None;
+            }
+        }
+
+        for track in tracks {
+            if self
+                .track_mute_slots
+                .iter()
+                .flatten()
+                .any(|track_id| *track_id == track.id)
+            {
+                continue;
+            }
+            if let Some(vacant) = self.track_mute_slots.iter_mut().find(|slot| slot.is_none()) {
+                *vacant = Some(track.id);
+            } else {
+                self.track_mute_slots.push(Some(track.id));
+            }
+        }
+
+        while self.track_mute_slots.last().is_some_and(Option::is_none) {
+            self.track_mute_slots.pop();
+        }
+
+        let last_bank = self.track_mute_slots.len().saturating_sub(1) / 16;
+        self.banks.track_mutes = self.banks.track_mutes.min(last_bank as u8);
+    }
+
+    fn track_mute_request(
+        &self,
+        position: PadPosition,
+        tracks: &[ProjectTrack],
+    ) -> Option<TrackMuteRequest> {
+        let slot = usize::from(self.banks.track_mutes) * 16 + position.index();
+        let track_id = self.track_mute_slots.get(slot).copied().flatten()?;
+        let track = tracks.iter().find(|track| track.id == track_id)?;
+        Some(TrackMuteRequest {
+            track_id,
+            muted: !track.mute,
+        })
+    }
+
+    pub fn track_for_mute_pad<'a>(
+        &self,
+        position: PadPosition,
+        tracks: &'a [ProjectTrack],
+    ) -> Option<&'a ProjectTrack> {
+        let slot = usize::from(self.banks.track_mutes) * 16 + position.index();
+        let track_id = self.track_mute_slots.get(slot).copied().flatten()?;
+        tracks.iter().find(|track| track.id == track_id)
+    }
+
     pub fn update(
         &mut self,
         msg: PerformMsg,
         _engine: &mut impl EngineHandle,
-        ctx: PerformCtx,
+        ctx: PerformCtx<'_>,
     ) -> PerformAction {
+        self.sync_track_mute_slots(ctx.project_tracks);
         match msg {
             PerformMsg::SelectMode(mode) => {
                 if ctx.workspace_visible {
@@ -358,6 +430,29 @@ impl PerformState {
             PerformMsg::CancelKeyRebind => {
                 self.key_rebind_target = None;
             }
+            PerformMsg::PreviousBank => {
+                if ctx.workspace_visible && self.mode == PerformMode::TrackMutes {
+                    self.banks.track_mutes = self.banks.track_mutes.saturating_sub(1);
+                }
+            }
+            PerformMsg::NextBank => {
+                if ctx.workspace_visible && self.mode == PerformMode::TrackMutes {
+                    let last_bank = self.track_mute_slots.len().saturating_sub(1) / 16;
+                    self.banks.track_mutes = self
+                        .banks
+                        .track_mutes
+                        .saturating_add(1)
+                        .min(last_bank as u8);
+                }
+            }
+            PerformMsg::ToggleTrackMuteFromPad(position) => {
+                if ctx.workspace_visible && self.mode == PerformMode::TrackMutes {
+                    return PerformAction {
+                        track_mute_request: self.track_mute_request(position, ctx.project_tracks),
+                        ..PerformAction::default()
+                    };
+                }
+            }
             PerformMsg::ComputerKeyPressed {
                 key,
                 key_id,
@@ -369,6 +464,7 @@ impl PerformState {
                         keyboard_consumed: true,
                         persist_settings: true,
                         gesture: None,
+                        ..PerformAction::default()
                     };
                 }
                 if !ctx.workspace_visible {
@@ -385,6 +481,9 @@ impl PerformState {
                 };
                 let source = PadGestureSource::ComputerKeyboard { key };
                 self.active_computer_keys.insert(key_id, (position, source));
+                let track_mute_request = (self.mode == PerformMode::TrackMutes)
+                    .then(|| self.track_mute_request(position, ctx.project_tracks))
+                    .flatten();
                 return PerformAction {
                     keyboard_consumed: true,
                     persist_settings: false,
@@ -395,6 +494,7 @@ impl PerformState {
                         source,
                         occurred_at,
                     }),
+                    track_mute_request,
                 };
             }
             PerformMsg::ComputerKeyReleased {
@@ -414,6 +514,7 @@ impl PerformState {
                         source,
                         occurred_at,
                     }),
+                    ..PerformAction::default()
                 };
             }
         }
@@ -425,12 +526,24 @@ impl PerformState {
             .values()
             .any(|(pressed, _)| *pressed == position)
     }
+
+    pub fn sync_project_tracks(&mut self, tracks: &[ProjectTrack]) {
+        self.sync_track_mute_slots(tracks);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::super::test_support::RecordingEngine;
     use super::*;
+
+    fn project_tracks(count: usize) -> Vec<ProjectTrack> {
+        (0..count)
+            .map(|index| {
+                ProjectTrack::new(TrackId::new(), format!("Track {}", index + 1), index as u8)
+            })
+            .collect()
+    }
 
     #[test]
     fn exposes_exactly_the_three_settled_v1_modes() {
@@ -454,6 +567,7 @@ mod tests {
             &mut engine,
             PerformCtx {
                 workspace_visible: true,
+                ..PerformCtx::default()
             },
         );
 
@@ -473,6 +587,7 @@ mod tests {
             &mut engine,
             PerformCtx {
                 workspace_visible: false,
+                ..PerformCtx::default()
             },
         );
 
@@ -512,6 +627,7 @@ mod tests {
             &mut engine,
             PerformCtx {
                 workspace_visible: true,
+                ..PerformCtx::default()
             },
         );
         assert_eq!(state.editor_focus, PerformEditorFocus::SectionConstruction);
@@ -535,6 +651,7 @@ mod tests {
         let released_at = pressed_at + std::time::Duration::from_millis(23);
         let ctx = PerformCtx {
             workspace_visible: true,
+            ..PerformCtx::default()
         };
 
         let press = state.update(
@@ -619,6 +736,7 @@ mod tests {
                     &mut engine,
                     PerformCtx {
                         workspace_visible: true,
+                        ..PerformCtx::default()
                     },
                 )
                 .gesture
@@ -637,6 +755,7 @@ mod tests {
         let mut engine = RecordingEngine::default();
         let ctx = PerformCtx {
             workspace_visible: true,
+            ..PerformCtx::default()
         };
         let at = Instant::now();
         let press = state.update(
@@ -694,5 +813,142 @@ mod tests {
         assert!(action.keyboard_consumed);
         assert!(action.persist_settings);
         assert!(action.gesture.is_none());
+    }
+
+    #[test]
+    fn track_mute_mode_resolves_keyboard_press_to_shared_track_request_once() {
+        let tracks = project_tracks(2);
+        let mut state = PerformState {
+            mode: PerformMode::TrackMutes,
+            ..PerformState::default()
+        };
+        let mut engine = RecordingEngine::default();
+        let at = Instant::now();
+        let ctx = PerformCtx {
+            workspace_visible: true,
+            project_tracks: &tracks,
+        };
+
+        let press = state.update(
+            PerformMsg::ComputerKeyPressed {
+                key: ComputerKey::Digit1,
+                key_id: "1".into(),
+                occurred_at: at,
+            },
+            &mut engine,
+            ctx,
+        );
+        let repeat = state.update(
+            PerformMsg::ComputerKeyPressed {
+                key: ComputerKey::Digit1,
+                key_id: "1".into(),
+                occurred_at: at,
+            },
+            &mut engine,
+            ctx,
+        );
+        let release = state.update(
+            PerformMsg::ComputerKeyReleased {
+                key_id: "1".into(),
+                occurred_at: at,
+            },
+            &mut engine,
+            ctx,
+        );
+
+        assert_eq!(
+            press.track_mute_request,
+            Some(TrackMuteRequest {
+                track_id: tracks[0].id,
+                muted: true,
+            })
+        );
+        assert!(repeat.track_mute_request.is_none());
+        assert!(release.track_mute_request.is_none());
+        assert!(engine.0.is_empty());
+    }
+
+    #[test]
+    fn pointer_pad_uses_the_same_track_mute_resolution() {
+        let mut tracks = project_tracks(1);
+        tracks[0].mute = true;
+        let mut state = PerformState {
+            mode: PerformMode::TrackMutes,
+            ..PerformState::default()
+        };
+        let mut engine = RecordingEngine::default();
+
+        let action = state.update(
+            PerformMsg::ToggleTrackMuteFromPad(PadPosition::ALL[0]),
+            &mut engine,
+            PerformCtx {
+                workspace_visible: true,
+                project_tracks: &tracks,
+            },
+        );
+
+        assert_eq!(
+            action.track_mute_request,
+            Some(TrackMuteRequest {
+                track_id: tracks[0].id,
+                muted: false,
+            })
+        );
+    }
+
+    #[test]
+    fn track_slots_survive_deletion_and_fill_without_scrambling_other_pads() {
+        let mut tracks = project_tracks(18);
+        let first_id = tracks[0].id;
+        let second_id = tracks[1].id;
+        let seventeenth_id = tracks[16].id;
+        let mut state = PerformState {
+            mode: PerformMode::TrackMutes,
+            ..PerformState::default()
+        };
+        let mut engine = RecordingEngine::default();
+
+        state.update(
+            PerformMsg::NextBank,
+            &mut engine,
+            PerformCtx {
+                workspace_visible: true,
+                project_tracks: &tracks,
+            },
+        );
+        assert_eq!(state.banks.track_mutes, 1);
+        assert_eq!(
+            state
+                .track_for_mute_pad(PadPosition::ALL[0], &tracks)
+                .map(|track| track.id),
+            Some(seventeenth_id)
+        );
+
+        state.banks.track_mutes = 0;
+        tracks.retain(|track| track.id != first_id);
+        state.sync_project_tracks(&tracks);
+        assert_eq!(
+            state
+                .track_for_mute_pad(PadPosition::ALL[1], &tracks)
+                .map(|track| track.id),
+            Some(second_id)
+        );
+
+        let replacement = ProjectTrack::new(TrackId::new(), "Replacement".into(), 3);
+        let replacement_id = replacement.id;
+        tracks.push(replacement);
+        state.sync_project_tracks(&tracks);
+        assert_eq!(
+            state
+                .track_for_mute_pad(PadPosition::ALL[0], &tracks)
+                .map(|track| track.id),
+            Some(replacement_id)
+        );
+        assert_eq!(
+            state
+                .track_for_mute_pad(PadPosition::ALL[1], &tracks)
+                .map(|track| track.id),
+            Some(second_id)
+        );
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -104,10 +104,12 @@ math happens in the domains.
 
 Perform follows the same boundary. `PerformState` owns runtime-only mode, bank,
 selection, and editor-focus state; `PerformMsg` changes that slice through the
-router and `EngineHandle`. The initial workspace shell sends no engine commands
-when its mode changes. Perform is a sibling of Arrange and Mix in the shared
+router and `EngineHandle`. Perform is a sibling of Arrange and Mix in the shared
 shell, and all three retain their interaction state when producers switch
-between them.
+between them. Track Mute pad slots retain stable `TrackId` assignments across
+track additions and deletions. A pad press resolves inside Perform to a narrow
+mute request; the router applies that request to the one project-owned mute
+field used by Arrange and Mix instead of storing a second Perform value.
 
 Perform input adapters resolve physical controls before mode semantics. The
 computer-key adapter maps physical key codes through the global
@@ -119,6 +121,12 @@ consume the same gesture action without deriving input from rendered state or
 the 60 fps engine-event pump. Widget-captured presses are not forwarded, so
 text fields suppress pad input. The mapping persists in the user's `ui.json`
 settings and is absent from the project document and undo snapshots.
+
+Track mute commands become authoritative when the audio callback drains them.
+The engine emits `EngineEvent::TrackMuteChanged` with the effective state and
+absolute transport sample; the UI mirrors that result into the shared Project
+Track. This keeps pad, mixer, persisted, and audible state aligned while giving
+later Capture work an engine-timestamped event source.
 
 ## Project Tracks and timeline content
 


### PR DESCRIPTION
## Summary

- map Track Mutes pads to stable Project Track slots with independent bank navigation
- route pointer and mapped-key presses through the shared Project Track mute state
- emit engine-effective mute events with absolute transport sample timestamps
- keep Arrange, Mix, Perform, persistence, and the engine aligned

## Verification

- cargo fmt --all -- --check
- CARGO_TARGET_DIR=target/card04-cargo nice -n 10 cargo clippy --workspace -j 4 -- -D warnings
- CARGO_TARGET_DIR=target/card04-cargo nice -n 10 cargo test --workspace -j 4
- CARGO_TARGET_DIR=target/card04-cargo nice -n 10 cargo build --workspace -j 4
- focused Perform, router, bank-stability, shortcut, and engine timestamp tests

## Dogfood

Recorded native dogfood during Arrange playback verified F2 mode selection, mapped-key and pointer toggles, mixer-to-pad and pad-to-mixer consistency, and persistence across mode/workspace switches. Local recording: target/card04-dogfood/card04-track-mutes.mp4.

## Scope

Card 04 only. Starts from merged Card 03 on dev at bf106fc. Sections, quantized changes, Capture, Solo pads, and Card 05 are intentionally excluded. Merge remains the human gate.