### PR TITLE
feat(perform): author MIDI section content

### DIFF
--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -212,16 +212,62 @@ impl App {
             self.state.view.context_menu = None;
         }
         if let Some(sel) = action.select_note_clip {
-            self.state.arrangement.selected_note_clip = Some(sel);
+            if self.state.view.workspace == crate::state::Workspace::Perform
+                && self.state.perform.selected_section.is_some()
+            {
+                self.state
+                    .perform
+                    .section_editor
+                    .editor_mut()
+                    .selected_note_clip = Some(sel);
+                self.state
+                    .perform
+                    .section_editor
+                    .editor_mut()
+                    .selected_clips
+                    .clear();
+                self.state
+                    .perform
+                    .section_editor
+                    .editor_mut()
+                    .selected_clips
+                    .insert(ArrangementSelection::NoteClip {
+                        track_id: sel.0,
+                        clip_id: sel.1,
+                    });
+            } else {
+                self.state.arrangement.selected_note_clip = Some(sel);
+            }
+            self.state.arrangement.selected_track = Some(sel.0);
+            self.state.view.detail_panel_tab = DetailPanelTab::Clip;
         }
         if let Some(track_id) = action.select_track {
             self.state.arrangement.selected_track = Some(track_id);
+            if self.state.view.workspace == crate::state::Workspace::Perform
+                && self.state.perform.selected_section.is_some()
+            {
+                self.state
+                    .perform
+                    .section_editor
+                    .editor_mut()
+                    .selected_track = Some(track_id);
+            }
         }
         if let Some(beat) = action.scroll_to_beat {
             self.auto_scroll_to_beat(beat);
         }
         if action.drag_resize_active {
-            self.state.arrangement.drag_resize_active = true;
+            if self.state.view.workspace == crate::state::Workspace::Perform
+                && self.state.perform.selected_section.is_some()
+            {
+                self.state
+                    .perform
+                    .section_editor
+                    .editor_mut()
+                    .drag_resize_active = true;
+            } else {
+                self.state.arrangement.drag_resize_active = true;
+            }
         }
         if let Some(status) = action.status {
             self.state.status_text = status;

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -297,7 +297,7 @@ pub(crate) fn global_key_handler(
                     Some(Message::Arrangement(ArrangementMsg::AddTrack))
                 }
             }
-            "m" => Some(Message::create_clip_from_selection()),
+            "m" | "M" => Some(Message::create_clip_from_selection()),
             "e" => Some(Message::split_selected_at_playhead()),
             "j" => Some(Message::join_selected_clips()),
             "l" | "L" => {
@@ -380,6 +380,21 @@ mod tests {
         assert!(matches!(
             wider,
             Some(Message::Browser(BrowserMsg::NudgeDockWidth(delta))) if delta == 40.0
+        ));
+    }
+
+    #[test]
+    fn create_clip_shortcut_accepts_shifted_m() {
+        use iced::keyboard::{Key, Modifiers};
+
+        assert!(matches!(
+            global_key_handler(
+                Key::Character("M".into()),
+                Modifiers::CTRL | Modifiers::SHIFT
+            ),
+            Some(Message::Arrangement(
+                ArrangementMsg::CreateClipFromSelection
+            ))
         ));
     }
 

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -136,6 +136,7 @@ impl super::App {
             let ctx = crate::domains::perform::PerformCtx {
                 workspace_visible: self.state.view.workspace == crate::state::Workspace::Perform,
                 project_tracks: &self.state.project_tracks.tracks,
+                selected_project_track: self.state.arrangement.selected_track,
             };
             let action = {
                 let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -147,6 +147,7 @@ mod project_sections;
 mod update;
 mod update_media;
 mod update_remote;
+mod update_timeline;
 mod views_arrangement;
 mod views_browser;
 mod views_browser_audition;
@@ -158,6 +159,7 @@ mod views_devices;
 mod views_mixer;
 mod views_overlays;
 mod views_perform;
+mod views_perform_sections;
 mod views_settings;
 mod views_settings_perform;
 mod views_shell;
@@ -403,14 +405,19 @@ impl App {
     }
 
     pub(super) fn active_editor_pixels_per_beat(&self) -> f32 {
-        if let Some((track_id, clip_id)) = self.state.arrangement.selected_note_clip {
-            if let Some(duration) = self.state.arrange_content(track_id).and_then(|content| {
-                content
-                    .note_clips
-                    .iter()
-                    .find(|clip| clip.id == clip_id)
-                    .map(|clip| clip.duration_beats)
-            }) {
+        let editor = self.state.active_timeline_editor();
+        if let Some((track_id, clip_id)) = editor.selected_note_clip {
+            if let Some(duration) =
+                self.state
+                    .active_timeline_content(track_id)
+                    .and_then(|content| {
+                        content
+                            .note_clips
+                            .iter()
+                            .find(|clip| clip.id == clip_id)
+                            .map(|clip| clip.duration_beats)
+                    })
+            {
                 return crate::timeline_geometry::TimelineGeometry::fitted(
                     duration,
                     self.state.view.window_width,

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -58,6 +58,7 @@ impl App {
         self.state.arrangement.timeline = Arc::new(crate::state::ArrangementTimeline::default());
         self.state.perform.sections = Arc::new(crate::domains::perform::SectionStore::default());
         self.state.perform.selected_section = None;
+        self.state.perform.section_editor.clear();
         self.state.perform.editing_section_name = None;
         self.state.perform.section_name_edit.clear();
         self.state.perform.duplicate_source = None;
@@ -786,6 +787,9 @@ impl App {
             .sections
             .first()
             .map(|section| section.id);
+        self.state
+            .perform
+            .sync_selected_section_editor(self.state.arrangement.selected_track);
         self.state.perform.section_name_edit = self
             .state
             .perform

--- a/crates/vibez-ui/src/app/project_replay.rs
+++ b/crates/vibez-ui/src/app/project_replay.rs
@@ -107,6 +107,9 @@ impl App {
         self.state.arrangement.selected_clips = snapshot.selected_clips;
         self.state.arrangement.selected_note_clip = snapshot.selected_note_clip;
         self.state.perform.selected_section = snapshot.selected_section;
+        self.state
+            .perform
+            .sync_selected_section_editor(self.state.arrangement.selected_track);
         self.state.perform.section_name_edit = self
             .state
             .perform

--- a/crates/vibez-ui/src/app/project_sections.rs
+++ b/crates/vibez-ui/src/app/project_sections.rs
@@ -178,3 +178,48 @@ pub(super) fn legacy_automation_for_track(
         })
         .unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibez_core::id::{ClipId, TrackId};
+    use vibez_core::midi::MidiNote;
+
+    #[test]
+    fn authored_section_midi_projects_to_document_and_back() {
+        let track_id = TrackId::new();
+        let mut section = Section::new(2);
+        Arc::make_mut(&mut section.timeline)
+            .ensure(track_id)
+            .note_clips
+            .push(UiNoteClip {
+                id: ClipId::new(),
+                name: "Kick Pattern".into(),
+                position_beats: 0.0,
+                duration_beats: 16.0,
+                notes: vec![MidiNote {
+                    pitch: 36,
+                    velocity: 100,
+                    start_beat: 0.0,
+                    duration_beats: 0.25,
+                }],
+                selected_notes: [0].into_iter().collect(),
+                loop_enabled: true,
+                loop_start_beats: 0.0,
+                loop_end_beats: 4.0,
+            });
+
+        let info = section_info_from_ui(&section);
+        let restored = section_store_from_project(&[info]);
+        let clip = &restored.sections[0]
+            .timeline
+            .get(track_id)
+            .expect("restored MIDI lane")
+            .note_clips[0];
+
+        assert_eq!(clip.name, "Kick Pattern");
+        assert_eq!(clip.notes.len(), 1);
+        assert_eq!(clip.notes[0].pitch, 36);
+        assert!(clip.selected_notes.is_empty(), "selection is runtime-only");
+    }
+}

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -6,6 +6,7 @@ use iced::Task;
 use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::browser::BrowserMsg;
 use crate::domains::project::ProjectMsg;
+use crate::domains::timeline_editor::TimelineEditorAdapter;
 use crate::domains::transport::TransportMsg;
 use crate::domains::view::ViewMsg;
 use vibez_engine::commands::EngineCommand;
@@ -16,7 +17,6 @@ use crate::services::plugin_loader::{load_plugin_effect_bg, load_plugin_instrume
 use crate::message::Message;
 
 use super::*;
-use crate::domains::timeline_editor::TimelineEditorAdapter;
 
 impl App {
     pub(super) fn update(&mut self, message: Message) -> Task<Message> {
@@ -180,15 +180,7 @@ impl App {
                     playhead_samples: self.state.transport.position_samples,
                     playhead_beats: self.state.position_beats(),
                 };
-                let action = {
-                    let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
-                    self.state.arrangement.update(
-                        Arc::make_mut(&mut self.state.project_tracks),
-                        msg,
-                        &mut engine,
-                        ctx,
-                    )
-                };
+                let action = self.route_arrangement_editor_message(msg, ctx);
                 self.state
                     .perform
                     .sync_project_tracks(&self.state.project_tracks.tracks);
@@ -202,15 +194,7 @@ impl App {
                         .grid_config()
                         .effective_grid(self.active_editor_pixels_per_beat()),
                 };
-                let action = {
-                    let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
-                    self.state.piano_roll.update(
-                        msg,
-                        &mut engine,
-                        self.state.arrangement.resolve_timeline_mut().editor,
-                        ctx,
-                    )
-                };
+                let action = self.route_piano_roll_editor_message(msg, ctx);
                 self.apply_piano_roll_action(action);
             }
             Message::Browser(msg) => {
@@ -237,6 +221,7 @@ impl App {
                     workspace_visible: self.state.view.workspace
                         == crate::state::Workspace::Perform,
                     project_tracks: &self.state.project_tracks.tracks,
+                    selected_project_track: self.state.arrangement.selected_track,
                 };
                 let action = {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -35,10 +35,10 @@ impl App {
             ));
         }
         // Priority 2: selected notes in the open piano roll.
-        if let Some((track_id, clip_id)) = self.state.arrangement.selected_note_clip {
+        if let Some((track_id, clip_id)) = self.state.active_timeline_editor().selected_note_clip {
             let has_selection = self
                 .state
-                .arrange_content(track_id)
+                .active_timeline_content(track_id)
                 .and_then(|content| content.note_clips.iter().find(|c| c.id == clip_id))
                 .is_some_and(|c| !c.selected_notes.is_empty());
             if has_selection {
@@ -48,7 +48,12 @@ impl App {
             }
         }
         // Priority 3: selected arrangement clips.
-        if !self.state.arrangement.selected_clips.is_empty() {
+        if !self
+            .state
+            .active_timeline_editor()
+            .selected_clips
+            .is_empty()
+        {
             return self.update(Message::Arrangement(ArrangementMsg::DeleteSelectedClip));
         }
         Task::none()

--- a/crates/vibez-ui/src/app/update_timeline.rs
+++ b/crates/vibez-ui/src/app/update_timeline.rs
@@ -1,0 +1,94 @@
+//! Routes shared editor messages to the active Arrange or Section adapter.
+
+use std::sync::Arc;
+
+use crate::domains::arrangement::{ArrangementAction, ArrangementCtx, ArrangementMsg};
+use crate::domains::piano_roll::{PianoRollAction, PianoRollCtx, PianoRollMsg};
+use crate::domains::timeline_editor::TimelineEditorAdapter;
+use crate::state::Workspace;
+
+use super::*;
+
+impl App {
+    pub(super) fn route_arrangement_editor_message(
+        &mut self,
+        msg: ArrangementMsg,
+        ctx: ArrangementCtx,
+    ) -> ArrangementAction {
+        let editing_section = self.state.view.workspace == Workspace::Perform
+            && self.state.perform.selected_section.is_some();
+        if editing_section {
+            if let ArrangementMsg::SelectTrack(track_id) = &msg {
+                self.state.arrangement.selected_track = Some(*track_id);
+                self.state
+                    .perform
+                    .section_editor
+                    .editor_mut()
+                    .selected_track = Some(*track_id);
+                return ArrangementAction::default();
+            }
+        }
+        if editing_section && msg.is_timeline_editor_message() {
+            let mut engine = crate::domains::DiscardingEngine;
+            let action = self.state.perform.section_editor.editor_mut().update(
+                Arc::make_mut(&mut self.state.project_tracks),
+                msg,
+                &mut engine,
+                ctx,
+            );
+            self.state.perform.commit_selected_section_timeline();
+            if let Some(track_id) = self.state.perform.section_editor.editor().selected_track {
+                self.state.arrangement.selected_track = Some(track_id);
+            }
+            action
+        } else {
+            let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+            self.state.arrangement.update(
+                Arc::make_mut(&mut self.state.project_tracks),
+                msg,
+                &mut engine,
+                ctx,
+            )
+        }
+    }
+
+    pub(super) fn route_piano_roll_editor_message(
+        &mut self,
+        msg: PianoRollMsg,
+        ctx: PianoRollCtx,
+    ) -> PianoRollAction {
+        let editing_section = self.state.view.workspace == Workspace::Perform
+            && self.state.perform.selected_section.is_some();
+        if editing_section {
+            if let PianoRollMsg::AddNoteClipToTrack(track_id) = &msg {
+                let midi_track = self
+                    .state
+                    .project_tracks
+                    .tracks
+                    .iter()
+                    .any(|track| track.id == *track_id && track.kind.is_midi());
+                if !midi_track {
+                    self.state.status_text = "MIDI clips require a MIDI Project Track".into();
+                    return PianoRollAction::default();
+                }
+            }
+            let mut engine = crate::domains::DiscardingEngine;
+            let action = self.state.piano_roll.update(
+                msg,
+                &mut engine,
+                self.state.perform.section_editor.editor_mut(),
+                ctx,
+            );
+            self.state.perform.commit_selected_section_timeline();
+            action
+        } else {
+            let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+            self.state.piano_roll.update(
+                msg,
+                &mut engine,
+                self.state.arrangement.resolve_timeline_mut().editor,
+                ctx,
+            )
+        }
+    }
+}

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -25,9 +25,10 @@ impl App {
     // ── Detail panel (Ableton-style device chain) ──
 
     pub(super) fn view_detail_panel(&self) -> Element<'_, Message> {
+        let editor = self.state.active_timeline_editor();
         let detail_content: Element<'_, Message> = if let Some(track) = self
             .state
-            .arrangement
+            .active_timeline_editor()
             .selected_track
             .and_then(|id| self.state.find_track(id))
         {
@@ -97,11 +98,11 @@ impl App {
                     let is_midi = track.kind.is_midi();
                     // Check for note clip selection on this MIDI track
                     let has_note_clip = is_midi
-                        && (self.state.arrangement.selected_clips.iter().any(|s| {
+                        && (editor.selected_clips.iter().any(|s| {
                             matches!(s, ArrangementSelection::NoteClip { track_id: tid, .. } if *tid == track_id)
                         }) || self
                             .state
-                            .arrangement
+                            .active_timeline_editor()
                             .selected_note_clip
                             .is_some_and(|(tid, _)| tid == track_id));
 
@@ -109,22 +110,22 @@ impl App {
                         self.view_piano_roll_panel(track_id, track_color)
                     } else {
                         // Find a single selected audio clip on this track
-                        let audio_sel =
-                            self.state
-                                .arrangement
-                                .selected_clips
-                                .iter()
-                                .find_map(|s| match s {
-                                    ArrangementSelection::AudioClip {
-                                        track_id: tid,
-                                        clip_id: cid,
-                                    } if *tid == track_id => Some(*cid),
-                                    _ => None,
-                                });
+                        let audio_sel = self
+                            .state
+                            .active_timeline_editor()
+                            .selected_clips
+                            .iter()
+                            .find_map(|s| match s {
+                                ArrangementSelection::AudioClip {
+                                    track_id: tid,
+                                    clip_id: cid,
+                                } if *tid == track_id => Some(*cid),
+                                _ => None,
+                            });
                         if let Some(sel_cid) = audio_sel {
                             if let Some(clip) = self
                                 .state
-                                .arrange_content(track_id)
+                                .active_timeline_content(track_id)
                                 .and_then(|content| content.clips.iter().find(|c| c.id == sel_cid))
                             {
                                 self.view_audio_clip_panel(track_id, clip, track_color)
@@ -157,6 +158,10 @@ impl App {
         // cards or demanded ugly vertical scrollbars.
         let panel_height = if self.state.view.detail_panel_tab == DetailPanelTab::Devices {
             Length::Fixed(th::DEVICE_BODY_H + 96.0)
+        } else if self.state.view.workspace == crate::state::Workspace::Perform
+            && self.state.perform.section_timeline_expanded
+        {
+            Length::FillPortion(1)
         } else {
             Length::FillPortion(2)
         };
@@ -197,10 +202,10 @@ impl App {
 
         // Extract clip data as owned values (avoids lifetime conflicts with widget construction)
         let clip_data: Option<(String, f64, f64, bool, TrackId, ClipId)> =
-            if let Some((tid, cid)) = self.state.arrangement.selected_note_clip {
+            if let Some((tid, cid)) = self.state.active_timeline_editor().selected_note_clip {
                 if tid == track_id {
                     self.state
-                        .arrange_content(track_id)
+                        .active_timeline_content(track_id)
                         .and_then(|content| content.note_clips.iter().find(|c| c.id == cid))
                         .map(|c| {
                             (
@@ -220,7 +225,7 @@ impl App {
             };
 
         let piano_widget = if let Some(ref cd) = clip_data {
-            if let Some(content) = self.state.arrange_content(track_id) {
+            if let Some(content) = self.state.active_timeline_content(track_id) {
                 if let Some(clip) = content.note_clips.iter().find(|c| c.id == cd.5) {
                     let clip_relative_playhead = playhead_beats - clip.position_beats;
                     PianoRollWidget::from_clip(

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -1,9 +1,8 @@
-//! Perform workspace shell: mode selector, 4x4 Pad Surface, and the empty
-//! Section construction area. Musical behavior arrives in later cards.
+//! Perform workspace shell, Pad Surface, and shared Section Timeline Editor.
 
 use iced::widget::{
-    button, center, column, container, horizontal_space, mouse_area, pick_list, row, scrollable,
-    stack, text, text_input, tooltip,
+    button, center, column, container, horizontal_space, mouse_area, pick_list, row, text,
+    text_input, tooltip,
 };
 use iced::{Element, Length, Shadow, Theme, Vector};
 
@@ -20,8 +19,8 @@ const MODE_SELECTOR_INSET: f32 = 17.0;
 const MODE_TAB_MIN_WIDTH: f32 = 108.0;
 const MODE_TAB_MAX_WIDTH: f32 = 132.0;
 const PAD_SURFACE_WIDTH_SHARE: f32 = 0.4;
-const SECTION_TRACK_GUTTER_WIDTH: f32 = 112.0;
-const SECTION_BAR_WIDTH: f32 = 160.0;
+pub(super) const SECTION_TRACK_GUTTER_WIDTH: f32 = 112.0;
+pub(super) const SECTION_BAR_WIDTH: f32 = 160.0;
 
 fn perform_tool_button(
     icon: char,
@@ -114,7 +113,13 @@ impl App {
 
         container(column![mode_selector, workspace].height(Length::Fill))
             .width(Length::Fill)
-            .height(Length::FillPortion(5))
+            .height(Length::FillPortion(
+                if self.state.perform.section_timeline_expanded {
+                    6
+                } else {
+                    5
+                },
+            ))
             .style(|_theme: &Theme| container::Style {
                 background: Some(th::bg_dark().into()),
                 border: iced::Border {
@@ -501,7 +506,7 @@ impl App {
         }
     }
 
-    fn view_section_toolbar(&self, section: Option<&Section>) -> Element<'_, Message> {
+    pub(super) fn view_section_toolbar(&self, section: Option<&Section>) -> Element<'_, Message> {
         let Some(section) = section else {
             return container(row![
                 column![
@@ -698,6 +703,17 @@ impl App {
             self.state.perform.duplicate_source == Some(section.id),
             false,
         );
+        let expand = perform_tool_button(
+            icons::LAYOUT_LIST,
+            if self.state.perform.section_timeline_expanded {
+                "Return to compact Section overview"
+            } else {
+                "Expand the Section timeline"
+            },
+            Message::Perform(PerformMsg::ToggleSectionTimelineExpanded),
+            self.state.perform.section_timeline_expanded,
+            false,
+        );
         let delete = perform_tool_button(
             icons::TRASH_2,
             "Delete Section",
@@ -721,6 +737,8 @@ impl App {
                 launch,
                 divider(),
                 loop_toggle,
+                divider(),
+                expand,
                 divider(),
                 duplicate,
                 divider(),
@@ -764,210 +782,6 @@ impl App {
                 },
                 ..Default::default()
             })
-            .into()
-    }
-
-    fn view_section_construction(&self) -> Element<'_, Message> {
-        let selected = self
-            .state
-            .perform
-            .selected_section
-            .and_then(|id| self.state.perform.sections.by_id(id));
-        let toolbar = self.view_section_toolbar(selected);
-
-        let bar_count = selected
-            .map(|section| (section.length_beats / 4.0).round() as usize)
-            .unwrap_or(4)
-            .max(1);
-        let timeline_width = SECTION_BAR_WIDTH * bar_count as f32;
-        let ruler_number_color = th::blend(th::text_dim(), th::text(), 0.36);
-        let ruler_gutter = container(
-            text("PROJECT TRACK")
-                .font(PERFORM_TECH)
-                .size(8)
-                .color(th::blend(th::text_dim(), th::text(), 0.16)),
-        )
-        .width(Length::Fixed(SECTION_TRACK_GUTTER_WIDTH))
-        .height(Length::Fixed(30.0))
-        .padding([8, 10])
-        .style(|_theme: &Theme| container::Style {
-            background: Some(th::bg_surface().into()),
-            border: iced::Border {
-                color: th::perform_grid_line(),
-                width: 1.0,
-                radius: 0.0.into(),
-            },
-            ..Default::default()
-        });
-        let mut ruler_marks = row![]
-            .width(Length::Fixed(timeline_width))
-            .height(Length::Fixed(30.0));
-        for bar in 0..bar_count {
-            ruler_marks = ruler_marks.push(
-                container(
-                    text((bar + 1).to_string())
-                        .font(PERFORM_TECH_STRONG)
-                        .size(11)
-                        .color(ruler_number_color),
-                )
-                .width(Length::Fixed(SECTION_BAR_WIDTH))
-                .height(Length::Fixed(30.0))
-                .padding(8)
-                .style(|_theme: &Theme| container::Style {
-                    background: Some(th::bg_dark().into()),
-                    border: iced::Border {
-                        color: th::perform_grid_line(),
-                        width: 1.0,
-                        radius: 0.0.into(),
-                    },
-                    ..Default::default()
-                }),
-            );
-        }
-
-        let mut track_gutters = column![].width(Length::Fill).height(Length::Fill);
-        let mut timeline_tracks = column![]
-            .width(Length::Fixed(timeline_width))
-            .height(Length::Fill);
-        for index in 0..6_u8 {
-            let marker = container(horizontal_space())
-                .width(Length::Fixed(3.0))
-                .height(Length::Fixed(18.0))
-                .style(move |_theme: &Theme| container::Style {
-                    background: Some(th::with_alpha(th::track_color(index), 0.38).into()),
-                    ..Default::default()
-                });
-            let gutter =
-                container(row![marker, horizontal_space()].align_y(iced::Alignment::Center))
-                    .width(Length::Fixed(SECTION_TRACK_GUTTER_WIDTH))
-                    .height(Length::Fill)
-                    .padding([0, 10])
-                    .style(|_theme: &Theme| container::Style {
-                        background: Some(th::bg_surface().into()),
-                        border: iced::Border {
-                            color: th::perform_grid_line(),
-                            width: 1.0,
-                            radius: 0.0.into(),
-                        },
-                        ..Default::default()
-                    });
-            let mut lanes = row![]
-                .width(Length::Fixed(timeline_width))
-                .height(Length::Fill);
-            for _ in 0..bar_count {
-                lanes = lanes.push(
-                    container(horizontal_space())
-                        .width(Length::Fixed(SECTION_BAR_WIDTH))
-                        .height(Length::Fill)
-                        .style(|_theme: &Theme| container::Style {
-                            border: iced::Border {
-                                color: th::perform_grid_line(),
-                                width: 1.0,
-                                radius: 0.0.into(),
-                            },
-                            ..Default::default()
-                        }),
-                );
-            }
-            track_gutters = track_gutters.push(gutter.height(Length::FillPortion(1)));
-            timeline_tracks = timeline_tracks.push(lanes.height(Length::FillPortion(1)));
-        }
-        let fixed_gutter = column![ruler_gutter, track_gutters]
-            .width(Length::Fixed(SECTION_TRACK_GUTTER_WIDTH))
-            .height(Length::Fill);
-        let timeline_content =
-            container(column![ruler_marks, timeline_tracks].height(Length::Fill))
-                .width(Length::Fixed(timeline_width))
-                .height(Length::Fill)
-                .style(|_theme: &Theme| container::Style {
-                    background: Some(th::display_bg().into()),
-                    ..Default::default()
-                });
-        let scrolling_timeline = scrollable::Scrollable::with_direction(
-            timeline_content,
-            scrollable::Direction::Horizontal(
-                scrollable::Scrollbar::new()
-                    .width(5)
-                    .scroller_width(5)
-                    .spacing(1),
-            ),
-        )
-        .width(Length::Fill)
-        .height(Length::Fill);
-        let timeline_grid = row![fixed_gutter, scrolling_timeline]
-            .width(Length::Fill)
-            .height(Length::Fill);
-
-        let (empty_title, empty_detail, empty_footnote) = if selected.is_some() {
-            (
-                format!("{bar_count} BAR SECTION"),
-                "This Section has its own local timeline",
-                "MUSICAL AUTHORING ARRIVES IN CARD 07",
-            )
-        } else {
-            (
-                "SELECT A SECTION".to_string(),
-                "Create one from an empty Pad Position",
-                "SECTION DATA IS SAVED WITH THE PROJECT",
-            )
-        };
-        let empty = center(
-            container(
-                column![
-                    text("SECTION SPACE")
-                        .font(PERFORM_LABEL)
-                        .size(9)
-                        .color(th::accent()),
-                    text(empty_title)
-                        .font(PERFORM_LABEL)
-                        .size(13)
-                        .color(th::text()),
-                    text(empty_detail).size(10).color(th::text_dim()),
-                    text(empty_footnote)
-                        .font(PERFORM_TECH)
-                        .size(8)
-                        .color(th::blend(th::text_dim(), th::text(), 0.1))
-                ]
-                .spacing(8)
-                .align_x(iced::Alignment::Center),
-            )
-            .padding([16, 22])
-            .style(|_theme: &Theme| container::Style {
-                background: Some(th::perform_inset().into()),
-                border: iced::Border {
-                    color: th::border(),
-                    width: 1.0,
-                    radius: 3.0.into(),
-                },
-                shadow: Shadow {
-                    color: th::perform_shadow(),
-                    offset: Vector::new(0.0, 4.0),
-                    blur_radius: 10.0,
-                },
-                ..Default::default()
-            }),
-        )
-        .width(Length::Fill)
-        .height(Length::Fill);
-        let empty_timeline = stack![timeline_grid, empty];
-
-        let construction = container(column![toolbar, empty_timeline].height(Length::Fill))
-            .width(Length::FillPortion(3))
-            .height(Length::Fill)
-            .style(|_theme: &Theme| container::Style {
-                background: Some(th::bg_dark().into()),
-                border: iced::Border {
-                    color: th::border(),
-                    width: 1.0,
-                    radius: 0.0.into(),
-                },
-                ..Default::default()
-            });
-
-        mouse_area(construction)
-            .on_press(Message::Perform(PerformMsg::FocusEditor(
-                PerformEditorFocus::SectionConstruction,
-            )))
             .into()
     }
 }

--- a/crates/vibez-ui/src/app/views_perform_sections.rs
+++ b/crates/vibez-ui/src/app/views_perform_sections.rs
@@ -1,0 +1,373 @@
+//! Section Timeline Editor view for the Perform workspace.
+
+use std::collections::HashSet;
+
+use iced::widget::{
+    button, canvas, center, column, container, horizontal_space, mouse_area, row, scrollable, text,
+    tooltip,
+};
+use iced::{Element, Length, Theme};
+
+use crate::domains::perform::{PerformEditorFocus, PerformMsg};
+use crate::domains::piano_roll::PianoRollMsg;
+use crate::icons;
+use crate::message::Message;
+use crate::state::{ArrangementSelection, TrackTimelineContent};
+use crate::theme as th;
+use crate::typography::{PERFORM_DISPLAY, PERFORM_LABEL, PERFORM_TECH, PERFORM_TECH_STRONG};
+use crate::widgets::timeline::TrackClipCanvas;
+
+use super::views_perform::{SECTION_BAR_WIDTH, SECTION_TRACK_GUTTER_WIDTH};
+use super::*;
+
+impl App {
+    pub(super) fn view_section_construction(&self) -> Element<'_, Message> {
+        let selected = self
+            .state
+            .perform
+            .selected_section
+            .and_then(|id| self.state.perform.sections.by_id(id));
+        let toolbar = self.view_section_toolbar(selected);
+        let editor = self.state.perform.section_editor.editor();
+        let bar_count = selected
+            .map(|section| (section.length_beats / 4.0).round() as usize)
+            .unwrap_or(4)
+            .max(1);
+        let total_beats = selected.map_or(16.0, |section| section.length_beats);
+        let timeline_width = SECTION_BAR_WIDTH * bar_count as f32;
+        let row_height = if self.state.perform.section_timeline_expanded {
+            72.0
+        } else {
+            48.0
+        };
+
+        let timeline: Element<'_, Message> = if selected.is_none() {
+            center(
+                column![
+                    text("SELECT A SECTION")
+                        .font(PERFORM_LABEL)
+                        .size(13)
+                        .color(th::text()),
+                    text("Create one from an empty Pad Position")
+                        .size(10)
+                        .color(th::text_dim()),
+                    text("SECTION DATA IS SAVED WITH THE PROJECT")
+                        .font(PERFORM_TECH)
+                        .size(8)
+                        .color(th::text_muted())
+                ]
+                .spacing(8)
+                .align_x(iced::Alignment::Center),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+        } else if self.state.project_tracks.tracks.is_empty() {
+            center(
+                column![
+                    text("NO PROJECT TRACKS")
+                        .font(PERFORM_LABEL)
+                        .size(12)
+                        .color(th::text()),
+                    text("Add a MIDI Project Track in Arrange, then return to author this Section")
+                        .size(10)
+                        .color(th::text_dim())
+                ]
+                .spacing(8)
+                .align_x(iced::Alignment::Center),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+        } else {
+            let ruler_gutter = container(
+                column![
+                    text("PROJECT TRACK")
+                        .font(PERFORM_TECH)
+                        .size(8)
+                        .color(th::text_dim()),
+                    text(if self.state.perform.section_timeline_expanded {
+                        "EXPANDED TIMELINE"
+                    } else {
+                        "COMPACT OVERVIEW"
+                    })
+                    .font(PERFORM_TECH_STRONG)
+                    .size(7)
+                    .color(th::accent())
+                ]
+                .spacing(3),
+            )
+            .width(Length::Fixed(SECTION_TRACK_GUTTER_WIDTH))
+            .height(Length::Fixed(32.0))
+            .padding([6, 9])
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::bg_surface().into()),
+                border: iced::Border {
+                    color: th::perform_grid_line(),
+                    width: 1.0,
+                    radius: 0.0.into(),
+                },
+                ..Default::default()
+            });
+
+            let mut ruler_marks = row![]
+                .width(Length::Fixed(timeline_width))
+                .height(Length::Fixed(32.0));
+            for bar in 0..bar_count {
+                ruler_marks = ruler_marks.push(
+                    container(
+                        text((bar + 1).to_string())
+                            .font(PERFORM_TECH_STRONG)
+                            .size(10)
+                            .color(th::text_dim()),
+                    )
+                    .width(Length::Fixed(SECTION_BAR_WIDTH))
+                    .height(Length::Fixed(32.0))
+                    .padding([8, 10])
+                    .style(|_theme: &Theme| container::Style {
+                        background: Some(th::bg_dark().into()),
+                        border: iced::Border {
+                            color: th::perform_grid_line(),
+                            width: 1.0,
+                            radius: 0.0.into(),
+                        },
+                        ..Default::default()
+                    }),
+                );
+            }
+
+            let track_ids: Vec<_> = self
+                .state
+                .project_tracks
+                .tracks
+                .iter()
+                .map(|track| track.id)
+                .collect();
+            let track_kinds: Vec<_> = self
+                .state
+                .project_tracks
+                .tracks
+                .iter()
+                .map(|track| track.kind.is_midi())
+                .collect();
+            let total_tracks = track_ids.len();
+            let empty_content = TrackTimelineContent::default();
+            let mut gutters = column![];
+            let mut lanes = column![].width(Length::Fixed(timeline_width));
+
+            for (index, track) in self.state.project_tracks.tracks.iter().enumerate() {
+                let content = editor.timeline.get(track.id).unwrap_or(&empty_content);
+                let selected_track = editor.selected_track == Some(track.id);
+                let track_color = th::track_color(track.color_index);
+                let clip_count = content.note_clips.len();
+                let track_id = track.id;
+                let type_label = if track.kind.is_midi() {
+                    "MIDI"
+                } else {
+                    "AUDIO"
+                };
+                let marker = container(horizontal_space())
+                    .width(Length::Fixed(3.0))
+                    .height(Length::Fixed(
+                        if self.state.perform.section_timeline_expanded {
+                            28.0
+                        } else {
+                            20.0
+                        },
+                    ))
+                    .style(move |_theme: &Theme| container::Style {
+                        background: Some(track_color.into()),
+                        ..Default::default()
+                    });
+                let identity = button(
+                    row![
+                        marker,
+                        column![
+                            text(track.name.clone())
+                                .font(PERFORM_DISPLAY)
+                                .size(11)
+                                .color(if selected_track {
+                                    th::text()
+                                } else {
+                                    th::text_dim()
+                                }),
+                            text(format!(
+                                "{type_label} · {clip_count} CLIP{}",
+                                if clip_count == 1 { "" } else { "S" }
+                            ))
+                            .font(PERFORM_TECH)
+                            .size(7)
+                            .color(th::text_muted())
+                        ]
+                        .spacing(3)
+                    ]
+                    .spacing(7)
+                    .align_y(iced::Alignment::Center),
+                )
+                .on_press(Message::select_track(track_id))
+                .padding([4, 6])
+                .width(Length::Fill)
+                .style(move |_theme: &Theme, status| button::Style {
+                    background: Some(
+                        if selected_track || matches!(status, button::Status::Hovered) {
+                            th::blend(th::bg_hover(), track_color, 0.12)
+                        } else {
+                            th::bg_surface()
+                        }
+                        .into(),
+                    ),
+                    text_color: th::text(),
+                    border: iced::Border::default(),
+                    ..Default::default()
+                });
+                let add_clip: Element<'_, Message> = if track.kind.is_midi() {
+                    tooltip(
+                        button(icons::icon(icons::PLUS).size(11).color(th::accent()))
+                            .on_press(Message::PianoRoll(PianoRollMsg::AddNoteClipToTrack(
+                                track_id,
+                            )))
+                            .padding([5, 7])
+                            .style(|_theme: &Theme, status| button::Style {
+                                background: Some(
+                                    if matches!(status, button::Status::Hovered) {
+                                        th::bg_hover()
+                                    } else {
+                                        th::perform_inset()
+                                    }
+                                    .into(),
+                                ),
+                                text_color: th::accent(),
+                                border: iced::Border {
+                                    color: th::border_light(),
+                                    width: 1.0,
+                                    radius: 2.0.into(),
+                                },
+                                ..Default::default()
+                            }),
+                        text("Add MIDI clip").font(PERFORM_TECH).size(8),
+                        tooltip::Position::Right,
+                    )
+                    .into()
+                } else {
+                    container(
+                        text("CARD 08")
+                            .font(PERFORM_TECH)
+                            .size(6)
+                            .color(th::text_muted()),
+                    )
+                    .padding([5, 3])
+                    .into()
+                };
+                let gutter = container(row![identity, add_clip].align_y(iced::Alignment::Center))
+                    .width(Length::Fixed(SECTION_TRACK_GUTTER_WIDTH))
+                    .height(Length::Fixed(row_height))
+                    .padding([2, 3])
+                    .style(move |_theme: &Theme| container::Style {
+                        background: Some(th::bg_surface().into()),
+                        border: iced::Border {
+                            color: if selected_track {
+                                th::blend(th::accent_dim(), track_color, 0.35)
+                            } else {
+                                th::perform_grid_line()
+                            },
+                            width: 1.0,
+                            radius: 0.0.into(),
+                        },
+                        ..Default::default()
+                    });
+
+                let selected_clips: HashSet<_> = editor
+                    .selected_clips
+                    .iter()
+                    .filter_map(|selection| match selection {
+                        ArrangementSelection::AudioClip { track_id, clip_id }
+                        | ArrangementSelection::NoteClip { track_id, clip_id }
+                            if *track_id == track.id =>
+                        {
+                            Some(*clip_id)
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                let clip_canvas = TrackClipCanvas::from_track(
+                    track,
+                    content,
+                    -1.0,
+                    2.0,
+                    self.state.view.grid_config(),
+                    0.0,
+                    total_beats,
+                    self.state.transport.sample_rate,
+                    selected_track,
+                    track_color,
+                    self.state.transport.bpm,
+                    track.id,
+                    index,
+                    total_tracks,
+                    track_ids.clone(),
+                    track_kinds.clone(),
+                    selected_clips,
+                    false,
+                    0.0,
+                    total_beats,
+                    editor.time_selection_active,
+                    editor.selection_start_beats,
+                    editor.selection_end_beats,
+                    editor.time_selection_track,
+                    false,
+                    None,
+                    None,
+                );
+                gutters = gutters.push(gutter);
+                lanes = lanes.push(
+                    canvas(clip_canvas)
+                        .width(Length::Fixed(timeline_width))
+                        .height(Length::Fixed(row_height)),
+                );
+            }
+
+            let fixed_gutter =
+                column![ruler_gutter, gutters].width(Length::Fixed(SECTION_TRACK_GUTTER_WIDTH));
+            let timeline_content = container(column![ruler_marks, lanes])
+                .width(Length::Fixed(timeline_width))
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(th::display_bg().into()),
+                    ..Default::default()
+                });
+            let scrolling_timeline = scrollable::Scrollable::with_direction(
+                timeline_content,
+                scrollable::Direction::Horizontal(
+                    scrollable::Scrollbar::new()
+                        .width(5)
+                        .scroller_width(5)
+                        .spacing(1),
+                ),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill);
+            row![fixed_gutter, scrolling_timeline]
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into()
+        };
+
+        let construction = container(column![toolbar, timeline].height(Length::Fill))
+            .width(Length::FillPortion(3))
+            .height(Length::Fill)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::bg_dark().into()),
+                border: iced::Border {
+                    color: th::border(),
+                    width: 1.0,
+                    radius: 0.0.into(),
+                },
+                ..Default::default()
+            });
+
+        mouse_area(construction)
+            .on_press(Message::Perform(PerformMsg::FocusEditor(
+                PerformEditorFocus::SectionConstruction,
+            )))
+            .into()
+    }
+}

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -134,7 +134,7 @@ pub enum ArrangementMsg {
 }
 
 impl ArrangementMsg {
-    pub(super) fn is_timeline_editor_message(&self) -> bool {
+    pub(crate) fn is_timeline_editor_message(&self) -> bool {
         matches!(
             self,
             Self::RenameClip(..)

--- a/crates/vibez-ui/src/domains/arrangement/ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/ops.rs
@@ -205,19 +205,18 @@ impl TimelineEditorState {
         let clip_id = ClipId::new();
         let position_beats = self.selection_start_beats;
         let duration_beats = self.selection_end_beats - self.selection_start_beats;
-        if let Some(track) = self.find_content_mut(track_id) {
-            track.note_clips.push(UiNoteClip {
-                id: clip_id,
-                name: format!("Pattern {}", track.note_clips.len() + 1),
-                position_beats,
-                duration_beats,
-                notes: Vec::new(),
-                selected_notes: HashSet::new(),
-                loop_enabled: false,
-                loop_start_beats: 0.0,
-                loop_end_beats: 0.0,
-            });
-        }
+        let track = Arc::make_mut(&mut self.timeline).ensure(track_id);
+        track.note_clips.push(UiNoteClip {
+            id: clip_id,
+            name: format!("Pattern {}", track.note_clips.len() + 1),
+            position_beats,
+            duration_beats,
+            notes: Vec::new(),
+            selected_notes: HashSet::new(),
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+        });
         engine.send(EngineCommand::AddNoteClip {
             track_id,
             clip_id,

--- a/crates/vibez-ui/src/domains/mod.rs
+++ b/crates/vibez-ui/src/domains/mod.rs
@@ -37,6 +37,18 @@ impl EngineHandle for EngineTx<'_> {
     }
 }
 
+/// Editor target whose content is not currently resident in the audio engine.
+///
+/// Section authoring uses this until the Section playback adapter lands. The
+/// shared editor still performs the same state transitions, but its Arrange
+/// synchronization commands must not mutate the audible Arrange source.
+#[derive(Default)]
+pub struct DiscardingEngine;
+
+impl EngineHandle for DiscardingEngine {
+    fn send(&mut self, _cmd: EngineCommand) {}
+}
+
 #[cfg(test)]
 pub mod test_support {
     use super::*;

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -15,7 +15,7 @@ use super::EngineHandle;
 use crate::state::ProjectTrack;
 
 mod sections;
-pub use sections::{Section, SectionStore};
+pub use sections::{Section, SectionStore, SectionTimelineEditor};
 
 /// The three Perform Modes exposed in V1. Macros stays absent until its
 /// behavior and Capture semantics are defined.
@@ -306,6 +306,8 @@ pub struct PerformState {
     pub key_rebind_target: Option<PadPosition>,
     pub sections: Arc<SectionStore>,
     pub selected_section: Option<SectionId>,
+    pub section_editor: SectionTimelineEditor,
+    pub section_timeline_expanded: bool,
     pub editing_section_name: Option<SectionId>,
     pub section_name_edit: String,
     pub duplicate_source: Option<SectionId>,
@@ -332,6 +334,7 @@ pub enum PerformMsg {
     SetSectionLengthBeats(SectionId, f64),
     SetSectionLaunchQuantization(SectionId, SectionLaunchQuantization),
     ToggleSectionLoop(SectionId),
+    ToggleSectionTimelineExpanded,
     PreviousBank,
     NextBank,
     ToggleTrackMuteFromPad(PadPosition),
@@ -366,6 +369,7 @@ impl PerformMsg {
 pub struct PerformCtx<'a> {
     pub workspace_visible: bool,
     pub project_tracks: &'a [ProjectTrack],
+    pub selected_project_track: Option<TrackId>,
 }
 
 /// A semantic mute request resolved by Perform against a stable pad slot.
@@ -468,7 +472,7 @@ impl PerformState {
             }
             PerformMsg::SelectSection(id) => {
                 if ctx.workspace_visible {
-                    self.select_section(id);
+                    self.select_section(id, ctx.selected_project_track);
                 }
             }
             PerformMsg::CreateSectionAt(slot) => {
@@ -477,7 +481,7 @@ impl PerformState {
                     let id = section.id;
                     Arc::make_mut(&mut self.sections).insert(section);
                     self.duplicate_source = None;
-                    self.select_section(id);
+                    self.select_section(id, ctx.selected_project_track);
                 }
             }
             PerformMsg::BeginDuplicateSection(id) => {
@@ -498,7 +502,7 @@ impl PerformState {
                         let id = section.id;
                         Arc::make_mut(&mut self.sections).insert(section);
                         self.duplicate_source = None;
-                        self.select_section(id);
+                        self.select_section(id, ctx.selected_project_track);
                     }
                 }
             }
@@ -506,6 +510,7 @@ impl PerformState {
                 if ctx.workspace_visible && Arc::make_mut(&mut self.sections).remove(id).is_some() {
                     if self.selected_section == Some(id) {
                         self.selected_section = None;
+                        self.section_editor.clear();
                         self.editing_section_name = None;
                         self.section_name_edit.clear();
                     }
@@ -516,7 +521,7 @@ impl PerformState {
             }
             PerformMsg::StartEditingSectionName(id) => {
                 if ctx.workspace_visible && self.sections.by_id(id).is_some() {
-                    self.select_section(id);
+                    self.select_section(id, ctx.selected_project_track);
                     self.editing_section_name = Some(id);
                 }
             }
@@ -563,6 +568,11 @@ impl PerformState {
                     if let Some(section) = Arc::make_mut(&mut self.sections).by_id_mut(id) {
                         section.looping = !section.looping;
                     }
+                }
+            }
+            PerformMsg::ToggleSectionTimelineExpanded => {
+                if ctx.workspace_visible && self.selected_section.is_some() {
+                    self.section_timeline_expanded = !self.section_timeline_expanded;
                 }
             }
             PerformMsg::PreviousBank => {
@@ -662,9 +672,11 @@ impl PerformState {
             .any(|(pressed, _)| *pressed == position)
     }
 
-    fn select_section(&mut self, id: SectionId) {
+    fn select_section(&mut self, id: SectionId, selected_track: Option<TrackId>) {
         if let Some(section) = self.sections.by_id(id) {
             self.selected_section = Some(id);
+            self.section_editor
+                .load(Arc::clone(&section.timeline), selected_track);
             self.editing_section_name = None;
             self.section_name_edit = section.name.clone();
             self.editor_focus = PerformEditorFocus::SectionConstruction;
@@ -673,6 +685,26 @@ impl PerformState {
 
     pub fn sync_project_tracks(&mut self, tracks: &[ProjectTrack]) {
         self.sync_track_mute_slots(tracks);
+    }
+
+    pub fn sync_selected_section_editor(&mut self, selected_track: Option<TrackId>) {
+        if let Some(section) = self.selected_section.and_then(|id| self.sections.by_id(id)) {
+            self.section_editor
+                .load(Arc::clone(&section.timeline), selected_track);
+        } else {
+            self.selected_section = None;
+            self.section_editor.clear();
+        }
+    }
+
+    pub fn commit_selected_section_timeline(&mut self) {
+        let Some(id) = self.selected_section else {
+            return;
+        };
+        let timeline = Arc::clone(&self.section_editor.editor().timeline);
+        if let Some(section) = Arc::make_mut(&mut self.sections).by_id_mut(id) {
+            section.timeline = timeline;
+        }
     }
 }
 

--- a/crates/vibez-ui/src/domains/perform/sections.rs
+++ b/crates/vibez-ui/src/domains/perform/sections.rs
@@ -3,11 +3,60 @@ use std::sync::Arc;
 use vibez_core::id::{ClipId, LaneId, SectionId, TrackId};
 use vibez_project::SectionLaunchQuantization;
 
-use crate::state::ArrangementTimeline;
+use crate::domains::timeline_editor::TimelineEditorAdapter;
+use crate::state::{
+    ArrangementTimeline, ResolvedTimeline, ResolvedTimelineMut, TimelineEditorState,
+};
 
 pub const DEFAULT_SECTION_LENGTH_BEATS: f64 = 16.0;
 pub const MIN_SECTION_LENGTH_BEATS: f64 = 4.0;
 pub const MAX_SECTION_LENGTH_BEATS: f64 = 1024.0;
+
+/// Runtime-only editor adapter for the selected Section.
+///
+/// Persisted Section content remains in [`Section::timeline`]. Selection,
+/// clipboard, and pointer interaction state stay outside the canonical Section
+/// store and are reset when a different Section is selected.
+#[derive(Debug, Default)]
+pub struct SectionTimelineEditor {
+    editor: TimelineEditorState,
+}
+
+impl SectionTimelineEditor {
+    pub fn load(&mut self, timeline: Arc<ArrangementTimeline>, selected_track: Option<TrackId>) {
+        self.editor = TimelineEditorState {
+            timeline,
+            selected_track,
+            ..TimelineEditorState::default()
+        };
+    }
+
+    pub fn clear(&mut self) {
+        self.editor = TimelineEditorState::default();
+    }
+
+    pub fn editor(&self) -> &TimelineEditorState {
+        &self.editor
+    }
+
+    pub fn editor_mut(&mut self) -> &mut TimelineEditorState {
+        &mut self.editor
+    }
+}
+
+impl TimelineEditorAdapter for SectionTimelineEditor {
+    fn resolve_timeline(&self) -> ResolvedTimeline<'_> {
+        ResolvedTimeline {
+            editor: &self.editor,
+        }
+    }
+
+    fn resolve_timeline_mut(&mut self) -> ResolvedTimelineMut<'_> {
+        ResolvedTimelineMut {
+            editor: &mut self.editor,
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct Section {
@@ -98,7 +147,8 @@ impl SectionStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{TrackTimelineContent, UiNoteClip};
+    use crate::domains::timeline_editor::conformance::assert_timeline_editor_conformance;
+    use crate::state::{ArrangementState, TrackTimelineContent, UiNoteClip};
 
     #[test]
     fn duplicate_remints_every_editable_identity() {
@@ -142,5 +192,63 @@ mod tests {
         assert!(duplicate.timeline.get(track_id).unwrap().note_clips[0]
             .selected_notes
             .is_empty());
+    }
+
+    #[test]
+    fn section_adapter_satisfies_the_shared_editor_contract() {
+        assert_timeline_editor_conformance(SectionTimelineEditor::default());
+    }
+
+    #[test]
+    fn arrange_and_section_adapters_never_share_timeline_mutations() {
+        let track_id = TrackId::new();
+        let mut arrange = ArrangementState::default();
+        let mut section = SectionTimelineEditor::default();
+        section.load(Arc::new(ArrangementTimeline::default()), Some(track_id));
+
+        Arc::make_mut(&mut section.editor_mut().timeline)
+            .ensure(track_id)
+            .note_clips
+            .push(UiNoteClip {
+                id: ClipId::new(),
+                name: "Section Pattern".into(),
+                position_beats: 0.0,
+                duration_beats: 4.0,
+                notes: Vec::new(),
+                selected_notes: Default::default(),
+                loop_enabled: false,
+                loop_start_beats: 0.0,
+                loop_end_beats: 0.0,
+            });
+
+        assert!(arrange.editor.timeline.get(track_id).is_none());
+        assert_eq!(
+            section
+                .editor()
+                .timeline
+                .get(track_id)
+                .expect("Section track content")
+                .note_clips
+                .len(),
+            1
+        );
+
+        Arc::make_mut(&mut arrange.editor.timeline)
+            .ensure(track_id)
+            .note_clips
+            .push(UiNoteClip {
+                id: ClipId::new(),
+                name: "Arrange Pattern".into(),
+                position_beats: 8.0,
+                duration_beats: 4.0,
+                notes: Vec::new(),
+                selected_notes: Default::default(),
+                loop_enabled: false,
+                loop_start_beats: 0.0,
+                loop_end_beats: 0.0,
+            });
+        let section_clip = &section.editor().timeline.get(track_id).unwrap().note_clips[0];
+        assert_eq!(section_clip.name, "Section Pattern");
+        assert_eq!(section_clip.position_beats, 0.0);
     }
 }

--- a/crates/vibez-ui/src/domains/perform_tests.rs
+++ b/crates/vibez-ui/src/domains/perform_tests.rs
@@ -341,6 +341,36 @@ fn section_crud_and_properties_update_the_ordered_store() {
 }
 
 #[test]
+fn selecting_a_section_preserves_project_track_selection_and_resets_clip_focus() {
+    let tracks = project_tracks(2);
+    let selected_track = tracks[1].id;
+    let mut state = PerformState::default();
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        project_tracks: &tracks,
+        selected_project_track: Some(selected_track),
+    };
+
+    state.update(PerformMsg::CreateSectionAt(0), &mut engine, ctx);
+    state.section_editor.editor_mut().selected_note_clip =
+        Some((selected_track, vibez_core::id::ClipId::new()));
+    let second = Section::new(1);
+    let second_id = second.id;
+    Arc::make_mut(&mut state.sections).insert(second);
+
+    state.update(PerformMsg::SelectSection(second_id), &mut engine, ctx);
+
+    assert_eq!(state.selected_section, Some(second_id));
+    assert_eq!(
+        state.section_editor.editor().selected_track,
+        Some(selected_track)
+    );
+    assert_eq!(state.section_editor.editor().selected_note_clip, None);
+    assert!(engine.0.is_empty());
+}
+
+#[test]
 fn track_mute_mode_resolves_keyboard_press_to_shared_track_request_once() {
     let tracks = project_tracks(2);
     let mut state = PerformState {
@@ -352,6 +382,7 @@ fn track_mute_mode_resolves_keyboard_press_to_shared_track_request_once() {
     let ctx = PerformCtx {
         workspace_visible: true,
         project_tracks: &tracks,
+        selected_project_track: None,
     };
 
     let press = state.update(
@@ -429,6 +460,7 @@ fn pointer_pad_uses_the_same_track_mute_resolution() {
         PerformCtx {
             workspace_visible: true,
             project_tracks: &tracks,
+            selected_project_track: None,
         },
     );
 
@@ -459,6 +491,7 @@ fn track_slots_survive_deletion_and_fill_without_scrambling_other_pads() {
         PerformCtx {
             workspace_visible: true,
             project_tracks: &tracks,
+            selected_project_track: None,
         },
     );
     assert_eq!(state.banks.track_mutes, 1);

--- a/crates/vibez-ui/src/domains/piano_roll.rs
+++ b/crates/vibez-ui/src/domains/piano_roll.rs
@@ -254,19 +254,18 @@ impl PianoRollState {
                 let clip_id = ClipId::new();
                 let position_beats = 0.0;
                 let duration_beats = 16.0;
-                if let Some(track) = find_track_mut(tracks, track_id) {
-                    track.note_clips.push(UiNoteClip {
-                        id: clip_id,
-                        name: format!("Pattern {}", track.note_clips.len() + 1),
-                        position_beats,
-                        duration_beats,
-                        notes: Vec::new(),
-                        selected_notes: HashSet::new(),
-                        loop_enabled: true,
-                        loop_start_beats: 0.0,
-                        loop_end_beats: duration_beats,
-                    });
-                }
+                let track = tracks.ensure(track_id);
+                track.note_clips.push(UiNoteClip {
+                    id: clip_id,
+                    name: format!("Pattern {}", track.note_clips.len() + 1),
+                    position_beats,
+                    duration_beats,
+                    notes: Vec::new(),
+                    selected_notes: HashSet::new(),
+                    loop_enabled: true,
+                    loop_start_beats: 0.0,
+                    loop_end_beats: duration_beats,
+                });
                 engine.send(EngineCommand::AddNoteClip {
                     track_id,
                     clip_id,
@@ -755,6 +754,25 @@ mod tests {
         );
         assert_eq!(tracks.get(tid).unwrap().note_clips[0].notes.len(), 3);
         assert!(matches!(engine.0[0], EngineCommand::AddNote { .. }));
+    }
+
+    #[test]
+    fn add_note_clip_creates_missing_timeline_lane_for_a_shared_track() {
+        let track_id = TrackId::new();
+        let mut editor = TimelineEditorState::default();
+        let mut piano_roll = PianoRollState::default();
+        let mut engine = RecordingEngine::default();
+
+        let action = piano_roll.update(
+            PianoRollMsg::AddNoteClipToTrack(track_id),
+            &mut engine,
+            &mut editor,
+            PianoRollCtx::default(),
+        );
+
+        assert_eq!(editor.timeline.get(track_id).unwrap().note_clips.len(), 1);
+        assert_eq!(action.select_note_clip.unwrap().0, track_id);
+        assert!(matches!(engine.0[0], EngineCommand::AddNoteClip { .. }));
     }
 
     #[test]

--- a/crates/vibez-ui/src/domains/timeline_editor.rs
+++ b/crates/vibez-ui/src/domains/timeline_editor.rs
@@ -2,7 +2,7 @@
 //!
 //! Adapters resolve their timeline once. Clip, note, automation, selection,
 //! and view code consume that resolved target without knowing whether it came
-//! from Arrange or, later, a Section.
+//! from Arrange or a Section.
 
 #[cfg(test)]
 use crate::state::TimelineEditorState;

--- a/crates/vibez-ui/src/domains/timeline_editor.rs
+++ b/crates/vibez-ui/src/domains/timeline_editor.rs
@@ -34,8 +34,6 @@ pub fn resolved_editor_mut(adapter: &mut impl TimelineEditorAdapter) -> &mut Tim
 
 #[cfg(test)]
 pub(crate) mod conformance {
-    use std::sync::Arc;
-
     use vibez_core::automation::AutomationTarget;
     use vibez_core::id::TrackId;
     use vibez_core::midi::TrackKind;
@@ -65,14 +63,13 @@ pub(crate) mod conformance {
 
         let clip_id = {
             let editor = resolved_editor_mut(&mut adapter);
-            Arc::make_mut(&mut editor.timeline).ensure(track_id);
             editor.selected_track = Some(track_id);
             editor.time_selection_active = true;
             editor.selection_start_beats = 4.0;
             editor.selection_end_beats = 8.0;
             editor.update(
                 &mut project_tracks,
-                ArrangementMsg::CreateNoteClipFromSelection(track_id),
+                ArrangementMsg::CreateClipFromSelection,
                 &mut engine,
                 ArrangementCtx::default(),
             );

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -755,6 +755,22 @@ impl AppState {
         Arc::make_mut(&mut self.arrangement.timeline).ensure(id)
     }
 
+    /// The Timeline Editor currently visible to the producer.
+    ///
+    /// Workspace identity is resolved here at the application boundary; the
+    /// editor and its widgets only receive the resolved target.
+    pub fn active_timeline_editor(&self) -> &TimelineEditorState {
+        if self.view.workspace == Workspace::Perform && self.perform.selected_section.is_some() {
+            self.perform.section_editor.editor()
+        } else {
+            &self.arrangement.editor
+        }
+    }
+
+    pub fn active_timeline_content(&self, id: TrackId) -> Option<&TrackTimelineContent> {
+        self.active_timeline_editor().timeline.get(id)
+    }
+
     /// Total duration in samples across all tracks (max clip end position).
     pub fn total_duration_samples(&self) -> u64 {
         let audio_max = self

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -44,6 +44,7 @@ fn perform_edit(state: &mut AppState, engine: &mut RecordingEngine, message: Per
         PerformCtx {
             workspace_visible: true,
             project_tracks: &state.project_tracks.tracks,
+            selected_project_track: state.arrangement.selected_track,
         },
     );
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,8 +154,17 @@ state; clip operations, piano-roll editing, automation editing, and timeline
 view behavior receive this already-resolved target. `ArrangementState` is a
 thin adapter that retains Arrange's Project Track/channel controls and
 implements `TimelineEditorAdapter` to resolve its editor. The editor never
-asks which workspace is active and contains no `Arrange | Section` branch, so
-a Section can provide the same adapter in the later authoring slice.
+asks which workspace is active and contains no `Arrange | Section` branch.
+
+The selected Perform Section now provides that second adapter through a
+runtime-only `SectionTimelineEditor`. Selecting a Section resolves its
+persisted Timeline Content into the adapter while preserving the project-wide
+Project Track selection; clip and piano-roll selection remain local to the
+resolved Section editor. Every edit commits the adapter's copy-on-write
+Timeline Content back into the selected Section store for undo and project
+persistence. Until the Section playback source lands, a discarding engine
+handle prevents shared editor synchronization commands from mutating the
+audible Arrange source.
 
 Every horizontal editor surface uses `TimelineGeometry` for beat-to-pixel,
 pixel-to-beat, fitted viewport, visible-range, and beat-width conversions.
@@ -170,9 +179,11 @@ flowchart LR
     AA["ArrangementState<br/>thin adapter + channel controls"]
     TE["TimelineEditorState<br/>selection + resolved TimelineContent"]
     SS["SectionStore<br/>Section → TimelineContent"]
+    SE["SectionTimelineEditor<br/>second editor adapter"]
     TG["TimelineGeometry<br/>one beat/pixel layer"]
     PT -- "shared TrackId" --> TE
     PT -- "shared TrackId" --> SS
+    SS -- "selected content" --> SE
     AA -- "resolves once" --> TE
     TG --> TE
 ```


### PR DESCRIPTION
## Summary

- add `SectionTimelineEditor` as the second consumer of the shared Timeline Editor boundary
- route shared clip and piano-roll editing to the selected Section while preserving project-wide Project Track selection
- render compact and deliberately expanded multitrack Section timelines with MIDI clip/note authoring
- commit authored Section content into the canonical project document for save/reopen
- keep Section authoring disconnected from the audible Arrange engine source until Section playback lands

## Blockers and scope

Card 05 and Card 06 are satisfied by merged PRs #74 and #75. This branch starts from current `dev` at `60d4760`.

Non-goals: audio Section clips, non-destructive Section length behavior, large-project scrolling, Project Track deletion UX, Section launch/playback, Capture, and any new Arrange editor feature.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace -j4`
- `cargo test --workspace -j4` (UI: 253 passed, 0 failed)
- `cargo clippy --workspace -j4 -- -D warnings`
- `git diff --check`
- every touched Rust file is at or below 1,000 lines
- native dogfood used the exact Card 07 target executable and verified create MIDI clip, draw C4 note, compact/expanded timeline, save/reopen persistence, and unchanged Arrange content

## Manual sign-off

1. Open a project with at least one MIDI Project Track and switch to Perform.
2. Click an empty Section pad, then click the + button on a MIDI row.
3. Click the new clip, switch the piano roll to Draw, and add a few notes.
4. Toggle the timeline expand button in the Section toolbar and return to compact view.
5. Save As, reopen the project, and confirm the Section clip/notes remain while Arrange is unchanged.

Card 08 will be a separate stacked PR based on this branch and will add audio authoring, length-boundary behavior, and scrolling only.