### PR TITLE
refactor(engine): separate playback source

### DIFF
--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -13,9 +13,9 @@ use crate::commands::{AuditionSync, EngineCommand};
 use crate::events::EngineEvent;
 use crate::metering;
 use crate::mixer::{
-    any_solo, calculate_total_length, equal_power_pan, EffectSlot, EngineClip, EngineNoteClip,
-    EngineTrack,
+    any_solo, equal_power_pan, EffectSlot, EngineClip, EngineNoteClip, EngineTrack,
 };
+use crate::playback_source::calculate_total_length;
 use crate::transport::Transport;
 
 /// Capacity of the UI spectrum-analyser sample ring: roughly a third
@@ -818,7 +818,12 @@ impl AudioEngine {
         } else {
             0.0
         };
-        let total = calculate_total_length(&self.tracks, samples_per_beat);
+        let total = calculate_total_length(
+            self.tracks
+                .iter()
+                .map(|track| track.playback_source.as_ref()),
+            samples_per_beat,
+        );
         if total > 0 {
             self.transport.set_audio_length(Some(total));
         } else if self.audio.is_none() {

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -77,7 +77,7 @@ impl AudioEngine {
                     loop_end,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        track.clips.push(EngineClip {
+                        track.playback_source.clips.push(EngineClip {
                             id: clip_id,
                             audio,
                             position,
@@ -92,7 +92,7 @@ impl AudioEngine {
                 }
                 EngineCommand::RemoveClip(track_id, clip_id) => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        track.clips.retain(|c| c.id != clip_id);
+                        track.playback_source.clips.retain(|c| c.id != clip_id);
                     }
                     self.recalculate_audio_length();
                 }
@@ -106,7 +106,12 @@ impl AudioEngine {
                     loop_end,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
+                        if let Some(clip) = track
+                            .playback_source
+                            .clips
+                            .iter_mut()
+                            .find(|c| c.id == clip_id)
+                        {
                             clip.audio = audio;
                             clip.duration = duration;
                             clip.source_offset = source_offset;
@@ -122,7 +127,12 @@ impl AudioEngine {
                     new_position,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
+                        if let Some(clip) = track
+                            .playback_source
+                            .clips
+                            .iter_mut()
+                            .find(|c| c.id == clip_id)
+                        {
                             clip.position = new_position;
                         }
                     }
@@ -135,15 +145,20 @@ impl AudioEngine {
                 }
                 EngineCommand::SetAutomationLane { track_id, lane } => {
                     if let Some(track) = self.channel_mut(track_id) {
-                        match track.automation.iter_mut().find(|l| l.id == lane.id) {
+                        match track
+                            .playback_source
+                            .automation
+                            .iter_mut()
+                            .find(|l| l.id == lane.id)
+                        {
                             Some(existing) => *existing = lane,
-                            None => track.automation.push(lane),
+                            None => track.playback_source.automation.push(lane),
                         }
                     }
                 }
                 EngineCommand::RemoveAutomationLane { track_id, lane_id } => {
                     if let Some(track) = self.channel_mut(track_id) {
-                        track.automation.retain(|l| l.id != lane_id);
+                        track.playback_source.automation.retain(|l| l.id != lane_id);
                     }
                 }
                 EngineCommand::SetTrackPan(id, pan) => {
@@ -181,7 +196,7 @@ impl AudioEngine {
                     }
                     for track in &mut self.tracks {
                         track.sends.retain(|(bus_id, _)| *bus_id != id);
-                        track.automation.retain(|lane| {
+                        track.playback_source.automation.retain(|lane| {
                             lane.target
                                 != vibez_core::automation::AutomationTarget::Send { bus_id: id }
                         });
@@ -321,7 +336,12 @@ impl AudioEngine {
                     duration_beats,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
+                        if let Some(clip) = track
+                            .playback_source
+                            .note_clips
+                            .iter_mut()
+                            .find(|c| c.id == clip_id)
+                        {
                             clip.duration_beats = duration_beats;
                         }
                         track.flush_notes();
@@ -338,7 +358,7 @@ impl AudioEngine {
                     loop_end_beats,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        track.note_clips.push(EngineNoteClip {
+                        track.playback_source.note_clips.push(EngineNoteClip {
                             id: clip_id,
                             position_beats,
                             duration_beats,
@@ -352,7 +372,7 @@ impl AudioEngine {
                 }
                 EngineCommand::RemoveNoteClip(track_id, clip_id) => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        track.note_clips.retain(|c| c.id != clip_id);
+                        track.playback_source.note_clips.retain(|c| c.id != clip_id);
                         // Sounding notes get their note-offs from the
                         // clip's schedule; without the clip they hang
                         // forever.
@@ -366,7 +386,12 @@ impl AudioEngine {
                     new_position_beats,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
+                        if let Some(clip) = track
+                            .playback_source
+                            .note_clips
+                            .iter_mut()
+                            .find(|c| c.id == clip_id)
+                        {
                             clip.position_beats = new_position_beats;
                         }
                     }
@@ -378,7 +403,12 @@ impl AudioEngine {
                     note,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
+                        if let Some(clip) = track
+                            .playback_source
+                            .note_clips
+                            .iter_mut()
+                            .find(|c| c.id == clip_id)
+                        {
                             clip.notes.push(note);
                         }
                     }
@@ -389,7 +419,12 @@ impl AudioEngine {
                     note_index,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
+                        if let Some(clip) = track
+                            .playback_source
+                            .note_clips
+                            .iter_mut()
+                            .find(|c| c.id == clip_id)
+                        {
                             if note_index < clip.notes.len() {
                                 clip.notes.remove(note_index);
                             }
@@ -404,7 +439,12 @@ impl AudioEngine {
                     note,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
+                        if let Some(clip) = track
+                            .playback_source
+                            .note_clips
+                            .iter_mut()
+                            .find(|c| c.id == clip_id)
+                        {
                             if note_index < clip.notes.len() {
                                 clip.notes[note_index] = note;
                             }
@@ -483,7 +523,12 @@ impl AudioEngine {
                     loop_end,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
+                        if let Some(clip) = track
+                            .playback_source
+                            .clips
+                            .iter_mut()
+                            .find(|c| c.id == clip_id)
+                        {
                             clip.loop_enabled = enabled;
                             clip.loop_start = loop_start;
                             clip.loop_end = loop_end;
@@ -498,7 +543,12 @@ impl AudioEngine {
                     loop_end_beats,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
+                        if let Some(clip) = track
+                            .playback_source
+                            .note_clips
+                            .iter_mut()
+                            .find(|c| c.id == clip_id)
+                        {
                             clip.loop_enabled = enabled;
                             clip.loop_start_beats = loop_start_beats;
                             clip.loop_end_beats = loop_end_beats;

--- a/crates/vibez-engine/src/engine_stuck_note_tests.rs
+++ b/crates/vibez-engine/src/engine_stuck_note_tests.rs
@@ -303,7 +303,7 @@ fn removing_clip_kills_sounding_notes() {
     // track exercises the same path.
     let cid = {
         // recover clip id from engine state
-        engine.tracks()[0].note_clips[0].id
+        engine.tracks()[0].playback_source.note_clips[0].id
     };
     cmd_tx
         .push(EngineCommand::RemoveNoteClip(tid, cid))

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -797,7 +797,7 @@ fn move_clip_changes_position() {
     engine.process(&mut buf, 2);
 
     // Clip is now at position 50, engine should recognize this
-    assert_eq!(engine.tracks()[0].clips[0].position, 50);
+    assert_eq!(engine.tracks()[0].playback_source.clips[0].position, 50);
 }
 
 #[test]

--- a/crates/vibez-engine/src/lib.rs
+++ b/crates/vibez-engine/src/lib.rs
@@ -3,5 +3,6 @@ pub mod engine;
 pub mod events;
 pub mod metering;
 pub mod mixer;
+pub mod playback_source;
 pub mod render;
 pub mod transport;

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -1,58 +1,19 @@
+use std::ops::{Deref, DerefMut};
+#[cfg(test)]
 use std::sync::Arc;
 
+#[cfg(test)]
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::constants::{DEFAULT_TRACK_GAIN, DEFAULT_TRACK_PAN};
-use vibez_core::id::{ClipId, EffectId, TrackId};
-use vibez_core::midi::MidiNote;
+#[cfg(test)]
+use vibez_core::id::ClipId;
+use vibez_core::id::{EffectId, TrackId};
 use vibez_core::time::TempoMap;
 use vibez_dsp::effect::AudioEffect;
 use vibez_instruments::Instrument;
 
-/// Map a raw timeline frame through the active arrangement loop.
-/// Anything at or past `loop_end` is wrapped to `loop_start +
-/// overshoot mod loop_len`, so mid-block wraps stay seamless.
-#[inline]
-fn apply_loop_wrap(global_frame: u64, loop_region: Option<(u64, u64)>) -> u64 {
-    match loop_region {
-        Some((start, end)) if end > start && global_frame >= end => {
-            let loop_len = end - start;
-            let overshoot = global_frame - end;
-            start + (overshoot % loop_len)
-        }
-        _ => global_frame,
-    }
-}
-
-/// A clip as it exists at runtime in the engine (on the audio thread).
-pub struct EngineClip {
-    pub id: ClipId,
-    pub audio: Arc<DecodedAudio>,
-    /// Position on the timeline in samples.
-    pub position: u64,
-    /// Offset into the source audio in samples.
-    pub source_offset: u64,
-    /// Duration in samples.
-    pub duration: u64,
-    // Looping
-    pub loop_enabled: bool,
-    pub loop_start: u64,
-    pub loop_end: u64,
-}
-
-impl EngineClip {
-    /// The end position of this clip on the timeline.
-    pub fn end_position(&self) -> u64 {
-        self.position.saturating_add(self.duration)
-    }
-
-    /// Whether this clip is active (has audio to contribute) at the given
-    /// global position for the given number of frames.
-    pub fn is_active(&self, pos: u64, frames: u64) -> bool {
-        let end = pos.saturating_add(frames);
-        // Clip overlaps the [pos, pos+frames) range
-        self.position < end && self.end_position() > pos
-    }
-}
+use crate::playback_source::{ArrangementPlaybackSource, PreparedPlaybackSource};
+pub use crate::playback_source::{EngineClip, EngineNoteClip};
 
 pub struct EffectSlot {
     pub id: EffectId,
@@ -60,21 +21,12 @@ pub struct EffectSlot {
     pub bypass: bool,
 }
 
-pub struct EngineNoteClip {
-    pub id: ClipId,
-    pub position_beats: f64,
-    pub duration_beats: f64,
-    pub notes: Vec<MidiNote>,
-    // Looping
-    pub loop_enabled: bool,
-    pub loop_start_beats: f64,
-    pub loop_end_beats: f64,
-}
-
 /// A track as it exists at runtime in the engine.
 pub struct EngineTrack {
     pub id: TrackId,
-    pub clips: Vec<EngineClip>,
+    /// Time-based content feeding this shared channel strip. It is prepared
+    /// outside the callback before any future source switch.
+    pub playback_source: Box<PreparedPlaybackSource>,
     pub gain: f32,
     pub pan: f32,
     pub mute: bool,
@@ -86,9 +38,6 @@ pub struct EngineTrack {
     /// Only regular tracks send; buses and the master never do, so
     /// the routing graph stays acyclic by construction.
     pub sends: Vec<(TrackId, f32)>,
-    pub note_clips: Vec<EngineNoteClip>,
-    /// Automation lanes, evaluated once per render segment.
-    pub automation: Vec<vibez_core::automation::AutomationLane>,
     pub instrument: Option<Box<dyn Instrument>>,
     /// Scratch storage for batch rendering: (frame_offset, pitch, velocity)
     timed_note_ons: Vec<(u32, u8, u8)>,
@@ -105,9 +54,14 @@ pub struct EngineTrack {
 
 impl EngineTrack {
     pub fn new(id: TrackId) -> Self {
+        Self::with_playback_source(id, ArrangementPlaybackSource::prepare_empty())
+    }
+
+    /// Wrap already-resident timeline content in a project-owned channel strip.
+    pub fn with_playback_source(id: TrackId, playback_source: PreparedPlaybackSource) -> Self {
         Self {
             id,
-            clips: Vec::new(),
+            playback_source: Box::new(playback_source),
             gain: DEFAULT_TRACK_GAIN,
             pan: DEFAULT_TRACK_PAN,
             mute: false,
@@ -115,8 +69,6 @@ impl EngineTrack {
             mix_buffer: Vec::new(),
             effects: Vec::new(),
             sends: Vec::new(),
-            note_clips: Vec::new(),
-            automation: Vec::new(),
             instrument: None,
             timed_note_ons: Vec::new(),
             timed_note_offs: Vec::new(),
@@ -124,10 +76,7 @@ impl EngineTrack {
         }
     }
 
-    /// Evaluate every automation lane at `beat` (block-rate): effect
-    /// and instrument parameters are applied in place; gain and pan
-    /// come back as overrides for the mix stage. Plugin parameter
-    /// lanes are handled by the plugin event path, not here.
+    /// Apply automation at `beat`; return gain and pan mix overrides.
     pub fn apply_automation(&mut self, beat: f64) -> (Option<f32>, Option<f32>) {
         use vibez_core::automation::AutomationTarget;
         let mut gain = None;
@@ -138,8 +87,7 @@ impl EngineTrack {
                 continue;
             };
             match lane.target {
-                // Lanes are normalized 0..1; gain's native range is
-                // 0..2 (unity at lane 0.5), pan is already 0..1.
+                // Gain's native range is 0..2; pan is already 0..1.
                 AutomationTarget::TrackGain => gain = Some(value * 2.0),
                 AutomationTarget::TrackPan => pan = Some(value),
                 AutomationTarget::EffectParam {
@@ -167,9 +115,7 @@ impl EngineTrack {
                 }
                 AutomationTarget::PluginParam { .. } => {}
                 AutomationTarget::Send { bus_id } => {
-                    // Send range is native 0..1, so the normalized
-                    // lane value applies directly. Written in place
-                    // like effect params.
+                    // Send range is native 0..1, so write the value in place.
                     match self.sends.iter_mut().find(|(b, _)| *b == bus_id) {
                         Some(send) => send.1 = value,
                         None => self.sends.push((bus_id, value)),
@@ -253,75 +199,13 @@ impl EngineTrack {
     ) -> bool {
         let buf_size = frames * channels;
         self.ensure_buffer(buf_size);
-
-        for s in self.mix_buffer[..buf_size].iter_mut() {
-            *s = 0.0;
-        }
-
-        let mut rendered_any = false;
-
-        // When the arrangement loop is crossed mid-block, `is_active`
-        // as computed against raw `pos..pos+frames` may not cover the
-        // clip that plays *after* the wrap. Fall back to iterating
-        // every clip on boundary-straddling blocks.
-        let block_crosses_loop = matches!(
+        self.playback_source.render_audio(
+            &mut self.mix_buffer[..buf_size],
+            pos,
+            frames,
+            channels,
             loop_region,
-            Some((start, end)) if end > start
-                && pos < end
-                && pos.saturating_add(frames as u64) > end
-        );
-
-        for clip in &self.clips {
-            if !block_crosses_loop && !clip.is_active(pos, frames as u64) {
-                continue;
-            }
-
-            let audio_channels = clip.audio.num_channels();
-            let mut clip_rendered = false;
-
-            for frame in 0..frames {
-                let raw_global = pos + frame as u64;
-                let global_frame = apply_loop_wrap(raw_global, loop_region);
-
-                if global_frame < clip.position {
-                    continue;
-                }
-                if global_frame >= clip.end_position() {
-                    continue;
-                }
-
-                let clip_frame = (global_frame - clip.position) as usize;
-                let source_frame = if clip.loop_enabled && clip.loop_end > clip.loop_start {
-                    let raw = clip.source_offset as usize + clip_frame;
-                    let loop_len = (clip.loop_end - clip.loop_start) as usize;
-                    if raw >= clip.loop_end as usize {
-                        clip.loop_start as usize + (raw - clip.loop_start as usize) % loop_len
-                    } else {
-                        raw
-                    }
-                } else {
-                    clip.source_offset as usize + clip_frame
-                };
-
-                for ch in 0..channels {
-                    let sample = if ch < audio_channels {
-                        clip.audio.sample(ch, source_frame)
-                    } else if audio_channels > 0 {
-                        clip.audio.sample(audio_channels - 1, source_frame)
-                    } else {
-                        0.0
-                    };
-                    self.mix_buffer[frame * channels + ch] += sample;
-                }
-                clip_rendered = true;
-            }
-
-            if clip_rendered {
-                rendered_any = true;
-            }
-        }
-
-        rendered_any
+        )
     }
 
     pub fn process_effects(&mut self, frames: usize, channels: usize) {
@@ -393,7 +277,7 @@ impl EngineTrack {
                 -1.0
             };
 
-            for clip in &self.note_clips {
+            for clip in &self.playback_source.note_clips {
                 let clip_start_beat = clip.position_beats;
                 let clip_end_beat = clip.position_beats + clip.duration_beats;
 
@@ -533,7 +417,7 @@ impl EngineTrack {
             note_ons.clear();
             note_offs.clear();
 
-            for clip in &self.note_clips {
+            for clip in &self.playback_source.note_clips {
                 let clip_start_beat = clip.position_beats;
                 let clip_end_beat = clip.position_beats + clip.duration_beats;
 
@@ -628,6 +512,23 @@ impl EngineTrack {
     }
 }
 
+/// Compatibility at the channel boundary: existing render/command code sees
+/// the already-resolved source fields without learning its adapter identity.
+/// The content is owned exactly once by `PreparedPlaybackSource`.
+impl Deref for EngineTrack {
+    type Target = PreparedPlaybackSource;
+
+    fn deref(&self) -> &Self::Target {
+        &self.playback_source
+    }
+}
+
+impl DerefMut for EngineTrack {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.playback_source
+    }
+}
+
 /// Equal-power pan law.
 /// `pan` ranges from 0.0 (hard left) to 1.0 (hard right).
 /// Returns `(left_gain, right_gain)`.
@@ -650,27 +551,6 @@ pub fn balance_pan(pan: f32) -> (f32, f32) {
 /// Returns `true` if any track in the slice has solo enabled.
 pub fn any_solo(tracks: &[EngineTrack]) -> bool {
     tracks.iter().any(|t| t.solo)
-}
-
-/// Calculate the total arrangement length across audio and note clips.
-pub fn calculate_total_length(tracks: &[EngineTrack], samples_per_beat: f64) -> u64 {
-    let audio_end = tracks
-        .iter()
-        .flat_map(|t| t.clips.iter())
-        .map(|c| c.end_position())
-        .max()
-        .unwrap_or(0);
-    let note_end = if samples_per_beat.is_finite() && samples_per_beat > 0.0 {
-        tracks
-            .iter()
-            .flat_map(|t| t.note_clips.iter())
-            .map(|c| ((c.position_beats + c.duration_beats) * samples_per_beat).round() as u64)
-            .max()
-            .unwrap_or(0)
-    } else {
-        0
-    };
-    audio_end.max(note_end)
 }
 
 #[cfg(test)]
@@ -786,46 +666,6 @@ mod tests {
         let mut track = EngineTrack::new(TrackId::new());
         let rendered = track.render(0, 8, 2, None);
         assert!(!rendered);
-    }
-
-    #[test]
-    fn total_length_calculation() {
-        let audio = make_test_audio(100, 0.5);
-        let mut tracks = vec![EngineTrack::new(TrackId::new())];
-        tracks[0].clips.push(EngineClip {
-            id: ClipId::new(),
-            audio: audio.clone(),
-            position: 50,
-            source_offset: 0,
-            duration: 100,
-            loop_enabled: false,
-            loop_start: 0,
-            loop_end: 0,
-        });
-
-        assert_eq!(calculate_total_length(&tracks, 22_050.0), 150);
-    }
-
-    #[test]
-    fn total_length_empty_tracks() {
-        let tracks: Vec<EngineTrack> = vec![];
-        assert_eq!(calculate_total_length(&tracks, 22_050.0), 0);
-    }
-
-    #[test]
-    fn total_length_includes_note_clips() {
-        let mut tracks = vec![EngineTrack::new(TrackId::new())];
-        tracks[0].note_clips.push(EngineNoteClip {
-            id: ClipId::new(),
-            position_beats: 2.0,
-            duration_beats: 4.0,
-            notes: Vec::new(),
-            loop_enabled: false,
-            loop_start_beats: 0.0,
-            loop_end_beats: 0.0,
-        });
-
-        assert_eq!(calculate_total_length(&tracks, 22_050.0), 132_300);
     }
 
     #[test]

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -1,4 +1,3 @@
-use std::ops::{Deref, DerefMut};
 #[cfg(test)]
 use std::sync::Arc;
 
@@ -81,8 +80,8 @@ impl EngineTrack {
         use vibez_core::automation::AutomationTarget;
         let mut gain = None;
         let mut pan = None;
-        for lane_idx in 0..self.automation.len() {
-            let lane = &self.automation[lane_idx];
+        for lane_idx in 0..self.playback_source.automation.len() {
+            let lane = &self.playback_source.automation[lane_idx];
             let Some(value) = lane.value_at(beat) else {
                 continue;
             };
@@ -512,23 +511,6 @@ impl EngineTrack {
     }
 }
 
-/// Compatibility at the channel boundary: existing render/command code sees
-/// the already-resolved source fields without learning its adapter identity.
-/// The content is owned exactly once by `PreparedPlaybackSource`.
-impl Deref for EngineTrack {
-    type Target = PreparedPlaybackSource;
-
-    fn deref(&self) -> &Self::Target {
-        &self.playback_source
-    }
-}
-
-impl DerefMut for EngineTrack {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.playback_source
-    }
-}
-
 /// Equal-power pan law.
 /// `pan` ranges from 0.0 (hard left) to 1.0 (hard right).
 /// Returns `(left_gain, right_gain)`.
@@ -611,7 +593,7 @@ mod tests {
     fn single_clip_render() {
         let audio = make_test_audio(64, 0.5);
         let mut track = EngineTrack::new(TrackId::new());
-        track.clips.push(EngineClip {
+        track.playback_source.clips.push(EngineClip {
             id: ClipId::new(),
             audio,
             position: 0,
@@ -642,7 +624,7 @@ mod tests {
         });
 
         let mut track = EngineTrack::new(TrackId::new());
-        track.clips.push(EngineClip {
+        track.playback_source.clips.push(EngineClip {
             id: ClipId::new(),
             audio: audio.clone(),
             position: 0,
@@ -718,7 +700,7 @@ mod tests {
     fn clip_loop_renders_audio_past_source() {
         let audio = make_test_audio(100, 0.5);
         let mut track = EngineTrack::new(TrackId::new());
-        track.clips.push(EngineClip {
+        track.playback_source.clips.push(EngineClip {
             id: ClipId::new(),
             audio,
             position: 0,
@@ -755,7 +737,7 @@ mod tests {
         });
 
         let mut track = EngineTrack::new(TrackId::new());
-        track.clips.push(EngineClip {
+        track.playback_source.clips.push(EngineClip {
             id: ClipId::new(),
             audio: audio.clone(),
             position: 0,
@@ -799,7 +781,7 @@ mod tests {
         });
 
         let mut track = EngineTrack::new(TrackId::new());
-        track.clips.push(EngineClip {
+        track.playback_source.clips.push(EngineClip {
             id: ClipId::new(),
             audio: audio.clone(),
             position: 0,
@@ -837,7 +819,7 @@ mod tests {
     fn clip_no_loop_silence_past_source() {
         let audio = make_test_audio(100, 0.5);
         let mut track = EngineTrack::new(TrackId::new());
-        track.clips.push(EngineClip {
+        track.playback_source.clips.push(EngineClip {
             id: ClipId::new(),
             audio,
             position: 0,
@@ -879,7 +861,7 @@ mod tests {
             sample_rate: 44_100,
         });
         let mut track = EngineTrack::new(TrackId::new());
-        track.clips.push(EngineClip {
+        track.playback_source.clips.push(EngineClip {
             id: ClipId::new(),
             audio: Arc::clone(&audio),
             position: 0,
@@ -933,7 +915,7 @@ mod tests {
             sample_rate: 44_100,
         });
         let mut track = EngineTrack::new(TrackId::new());
-        track.clips.push(EngineClip {
+        track.playback_source.clips.push(EngineClip {
             id: ClipId::new(),
             audio,
             position: 0,

--- a/crates/vibez-engine/src/playback_source.rs
+++ b/crates/vibez-engine/src/playback_source.rs
@@ -217,7 +217,7 @@ mod tests {
         };
 
         let mut existing_path = EngineTrack::new(TrackId::new());
-        existing_path.clips.push(clip());
+        existing_path.playback_source.clips.push(clip());
         let mut prepared_path = EngineTrack::with_playback_source(
             TrackId::new(),
             PreparedPlaybackSource::new(vec![clip()], Vec::new(), Vec::new()),

--- a/crates/vibez-engine/src/playback_source.rs
+++ b/crates/vibez-engine/src/playback_source.rs
@@ -1,0 +1,272 @@
+//! Resident timeline content that feeds a shared engine channel strip.
+//!
+//! A playback source contains time-based musical content only. Instruments,
+//! effects, sends, gain/pan, mute/solo, meters, and scratch buffers remain on
+//! [`EngineTrack`](crate::mixer::EngineTrack), the project-owned channel strip.
+
+use std::sync::Arc;
+
+use vibez_core::audio_buffer::DecodedAudio;
+use vibez_core::automation::AutomationLane;
+use vibez_core::id::ClipId;
+use vibez_core::midi::MidiNote;
+
+/// A resident audio clip on a prepared timeline.
+pub struct EngineClip {
+    pub id: ClipId,
+    pub audio: Arc<DecodedAudio>,
+    pub position: u64,
+    pub source_offset: u64,
+    pub duration: u64,
+    pub loop_enabled: bool,
+    pub loop_start: u64,
+    pub loop_end: u64,
+}
+
+impl EngineClip {
+    pub fn end_position(&self) -> u64 {
+        self.position.saturating_add(self.duration)
+    }
+
+    pub fn is_active(&self, pos: u64, frames: u64) -> bool {
+        let end = pos.saturating_add(frames);
+        self.position < end && self.end_position() > pos
+    }
+}
+
+/// A resident MIDI note clip on a prepared timeline.
+pub struct EngineNoteClip {
+    pub id: ClipId,
+    pub position_beats: f64,
+    pub duration_beats: f64,
+    pub notes: Vec<MidiNote>,
+    pub loop_enabled: bool,
+    pub loop_start_beats: f64,
+    pub loop_end_beats: f64,
+}
+
+/// Map a raw timeline frame through the active Arrange loop.
+#[inline]
+fn apply_loop_wrap(global_frame: u64, loop_region: Option<(u64, u64)>) -> u64 {
+    match loop_region {
+        Some((start, end)) if end > start && global_frame >= end => {
+            let loop_len = end - start;
+            let overshoot = global_frame - end;
+            start + (overshoot % loop_len)
+        }
+        _ => global_frame,
+    }
+}
+
+/// Timeline content prepared before it is handed to the audio callback.
+///
+/// All audio clips already own decoded sample `Arc`s. The type deliberately
+/// exposes no loading or I/O API: a later source switch can transfer one
+/// prepared owner and swap only its pointer in the callback.
+#[derive(Default)]
+pub struct PreparedPlaybackSource {
+    pub clips: Vec<EngineClip>,
+    pub note_clips: Vec<EngineNoteClip>,
+    pub automation: Vec<AutomationLane>,
+}
+
+impl PreparedPlaybackSource {
+    pub fn new(
+        clips: Vec<EngineClip>,
+        note_clips: Vec<EngineNoteClip>,
+        automation: Vec<AutomationLane>,
+    ) -> Self {
+        Self {
+            clips,
+            note_clips,
+            automation,
+        }
+    }
+
+    /// Render this resident source into a caller-owned channel buffer.
+    /// Channel processing remains outside this type.
+    pub fn render_audio(
+        &self,
+        output: &mut [f32],
+        pos: u64,
+        frames: usize,
+        channels: usize,
+        loop_region: Option<(u64, u64)>,
+    ) -> bool {
+        output.fill(0.0);
+        let mut rendered_any = false;
+        let block_crosses_loop = matches!(
+            loop_region,
+            Some((start, end)) if end > start
+                && pos < end
+                && pos.saturating_add(frames as u64) > end
+        );
+
+        for clip in &self.clips {
+            if !block_crosses_loop && !clip.is_active(pos, frames as u64) {
+                continue;
+            }
+            let audio_channels = clip.audio.num_channels();
+            let mut clip_rendered = false;
+            for frame in 0..frames {
+                let global_frame = apply_loop_wrap(pos + frame as u64, loop_region);
+                if global_frame < clip.position || global_frame >= clip.end_position() {
+                    continue;
+                }
+                let clip_frame = (global_frame - clip.position) as usize;
+                let source_frame = if clip.loop_enabled && clip.loop_end > clip.loop_start {
+                    let raw = clip.source_offset as usize + clip_frame;
+                    let loop_len = (clip.loop_end - clip.loop_start) as usize;
+                    if raw >= clip.loop_end as usize {
+                        clip.loop_start as usize + (raw - clip.loop_start as usize) % loop_len
+                    } else {
+                        raw
+                    }
+                } else {
+                    clip.source_offset as usize + clip_frame
+                };
+                for ch in 0..channels {
+                    let sample = if ch < audio_channels {
+                        clip.audio.sample(ch, source_frame)
+                    } else if audio_channels > 0 {
+                        clip.audio.sample(audio_channels - 1, source_frame)
+                    } else {
+                        0.0
+                    };
+                    output[frame * channels + ch] += sample;
+                }
+                clip_rendered = true;
+            }
+            rendered_any |= clip_rendered;
+        }
+        rendered_any
+    }
+}
+
+/// Calculate the total resident length across already-resolved sources.
+pub fn calculate_total_length<'a, I>(sources: I, samples_per_beat: f64) -> u64
+where
+    I: Iterator<Item = &'a PreparedPlaybackSource> + Clone,
+{
+    let audio_end = sources
+        .clone()
+        .flat_map(|source| source.clips.iter())
+        .map(EngineClip::end_position)
+        .max()
+        .unwrap_or(0);
+    let note_end = if samples_per_beat.is_finite() && samples_per_beat > 0.0 {
+        sources
+            .flat_map(|source| source.note_clips.iter())
+            .map(|clip| {
+                ((clip.position_beats + clip.duration_beats) * samples_per_beat).round() as u64
+            })
+            .max()
+            .unwrap_or(0)
+    } else {
+        0
+    };
+    audio_end.max(note_end)
+}
+
+/// Arrange's adapter into the engine playback-source boundary.
+///
+/// Live Arrange editing still mutates this resident source through the
+/// existing lock-free command queue. Section playback supplies the second
+/// adapter and pointer-switch behavior in Card 10.
+pub struct ArrangementPlaybackSource;
+
+impl ArrangementPlaybackSource {
+    pub fn prepare_empty() -> PreparedPlaybackSource {
+        PreparedPlaybackSource::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vibez_core::audio_buffer::DecodedAudio;
+    use vibez_core::id::{ClipId, TrackId};
+
+    use super::*;
+    use crate::mixer::EngineTrack;
+
+    #[test]
+    fn arrangement_adapter_prepares_an_empty_resident_source() {
+        let source = ArrangementPlaybackSource::prepare_empty();
+        assert!(source.clips.is_empty());
+        assert!(source.note_clips.is_empty());
+        assert!(source.automation.is_empty());
+    }
+
+    #[test]
+    fn prepared_arrangement_source_renders_identically_through_the_channel_strip() {
+        let audio = Arc::new(DecodedAudio {
+            channels: vec![vec![0.25, -0.5, 0.75, -1.0]],
+            sample_rate: 48_000,
+        });
+        let clip = || EngineClip {
+            id: ClipId::new(),
+            audio: Arc::clone(&audio),
+            position: 0,
+            source_offset: 0,
+            duration: 4,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        };
+
+        let mut existing_path = EngineTrack::new(TrackId::new());
+        existing_path.clips.push(clip());
+        let mut prepared_path = EngineTrack::with_playback_source(
+            TrackId::new(),
+            PreparedPlaybackSource::new(vec![clip()], Vec::new(), Vec::new()),
+        );
+
+        assert!(existing_path.render(0, 4, 1, None));
+        assert!(prepared_path.render(0, 4, 1, None));
+        assert_eq!(existing_path.mix_buffer, prepared_path.mix_buffer);
+    }
+
+    #[test]
+    fn total_length_combines_resident_audio_and_note_sources() {
+        let audio = Arc::new(DecodedAudio {
+            channels: vec![vec![0.5; 100]],
+            sample_rate: 44_100,
+        });
+        let audio_source = PreparedPlaybackSource::new(
+            vec![EngineClip {
+                id: ClipId::new(),
+                audio,
+                position: 50,
+                source_offset: 0,
+                duration: 100,
+                loop_enabled: false,
+                loop_start: 0,
+                loop_end: 0,
+            }],
+            Vec::new(),
+            Vec::new(),
+        );
+        let note_source = PreparedPlaybackSource::new(
+            Vec::new(),
+            vec![EngineNoteClip {
+                id: ClipId::new(),
+                position_beats: 2.0,
+                duration_beats: 4.0,
+                notes: Vec::new(),
+                loop_enabled: false,
+                loop_start_beats: 0.0,
+                loop_end_beats: 0.0,
+            }],
+            Vec::new(),
+        );
+        let sources = [audio_source, note_source];
+
+        assert_eq!(calculate_total_length(sources.iter(), 22_050.0), 132_300);
+        assert_eq!(
+            calculate_total_length(std::iter::empty::<&PreparedPlaybackSource>(), 22_050.0),
+            0
+        );
+    }
+}

--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -164,7 +164,7 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
                 continue;
             }
             match req.clip_audio.get(&clip.id) {
-                Some(audio) => engine.clips.push(EngineClip {
+                Some(audio) => engine.playback_source.clips.push(EngineClip {
                     id: clip.id,
                     audio: Arc::clone(audio),
                     position: clip.position,
@@ -186,7 +186,7 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
             if !clip_included_for_mode(nc.id, req.mode, true) {
                 continue;
             }
-            engine.note_clips.push(EngineNoteClip {
+            engine.playback_source.note_clips.push(EngineNoteClip {
                 id: nc.id,
                 position_beats: nc.position_beats,
                 duration_beats: nc.duration_beats,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -210,6 +210,24 @@ flowchart LR
     MET -- "peaks, position" --> EV["EngineEvent ring"]
 ```
 
+`EngineTrack` is the shared project channel strip: it owns the instrument,
+effects, sends, gain/pan, mute/solo, meters, and preallocated render scratch.
+Time-based Arrange content is now a separate `PreparedPlaybackSource` behind
+one owned pointer. `ArrangementPlaybackSource` is the first adapter and the
+same source renderer feeds the existing channel path, so there is no second
+clip, note, automation, instrument, or effect implementation. Prepared sources
+contain decoded clip `Arc`s and expose no loader or I/O API. Card 10 supplies
+the Section adapter and the first pointer transfer; the callback must exchange
+prepared ownership only and return superseded ownership for disposal outside
+the real-time thread rather than dropping it there.
+
+```mermaid
+flowchart LR
+    A["ArrangementPlaybackSource adapter"] --> P["PreparedPlaybackSource<br/>audio + note clips + automation"]
+    P -- "resident source pointer" --> C["EngineTrack channel strip<br/>instrument + effects + sends + mixer"]
+    C --> M["metering + master"]
+```
+
 ## Plugins (VST3 and CLAP)
 
 Third-party plugins are the least trustworthy code in the process, so they


### PR DESCRIPTION
## Summary

- separate time-based clips, note clips, and automation into `PreparedPlaybackSource`
- keep instruments, effects, sends, channel controls, meters, and render scratch on the shared `EngineTrack` channel strip
- make `ArrangementPlaybackSource` the first active adapter while retaining the existing lock-free command and render behavior
- document the fully resident ownership-transfer contract that Card 10 will exercise

## Blockers and scope

Card 01 is complete. This branch starts independently from current `dev` at `60d4760` and has no dependency on Card 07 PR #76.

Non-goals: the Section adapter, source switching, launch behavior, immediate note release, quantized scheduling, transition events, and Capture.

## Real-time contract

A prepared source contains decoded clip `Arc` values and exposes no loader, lock, or I/O API. Its owned pointer is allocated before playback. Card 10 must transfer prepared ownership in the callback and return the superseded owner for disposal outside the real-time thread; it must not drop that owner in the callback.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace -j4`
- `cargo test --workspace -j4` (engine: 136 passed; UI: 248 passed)
- `cargo clippy --workspace -j4 -- -D warnings`
- `git diff --check`
- touched Rust files remain below 1,000 lines
- branch-exact native dogfood loaded and played the four-track demo Arrange project through 17.56 seconds with transport, playhead, and master metering active, then stopped cleanly on an isolated display

The initial workspace link exhausted the dedicated target disk allocation. Only regenerable Card 09 target artifacts were cleaned; the complete gates then passed with incremental output and debug info disabled.