### PR TITLE
feat(ui): resize the shared detail panel

### DIFF
--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -246,6 +246,7 @@ impl App {
             confirm_project_track_deletion: ui_settings.confirm_project_track_deletion,
             view: crate::state::ViewState {
                 perform_surface_width: ui_settings.perform_surface_width,
+                detail_panel_height: ui_settings.detail_panel_height,
                 ..Default::default()
             },
             browser: crate::state::BrowserState {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -230,6 +230,7 @@ impl App {
             sample_browser_open: self.state.browser.open,
             sample_browser_width: self.state.browser.dock_width,
             perform_surface_width: self.state.view.perform_surface_width,
+            detail_panel_height: self.state.view.detail_panel_height,
             audition_enabled: self.state.browser.audition_enabled,
             audition_gain: self.state.browser.audition_gain,
             audition_loop: self.state.browser.audition_loop,

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -254,6 +254,30 @@ impl App {
                         self.persist_ui_settings();
                     }
                 }
+                let detail_panel_resize = match &msg {
+                    ViewMsg::CursorMoved(_, y) if self.state.view.detail_panel_resize_active => {
+                        Some(ViewMsg::ResizeDetailPanel(
+                            self.detail_panel_drag_height(*y),
+                        ))
+                    }
+                    ViewMsg::MouseReleased if self.state.view.detail_panel_resize_active => {
+                        Some(ViewMsg::EndDetailPanelResize)
+                    }
+                    _ => None,
+                };
+                if let Some(resize_msg) = detail_panel_resize {
+                    let ctx = crate::domains::view::ViewCtx {
+                        total_beats: self.state.total_beats(),
+                    };
+                    let action = self.state.view.update(
+                        resize_msg,
+                        self.state.arrangement.resolve_timeline().editor,
+                        ctx,
+                    );
+                    if action.persist_settings {
+                        self.persist_ui_settings();
+                    }
+                }
                 let perform_surface_resize = match &msg {
                     ViewMsg::CursorMoved(x, _) if self.state.view.perform_surface_resize_active => {
                         Some(ViewMsg::ResizePerformSurface(

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -21,6 +21,15 @@ use crate::widgets::piano_roll::PianoRollWidget;
 
 use super::*;
 
+const DETAIL_PANEL_MIN_HEIGHT: f32 = 180.0;
+const SHELL_AND_WORKSPACE_MIN_HEIGHT: f32 = 360.0;
+const STATUS_BAR_HEIGHT: f32 = 24.0;
+
+fn effective_detail_panel_height(preferred_height: f32, window_height: f32) -> f32 {
+    let maximum = (window_height - SHELL_AND_WORKSPACE_MIN_HEIGHT).max(DETAIL_PANEL_MIN_HEIGHT);
+    preferred_height.clamp(DETAIL_PANEL_MIN_HEIGHT, maximum)
+}
+
 impl App {
     // ── Detail panel (Ableton-style device chain) ──
 
@@ -151,23 +160,13 @@ impl App {
                 .into()
         };
 
-        // Ableton-style panel heights: the Devices tab is a FIXED
-        // strip that device cards are designed to fit exactly (the
-        // arrangement flexes instead); the Clip tab keeps flexible
-        // height for the piano roll. Window-fraction heights clipped
-        // cards or demanded ugly vertical scrollbars.
-        let panel_height = if self.state.view.detail_panel_tab == DetailPanelTab::Devices {
-            Length::Fixed(th::DEVICE_BODY_H + 96.0)
-        } else if self.state.view.workspace == crate::state::Workspace::Perform
-            && self.state.perform.section_timeline_expanded
-        {
-            Length::FillPortion(1)
-        } else {
-            Length::FillPortion(2)
-        };
+        let panel_height = effective_detail_panel_height(
+            self.state.view.detail_panel_height,
+            self.state.view.window_height,
+        );
         container(detail_content)
             .width(Length::Fill)
-            .height(panel_height)
+            .height(Length::Fixed(panel_height))
             .style(|_theme: &Theme| container::Style {
                 background: Some(th::bg_dark().into()),
                 border: iced::Border {
@@ -178,6 +177,13 @@ impl App {
                 ..Default::default()
             })
             .into()
+    }
+
+    pub(super) fn detail_panel_drag_height(&self, cursor_y: f32) -> f32 {
+        effective_detail_panel_height(
+            self.state.view.window_height - cursor_y - STATUS_BAR_HEIGHT,
+            self.state.view.window_height,
+        )
     }
 
     pub(super) fn view_clip_placeholder(&self) -> Element<'_, Message> {
@@ -667,5 +673,18 @@ impl App {
         .spacing(6)
         .align_y(iced::Alignment::Center)
         .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::effective_detail_panel_height;
+
+    #[test]
+    fn detail_panel_height_preserves_the_workspace_at_small_windows() {
+        assert_eq!(effective_detail_panel_height(80.0, 900.0), 180.0);
+        assert_eq!(effective_detail_panel_height(360.0, 900.0), 360.0);
+        assert_eq!(effective_detail_panel_height(800.0, 900.0), 540.0);
+        assert_eq!(effective_detail_panel_height(320.0, 520.0), 180.0);
     }
 }

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -20,6 +20,7 @@ const MODE_TAB_MIN_WIDTH: f32 = 92.0;
 const MODE_TAB_MAX_WIDTH: f32 = 132.0;
 const PAD_SURFACE_MIN_WIDTH: f32 = 320.0;
 const SECTION_CONSTRUCTION_MIN_WIDTH: f32 = 460.0;
+const SECTION_TOOLBAR_INLINE_MIN_WIDTH: f32 = 640.0;
 pub(super) const SECTION_TRACK_GUTTER_WIDTH: f32 = 112.0;
 pub(super) const SECTION_BAR_WIDTH: f32 = 160.0;
 
@@ -105,6 +106,10 @@ fn effective_perform_surface_width(preferred_width: f32, workspace_width: f32) -
     preferred_width.clamp(minimum, maximum)
 }
 
+fn section_toolbar_stacks(section_width: f32) -> bool {
+    section_width < SECTION_TOOLBAR_INLINE_MIN_WIDTH
+}
+
 fn perform_pad_grid_height(window_height: f32) -> f32 {
     (window_height * 0.48).clamp(272.0, 480.0)
 }
@@ -114,9 +119,12 @@ impl App {
         let workspace_width = self.perform_workspace_width();
         let surface_width =
             effective_perform_surface_width(self.state.view.perform_surface_width, workspace_width);
+        let section_width =
+            (workspace_width - surface_width - super::views_shell::HORIZONTAL_PANE_SPLITTER_WIDTH)
+                .max(0.0);
         let mode_selector = self.view_perform_mode_selector(surface_width);
         let pad_surface = self.view_pad_surface(surface_width);
-        let section_construction = self.view_section_construction();
+        let section_construction = self.view_section_construction(section_width);
 
         let workspace = row![
             pad_surface,
@@ -544,7 +552,11 @@ impl App {
         }
     }
 
-    pub(super) fn view_section_toolbar(&self, section: Option<&Section>) -> Element<'_, Message> {
+    pub(super) fn view_section_toolbar(
+        &self,
+        section: Option<&Section>,
+        section_width: f32,
+    ) -> Element<'_, Message> {
         let Some(section) = section else {
             return container(row![
                 column![
@@ -800,10 +812,18 @@ impl App {
         ]
         .spacing(3)
         .width(Length::Fill);
-        let toolbar = row![identity, controls]
-            .spacing(12)
-            .align_y(iced::Alignment::Center)
-            .padding([8, 12]);
+        let toolbar: Element<'_, Message> = if section_toolbar_stacks(section_width) {
+            column![identity, controls]
+                .spacing(8)
+                .padding([8, 12])
+                .into()
+        } else {
+            row![identity, controls]
+                .spacing(12)
+                .align_y(iced::Alignment::Center)
+                .padding([8, 12])
+                .into()
+        };
 
         container(toolbar)
             .width(Length::Fill)
@@ -849,5 +869,11 @@ mod tests {
         assert_eq!(effective_perform_surface_width(640.0, 1400.0), 640.0);
         assert_eq!(effective_perform_surface_width(1200.0, 1400.0), 933.0);
         assert_eq!(effective_perform_surface_width(500.0, 820.0), 353.0);
+    }
+
+    #[test]
+    fn section_toolbar_stacks_before_identity_text_collapses() {
+        assert!(section_toolbar_stacks(SECTION_CONSTRUCTION_MIN_WIDTH));
+        assert!(!section_toolbar_stacks(760.0));
     }
 }

--- a/crates/vibez-ui/src/app/views_perform_sections.rs
+++ b/crates/vibez-ui/src/app/views_perform_sections.rs
@@ -22,13 +22,13 @@ use super::views_perform::{SECTION_BAR_WIDTH, SECTION_TRACK_GUTTER_WIDTH};
 use super::*;
 
 impl App {
-    pub(super) fn view_section_construction(&self) -> Element<'_, Message> {
+    pub(super) fn view_section_construction(&self, section_width: f32) -> Element<'_, Message> {
         let selected = self
             .state
             .perform
             .selected_section
             .and_then(|id| self.state.perform.sections.by_id(id));
-        let toolbar = self.view_section_toolbar(selected);
+        let toolbar = self.view_section_toolbar(selected, section_width);
         let editor = self.state.perform.section_editor.editor();
         let bar_count = selected
             .map(|section| (section.length_beats / 4.0).round() as usize)

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -17,6 +17,21 @@ use crate::theme as th;
 use super::*;
 
 pub(super) const HORIZONTAL_PANE_SPLITTER_WIDTH: f32 = 7.0;
+pub(super) const VERTICAL_PANE_SPLITTER_HEIGHT: f32 = 7.0;
+
+fn pane_splitter_style(active: bool) -> container::Style {
+    container::Style {
+        background: Some(
+            if active {
+                th::accent_dim()
+            } else {
+                th::divider()
+            }
+            .into(),
+        ),
+        ..Default::default()
+    }
+}
 
 pub(super) fn horizontal_pane_splitter(
     active: bool,
@@ -26,20 +41,22 @@ pub(super) fn horizontal_pane_splitter(
         container(text(""))
             .width(Length::Fixed(HORIZONTAL_PANE_SPLITTER_WIDTH))
             .height(Length::Fill)
-            .style(move |_theme: &Theme| container::Style {
-                background: Some(
-                    if active {
-                        th::accent_dim()
-                    } else {
-                        th::divider()
-                    }
-                    .into(),
-                ),
-                ..Default::default()
-            }),
+            .style(move |_theme: &Theme| pane_splitter_style(active)),
     )
     .on_press(on_press)
     .interaction(iced::mouse::Interaction::ResizingHorizontally)
+    .into()
+}
+
+pub(super) fn vertical_pane_splitter(active: bool, on_press: Message) -> Element<'static, Message> {
+    mouse_area(
+        container(text(""))
+            .width(Length::Fill)
+            .height(Length::Fixed(VERTICAL_PANE_SPLITTER_HEIGHT))
+            .style(move |_theme: &Theme| pane_splitter_style(active)),
+    )
+    .on_press(on_press)
+    .interaction(iced::mouse::Interaction::ResizingVertically)
     .into()
 }
 
@@ -70,11 +87,22 @@ impl App {
             workspace_content
         };
 
+        let detail_splitter = vertical_pane_splitter(
+            self.state.view.detail_panel_resize_active,
+            Message::View(ViewMsg::BeginDetailPanelResize),
+        );
         let detail_panel = self.view_detail_panel();
         let transport_bar = self.view_transport();
         let status_bar = self.view_status();
 
-        let layout = column![header, transport_bar, content, detail_panel, status_bar];
+        let layout = column![
+            header,
+            transport_bar,
+            content,
+            detail_splitter,
+            detail_panel,
+            status_bar
+        ];
 
         let layout_container = container(layout).width(Length::Fill).height(Length::Fill);
         // Outer mouse_area cancels an active sample-drag on any release

--- a/crates/vibez-ui/src/domains/view.rs
+++ b/crates/vibez-ui/src/domains/view.rs
@@ -26,6 +26,9 @@ pub enum ViewMsg {
     ToggleTripletGrid,
     ToggleSnapToGrid,
     ToggleAdaptiveGrid,
+    BeginDetailPanelResize,
+    ResizeDetailPanel(f32),
+    EndDetailPanelResize,
     BeginPerformSurfaceResize,
     ResizePerformSurface(f32),
     EndPerformSurfaceResize,
@@ -147,6 +150,20 @@ impl ViewState {
             }
             ViewMsg::ToggleAdaptiveGrid => {
                 self.adaptive_grid = !self.adaptive_grid;
+            }
+            ViewMsg::BeginDetailPanelResize => {
+                self.detail_panel_resize_active = true;
+            }
+            ViewMsg::ResizeDetailPanel(height) => {
+                if self.detail_panel_resize_active {
+                    self.detail_panel_height = height;
+                }
+            }
+            ViewMsg::EndDetailPanelResize => {
+                if self.detail_panel_resize_active {
+                    self.detail_panel_resize_active = false;
+                    action.persist_settings = true;
+                }
             }
             ViewMsg::BeginPerformSurfaceResize => {
                 self.perform_surface_resize_active = true;
@@ -498,6 +515,38 @@ mod tests {
 
         assert_eq!(view.perform_surface_width, 720.0);
         assert!(!view.perform_surface_resize_active);
+        assert!(action.persist_settings);
+    }
+
+    #[test]
+    fn detail_panel_resize_commits_one_global_view_preference() {
+        let mut view = ViewState::default();
+        let timeline = TimelineEditorState::default();
+
+        view.update(
+            ViewMsg::ResizeDetailPanel(420.0),
+            &timeline,
+            ViewCtx::default(),
+        );
+        assert_eq!(
+            view.detail_panel_height,
+            crate::state::DETAIL_PANEL_DEFAULT_HEIGHT
+        );
+
+        view.update(
+            ViewMsg::BeginDetailPanelResize,
+            &timeline,
+            ViewCtx::default(),
+        );
+        view.update(
+            ViewMsg::ResizeDetailPanel(420.0),
+            &timeline,
+            ViewCtx::default(),
+        );
+        let action = view.update(ViewMsg::EndDetailPanelResize, &timeline, ViewCtx::default());
+
+        assert_eq!(view.detail_panel_height, 420.0);
+        assert!(!view.detail_panel_resize_active);
         assert!(action.persist_settings);
     }
 }

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 mod browser_results;
 mod browser_state;
 mod ui_types;
+
+use crate::remote_provider::RemoteCatalogSnapshot;
 pub use browser_results::LocalResults;
 pub use browser_state::*;
 pub use ui_types::*;
@@ -16,8 +18,6 @@ use vibez_core::id::{ClipId, TrackId};
 use vibez_core::track::MediaSourceRef;
 use vibez_engine::commands::AuditionSync;
 use vibez_plugin_host::PluginSettings;
-
-use crate::remote_provider::RemoteCatalogSnapshot;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AuditionMode {
@@ -34,15 +34,14 @@ impl AuditionMode {
         }
     }
 }
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AuditionImportInput {
     pub mode: AuditionMode,
     pub source_bpm: Option<f64>,
 }
-
 pub const MEDIA_DRAG_THRESHOLD_PX: f32 = 6.0;
 pub const PERFORM_SURFACE_DEFAULT_WIDTH: f32 = 560.0;
+pub const DETAIL_PANEL_DEFAULT_HEIGHT: f32 = 280.0;
 #[derive(Debug, Clone, PartialEq)]
 pub struct PendingMediaDrag {
     pub source: MediaSourceRef,
@@ -69,12 +68,13 @@ pub enum BrowserDropTarget {
         pad_index: usize,
     },
 }
-/// View domain slice: everything about how the project is being
-/// looked at, none of it part of the project itself.
+/// View-domain state; none of it is part of the project itself.
 #[derive(Debug)]
 pub struct ViewState {
     pub workspace: Workspace,
     pub detail_panel_tab: DetailPanelTab,
+    pub detail_panel_height: f32,
+    pub detail_panel_resize_active: bool,
     pub perform_surface_width: f32,
     pub perform_surface_resize_active: bool,
     pub zoom_level: f32,
@@ -89,7 +89,6 @@ pub struct ViewState {
     pub cursor_y: f32,
     pub window_width: f32, // last known size for responsive view clamping
     pub window_height: f32,
-    // Inline renaming
     pub editing_track_name: Option<TrackId>,
     pub editing_clip_name: Option<(TrackId, ClipId)>,
     pub edit_name_text: String,
@@ -99,6 +98,8 @@ impl Default for ViewState {
         Self {
             workspace: Workspace::Arrange,
             detail_panel_tab: DetailPanelTab::Clip,
+            detail_panel_height: DETAIL_PANEL_DEFAULT_HEIGHT,
+            detail_panel_resize_active: false,
             perform_surface_width: PERFORM_SURFACE_DEFAULT_WIDTH,
             perform_surface_resize_active: false,
             zoom_level: 1.0,
@@ -530,9 +531,7 @@ pub struct AppState {
     /// the selected track); drawn behind the channel EQ curve.
     pub spectrum: crate::spectrum::SpectrumState,
 
-    // UI
     pub status_text: String,
-    // View domain slice (workspace, zoom, snap, menus, renames).
     pub view: ViewState,
 
     pub piano_roll: PianoRollState,

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -14,6 +14,8 @@ pub struct UiSettings {
     pub sample_browser_width: f32,
     #[serde(default = "default_perform_surface_width")]
     pub perform_surface_width: f32,
+    #[serde(default = "default_detail_panel_height")]
+    pub detail_panel_height: f32,
     #[serde(default = "default_audition_enabled")]
     pub audition_enabled: bool,
     #[serde(default = "default_audition_gain")]
@@ -57,6 +59,7 @@ impl Default for UiSettings {
             sample_browser_open: default_sample_browser_open(),
             sample_browser_width: default_sample_browser_width(),
             perform_surface_width: default_perform_surface_width(),
+            detail_panel_height: default_detail_panel_height(),
             audition_enabled: default_audition_enabled(),
             audition_gain: default_audition_gain(),
             audition_loop: false,
@@ -117,6 +120,10 @@ fn default_perform_surface_width() -> f32 {
     crate::state::PERFORM_SURFACE_DEFAULT_WIDTH
 }
 
+fn default_detail_panel_height() -> f32 {
+    crate::state::DETAIL_PANEL_DEFAULT_HEIGHT
+}
+
 fn default_audition_enabled() -> bool {
     true
 }
@@ -171,6 +178,23 @@ mod tests {
         let loaded: UiSettings =
             serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
         assert_eq!(loaded.perform_surface_width, 704.0);
+    }
+
+    #[test]
+    fn detail_panel_height_defaults_and_roundtrips() {
+        let old: UiSettings = serde_json::from_str("{}").unwrap();
+        assert_eq!(
+            old.detail_panel_height,
+            crate::state::DETAIL_PANEL_DEFAULT_HEIGHT
+        );
+
+        let settings = UiSettings {
+            detail_panel_height: 412.0,
+            ..UiSettings::default()
+        };
+        let loaded: UiSettings =
+            serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
+        assert_eq!(loaded.detail_panel_height, 412.0);
     }
 
     #[test]


### PR DESCRIPTION
## Outcome

The shared Clip/Devices detail panel is vertically resizable in both Arrange and Perform. Its height persists globally and reclamps on smaller windows so the workspace remains usable.

## Scope

- reuses the shared shell and one pane-splitter visual primitive
- adds begin/resize/end view-domain state and persists only on release
- keeps both Clip and Devices tabs at the chosen height
- no Card 10 playback changes and no unrelated Arrange/Perform styling

## Evidence

- red-first drag lifecycle, geometry/clamping, legacy settings, and round-trip tests
- `cargo fmt --all -- --check`
- `cargo check --workspace -j4`
- `cargo clippy --workspace -j4 -- -D warnings`
- `cargo test --workspace -j4` (270 UI tests; 136 engine tests)
- exact branch executable `/home/alexander/Code/Apps/vibez-targets/fix-bottom-inspector/debug/vibez` verified by window PID and `/proc`; native Xvfb dogfood resized 280px to 446px and verified persistence after restart
- screenshots: `inspector-before.png`, `inspector-resized-slow.png`, `inspector-reopened.png` in the dedicated target

## Manual demo

1. Open Arrange or Perform and select a Track/clip so the bottom panel is visible.
2. Drag the thin horizontal divider above Clip/Devices up and down.
3. Switch between Clip and Devices and between Arrange and Perform; the same height should remain.
4. Restart Vibez; the chosen height should persist.
5. Shrink the window and confirm neither the workspace nor panel collapses.