### PR TITLE
fix(ui): dispatch track shortcut once per press

### DIFF
--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -12,6 +12,43 @@ use crate::domains::view::ViewMsg;
 
 use crate::message::Message;
 
+#[derive(Default)]
+pub(crate) struct EdgeShortcutState {
+    pressed_keys: std::collections::HashSet<String>,
+    released_at: std::collections::HashMap<String, std::time::Instant>,
+}
+
+impl EdgeShortcutState {
+    fn should_dispatch(
+        &mut self,
+        key_id: &str,
+        message: &Message,
+        occurred_at: std::time::Instant,
+    ) -> bool {
+        let edge_triggered = matches!(
+            message,
+            Message::Arrangement(ArrangementMsg::AddTrack | ArrangementMsg::AddInstrumentTrack)
+        );
+        if !edge_triggered {
+            return true;
+        }
+
+        let release_gap = self
+            .released_at
+            .get(key_id)
+            .map(|released_at| occurred_at.saturating_duration_since(*released_at));
+        let synthetic_repeat =
+            release_gap.is_some_and(|gap| gap <= std::time::Duration::from_millis(30));
+        let first_press = self.pressed_keys.insert(key_id.to_owned());
+        first_press && !synthetic_repeat
+    }
+
+    fn release(&mut self, key_id: &str, occurred_at: std::time::Instant) {
+        self.pressed_keys.remove(key_id);
+        self.released_at.insert(key_id.to_owned(), occurred_at);
+    }
+}
+
 pub(crate) fn keyboard_input_message(
     event: iced::keyboard::Event,
     status: iced::event::Status,
@@ -98,6 +135,7 @@ impl super::App {
                 modifiers,
                 ..
             } => {
+                let edge_key_id = runtime_key_id(&key);
                 if self.state.perform.key_rebind_target.is_some()
                     && matches!(key, iced::keyboard::Key::Named(Named::Escape))
                 {
@@ -110,25 +148,29 @@ impl super::App {
                                 key_id: runtime_key_id(&key),
                                 occurred_at,
                             }),
-                            Some((key, modifiers)),
+                            Some((key, modifiers, edge_key_id)),
                         )
                     } else {
-                        (None, Some((key, modifiers)))
+                        (None, Some((key, modifiers, edge_key_id)))
                     }
                 } else if self.state.perform.key_rebind_target.is_some() {
                     self.state.status_text = "Perform keys must be letters or numbers".into();
                     return iced::Task::none();
                 } else {
-                    (None, Some((key, modifiers)))
+                    (None, Some((key, modifiers, edge_key_id)))
                 }
             }
-            iced::keyboard::Event::KeyReleased { key, .. } => (
-                Some(PerformMsg::ComputerKeyReleased {
-                    key_id: runtime_key_id(&key),
-                    occurred_at,
-                }),
-                None,
-            ),
+            iced::keyboard::Event::KeyReleased { key, .. } => {
+                let key_id = runtime_key_id(&key);
+                self.edge_shortcuts.release(&key_id, occurred_at);
+                (
+                    Some(PerformMsg::ComputerKeyReleased {
+                        key_id,
+                        occurred_at,
+                    }),
+                    None,
+                )
+            }
             iced::keyboard::Event::ModifiersChanged(_) => return iced::Task::none(),
         };
 
@@ -150,7 +192,12 @@ impl super::App {
         }
 
         fallback
-            .and_then(|(key, modifiers)| global_key_handler(key, modifiers))
+            .and_then(|(key, modifiers, key_id)| {
+                let message = global_key_handler(key, modifiers)?;
+                self.edge_shortcuts
+                    .should_dispatch(&key_id, &message, occurred_at)
+                    .then_some(message)
+            })
             .map_or_else(iced::Task::none, iced::Task::done)
     }
 }
@@ -395,6 +442,37 @@ mod tests {
             Some(Message::Arrangement(
                 ArrangementMsg::CreateClipFromSelection
             ))
+        ));
+    }
+
+    #[test]
+    fn held_track_shortcut_dispatches_once_until_key_release() {
+        let mut state = EdgeShortcutState::default();
+        let add = Message::Arrangement(ArrangementMsg::AddInstrumentTrack);
+        let started = std::time::Instant::now();
+
+        assert!(state.should_dispatch("Character(\"T\")", &add, started));
+        assert!(!state.should_dispatch("Character(\"T\")", &add, started));
+
+        // X11 auto-repeat is delivered as a synthetic release/press pair.
+        state.release(
+            "Character(\"T\")",
+            started + std::time::Duration::from_millis(500),
+        );
+        assert!(!state.should_dispatch(
+            "Character(\"T\")",
+            &add,
+            started + std::time::Duration::from_millis(501),
+        ));
+
+        state.release(
+            "Character(\"T\")",
+            started + std::time::Duration::from_millis(900),
+        );
+        assert!(state.should_dispatch(
+            "Character(\"T\")",
+            &add,
+            started + std::time::Duration::from_millis(1_000),
         ));
     }
 

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -33,6 +33,7 @@ use crate::ui_settings::UiSettings;
 
 struct App {
     state: AppState,
+    edge_shortcuts: EdgeShortcutState,
     cmd_tx: Option<Producer<EngineCommand>>,
     event_rx: Option<Consumer<EngineEvent>>,
     /// Post-effects mono samples from the engine's spectrum tap,
@@ -303,6 +304,7 @@ impl App {
 
         let mut app = Self {
             state,
+            edge_shortcuts: EdgeShortcutState::default(),
             cmd_tx: Some(cmd_tx),
             event_rx: Some(event_rx),
             spectrum_rx,


### PR DESCRIPTION
## Outcome

`Ctrl+T` and `Ctrl+Shift+T` create exactly one Track for one physical key press, including on X11 where auto-repeat arrives as synthetic release/press pairs.

## Scope

- one keyboard-adapter guard for the two Track-creation shortcuts
- ordinary shortcuts and intentional later Track shortcut presses remain unchanged
- no Track-domain or Arrange/Perform duplication

## Root cause

Iced 0.13 exposes no repeat flag. X11 may synthesize release/press pairs while a key remains held, so the original global shortcut handler dispatched every repeated keydown. The adapter now suppresses a press immediately following a synthetic release while allowing a genuine later press.

## Evidence

- red-first regression models an initial press, same-key keydown repeat, X11 synthetic release/press, and a later genuine press
- `cargo fmt --all -- --check`
- `cargo check --workspace -j4`
- `cargo clippy --workspace -j4 -- -D warnings`
- `cargo test --workspace -j4` (268 UI tests; 136 engine tests)
- exact branch PID/executable verified under Xvfb; held `Ctrl+Shift+T` produced one MIDI Track in `held-shortcut-fixed.png`/`instrumented-held.png`
- the first audio-enabled dogfood was independently interrupted by the known `SIGXCPU` device failure now isolated in the separate audio-disconnect PR

## Manual demo

1. Open an empty Arrange project.
2. Hold `Ctrl+Shift+T` long enough for keyboard repeat; exactly one MIDI Track should appear.
3. Release, then press it again; exactly one additional MIDI Track should appear.
4. Repeat with `Ctrl+T`; each physical press should add one Audio Track.