### PR TITLE
refactor(ui): deepen shared timeline editor

### DIFF
--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -410,10 +410,19 @@ impl App {
                     .find(|clip| clip.id == clip_id)
                     .map(|clip| clip.duration_beats)
             }) {
-                return (self.state.view.window_width - 52.0).max(1.0) / duration.max(1.0) as f32;
+                return crate::timeline_geometry::TimelineGeometry::fitted(
+                    duration,
+                    self.state.view.window_width,
+                    52.0,
+                )
+                .pixels_per_beat();
             }
         }
-        20.0 * self.state.view.zoom_level
+        crate::timeline_geometry::TimelineGeometry::from_zoom(
+            self.state.view.zoom_level,
+            self.state.view.scroll_offset_beats,
+        )
+        .pixels_per_beat()
     }
 
     /// Walk `next_track_number` forward past any names already in use so
@@ -440,10 +449,13 @@ impl App {
     /// Auto-scroll the arrangement when a clip's right edge nears the visible boundary.
     /// Called from resize/move handlers so the view follows the drag.
     fn auto_scroll_to_beat(&mut self, clip_end_beat: f64) {
-        let ppb = 20.0 * self.state.view.zoom_level as f64;
         // Conservative estimate of canvas width (window minus track headers)
-        let canvas_width = 1400.0_f64;
-        let visible_beats = canvas_width / ppb;
+        let canvas_width = 1400.0_f32;
+        let geometry = crate::timeline_geometry::TimelineGeometry::from_zoom(
+            self.state.view.zoom_level,
+            self.state.view.scroll_offset_beats,
+        );
+        let visible_beats = geometry.visible_beats(canvas_width);
         let visible_end = self.state.view.scroll_offset_beats + visible_beats;
         let margin = 2.0_f64;
 

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -16,6 +16,7 @@ use crate::services::plugin_loader::{load_plugin_effect_bg, load_plugin_instrume
 use crate::message::Message;
 
 use super::*;
+use crate::domains::timeline_editor::TimelineEditorAdapter;
 
 impl App {
     pub(super) fn update(&mut self, message: Message) -> Task<Message> {
@@ -202,7 +203,7 @@ impl App {
                     self.state.piano_roll.update(
                         msg,
                         &mut engine,
-                        Arc::make_mut(&mut self.state.arrangement.timeline),
+                        self.state.arrangement.resolve_timeline_mut().editor,
                         ctx,
                     )
                 };
@@ -220,7 +221,7 @@ impl App {
                         msg,
                         &mut engine,
                         project_tracks,
-                        Arc::make_mut(&mut self.state.arrangement.timeline),
+                        self.state.arrangement.resolve_timeline_mut().editor,
                     )
                 };
                 if let Some(status) = action.status {
@@ -284,10 +285,11 @@ impl App {
                 let ctx = crate::domains::view::ViewCtx {
                     total_beats: self.state.total_beats(),
                 };
-                let action = self
-                    .state
-                    .view
-                    .update(msg, &self.state.arrangement.timeline, ctx);
+                let action = self.state.view.update(
+                    msg,
+                    self.state.arrangement.resolve_timeline().editor,
+                    ctx,
+                );
                 return self.apply_view_action(action);
             }
             Message::Project(msg) => {

--- a/crates/vibez-ui/src/app/views_arrangement.rs
+++ b/crates/vibez-ui/src/app/views_arrangement.rs
@@ -10,6 +10,7 @@ use iced::widget::{
 use iced::{Element, Length, Theme};
 
 use crate::domains::browser::BrowserMsg;
+use crate::domains::timeline_editor::TimelineEditorAdapter;
 use crate::domains::view::ViewMsg;
 use vibez_core::id::{ClipId, TrackId};
 
@@ -17,6 +18,7 @@ use crate::icons;
 use crate::message::Message;
 use crate::state::{ArrangementSelection, ContextMenuTarget, TrackTimelineContent};
 use crate::theme as th;
+use crate::timeline_geometry::TimelineGeometry;
 use crate::widgets::timeline::{ArrangementMinimap, MinimapTrack, RulerWidget, TrackClipCanvas};
 use crate::widgets::track_header::{view_editable_channel_name, view_track_header};
 
@@ -24,6 +26,7 @@ use super::*;
 
 impl App {
     pub(super) fn view_arrangement(&self) -> Element<'_, Message> {
+        let timeline = self.state.arrangement.resolve_timeline().editor;
         if self.state.project_tracks.tracks.is_empty() {
             let browser_drag_active = self.state.browser.drag_source.is_some();
             let empty_beat = match self.state.browser.drag_target {
@@ -61,14 +64,14 @@ impl App {
             }));
             if browser_drag_active {
                 let grid = self.state.view.grid_config();
-                let pixels_per_beat = 20.0 * self.state.view.zoom_level;
-                let scroll = self.state.view.scroll_offset_beats;
+                let geometry = TimelineGeometry::from_zoom(
+                    self.state.view.zoom_level,
+                    self.state.view.scroll_offset_beats,
+                );
                 area = area
                     .on_move(move |point| {
-                        let beat = grid.snap_beat(
-                            point.x as f64 / pixels_per_beat as f64 + scroll,
-                            pixels_per_beat,
-                        );
+                        let beat =
+                            grid.snap_beat(geometry.x_to_beat(point.x), geometry.pixels_per_beat());
                         Message::Browser(BrowserMsg::DragHoverEmptyArrangement {
                             beat: beat.max(0.0),
                         })
@@ -83,6 +86,7 @@ impl App {
         let bpm = self.state.transport.bpm;
         let zoom_level = self.state.view.zoom_level;
         let scroll_offset = self.state.view.scroll_offset_beats;
+        let geometry = TimelineGeometry::from_zoom(zoom_level, scroll_offset);
         let total_beats = self.state.total_beats();
 
         // Beat-based ruler across the top (offset by track header width)
@@ -96,9 +100,9 @@ impl App {
             loop_enabled: self.state.transport.loop_enabled,
             loop_start_beats: self.state.transport.loop_start_beats,
             loop_end_beats: self.state.transport.loop_end_beats,
-            time_selection_active: self.state.arrangement.time_selection_active,
-            selection_start_beats: self.state.arrangement.selection_start_beats,
-            selection_end_beats: self.state.arrangement.selection_end_beats,
+            time_selection_active: timeline.time_selection_active,
+            selection_start_beats: timeline.selection_start_beats,
+            selection_end_beats: timeline.selection_end_beats,
         };
         let ruler_canvas: Element<'_, Message> = canvas(ruler)
             .width(Length::Fill)
@@ -140,7 +144,7 @@ impl App {
                 .iter()
                 .map(|t| {
                     let color = th::track_color(t.color_index);
-                    let content = self.state.arrange_content(t.id);
+                    let content = timeline.timeline.get(t.id);
                     let mut clips: Vec<(f64, f64)> = content
                         .into_iter()
                         .flat_map(|content| {
@@ -211,17 +215,12 @@ impl App {
         let empty_content = TrackTimelineContent::default();
 
         for (track_index, track) in self.state.project_tracks.tracks.iter().enumerate() {
-            let content = self
-                .state
-                .arrange_content(track.id)
-                .unwrap_or(&empty_content);
-            let selected = self.state.arrangement.selected_track == Some(track.id);
+            let content = timeline.timeline.get(track.id).unwrap_or(&empty_content);
+            let selected = timeline.selected_track == Some(track.id);
             let track_color = th::track_color(track.color_index);
 
             // Collect selected clip IDs for this track
-            let selected_clips: HashSet<ClipId> = self
-                .state
-                .arrangement
+            let selected_clips: HashSet<ClipId> = timeline
                 .selected_clips
                 .iter()
                 .filter_map(|sel| match sel {
@@ -272,10 +271,10 @@ impl App {
                 self.state.transport.loop_enabled,
                 self.state.transport.loop_start_beats,
                 self.state.transport.loop_end_beats,
-                self.state.arrangement.time_selection_active,
-                self.state.arrangement.selection_start_beats,
-                self.state.arrangement.selection_end_beats,
-                self.state.arrangement.time_selection_track,
+                timeline.time_selection_active,
+                timeline.selection_start_beats,
+                timeline.selection_end_beats,
+                timeline.time_selection_track,
                 self.state.browser.drag_source.is_some(),
                 browser_drag_duration,
                 browser_drag_detail.clone(),
@@ -283,8 +282,7 @@ impl App {
             let track_id = track.id;
             let compatible = !track.kind.is_midi();
             let grid = self.state.view.grid_config();
-            let pixels_per_beat = 20.0 * zoom_level;
-            let scroll = scroll_offset;
+            let track_geometry = geometry;
             let clip_canvas: Element<'_, Message> = mouse_area(
                 canvas(clip_canvas_widget)
                     .width(Length::Fill)
@@ -292,8 +290,8 @@ impl App {
             )
             .on_move(move |point| {
                 let beat = grid.snap_beat(
-                    point.x as f64 / pixels_per_beat as f64 + scroll,
-                    pixels_per_beat,
+                    track_geometry.x_to_beat(point.x),
+                    track_geometry.pixels_per_beat(),
                 );
                 Message::Browser(BrowserMsg::DragHoverTrack {
                     track_id,
@@ -309,14 +307,13 @@ impl App {
             track_rows = track_rows.push(track_row);
 
             if automation_open {
-                track_rows = self.push_automation_lanes(track_rows, track, track_color);
+                track_rows = self.push_automation_lanes(track_rows, timeline, track, track_color);
             }
         }
 
         if self.state.browser.drag_source.is_some() {
             let grid = self.state.view.grid_config();
-            let pixels_per_beat = 20.0 * self.state.view.zoom_level;
-            let scroll = self.state.view.scroll_offset_beats;
+            let empty_geometry = geometry;
             let empty_beat = match self.state.browser.drag_target {
                 Some(crate::state::BrowserDropTarget::EmptyArrangement { beat }) => Some(beat),
                 _ => None,
@@ -358,8 +355,8 @@ impl App {
             )
             .on_move(move |point| {
                 let beat = grid.snap_beat(
-                    point.x as f64 / pixels_per_beat as f64 + scroll,
-                    pixels_per_beat,
+                    empty_geometry.x_to_beat(point.x),
+                    empty_geometry.pixels_per_beat(),
                 );
                 Message::Browser(BrowserMsg::DragHoverEmptyArrangement {
                     beat: beat.max(0.0),
@@ -388,7 +385,7 @@ impl App {
             } else {
                 th::track_color(channel.color_index)
             };
-            let selected = self.state.arrangement.selected_track == Some(channel.id);
+            let selected = timeline.selected_track == Some(channel.id);
             let expanded = self.state.automation_ui.expanded.contains(&channel.id);
 
             let toggle = button(
@@ -489,7 +486,7 @@ impl App {
 
             track_rows = track_rows.push(row![header, filler].height(Length::Fixed(26.0)));
             if expanded {
-                track_rows = self.push_automation_lanes(track_rows, channel, chan_color);
+                track_rows = self.push_automation_lanes(track_rows, timeline, channel, chan_color);
             }
         }
 
@@ -525,15 +522,16 @@ impl App {
     pub(super) fn push_automation_lanes<'a>(
         &'a self,
         mut rows: iced::widget::Column<'a, Message>,
+        timeline: &'a crate::state::TimelineEditorState,
         track: &'a crate::state::ProjectTrack,
         track_color: iced::Color,
     ) -> iced::widget::Column<'a, Message> {
         use crate::domains::automation::{target_label_with_buses, AutomationMsg};
         use crate::widgets::automation_lane::{AutomationLaneWidget, LANE_HEIGHT};
 
-        let automation = self
-            .state
-            .arrange_content(track.id)
+        let automation = timeline
+            .timeline
+            .get(track.id)
             .map(|content| content.automation.as_slice())
             .unwrap_or(&[]);
         for lane in automation {

--- a/crates/vibez-ui/src/domains/arrangement/media_ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/media_ops.rs
@@ -11,7 +11,7 @@ use vibez_core::midi::MidiNote;
 use vibez_engine::commands::EngineCommand;
 
 use super::EngineHandle;
-use crate::state::{ArrangementSelection, ArrangementState, UiClip, UiNoteClip};
+use crate::state::{ArrangementSelection, TimelineEditorState, UiClip, UiNoteClip};
 
 use super::*;
 
@@ -61,7 +61,67 @@ fn visible_notes(clip: &UiNoteClip, local_start: f64, local_end: f64) -> Vec<Mid
     visible
 }
 
-impl ArrangementState {
+impl TimelineEditorState {
+    pub(super) fn op_resize_audio_clip(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        ctx: ArrangementCtx,
+        track_id: TrackId,
+        clip_id: ClipId,
+        new_duration: u64,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        let mut sync_data = None;
+        let mut clip_end_beat = None;
+        if let Some(track) = self.find_content_mut(track_id) {
+            if let Some(clip) = track.clips.iter_mut().find(|clip| clip.id == clip_id) {
+                let source_len = clip.audio.num_frames() as u64 - clip.source_offset;
+                clip.duration = new_duration;
+                if new_duration > source_len && !clip.loop_enabled {
+                    clip.loop_enabled = true;
+                    clip.loop_start = clip.source_offset;
+                    clip.loop_end = clip.source_offset + source_len;
+                }
+                clip_end_beat = Some((clip.position + clip.duration) as f64 / ctx.samples_per_beat);
+                sync_data = Some((
+                    Arc::clone(&clip.audio),
+                    clip.position,
+                    clip.source_offset,
+                    clip.duration,
+                    clip.loop_enabled,
+                    clip.loop_start,
+                    clip.loop_end,
+                ));
+            }
+        }
+        if let Some((
+            audio,
+            position,
+            source_offset,
+            duration,
+            loop_enabled,
+            loop_start,
+            loop_end,
+        )) = sync_data
+        {
+            engine.send(EngineCommand::RemoveClip(track_id, clip_id));
+            engine.send(EngineCommand::AddClip {
+                track_id,
+                clip_id,
+                audio,
+                position,
+                source_offset,
+                duration,
+                loop_enabled,
+                loop_start,
+                loop_end,
+            });
+        }
+        action.scroll_to_beat = clip_end_beat;
+        self.drag_resize_active = true;
+        action
+    }
+
     /// A background warp finished: swap in the stretched audio and
     /// record the warp geometry on the clip.
     pub fn apply_clip_warp_success(

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -134,6 +134,44 @@ pub enum ArrangementMsg {
 }
 
 impl ArrangementMsg {
+    pub(super) fn is_timeline_editor_message(&self) -> bool {
+        matches!(
+            self,
+            Self::RenameClip(..)
+                | Self::RemoveClip(..)
+                | Self::SelectArrangementClip { .. }
+                | Self::MoveAudioClip { .. }
+                | Self::MoveNoteClipPosition { .. }
+                | Self::ResizeAudioClip { .. }
+                | Self::MoveClipToTrack { .. }
+                | Self::ToggleClipLoop(..)
+                | Self::SetClipLoopRegion { .. }
+                | Self::SetTimeSelection { .. }
+                | Self::SetTimeSelectionActive(_)
+                | Self::SetSelectionAsLoop
+                | Self::DeleteSelectedClip
+                | Self::DuplicateSelectedClip
+                | Self::CopySelectedClips
+                | Self::CutSelectedClips
+                | Self::PasteClipsAtPlayhead
+                | Self::ToggleSelectedClipLoop
+                | Self::ResizeSelectedClips { .. }
+                | Self::DuplicateNoteClip(..)
+                | Self::SplitAudioClip { .. }
+                | Self::SplitNoteClip { .. }
+                | Self::SplitSelectedAtPlayhead
+                | Self::JoinSelectedClips
+                | Self::DeleteClipsInRegion { .. }
+                | Self::SplitClipsAtRegion { .. }
+                | Self::CreateClipFromSelection
+                | Self::CreateNoteClipFromSelection(_)
+                | Self::ClipBpmInputChanged { .. }
+                | Self::SubmitClipBpm { .. }
+                | Self::SetClipNominalBpm { .. }
+                | Self::ClearClipWarp { .. }
+        )
+    }
+
     /// Whether this message edits the project (drives the dirty flag).
     pub fn marks_dirty(&self) -> bool {
         !matches!(

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -13,10 +13,11 @@ use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::TrackKind;
 use vibez_engine::commands::EngineCommand;
 
+use super::timeline_editor::TimelineEditorAdapter;
 use super::EngineHandle;
 use crate::state::{
-    ArrangementSelection, ArrangementState, ProjectTrack, ProjectTracksState, TrackTimelineContent,
-    UiNoteClip,
+    ArrangementSelection, ArrangementState, ProjectTrack, ProjectTracksState, TimelineEditorState,
+    TrackTimelineContent, UiNoteClip,
 };
 
 mod messages;
@@ -78,7 +79,7 @@ impl ProjectTracksState {
     }
 }
 
-impl ArrangementState {
+impl TimelineEditorState {
     fn find_content(&self, track_id: TrackId) -> Option<&TrackTimelineContent> {
         self.timeline.get(track_id)
     }
@@ -86,7 +87,11 @@ impl ArrangementState {
     fn find_content_mut(&mut self, track_id: TrackId) -> Option<&mut TrackTimelineContent> {
         Arc::make_mut(&mut self.timeline).get_mut(track_id)
     }
+}
 
+impl ArrangementState {
+    /// Arrange owns Project Track controls and resolves its local timeline
+    /// before forwarding editor messages to the shared boundary.
     pub fn update(
         &mut self,
         project_tracks: &mut ProjectTracksState,
@@ -94,7 +99,13 @@ impl ArrangementState {
         engine: &mut impl EngineHandle,
         ctx: ArrangementCtx,
     ) -> ArrangementAction {
-        let _ = ctx.samples_per_beat; // used by clip arms below
+        if msg.is_timeline_editor_message() {
+            return self
+                .resolve_timeline_mut()
+                .editor
+                .update(project_tracks, msg, engine, ctx);
+        }
+
         let mut action = ArrangementAction::default();
         match msg {
             ArrangementMsg::AddTrack => {
@@ -129,33 +140,29 @@ impl ArrangementState {
             }
             ArrangementMsg::RemoveTrack(track_id) => {
                 if track_id.is_master() {
-                    // The master bus cannot be deleted.
                     return action;
                 }
                 let removed_name = project_tracks
                     .tracks
                     .iter()
-                    .find(|t| t.id == track_id)
-                    .map(|t| t.name.clone())
+                    .find(|track| track.id == track_id)
+                    .map(|track| track.name.clone())
                     .unwrap_or_else(|| format!("{track_id}"));
-
                 engine.send(EngineCommand::RemoveTrack(track_id));
-                project_tracks.tracks.retain(|t| t.id != track_id);
+                project_tracks.tracks.retain(|track| track.id != track_id);
                 Arc::make_mut(&mut self.timeline).remove(track_id);
                 if self.selected_track == Some(track_id) {
-                    self.selected_track = project_tracks.tracks.first().map(|t| t.id);
+                    self.selected_track = project_tracks.tracks.first().map(|track| track.id);
                 }
-                if let Some((tid, _)) = self.selected_note_clip {
-                    if tid == track_id {
-                        self.selected_note_clip = None;
-                    }
+                if self
+                    .selected_note_clip
+                    .is_some_and(|(id, _)| id == track_id)
+                {
+                    self.selected_note_clip = None;
                 }
-                self.selected_clips.retain(|sel| {
-                    let sel_track = match sel {
-                        ArrangementSelection::AudioClip { track_id: t, .. } => *t,
-                        ArrangementSelection::NoteClip { track_id: t, .. } => *t,
-                    };
-                    sel_track != track_id
+                self.selected_clips.retain(|selection| match selection {
+                    ArrangementSelection::AudioClip { track_id: id, .. }
+                    | ArrangementSelection::NoteClip { track_id: id, .. } => *id != track_id,
                 });
                 action.close_track_guis = Some(track_id);
                 action.status = Some(format!(
@@ -163,22 +170,10 @@ impl ArrangementState {
                     project_tracks.tracks.len()
                 ));
             }
-            ArrangementMsg::SelectTrack(track_id) => {
-                self.selected_track = Some(track_id);
-            }
+            ArrangementMsg::SelectTrack(track_id) => self.selected_track = Some(track_id),
             ArrangementMsg::RenameTrack(track_id, new_name) => {
                 if let Some(track) = project_tracks.find_mut(track_id) {
                     track.name = new_name;
-                }
-            }
-            ArrangementMsg::RenameClip(track_id, clip_id, new_name) => {
-                if let Some(track) = self.find_content_mut(track_id) {
-                    if let Some(c) = track.clips.iter_mut().find(|c| c.id == clip_id) {
-                        c.name = new_name.clone();
-                    }
-                    if let Some(c) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
-                        c.name = new_name;
-                    }
                 }
             }
             ArrangementMsg::MoveTrackUp(track_id) => {
@@ -188,13 +183,13 @@ impl ArrangementState {
                 project_tracks.move_track(track_id, false, engine)
             }
             ArrangementMsg::MoveSelectedTrackUp => {
-                if let Some(tid) = self.selected_track {
-                    project_tracks.move_track(tid, true, engine);
+                if let Some(track_id) = self.selected_track {
+                    project_tracks.move_track(track_id, true, engine);
                 }
             }
             ArrangementMsg::MoveSelectedTrackDown => {
-                if let Some(tid) = self.selected_track {
-                    project_tracks.move_track(tid, false, engine);
+                if let Some(track_id) = self.selected_track {
+                    project_tracks.move_track(track_id, false, engine);
                 }
             }
             ArrangementMsg::SetTrackGain(track_id, gain) => {
@@ -214,15 +209,13 @@ impl ArrangementState {
             ArrangementMsg::SetTrackMute(track_id) => {
                 if let Some(track) = project_tracks.find_mut(track_id) {
                     track.mute = !track.mute;
-                    let mute = track.mute;
-                    engine.send(EngineCommand::SetTrackMute(track_id, mute));
+                    engine.send(EngineCommand::SetTrackMute(track_id, track.mute));
                 }
             }
             ArrangementMsg::SetTrackSolo(track_id) => {
                 if let Some(track) = project_tracks.find_mut(track_id) {
                     track.solo = !track.solo;
-                    let solo = track.solo;
-                    engine.send(EngineCommand::SetTrackSolo(track_id, solo));
+                    engine.send(EngineCommand::SetTrackSolo(track_id, track.solo));
                 }
             }
             ArrangementMsg::AddBus => {
@@ -230,8 +223,6 @@ impl ArrangementState {
                 let id = TrackId::new();
                 let name = format!("{letter} Return");
                 engine.send(EngineCommand::AddBus(id, name.clone()));
-                // Offset into the palette so the first buses don't
-                // mirror the first tracks' colors.
                 let color_index = ((project_tracks.buses.len() + 4) % 8) as u8;
                 let mut bus = ProjectTrack::new(id, name.clone(), color_index);
                 attach_channel_eq(engine, &mut bus);
@@ -242,10 +233,10 @@ impl ArrangementState {
             }
             ArrangementMsg::RemoveBus(bus_id) => {
                 engine.send(EngineCommand::RemoveBus(bus_id));
-                project_tracks.buses.retain(|b| b.id != bus_id);
+                project_tracks.buses.retain(|bus| bus.id != bus_id);
                 Arc::make_mut(&mut self.timeline).remove(bus_id);
                 for track in &mut project_tracks.tracks {
-                    track.sends.retain(|(b, _)| *b != bus_id);
+                    track.sends.retain(|(id, _)| *id != bus_id);
                 }
                 for content in Arc::make_mut(&mut self.timeline).by_track.values_mut() {
                     content.automation.retain(|lane| {
@@ -253,9 +244,8 @@ impl ArrangementState {
                     });
                 }
                 if self.selected_track == Some(bus_id) {
-                    self.selected_track = project_tracks.tracks.first().map(|t| t.id);
+                    self.selected_track = project_tracks.tracks.first().map(|track| track.id);
                 }
-                // Plugin GUIs on the bus die with its devices.
                 action.close_track_guis = Some(bus_id);
                 action.status = Some("Removed bus".to_string());
             }
@@ -266,7 +256,7 @@ impl ArrangementState {
             } => {
                 let amount = amount.clamp(0.0, 1.0);
                 if let Some(track) = project_tracks.tracks.iter_mut().find(|t| t.id == track_id) {
-                    match track.sends.iter_mut().find(|(b, _)| *b == bus_id) {
+                    match track.sends.iter_mut().find(|(id, _)| *id == bus_id) {
                         Some(send) => send.1 = amount,
                         None => track.sends.push((bus_id, amount)),
                     }
@@ -285,6 +275,35 @@ impl ArrangementState {
                 if let Some(track) = project_tracks.find_mut(track_id) {
                     track.peak_l = peak_l.max(track.peak_l * 0.85);
                     track.peak_r = peak_r.max(track.peak_r * 0.85);
+                }
+            }
+            _ => unreachable!("editor messages are delegated before Arrange track handling"),
+        }
+        action
+    }
+}
+
+impl TimelineEditorState {
+    pub fn update(
+        &mut self,
+        project_tracks: &mut ProjectTracksState,
+        msg: ArrangementMsg,
+        engine: &mut impl EngineHandle,
+        ctx: ArrangementCtx,
+    ) -> ArrangementAction {
+        debug_assert!(msg.is_timeline_editor_message());
+        let _ = ctx.samples_per_beat; // used by clip arms below
+        let mut action = ArrangementAction::default();
+        match msg {
+            ArrangementMsg::RenameClip(track_id, clip_id, new_name) => {
+                if let Some(track) = self.find_content_mut(track_id) {
+                    if let Some(clip) = track.clips.iter_mut().find(|clip| clip.id == clip_id) {
+                        clip.name = new_name.clone();
+                    }
+                    if let Some(clip) = track.note_clips.iter_mut().find(|clip| clip.id == clip_id)
+                    {
+                        clip.name = new_name;
+                    }
                 }
             }
             ArrangementMsg::RemoveClip(track_id, clip_id) => {
@@ -407,64 +426,7 @@ impl ArrangementState {
                 clip_id,
                 new_duration,
             } => {
-                // Update UI state — auto-enable loop when extending past source length
-                let spb = ctx.samples_per_beat;
-                let mut sync_data = None;
-                let mut clip_end_beat = None;
-                if let Some(track) = self.find_content_mut(track_id) {
-                    if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
-                        let source_len = clip.audio.num_frames() as u64 - clip.source_offset;
-                        if new_duration > source_len {
-                            // Extending past source: enable loop over full source region
-                            clip.duration = new_duration;
-                            if !clip.loop_enabled {
-                                clip.loop_enabled = true;
-                                clip.loop_start = clip.source_offset;
-                                clip.loop_end = clip.source_offset + source_len;
-                            }
-                        } else {
-                            clip.duration = new_duration;
-                        }
-                        clip_end_beat = Some((clip.position + clip.duration) as f64 / spb);
-                        sync_data = Some((
-                            Arc::clone(&clip.audio),
-                            clip.position,
-                            clip.source_offset,
-                            clip.duration,
-                            clip.loop_enabled,
-                            clip.loop_start,
-                            clip.loop_end,
-                        ));
-                    }
-                }
-                // Sync to engine via Remove+Add (loop state included atomically)
-                if let Some((
-                    audio,
-                    position,
-                    source_offset,
-                    duration,
-                    loop_enabled,
-                    loop_start,
-                    loop_end,
-                )) = sync_data
-                {
-                    engine.send(EngineCommand::RemoveClip(track_id, clip_id));
-                    engine.send(EngineCommand::AddClip {
-                        track_id,
-                        clip_id,
-                        audio,
-                        position,
-                        source_offset,
-                        duration,
-                        loop_enabled,
-                        loop_start,
-                        loop_end,
-                    });
-                }
-                if let Some(end_beat) = clip_end_beat {
-                    action.scroll_to_beat = Some(end_beat);
-                }
-                self.drag_resize_active = true;
+                return self.op_resize_audio_clip(engine, ctx, track_id, clip_id, new_duration);
             }
             ArrangementMsg::MoveClipToTrack {
                 source_track,
@@ -948,6 +910,7 @@ impl ArrangementState {
             ArrangementMsg::ClearClipWarp { track_id, clip_id } => {
                 return self.apply_clear_clip_warp(engine, track_id, clip_id);
             }
+            _ => unreachable!("Project Track messages never enter the Timeline Editor"),
         }
         action
     }

--- a/crates/vibez-ui/src/domains/arrangement/ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/ops.rs
@@ -7,13 +7,13 @@ use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::MidiNote;
 use vibez_engine::commands::EngineCommand;
 
-use super::{ArrangementAction, ArrangementCtx, ArrangementMsg, EngineHandle};
+use super::{ArrangementAction, ArrangementCtx, EngineHandle};
 use crate::state::{
-    ArrangementSelection, ArrangementState, ClipClipboard, ClipboardClip, ProjectTracksState,
+    ArrangementSelection, ClipClipboard, ClipboardClip, ProjectTracksState, TimelineEditorState,
     UiNoteClip,
 };
 
-impl ArrangementState {
+impl TimelineEditorState {
     pub(super) fn op_delete_clips_in_region(
         &mut self,
         engine: &mut impl EngineHandle,
@@ -614,7 +614,7 @@ impl ArrangementState {
 
     pub(super) fn op_resize_selected_clips(
         &mut self,
-        project_tracks: &mut ProjectTracksState,
+        _project_tracks: &mut ProjectTracksState,
         engine: &mut impl EngineHandle,
         ctx: ArrangementCtx,
         anchor: ArrangementSelection,
@@ -653,15 +653,12 @@ impl ArrangementState {
                     if let Some(old) = old {
                         let duration =
                             ((old + delta).max(0.25) * ctx.samples_per_beat).round() as u64;
-                        let action = self.update(
-                            project_tracks,
-                            ArrangementMsg::ResizeAudioClip {
-                                track_id,
-                                clip_id,
-                                new_duration: duration.max(1),
-                            },
+                        let action = self.op_resize_audio_clip(
                             engine,
                             ctx,
+                            track_id,
+                            clip_id,
+                            duration.max(1),
                         );
                         max_end = match (max_end, action.scroll_to_beat) {
                             (Some(a), Some(b)) => Some(a.max(b)),

--- a/crates/vibez-ui/src/domains/automation.rs
+++ b/crates/vibez-ui/src/domains/automation.rs
@@ -7,13 +7,14 @@
 //! vectors.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
 use vibez_core::id::{LaneId, TrackId};
 use vibez_engine::commands::EngineCommand;
 
 use super::EngineHandle;
-use crate::state::{ArrangementTimeline, ProjectTrack, ProjectTracksState};
+use crate::state::{ProjectTrack, ProjectTracksState, TimelineEditorState};
 
 /// Messages the automation domain handles.
 #[derive(Debug, Clone)]
@@ -272,8 +273,9 @@ impl AutomationState {
         msg: AutomationMsg,
         engine: &mut impl EngineHandle,
         project_tracks: &mut ProjectTracksState,
-        timeline: &mut ArrangementTimeline,
+        editor: &mut TimelineEditorState,
     ) -> AutomationAction {
+        let timeline = Arc::make_mut(&mut editor.timeline);
         let mut action = AutomationAction::default();
         match msg {
             AutomationMsg::ToggleTrackLanes(track_id) => {
@@ -481,16 +483,19 @@ impl AutomationState {
             }
             AutomationMsg::DeleteSelectedPoint => {
                 if let Some((track_id, lane_id, index)) = self.selected.take() {
-                    return self.update(
-                        AutomationMsg::RemovePoint {
-                            track_id,
-                            lane_id,
-                            index,
-                        },
-                        engine,
-                        project_tracks,
-                        timeline,
-                    );
+                    let Some(lane) = timeline.get_mut(track_id).and_then(|content| {
+                        content
+                            .automation
+                            .iter_mut()
+                            .find(|lane| lane.id == lane_id)
+                    }) else {
+                        return action;
+                    };
+                    if index < lane.points.len() {
+                        lane.points.remove(index);
+                        let lane = lane.clone();
+                        sync_lane(engine, track_id, &lane);
+                    }
                 }
             }
         }
@@ -503,12 +508,12 @@ mod tests {
     use super::super::test_support::RecordingEngine;
     use super::*;
 
-    fn track() -> (ProjectTracksState, ArrangementTimeline, TrackId) {
+    fn track() -> (ProjectTracksState, TimelineEditorState, TrackId) {
         let track = ProjectTrack::new(TrackId::new(), "T1".to_string(), 0);
         let track_id = track.id;
         let mut project_tracks = ProjectTracksState::default();
         project_tracks.tracks.push(track);
-        let mut timeline = ArrangementTimeline::default();
+        let mut timeline = TimelineEditorState::default();
         timeline.ensure(track_id);
         (project_tracks, timeline, track_id)
     }

--- a/crates/vibez-ui/src/domains/mod.rs
+++ b/crates/vibez-ui/src/domains/mod.rs
@@ -13,6 +13,7 @@ pub mod devices;
 pub mod perform;
 pub mod piano_roll;
 pub mod project;
+pub mod timeline_editor;
 pub mod transport;
 pub mod view;
 

--- a/crates/vibez-ui/src/domains/piano_roll.rs
+++ b/crates/vibez-ui/src/domains/piano_roll.rs
@@ -7,6 +7,7 @@
 //! [`PianoRollAction`] for app.rs to route.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::MidiNote;
@@ -14,7 +15,8 @@ use vibez_engine::commands::EngineCommand;
 
 use super::EngineHandle;
 use crate::state::{
-    ArrangementTimeline, PianoRollState, SnapGrid, TrackTimelineContent, UiNoteClip,
+    PianoRollState, SnapGrid, TimelineContent, TimelineEditorState, TrackTimelineContent,
+    UiNoteClip,
 };
 
 /// Messages the piano roll domain handles.
@@ -116,12 +118,12 @@ pub struct PianoRollAction {
     pub close_context_menu: bool,
 }
 
-fn find_track(timeline: &ArrangementTimeline, track_id: TrackId) -> Option<&TrackTimelineContent> {
+fn find_track(timeline: &TimelineContent, track_id: TrackId) -> Option<&TrackTimelineContent> {
     timeline.get(track_id)
 }
 
 fn find_track_mut(
-    timeline: &mut ArrangementTimeline,
+    timeline: &mut TimelineContent,
     track_id: TrackId,
 ) -> Option<&mut TrackTimelineContent> {
     timeline.get_mut(track_id)
@@ -145,7 +147,7 @@ pub fn default_loop_end(notes: &[MidiNote], duration_beats: f64) -> f64 {
 /// Snap every note start to the grid and sync changed notes to the
 /// engine.
 fn quantize_note_clip(
-    tracks: &mut ArrangementTimeline,
+    tracks: &mut TimelineContent,
     track_id: TrackId,
     clip_id: ClipId,
     grid: SnapGrid,
@@ -183,9 +185,10 @@ impl PianoRollState {
         &mut self,
         msg: PianoRollMsg,
         engine: &mut impl EngineHandle,
-        tracks: &mut ArrangementTimeline,
+        editor: &mut TimelineEditorState,
         ctx: PianoRollCtx,
     ) -> PianoRollAction {
+        let tracks = Arc::make_mut(&mut editor.timeline);
         let mut action = PianoRollAction::default();
         match msg {
             PianoRollMsg::ToggleNoteClipLoop(track_id, clip_id) => {
@@ -701,10 +704,10 @@ mod tests {
     use super::*;
     use crate::state::PianoRollEditMode;
 
-    fn midi_track_with_clip() -> (ArrangementTimeline, TrackId, ClipId) {
+    fn midi_track_with_clip() -> (TimelineEditorState, TrackId, ClipId) {
         let track_id = TrackId::new();
         let clip_id = ClipId::new();
-        let mut timeline = ArrangementTimeline::default();
+        let mut timeline = TimelineEditorState::default();
         let track = timeline.ensure(track_id);
         track.note_clips.push(UiNoteClip {
             id: clip_id,
@@ -840,7 +843,7 @@ mod tests {
     fn toggle_edit_mode_flips_and_reports() {
         let mut pr = PianoRollState::default();
         let mut engine = RecordingEngine::default();
-        let mut tracks = ArrangementTimeline::default();
+        let mut tracks = TimelineEditorState::default();
         let action = pr.update(
             PianoRollMsg::ToggleEditMode,
             &mut engine,

--- a/crates/vibez-ui/src/domains/timeline_editor.rs
+++ b/crates/vibez-ui/src/domains/timeline_editor.rs
@@ -1,0 +1,137 @@
+//! Shared Timeline Editor adapter boundary.
+//!
+//! Adapters resolve their timeline once. Clip, note, automation, selection,
+//! and view code consume that resolved target without knowing whether it came
+//! from Arrange or, later, a Section.
+
+#[cfg(test)]
+use crate::state::TimelineEditorState;
+use crate::state::{ArrangementState, ResolvedTimeline, ResolvedTimelineMut};
+
+pub trait TimelineEditorAdapter {
+    fn resolve_timeline(&self) -> ResolvedTimeline<'_>;
+    fn resolve_timeline_mut(&mut self) -> ResolvedTimelineMut<'_>;
+}
+
+impl TimelineEditorAdapter for ArrangementState {
+    fn resolve_timeline(&self) -> ResolvedTimeline<'_> {
+        ResolvedTimeline {
+            editor: &self.editor,
+        }
+    }
+
+    fn resolve_timeline_mut(&mut self) -> ResolvedTimelineMut<'_> {
+        ResolvedTimelineMut {
+            editor: &mut self.editor,
+        }
+    }
+}
+
+#[cfg(test)]
+pub fn resolved_editor_mut(adapter: &mut impl TimelineEditorAdapter) -> &mut TimelineEditorState {
+    adapter.resolve_timeline_mut().editor
+}
+
+#[cfg(test)]
+pub(crate) mod conformance {
+    use std::sync::Arc;
+
+    use vibez_core::automation::AutomationTarget;
+    use vibez_core::id::TrackId;
+    use vibez_core::midi::TrackKind;
+
+    use super::*;
+    use crate::domains::arrangement::{ArrangementCtx, ArrangementMsg};
+    use crate::domains::automation::{AutomationMsg, AutomationState};
+    use crate::domains::piano_roll::{PianoRollCtx, PianoRollMsg};
+    use crate::domains::test_support::RecordingEngine;
+    use crate::state::{PianoRollState, ProjectTrack, ProjectTracksState};
+
+    /// Reusable contract: Card 07 calls this same harness for its Section
+    /// adapter rather than building a parallel editing implementation.
+    pub(crate) fn assert_timeline_editor_conformance<A>(mut adapter: A)
+    where
+        A: TimelineEditorAdapter,
+    {
+        let track_id = TrackId::new();
+        let mut project_tracks = ProjectTracksState::default();
+        project_tracks.tracks.push(ProjectTrack::new_instrument(
+            track_id,
+            "MIDI 1".into(),
+            TrackKind::Midi,
+            0,
+        ));
+        let mut engine = RecordingEngine::default();
+
+        let clip_id = {
+            let editor = resolved_editor_mut(&mut adapter);
+            Arc::make_mut(&mut editor.timeline).ensure(track_id);
+            editor.selected_track = Some(track_id);
+            editor.time_selection_active = true;
+            editor.selection_start_beats = 4.0;
+            editor.selection_end_beats = 8.0;
+            editor.update(
+                &mut project_tracks,
+                ArrangementMsg::CreateNoteClipFromSelection(track_id),
+                &mut engine,
+                ArrangementCtx::default(),
+            );
+            editor.selected_note_clip.expect("created note clip").1
+        };
+
+        let mut piano_roll = PianoRollState::default();
+        piano_roll.update(
+            PianoRollMsg::AddNote {
+                track_id,
+                clip_id,
+                pitch: 60,
+                start_beat: 0.0,
+                duration_beats: 1.0,
+            },
+            &mut engine,
+            resolved_editor_mut(&mut adapter),
+            PianoRollCtx::default(),
+        );
+        resolved_editor_mut(&mut adapter).update(
+            &mut project_tracks,
+            ArrangementMsg::MoveNoteClipPosition {
+                track_id,
+                clip_id,
+                new_position_beats: 12.0,
+            },
+            &mut engine,
+            ArrangementCtx::default(),
+        );
+
+        let mut automation = AutomationState::default();
+        automation.update(
+            AutomationMsg::AddLane {
+                track_id,
+                target: AutomationTarget::TrackGain,
+            },
+            &mut engine,
+            &mut project_tracks,
+            resolved_editor_mut(&mut adapter),
+        );
+
+        let resolved = adapter.resolve_timeline();
+        let content = resolved
+            .editor
+            .timeline
+            .get(track_id)
+            .expect("resolved track content");
+        let clip = content
+            .note_clips
+            .iter()
+            .find(|clip| clip.id == clip_id)
+            .expect("shared note clip");
+        assert_eq!(clip.position_beats, 12.0);
+        assert_eq!(clip.notes.len(), 1);
+        assert_eq!(content.automation.len(), 1);
+    }
+
+    #[test]
+    fn arrange_adapter_satisfies_the_shared_editor_contract() {
+        assert_timeline_editor_conformance(ArrangementState::default());
+    }
+}

--- a/crates/vibez-ui/src/domains/view.rs
+++ b/crates/vibez-ui/src/domains/view.rs
@@ -6,8 +6,9 @@
 use vibez_core::id::{ClipId, TrackId};
 
 use crate::state::{
-    ArrangementTimeline, ContextMenuTarget, DetailPanelTab, SnapGrid, ViewState, Workspace,
+    ContextMenuTarget, DetailPanelTab, SnapGrid, TimelineEditorState, ViewState, Workspace,
 };
+use crate::timeline_geometry::{TimelineGeometry, BASE_PIXELS_PER_BEAT};
 
 /// Messages the view domain handles.
 #[derive(Debug, Clone)]
@@ -79,7 +80,7 @@ impl ViewState {
     pub fn update(
         &mut self,
         msg: ViewMsg,
-        timeline: &ArrangementTimeline,
+        timeline: &TimelineEditorState,
         ctx: ViewCtx,
     ) -> ViewAction {
         let mut action = ViewAction::default();
@@ -104,8 +105,9 @@ impl ViewState {
                 if content_beats > 0.0 {
                     // Conservative estimate of canvas width (window minus track headers)
                     let canvas_width = 1400.0_f32;
-                    let target_ppb = canvas_width / content_beats as f32;
-                    self.zoom_level = (target_ppb / 20.0).clamp(0.01, 16.0);
+                    let target_ppb = TimelineGeometry::fitted(content_beats, canvas_width, 0.0)
+                        .pixels_per_beat();
+                    self.zoom_level = (target_ppb / BASE_PIXELS_PER_BEAT).clamp(0.01, 16.0);
                     self.scroll_offset_beats = 0.0;
                 }
             }
@@ -248,13 +250,13 @@ mod tests {
         let mut v = ViewState::default();
         v.update(
             ViewMsg::SetZoom(99.0),
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert_eq!(v.zoom_level, 16.0);
         v.update(
             ViewMsg::SetZoom(0.0),
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert_eq!(v.zoom_level, 0.01);
@@ -267,7 +269,7 @@ mod tests {
             scroll_offset_beats: 12.0,
             ..ViewState::default()
         };
-        let timeline = ArrangementTimeline::default();
+        let timeline = TimelineEditorState::default();
 
         for workspace in [Workspace::Perform, Workspace::Mix, Workspace::Arrange] {
             view.update(
@@ -287,13 +289,13 @@ mod tests {
         let ctx = ViewCtx { total_beats: 32.0 };
         v.update(
             ViewMsg::ScrollArrangement(100.0),
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ctx,
         );
         assert_eq!(v.scroll_offset_beats, 32.0);
         v.update(
             ViewMsg::ScrollArrangement(-100.0),
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ctx,
         );
         assert_eq!(v.scroll_offset_beats, 0.0);
@@ -314,7 +316,7 @@ mod tests {
                     is_note_clip: false,
                 },
             },
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert!(v.context_menu.is_some());
@@ -325,7 +327,7 @@ mod tests {
     fn finish_editing_track_name_emits_rename() {
         let mut v = ViewState::default();
         let tid = TrackId::new();
-        let timeline = ArrangementTimeline::default();
+        let timeline = TimelineEditorState::default();
         v.update(
             ViewMsg::StartEditingTrackName {
                 track_id: tid,
@@ -358,7 +360,7 @@ mod tests {
                 track_id: bus_id,
                 name: "A Return".to_string(),
             },
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
 
@@ -375,31 +377,31 @@ mod tests {
 
         v.update(
             ViewMsg::NarrowGrid,
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert_eq!(v.snap_grid, SnapGrid::SIXTEENTH);
         v.update(
             ViewMsg::WidenGrid,
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert_eq!(v.snap_grid, SnapGrid::EIGHTH);
         v.update(
             ViewMsg::ToggleTripletGrid,
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert_eq!(v.snap_grid, SnapGrid::EIGHTH.triplet());
         v.update(
             ViewMsg::ToggleSnapToGrid,
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert!(!v.snap_enabled);
         v.update(
             ViewMsg::ToggleAdaptiveGrid,
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert!(v.adaptive_grid);
@@ -409,7 +411,7 @@ mod tests {
         );
         v.update(
             ViewMsg::NarrowGrid,
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert_eq!(
@@ -418,7 +420,7 @@ mod tests {
         );
         v.update(
             ViewMsg::WidenGrid,
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert_eq!(
@@ -436,7 +438,7 @@ mod tests {
         };
         let action = v.update(
             ViewMsg::CancelEditing,
-            &ArrangementTimeline::default(),
+            &TimelineEditorState::default(),
             ViewCtx::default(),
         );
         assert_eq!(v.editing_track_name, None);

--- a/crates/vibez-ui/src/lib.rs
+++ b/crates/vibez-ui/src/lib.rs
@@ -9,6 +9,7 @@ mod spectrum;
 mod state;
 mod theme;
 mod themes;
+mod timeline_geometry;
 mod typography;
 mod ui_settings;
 mod warp;

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -407,11 +407,11 @@ impl ProjectTracksState {
 /// stable identity. Hash-map storage prevents track reordering from moving or
 /// cloning timeline content.
 #[derive(Debug, Clone, Default)]
-pub struct ArrangementTimeline {
+pub struct TimelineContent {
     pub by_track: HashMap<TrackId, TrackTimelineContent>,
 }
 
-impl ArrangementTimeline {
+impl TimelineContent {
     pub fn get(&self, track_id: TrackId) -> Option<&TrackTimelineContent> {
         self.by_track.get(&track_id)
     }
@@ -429,10 +429,13 @@ impl ArrangementTimeline {
     }
 }
 
-/// Arrange-owned timeline content and editor interaction state.
+/// Backward-compatible name for the project's linear Arrange content.
+pub type ArrangementTimeline = TimelineContent;
+
+/// Editing state shared by every resolved musical timeline.
 #[derive(Debug)]
-pub struct ArrangementState {
-    pub timeline: Arc<ArrangementTimeline>,
+pub struct TimelineEditorState {
+    pub timeline: Arc<TimelineContent>,
     pub selected_track: Option<TrackId>,
     pub selected_clips: HashSet<ArrangementSelection>,
     pub selected_note_clip: Option<(TrackId, ClipId)>,
@@ -451,10 +454,10 @@ pub struct ArrangementState {
     pub clip_bpm_edit: HashMap<ClipId, String>,
 }
 
-impl Default for ArrangementState {
+impl Default for TimelineEditorState {
     fn default() -> Self {
         Self {
-            timeline: Arc::new(ArrangementTimeline::default()),
+            timeline: Arc::new(TimelineContent::default()),
             selected_track: None,
             selected_clips: HashSet::new(),
             selected_note_clip: None,
@@ -467,6 +470,52 @@ impl Default for ArrangementState {
             clip_bpm_edit: HashMap::new(),
         }
     }
+}
+
+impl std::ops::Deref for TimelineEditorState {
+    type Target = TimelineContent;
+
+    fn deref(&self) -> &Self::Target {
+        &self.timeline
+    }
+}
+
+impl std::ops::DerefMut for TimelineEditorState {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        Arc::make_mut(&mut self.timeline)
+    }
+}
+
+/// Arrange's thin adapter over the shared Timeline Editor state.
+#[derive(Debug, Default)]
+pub struct ArrangementState {
+    pub(crate) editor: TimelineEditorState,
+}
+
+impl std::ops::Deref for ArrangementState {
+    type Target = TimelineEditorState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.editor
+    }
+}
+
+impl std::ops::DerefMut for ArrangementState {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.editor
+    }
+}
+
+/// An adapter-resolved, read-only Timeline Editor target.
+#[derive(Debug, Clone, Copy)]
+pub struct ResolvedTimeline<'a> {
+    pub editor: &'a TimelineEditorState,
+}
+
+/// An adapter-resolved, mutable Timeline Editor target.
+#[derive(Debug)]
+pub struct ResolvedTimelineMut<'a> {
+    pub editor: &'a mut TimelineEditorState,
 }
 
 pub struct AppState {
@@ -610,25 +659,41 @@ impl AppState {
     /// Pixels per beat at the current zoom level.
     #[allow(dead_code)]
     pub fn pixels_per_beat(&self) -> f32 {
-        20.0 * self.view.zoom_level
+        crate::timeline_geometry::TimelineGeometry::from_zoom(
+            self.view.zoom_level,
+            self.view.scroll_offset_beats,
+        )
+        .pixels_per_beat()
     }
 
     /// Number of beats visible in a canvas of the given width.
     #[allow(dead_code)]
     pub fn visible_beats(&self, canvas_width: f32) -> f64 {
-        canvas_width as f64 / self.pixels_per_beat() as f64
+        crate::timeline_geometry::TimelineGeometry::from_zoom(
+            self.view.zoom_level,
+            self.view.scroll_offset_beats,
+        )
+        .visible_beats(canvas_width)
     }
 
     /// Convert a beat value to a pixel x coordinate in the viewport.
     #[allow(dead_code)]
     pub fn beat_to_x(&self, beat: f64) -> f32 {
-        ((beat - self.view.scroll_offset_beats) * self.pixels_per_beat() as f64) as f32
+        crate::timeline_geometry::TimelineGeometry::from_zoom(
+            self.view.zoom_level,
+            self.view.scroll_offset_beats,
+        )
+        .beat_to_x(beat)
     }
 
     /// Convert a pixel x coordinate in the viewport to a beat value.
     #[allow(dead_code)]
     pub fn x_to_beat(&self, x: f32) -> f64 {
-        x as f64 / self.pixels_per_beat() as f64 + self.view.scroll_offset_beats
+        crate::timeline_geometry::TimelineGeometry::from_zoom(
+            self.view.zoom_level,
+            self.view.scroll_offset_beats,
+        )
+        .x_to_beat(x)
     }
 
     /// Total duration in beats across all tracks, with generous padding.

--- a/crates/vibez-ui/src/timeline_geometry.rs
+++ b/crates/vibez-ui/src/timeline_geometry.rs
@@ -1,0 +1,85 @@
+//! Shared beat/pixel geometry for every timeline editor surface.
+
+/// Arrange's baseline horizontal scale before zoom is applied.
+pub const BASE_PIXELS_PER_BEAT: f32 = 20.0;
+
+/// A resolved horizontal timeline viewport.
+///
+/// Widgets may use a zoom-derived scale (Arrange) or a fitted scale (piano
+/// roll), but all beat/pixel conversion goes through this value type.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TimelineGeometry {
+    pixels_per_beat: f32,
+    scroll_offset_beats: f64,
+    origin_x: f32,
+}
+
+impl TimelineGeometry {
+    pub fn new(pixels_per_beat: f32, scroll_offset_beats: f64) -> Self {
+        Self {
+            pixels_per_beat: pixels_per_beat.max(f32::EPSILON),
+            scroll_offset_beats,
+            origin_x: 0.0,
+        }
+    }
+
+    pub fn from_zoom(zoom_level: f32, scroll_offset_beats: f64) -> Self {
+        Self::new(BASE_PIXELS_PER_BEAT * zoom_level, scroll_offset_beats)
+    }
+
+    pub fn fitted(total_beats: f64, viewport_width: f32, origin_x: f32) -> Self {
+        let usable_width = (viewport_width - origin_x).max(1.0);
+        Self {
+            pixels_per_beat: usable_width / total_beats.max(1.0) as f32,
+            scroll_offset_beats: 0.0,
+            origin_x,
+        }
+    }
+
+    pub fn pixels_per_beat(self) -> f32 {
+        self.pixels_per_beat
+    }
+
+    pub fn visible_beats(self, width: f32) -> f64 {
+        (width - self.origin_x).max(0.0) as f64 / self.pixels_per_beat as f64
+    }
+
+    pub fn beat_to_x(self, beat: f64) -> f32 {
+        self.origin_x + ((beat - self.scroll_offset_beats) * self.pixels_per_beat as f64) as f32
+    }
+
+    pub fn x_to_beat(self, x: f32) -> f64 {
+        (x - self.origin_x) as f64 / self.pixels_per_beat as f64 + self.scroll_offset_beats
+    }
+
+    pub fn width_for_beats(self, beats: f64) -> f32 {
+        (beats * self.pixels_per_beat as f64) as f32
+    }
+
+    pub fn beats_for_width(self, pixels: f32) -> f64 {
+        pixels as f64 / self.pixels_per_beat as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zoomed_geometry_round_trips_with_scroll() {
+        let geometry = TimelineGeometry::from_zoom(2.0, 8.0);
+        assert_eq!(geometry.pixels_per_beat(), 40.0);
+        assert_eq!(geometry.beat_to_x(10.0), 80.0);
+        assert_eq!(geometry.x_to_beat(80.0), 10.0);
+        assert_eq!(geometry.visible_beats(400.0), 10.0);
+    }
+
+    #[test]
+    fn fitted_geometry_accounts_for_a_fixed_header() {
+        let geometry = TimelineGeometry::fitted(16.0, 852.0, 52.0);
+        assert_eq!(geometry.pixels_per_beat(), 50.0);
+        assert_eq!(geometry.beat_to_x(4.0), 252.0);
+        assert_eq!(geometry.x_to_beat(252.0), 4.0);
+        assert_eq!(geometry.width_for_beats(2.0), 100.0);
+    }
+}

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -23,6 +23,7 @@ use crate::domains::automation::AutomationMsg;
 use crate::message::Message;
 use crate::state::GridConfig;
 use crate::theme as th;
+use crate::timeline_geometry::TimelineGeometry;
 use crate::widgets::double_click::DoubleClick;
 use crate::widgets::local_drag::LocalDrag;
 
@@ -69,16 +70,20 @@ pub struct LaneInteraction {
 }
 
 impl AutomationLaneWidget {
+    fn geometry(&self) -> TimelineGeometry {
+        TimelineGeometry::from_zoom(self.zoom_level, self.scroll_offset_beats)
+    }
+
     fn pixels_per_beat(&self) -> f32 {
-        20.0 * self.zoom_level
+        self.geometry().pixels_per_beat()
     }
 
     fn beat_to_x(&self, beat: f64) -> f32 {
-        ((beat - self.scroll_offset_beats) * self.pixels_per_beat() as f64) as f32
+        self.geometry().beat_to_x(beat)
     }
 
     fn x_to_beat(&self, x: f32) -> f64 {
-        (x as f64 / self.pixels_per_beat() as f64 + self.scroll_offset_beats).max(0.0)
+        self.geometry().x_to_beat(x).max(0.0)
     }
 
     /// Cursor x to beat, snapped to the grid unless shift is held.

--- a/crates/vibez-ui/src/widgets/piano_roll/draw.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/draw.rs
@@ -33,7 +33,8 @@ impl PianoRollWidget {
         let h = bounds.height;
         let grid_width = w - KEY_WIDTH;
         let total = self.total_beats.max(1.0);
-        let grid_ppb = grid_width / total as f32;
+        let geometry = self.geometry(&bounds);
+        let grid_ppb = geometry.pixels_per_beat();
 
         // Full background
         frame.fill_rectangle(iced::Point::ORIGIN, iced::Size::new(w, h), theme::bg_dark());
@@ -212,7 +213,7 @@ impl PianoRollWidget {
         for step in 0..=num_steps {
             let beat = step as f64 * grid_step;
             // Snap to half-pixel for crisp 1px rendering (avoids blurry subpixel splits)
-            let x = (KEY_WIDTH + (beat / total) as f32 * grid_width).floor() + 0.5;
+            let x = geometry.beat_to_x(beat).floor() + 0.5;
             if x > w {
                 break;
             }
@@ -312,7 +313,7 @@ impl PianoRollWidget {
 
                 let x = self.beat_to_x(note.start_beat, &bounds);
                 let y = self.pitch_to_y(note.pitch);
-                let note_w = ((note.duration_beats / total) as f32 * grid_width).max(4.0);
+                let note_w = geometry.width_for_beats(note.duration_beats).max(4.0);
                 let note_h = KEY_HEIGHT - 1.0;
 
                 // Skip off-screen notes
@@ -415,7 +416,7 @@ impl PianoRollWidget {
 
                         let gx = self.beat_to_x(ghost_beat, &bounds);
                         let gy = self.pitch_to_y(note.pitch);
-                        let gw = ((note.duration_beats / total) as f32 * grid_width).max(4.0);
+                        let gw = geometry.width_for_beats(note.duration_beats).max(4.0);
                         let gh = KEY_HEIGHT - 1.0;
 
                         if gy + gh < RULER_HEIGHT || gy > h {
@@ -481,7 +482,7 @@ impl PianoRollWidget {
         // Ruler tick marks and labels
         for step in 0..=num_steps {
             let beat = step as f64 * grid_step;
-            let x = (KEY_WIDTH + (beat / total) as f32 * grid_width).floor() + 0.5;
+            let x = geometry.beat_to_x(beat).floor() + 0.5;
             if x > w {
                 break;
             }

--- a/crates/vibez-ui/src/widgets/piano_roll/mod.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/mod.rs
@@ -8,6 +8,7 @@ use iced::{Color, Point, Rectangle, Renderer, Theme};
 use crate::domains::piano_roll::PianoRollMsg;
 use crate::message::Message;
 use crate::state::{GridConfig, PianoRollEditMode, SnapGrid, UiNoteClip};
+use crate::timeline_geometry::TimelineGeometry;
 use crate::widgets::double_click::DoubleClick;
 use crate::widgets::local_drag::LocalDrag;
 use vibez_core::id::{ClipId, TrackId};
@@ -103,20 +104,20 @@ impl PianoRollWidget {
         }
     }
 
+    fn geometry(&self, bounds: &Rectangle) -> TimelineGeometry {
+        TimelineGeometry::fitted(self.total_beats, bounds.width, KEY_WIDTH)
+    }
+
     fn beat_to_x(&self, beat: f64, bounds: &Rectangle) -> f32 {
-        let grid_width = bounds.width - KEY_WIDTH;
-        let total = self.total_beats.max(1.0);
-        KEY_WIDTH + (beat / total) as f32 * grid_width
+        self.geometry(bounds).beat_to_x(beat)
     }
 
     fn x_to_beat(&self, x: f32, bounds: &Rectangle) -> f64 {
-        let grid_width = bounds.width - KEY_WIDTH;
-        let total = self.total_beats.max(1.0);
-        ((x - KEY_WIDTH) / grid_width) as f64 * total
+        self.geometry(bounds).x_to_beat(x)
     }
 
     fn pixels_per_beat(&self, bounds: &Rectangle) -> f32 {
-        (bounds.width - KEY_WIDTH) / self.total_beats.max(1.0) as f32
+        self.geometry(bounds).pixels_per_beat()
     }
 
     fn effective_grid(&self, bounds: &Rectangle) -> SnapGrid {
@@ -141,8 +142,7 @@ impl PianoRollWidget {
     /// Hit test: find note at position, return (index, near_right_edge).
     fn hit_test_note(&self, pos: Point, bounds: &Rectangle) -> Option<(usize, bool)> {
         let clip_data = self.clip.as_ref()?;
-        let grid_width = bounds.width - KEY_WIDTH;
-        let total = self.total_beats.max(1.0);
+        let geometry = self.geometry(bounds);
 
         for (idx, note) in clip_data.notes.iter().enumerate() {
             if !(LOW_NOTE..HIGH_NOTE).contains(&note.pitch) {
@@ -151,7 +151,7 @@ impl PianoRollWidget {
 
             let x = self.beat_to_x(note.start_beat, bounds);
             let y = self.pitch_to_y(note.pitch);
-            let note_w = ((note.duration_beats / total) as f32 * grid_width).max(4.0);
+            let note_w = geometry.width_for_beats(note.duration_beats).max(4.0);
             let note_h = KEY_HEIGHT - 1.0;
 
             if pos.x >= x && pos.x <= x + note_w && pos.y >= y + 0.5 && pos.y <= y + 0.5 + note_h {
@@ -528,9 +528,7 @@ impl canvas::Program<Message> for PianoRollWidget {
 
                     if let Some(ref drag) = state.drag {
                         if let Some(ref clip_data) = self.clip {
-                            let grid_width = bounds.width - KEY_WIDTH;
-                            let total = self.total_beats.max(1.0);
-                            let beats_per_pixel = total / grid_width as f64;
+                            let geometry = self.geometry(&bounds);
 
                             match drag {
                                 DragAction::MoveNote {
@@ -543,7 +541,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                                 } => {
                                     let dx = local.x - start_x;
                                     let dy = local.y - start_y;
-                                    let beat_delta = dx as f64 * beats_per_pixel;
+                                    let beat_delta = geometry.beats_for_width(dx);
                                     let pitch_delta = -(dy / KEY_HEIGHT).round() as i16;
 
                                     let anchor_new_beat = self
@@ -583,7 +581,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                                     start_x,
                                 } => {
                                     let dx = local.x - start_x;
-                                    let beat_delta = dx as f64 * beats_per_pixel;
+                                    let beat_delta = geometry.beats_for_width(dx);
                                     let min_duration = if self.grid.snap_enabled {
                                         self.effective_grid(&bounds).beat_size()
                                     } else {
@@ -619,7 +617,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                                 } => {
                                     // Extend note duration while dragging
                                     let dx = local.x - start_x;
-                                    let beat_delta = dx as f64 * beats_per_pixel;
+                                    let beat_delta = geometry.beats_for_width(dx);
                                     let min_duration = self.effective_grid(&bounds).beat_size();
                                     let new_duration = self
                                         .snapped_beat(
@@ -679,13 +677,11 @@ impl canvas::Program<Message> for PianoRollWidget {
                         if original_notes.len() > 1 {
                             if let Some(ref clip_data) = self.clip {
                                 if let Some(pos) = state.last_cursor {
-                                    let grid_width = bounds.width - KEY_WIDTH;
-                                    let total = self.total_beats.max(1.0);
-                                    let beats_per_pixel = total / grid_width as f64;
+                                    let geometry = self.geometry(&bounds);
 
                                     let dx = pos.x - start_x;
                                     let dy = pos.y - start_y;
-                                    let beat_delta = dx as f64 * beats_per_pixel;
+                                    let beat_delta = geometry.beats_for_width(dx);
                                     let pitch_delta = -(dy / KEY_HEIGHT).round() as i16;
 
                                     let anchor_new_beat = self

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -16,6 +16,7 @@ use crate::state::{
     ArrangementSelection, ContextMenuTarget, GridConfig, ProjectTrack, TrackTimelineContent,
     UndoGestureId,
 };
+use crate::timeline_geometry::TimelineGeometry;
 use crate::widgets::local_drag::LocalDrag;
 use vibez_core::id::{ClipId, TrackId};
 
@@ -197,16 +198,20 @@ impl TrackClipCanvas {
         }
     }
 
+    pub(super) fn geometry(&self) -> TimelineGeometry {
+        TimelineGeometry::from_zoom(self.zoom_level, self.scroll_offset_beats)
+    }
+
     pub(super) fn pixels_per_beat(&self) -> f32 {
-        20.0 * self.zoom_level
+        self.geometry().pixels_per_beat()
     }
 
     pub(super) fn beat_to_x(&self, beat: f64) -> f32 {
-        ((beat - self.scroll_offset_beats) * self.pixels_per_beat() as f64) as f32
+        self.geometry().beat_to_x(beat)
     }
 
     pub(super) fn x_to_beat(&self, x: f32) -> f64 {
-        x as f64 / self.pixels_per_beat() as f64 + self.scroll_offset_beats
+        self.geometry().x_to_beat(x)
     }
 
     pub(super) fn snapped_beat(&self, beat: f64) -> f64 {
@@ -225,7 +230,7 @@ impl TrackClipCanvas {
     /// Hit test: find a clip at the given pixel x position.
     /// Returns (clip_id, is_note_clip, near_right_edge, position_beats, duration_beats).
     pub(super) fn hit_test(&self, pos_x: f32) -> Option<(ClipId, bool, bool, f64, f64)> {
-        let ppb = self.pixels_per_beat();
+        let geometry = self.geometry();
         let spb = self.spb();
 
         // Check audio clips
@@ -233,7 +238,7 @@ impl TrackClipCanvas {
             let clip_start_beat = clip.position as f64 / spb;
             let clip_dur_beats = clip.duration as f64 / spb;
             let clip_x = self.beat_to_x(clip_start_beat);
-            let clip_w = (clip_dur_beats * ppb as f64) as f32;
+            let clip_w = geometry.width_for_beats(clip_dur_beats);
 
             if pos_x >= clip_x && pos_x <= clip_x + clip_w {
                 let near_right = pos_x > clip_x + clip_w - RESIZE_EDGE_PX;
@@ -250,7 +255,7 @@ impl TrackClipCanvas {
         // Check note clips
         for note_clip in &self.note_clips {
             let clip_x = self.beat_to_x(note_clip.position_beats);
-            let clip_w = (note_clip.duration_beats * ppb as f64) as f32;
+            let clip_w = geometry.width_for_beats(note_clip.duration_beats);
 
             if pos_x >= clip_x && pos_x <= clip_x + clip_w {
                 let near_right = pos_x > clip_x + clip_w - RESIZE_EDGE_PX;
@@ -392,8 +397,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                     // Also surface the track as the selection target so subsequent
                     // browser imports / dropdowns know which lane is "active".
                     if bounds.width > 0.0 {
-                        let ppb = self.pixels_per_beat();
-                        let beat = pos.x as f64 / ppb as f64 + self.scroll_offset_beats;
+                        let beat = self.geometry().x_to_beat(pos.x);
                         state.drag = Some(ClipDragAction::PendingSeek {
                             beat,
                             start_x: pos.x,
@@ -432,8 +436,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                     if self.time_selection_active
                         && self.selection_end_beats > self.selection_start_beats
                     {
-                        let ppb = self.pixels_per_beat();
-                        let beat = pos.x as f64 / ppb as f64 + self.scroll_offset_beats;
+                        let beat = self.geometry().x_to_beat(pos.x);
                         if beat >= self.selection_start_beats && beat <= self.selection_end_beats {
                             return (
                                 canvas::event::Status::Captured,
@@ -467,7 +470,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                 if let Some(ref drag) = state.drag {
                     if let Some(local) = LocalDrag::unclamped().position(cursor, bounds) {
                         let local_x = local.x;
-                        let ppb = self.pixels_per_beat();
+                        let geometry = self.geometry();
 
                         match drag {
                             ClipDragAction::PendingSeek {
@@ -477,8 +480,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 let dx = (local_x - start_x).abs();
                                 if dx > 4.0 {
                                     let anchor_snapped = self.snapped_beat(*anchor);
-                                    let beat =
-                                        local_x as f64 / ppb as f64 + self.scroll_offset_beats;
+                                    let beat = geometry.x_to_beat(local_x);
                                     let current = self.snapped_beat(beat);
                                     let start = anchor_snapped.min(current);
                                     let end = anchor_snapped.max(current);
@@ -501,7 +503,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 return (canvas::event::Status::Captured, None);
                             }
                             ClipDragAction::RegionSelect { anchor_beat } => {
-                                let beat = local_x as f64 / ppb as f64 + self.scroll_offset_beats;
+                                let beat = geometry.x_to_beat(local_x);
                                 let current = self.snapped_beat(beat);
                                 let start = anchor_beat.min(current);
                                 let end = anchor_beat.max(current);
@@ -528,7 +530,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 start_y,
                             } => {
                                 let delta_px = local_x - start_local_x;
-                                let delta_beats = delta_px as f64 / ppb as f64;
+                                let delta_beats = geometry.beats_for_width(delta_px);
                                 let new_pos = (original_position_beats + delta_beats).max(0.0);
 
                                 let snapped = self.snapped_beat(new_pos);

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -5,6 +5,7 @@ use iced::widget::canvas;
 use iced::{Color, Rectangle, Renderer};
 
 use crate::theme;
+use crate::timeline_geometry::TimelineGeometry;
 
 use super::*;
 
@@ -70,7 +71,8 @@ impl TrackClipCanvas {
         let mut frame = canvas::Frame::new(renderer, bounds.size());
         let w = bounds.width;
         let h = bounds.height;
-        let ppb = self.pixels_per_beat();
+        let geometry = self.geometry();
+        let ppb = geometry.pixels_per_beat();
 
         // True when a sample drag is active and the cursor is hovering this
         // lane. Used to paint a drop indicator.
@@ -91,7 +93,7 @@ impl TrackClipCanvas {
 
         // Grid lines use the same effective division as interaction.
         if self.bpm > 0.0 {
-            let visible = w as f64 / ppb as f64;
+            let visible = geometry.visible_beats(w);
             let grid = self.grid.effective_grid(ppb);
             let step = grid.beat_size();
             let start = (self.scroll_offset_beats / step).floor().max(0.0) as i64;
@@ -134,7 +136,7 @@ impl TrackClipCanvas {
                 let clip_dur_beats = clip.duration as f64 / spb;
 
                 let clip_x = self.beat_to_x(clip_start_beat);
-                let clip_w = (clip_dur_beats * ppb as f64) as f32;
+                let clip_w = geometry.width_for_beats(clip_dur_beats);
 
                 // Skip clips entirely outside viewport
                 if clip_x + clip_w < 0.0 || clip_x > w {
@@ -187,7 +189,7 @@ impl TrackClipCanvas {
                     let mut repeat_beat = clip_start_beat + first_loop_offset_beats;
                     while repeat_beat < clip_start_beat + clip_dur_beats {
                         let rx = self.beat_to_x(repeat_beat);
-                        let rw = (loop_region_beats * ppb as f64) as f32;
+                        let rw = geometry.width_for_beats(loop_region_beats);
                         if rx < w && rx + rw > 0.0 {
                             frame.fill_rectangle(
                                 iced::Point::new(rx, clip_y),
@@ -323,7 +325,7 @@ impl TrackClipCanvas {
 
             for note_clip in &self.note_clips {
                 let clip_x = self.beat_to_x(note_clip.position_beats);
-                let clip_w = (note_clip.duration_beats * ppb as f64) as f32;
+                let clip_w = geometry.width_for_beats(note_clip.duration_beats);
 
                 // Skip clips outside viewport
                 if clip_x + clip_w < 0.0 || clip_x > w {
@@ -342,6 +344,8 @@ impl TrackClipCanvas {
 
                 // Draw note blocks inside the clip (below title bar)
                 if !note_clip.notes.is_empty() && clip_w > 4.0 {
+                    let clip_geometry =
+                        TimelineGeometry::fitted(note_clip.duration_beats, clip_w, 0.0);
                     let body_top = clip_y + CLIP_TITLE_HEIGHT;
                     let body_h = clip_h - CLIP_TITLE_HEIGHT;
                     let pitches: Vec<u8> = note_clip.notes.iter().map(|n| n.0).collect();
@@ -351,10 +355,8 @@ impl TrackClipCanvas {
 
                     for &(pitch, start_beat, duration_beats) in &note_clip.notes {
                         // start_beat is clip-local (0.0 = clip start)
-                        let note_x =
-                            clip_x + (start_beat / note_clip.duration_beats * clip_w as f64) as f32;
-                        let note_w =
-                            (duration_beats / note_clip.duration_beats * clip_w as f64) as f32;
+                        let note_x = clip_x + clip_geometry.beat_to_x(start_beat);
+                        let note_w = clip_geometry.width_for_beats(duration_beats);
                         let note_y_frac = (max_pitch.saturating_sub(pitch)) as f32 / pitch_range;
                         let note_y = body_top + 2.0 + note_y_frac * (body_h - 4.0);
                         let note_h = ((body_h - 4.0) / pitch_range).clamp(2.0, 6.0);
@@ -375,7 +377,7 @@ impl TrackClipCanvas {
                     let mut repeat_beat = note_clip.position_beats + note_clip.loop_end_beats;
                     while repeat_beat < note_clip.position_beats + note_clip.duration_beats {
                         let rx = self.beat_to_x(repeat_beat);
-                        let rw = (loop_len * ppb as f64) as f32;
+                        let rw = geometry.width_for_beats(loop_len);
                         if rx < w && rx + rw > 0.0 {
                             frame.fill_rectangle(
                                 iced::Point::new(rx, clip_y),
@@ -386,6 +388,8 @@ impl TrackClipCanvas {
 
                         // Draw ghost note blocks in this repeat (below title bar)
                         if !note_clip.notes.is_empty() && clip_w > 4.0 {
+                            let clip_geometry =
+                                TimelineGeometry::fitted(note_clip.duration_beats, clip_w, 0.0);
                             let gbody_top = clip_y + CLIP_TITLE_HEIGHT;
                             let gbody_h = clip_h - CLIP_TITLE_HEIGHT;
                             let pitches: Vec<u8> = note_clip.notes.iter().map(|n| n.0).collect();
@@ -401,13 +405,8 @@ impl TrackClipCanvas {
                                 {
                                     continue;
                                 }
-                                let gx = clip_x
-                                    + ((start_beat + offset) / note_clip.duration_beats
-                                        * clip_w as f64)
-                                        as f32;
-                                let gnw = (duration_beats / note_clip.duration_beats
-                                    * clip_w as f64)
-                                    as f32;
+                                let gx = clip_x + clip_geometry.beat_to_x(start_beat + offset);
+                                let gnw = clip_geometry.width_for_beats(duration_beats);
                                 let gy_frac = (gmax.saturating_sub(pitch)) as f32 / gpitch_range;
                                 let gy = gbody_top + 2.0 + gy_frac * (gbody_h - 4.0);
                                 let gnh = ((gbody_h - 4.0) / gpitch_range).clamp(2.0, 6.0);
@@ -601,7 +600,7 @@ impl TrackClipCanvas {
                 }
                 if drop_compatible {
                     if let Some(duration_beats) = self.sample_drop_duration_beats {
-                        let preview_width = (duration_beats * self.pixels_per_beat() as f64) as f32;
+                        let preview_width = geometry.width_for_beats(duration_beats);
                         let visible_width = preview_width.min((w - snapped_x).max(0.0));
                         if visible_width > 0.0 {
                             frame.fill_rectangle(

--- a/crates/vibez-ui/src/widgets/timeline/minimap.rs
+++ b/crates/vibez-ui/src/widgets/timeline/minimap.rs
@@ -7,6 +7,7 @@ use iced::{Color, Rectangle, Renderer, Theme};
 use crate::domains::view::ViewMsg;
 use crate::message::Message;
 use crate::theme;
+use crate::timeline_geometry::TimelineGeometry;
 
 /// Per-track data for the minimap overview.
 pub struct MinimapTrack {
@@ -30,8 +31,8 @@ pub struct ArrangementMinimap {
 
 impl ArrangementMinimap {
     fn visible_beats(&self, canvas_width: f32) -> f64 {
-        let ppb = 20.0 * self.zoom_level;
-        canvas_width as f64 / ppb as f64
+        TimelineGeometry::from_zoom(self.zoom_level, self.scroll_offset_beats)
+            .visible_beats(canvas_width)
     }
 }
 
@@ -75,7 +76,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
             return vec![frame.into_geometry()];
         }
 
-        let ppb_mini = w as f64 / self.total_beats;
+        let overview = TimelineGeometry::fitted(self.total_beats, w, 0.0);
         let num_tracks = self.tracks.len();
         let track_h = (h / num_tracks as f32).max(2.0);
 
@@ -84,8 +85,8 @@ impl canvas::Program<Message> for ArrangementMinimap {
             let y = i as f32 * track_h;
             let clip_color = theme::with_alpha(track.color, 0.6);
             for &(start, dur) in &track.clips {
-                let cx = (start * ppb_mini) as f32;
-                let cw = (dur * ppb_mini).max(1.0) as f32;
+                let cx = overview.beat_to_x(start);
+                let cw = overview.width_for_beats(dur).max(1.0);
                 if cx + cw < 0.0 || cx > w {
                     continue;
                 }
@@ -99,8 +100,8 @@ impl canvas::Program<Message> for ArrangementMinimap {
 
         // Loop region overlay
         if self.loop_enabled && self.loop_end_beats > self.loop_start_beats {
-            let lx1 = (self.loop_start_beats * ppb_mini) as f32;
-            let lx2 = (self.loop_end_beats * ppb_mini) as f32;
+            let lx1 = overview.beat_to_x(self.loop_start_beats);
+            let lx2 = overview.beat_to_x(self.loop_end_beats);
             let fill_x = lx1.max(0.0);
             let fill_w = lx2.min(w) - fill_x;
             if fill_w > 0.0 {
@@ -114,8 +115,8 @@ impl canvas::Program<Message> for ArrangementMinimap {
 
         // Viewport rectangle
         let visible = self.visible_beats(w);
-        let vx_start = (self.scroll_offset_beats * ppb_mini) as f32;
-        let vx_end = ((self.scroll_offset_beats + visible) * ppb_mini) as f32;
+        let vx_start = overview.beat_to_x(self.scroll_offset_beats);
+        let vx_end = overview.beat_to_x(self.scroll_offset_beats + visible);
         let vx = vx_start.max(0.0);
         let vw = vx_end.min(w) - vx;
         if vw > 0.0 {
@@ -145,7 +146,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
         }
 
         // Playhead line
-        let ph_x = (self.playhead_beats * ppb_mini) as f32;
+        let ph_x = overview.beat_to_x(self.playhead_beats);
         if ph_x >= 0.0 && ph_x <= w {
             let playhead =
                 canvas::Path::line(iced::Point::new(ph_x, 0.0), iced::Point::new(ph_x, h));
@@ -181,17 +182,17 @@ impl canvas::Program<Message> for ArrangementMinimap {
             return (canvas::event::Status::Ignored, None);
         }
 
-        let ppb_mini = bounds.width as f64 / self.total_beats;
+        let overview = TimelineGeometry::fitted(self.total_beats, bounds.width, 0.0);
         let visible = self.visible_beats(bounds.width);
 
         match event {
             canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
                 if let Some(pos) = cursor.position_in(bounds) {
-                    let click_beat = pos.x as f64 / ppb_mini;
+                    let click_beat = overview.x_to_beat(pos.x);
 
                     // Check if click is inside the viewport rectangle
-                    let vx_start = (self.scroll_offset_beats * ppb_mini) as f32;
-                    let vx_end = ((self.scroll_offset_beats + visible) * ppb_mini) as f32;
+                    let vx_start = overview.beat_to_x(self.scroll_offset_beats);
+                    let vx_end = overview.beat_to_x(self.scroll_offset_beats + visible);
 
                     if pos.x >= vx_start && pos.x <= vx_end {
                         // Start panning the viewport
@@ -222,7 +223,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
                                 start_scroll,
                             } => {
                                 let dx = local_x - start_x;
-                                let delta_beats = dx as f64 / ppb_mini;
+                                let delta_beats = overview.beats_for_width(dx);
                                 let target = (start_scroll + delta_beats).max(0.0);
                                 let delta = target - self.scroll_offset_beats;
                                 return (
@@ -231,7 +232,7 @@ impl canvas::Program<Message> for ArrangementMinimap {
                                 );
                             }
                             MinimapDragAction::Seeking => {
-                                let click_beat = local_x as f64 / ppb_mini;
+                                let click_beat = overview.x_to_beat(local_x);
                                 let target = (click_beat - visible / 2.0).max(0.0);
                                 let delta = target - self.scroll_offset_beats;
                                 return (
@@ -273,10 +274,10 @@ impl canvas::Program<Message> for ArrangementMinimap {
         }
 
         if let Some(pos) = cursor.position_in(bounds) {
-            let ppb_mini = bounds.width as f64 / self.total_beats;
+            let overview = TimelineGeometry::fitted(self.total_beats, bounds.width, 0.0);
             let visible = self.visible_beats(bounds.width);
-            let vx_start = (self.scroll_offset_beats * ppb_mini) as f32;
-            let vx_end = ((self.scroll_offset_beats + visible) * ppb_mini) as f32;
+            let vx_start = overview.beat_to_x(self.scroll_offset_beats);
+            let vx_end = overview.beat_to_x(self.scroll_offset_beats + visible);
 
             if pos.x >= vx_start && pos.x <= vx_end {
                 return mouse::Interaction::Grab;

--- a/crates/vibez-ui/src/widgets/timeline/ruler.rs
+++ b/crates/vibez-ui/src/widgets/timeline/ruler.rs
@@ -10,6 +10,7 @@ use crate::domains::view::ViewMsg;
 use crate::message::Message;
 use crate::state::{ContextMenuTarget, GridConfig};
 use crate::theme;
+use crate::timeline_geometry::TimelineGeometry;
 
 /// Canvas widget that draws a beat-based ruler with bar.beat labels.
 pub struct RulerWidget {
@@ -42,16 +43,20 @@ pub struct RulerInteractionState {
 }
 
 impl RulerWidget {
+    fn geometry(&self) -> TimelineGeometry {
+        TimelineGeometry::from_zoom(self.zoom_level, self.scroll_offset_beats)
+    }
+
     fn pixels_per_beat(&self) -> f32 {
-        20.0 * self.zoom_level
+        self.geometry().pixels_per_beat()
     }
 
     fn visible_beats(&self, width: f32) -> f64 {
-        width as f64 / self.pixels_per_beat() as f64
+        self.geometry().visible_beats(width)
     }
 
     fn beat_to_x(&self, beat: f64, _width: f32) -> f32 {
-        ((beat - self.scroll_offset_beats) * self.pixels_per_beat() as f64) as f32
+        self.geometry().beat_to_x(beat)
     }
 
     fn snapped_beat(&self, beat: f64) -> f64 {
@@ -336,8 +341,7 @@ impl canvas::Program<Message> for RulerWidget {
             // Left-click: PendingSeek (may become RegionSelect on drag)
             canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
                 if let Some(pos) = cursor.position_in(bounds) {
-                    let ppb = self.pixels_per_beat();
-                    let beat = pos.x as f64 / ppb as f64 + self.scroll_offset_beats;
+                    let beat = self.geometry().x_to_beat(pos.x);
                     state.drag = Some(RulerDragAction::PendingSeek {
                         beat,
                         start_x: pos.x,
@@ -350,8 +354,7 @@ impl canvas::Program<Message> for RulerWidget {
                 if let Some(ref drag) = state.drag {
                     if let Some(pos) = cursor.position() {
                         let local_x = pos.x - bounds.x;
-                        let ppb = self.pixels_per_beat();
-                        let beat = local_x as f64 / ppb as f64 + self.scroll_offset_beats;
+                        let beat = self.geometry().x_to_beat(local_x);
 
                         // Auto-scroll when dragging near ruler edges
                         if matches!(drag, RulerDragAction::RegionSelect { .. }) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,19 +126,37 @@ Project Tracks exist once per project. `ProjectTracksState` owns their stable
 `TrackId`, channel name/type, instruments, effects, routing, sends, and mixer
 state. Arrange does not own or duplicate those channels.
 
-`ArrangementState` instead owns an `ArrangementTimeline`: a separate store
-keyed by the shared `TrackId`. Each `TrackTimelineContent` contains only the
-audio clips, note clips, and automation associated with that Project Track in
-Arrange. Track order is therefore independent from timeline storage, and a
-timeline edit cannot clone instruments, effects, routing, or mixer state.
+`TimelineContent` is the separate musical-content store keyed by shared
+`TrackId`. Each `TrackTimelineContent` contains only the audio clips, note
+clips, and automation associated with that Project Track in one timeline.
+Track order is therefore independent from timeline storage, and a timeline
+edit cannot clone instruments, effects, routing, or mixer state.
+
+`TimelineEditorState` is the shared editing boundary around that content. It
+owns clip/note selection, the clipboard, time selection, and other interaction
+state; clip operations, piano-roll editing, automation editing, and timeline
+view behavior receive this already-resolved target. `ArrangementState` is a
+thin adapter that retains Arrange's Project Track/channel controls and
+implements `TimelineEditorAdapter` to resolve its editor. The editor never
+asks which workspace is active and contains no `Arrange | Section` branch, so
+a Section can provide the same adapter in the later authoring slice.
+
+Every horizontal editor surface uses `TimelineGeometry` for beat-to-pixel,
+pixel-to-beat, fitted viewport, visible-range, and beat-width conversions.
+Ruler, clip lanes, automation, piano roll, minimap, drag/drop, and auto-scroll
+therefore share one geometry implementation even when they use different
+resolved scales. A generic conformance harness currently runs against the
+Arrange adapter and is reusable unchanged by the Section adapter.
 
 ```mermaid
 flowchart LR
     PT["ProjectTracksState<br/>TrackId + channel/devices/mixer"]
-    AT["ArrangementTimeline<br/>TrackId → TrackTimelineContent"]
-    UI["Arrange editor selection/view state"]
-    PT -- "shared TrackId" --> AT
-    AT --> UI
+    AA["ArrangementState<br/>thin adapter + channel controls"]
+    TE["TimelineEditorState<br/>selection + resolved TimelineContent"]
+    TG["TimelineGeometry<br/>one beat/pixel layer"]
+    PT -- "shared TrackId" --> TE
+    AA -- "resolves once" --> TE
+    TG --> TE
 ```
 
 Undo snapshots retain the Project Track store and Arrange Timeline Content as


### PR DESCRIPTION
## Summary

- introduce a reusable `TimelineEditorState` resolved through a thin `TimelineEditorAdapter`, with Arrange as the first adapter
- route clip, selection, piano-roll, automation, and timeline-view behavior through the resolved editor without workspace branching
- centralize every beat/pixel conversion in `TimelineGeometry`
- add a generic editor conformance harness ready for Card 07's Section adapter
- document the shared editor boundary in `docs/ARCHITECTURE.md`

This is Card 05 only. It starts from merged Card 03/current `dev` (`bf106fc`) and is independent of open Card 04 PR #73. It adds no Sections or Perform-visible behavior.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -j4 -- -D warnings`
- `cargo test -p vibez-ui` — 236 passed
- `cargo test --workspace -j4`
- `cargo build --workspace -j4`
- `git diff --check`
- all touched Rust sources remain below 1,000 lines (largest: 983)
- native Arrange dogfood: project load, time selection, note-clip creation/cropping, piano-roll note authoring, and automation-lane authoring; no panic

## Review notes

The reusable conformance test is `domains::timeline_editor::conformance::assert_timeline_editor_conformance`. Card 07 should invoke that same harness for its Section adapter rather than introduce parallel editor behavior.
