### PR TITLE
feat(perform): play one Section

### DIFF
--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -7,6 +7,8 @@ use vibez_core::track::DrumPadState;
 use vibez_dsp::effect::AudioEffect;
 use vibez_instruments::Instrument;
 
+use crate::playback_source::PreparedSectionPlaybackSource;
+
 /// Quantization policy for the next Browser Audition start.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuditionSync {
@@ -30,6 +32,8 @@ pub enum EngineCommand {
     Seek(u64),
     /// Change the project tempo.
     SetBpm(f64),
+    /// Immediately activate a complete resident Section playback source.
+    LaunchSection(Box<PreparedSectionPlaybackSource>),
     /// Load decoded audio into the engine for playback (legacy single-file).
     LoadAudio(Arc<DecodedAudio>),
     /// Remove any loaded audio from the engine (legacy single-file).

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -34,6 +34,10 @@ pub enum EngineCommand {
     SetBpm(f64),
     /// Immediately activate a complete resident Section playback source.
     LaunchSection(Box<PreparedSectionPlaybackSource>),
+    /// Replace the currently active Section's resident source in place.
+    /// The engine preserves its local playhead and returns ownership of the
+    /// displaced source through `SectionSourceRefreshed`.
+    RefreshSection(Box<PreparedSectionPlaybackSource>),
     /// Load decoded audio into the engine for playback (legacy single-file).
     LoadAudio(Arc<DecodedAudio>),
     /// Remove any loaded audio from the engine (legacy single-file).

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -3,13 +3,14 @@ use std::sync::Arc;
 use rtrb::{Consumer, Producer, RingBuffer};
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::constants::RING_BUFFER_CAPACITY;
-use vibez_core::id::TrackId;
+use vibez_core::id::{SectionId, TrackId};
 
 use vibez_core::time::TempoMap;
 use vibez_dsp::factory::create_effect;
 use vibez_instruments::create_instrument;
 
 use crate::commands::{AuditionSync, EngineCommand};
+use crate::engine_audition::{audition_fade_frames, next_audition_boundary, AuditionBus};
 use crate::events::EngineEvent;
 use crate::metering;
 use crate::mixer::{
@@ -67,110 +68,16 @@ pub struct AudioEngine {
     /// loop boundary; suppresses the post-advance discontinuity flush
     /// for that block (segment-2 notes are legitimately sounding).
     split_wrap_handled: bool,
+    active_section: Option<ActiveSectionPlayback>,
+    arrangement_audio_length: Option<u64>,
 }
 
-/// How many replaced voices can fade out simultaneously. With tiny
-/// audio buffers a retrigger can arrive before the previous ~5ms fade
-/// finishes; a couple of fixed slots absorb the overlap without
-/// clicking or allocating on the audio thread.
-const AUDITION_OUTGOING_VOICES: usize = 3;
-
-/// Dedicated Browser signal path mixed after project master processing.
-struct AuditionBus {
-    active: Option<AuditionVoice>,
-    outgoing: [Option<AuditionVoice>; AUDITION_OUTGOING_VOICES],
-    queued: Option<QueuedAudition>,
-    gain: f32,
-}
-
-struct AuditionVoice {
-    audio: Arc<DecodedAudio>,
-    position: u64,
-    fade_in_frames: usize,
-    fade_out_remaining: Option<usize>,
-    looped: bool,
-}
-
-struct QueuedAudition {
-    audio: Arc<DecodedAudio>,
-    target_position: u64,
-    looped: bool,
-}
-
-impl AuditionBus {
-    fn new() -> Self {
-        Self {
-            active: None,
-            outgoing: std::array::from_fn(|_| None),
-            queued: None,
-            gain: 1.0,
-        }
-    }
-
-    fn start(&mut self, audio: Arc<DecodedAudio>, fade_frames: usize, looped: bool) {
-        self.queued = None;
-        self.stop_active(fade_frames);
-        self.active = Some(AuditionVoice {
-            audio,
-            position: 0,
-            fade_in_frames: fade_frames,
-            fade_out_remaining: None,
-            looped,
-        });
-    }
-
-    fn queue(
-        &mut self,
-        audio: Arc<DecodedAudio>,
-        target_position: u64,
-        fade_frames: usize,
-        looped: bool,
-    ) {
-        self.stop_active(fade_frames);
-        self.queued = Some(QueuedAudition {
-            audio,
-            target_position,
-            looped,
-        });
-    }
-
-    fn stop(&mut self, fade_frames: usize) {
-        self.queued = None;
-        self.stop_active(fade_frames);
-    }
-
-    fn stop_active(&mut self, fade_frames: usize) {
-        if let Some(mut active) = self.active.take() {
-            if active.position > 0 {
-                active.fade_out_remaining = Some(fade_frames);
-                // Prefer a free slot; when a rapid retrigger burst has
-                // every slot fading, replace the voice closest to done
-                // (the smallest possible click).
-                let slot = self
-                    .outgoing
-                    .iter_mut()
-                    .min_by_key(|slot| {
-                        slot.as_ref()
-                            .map_or(0, |voice| voice.fade_out_remaining.unwrap_or(0))
-                    })
-                    .expect("outgoing slots are non-empty");
-                *slot = Some(active);
-            }
-        }
-    }
-
-    fn has_outgoing(&self) -> bool {
-        self.outgoing.iter().any(Option::is_some)
-    }
-
-    fn set_looped(&mut self, looped: bool) {
-        if let Some(active) = self.active.as_mut() {
-            active.looped = looped;
-        }
-        if let Some(queued) = self.queued.as_mut() {
-            queued.looped = looped;
-        }
-    }
+#[derive(Debug, Clone, Copy)]
+struct ActiveSectionPlayback {
+    section_id: SectionId,
+    position_samples: u64,
+    length_samples: u64,
+    looping: bool,
 }
 
 impl AudioEngine {
@@ -198,6 +105,8 @@ impl AudioEngine {
             cmd_rx,
             event_tx,
             split_wrap_handled: false,
+            active_section: None,
+            arrangement_audio_length: None,
         };
 
         (engine, cmd_tx, event_rx)
@@ -340,12 +249,49 @@ impl AudioEngine {
         }
 
         // ---- 4.5 Audition Bus (post-master, outside project graph) ------
-        self.process_audition(output, frames, channels);
+        self.audition.process(
+            output,
+            frames,
+            channels,
+            &self.transport,
+            self.sample_rate,
+            &mut self.event_tx,
+        );
 
         // ---- 5. Advance transport and send events -----------------------
         let was_playing = self.transport.is_playing();
         let pos_before = self.transport.position();
-        let new_pos = self.transport.advance(frames as u64);
+        let new_pos = if self.active_section.is_some() {
+            self.transport.advance_unbounded(frames as u64)
+        } else {
+            self.transport.advance(frames as u64)
+        };
+
+        let mut section_ended = false;
+        if was_playing {
+            if let Some(section) = self.active_section.as_mut() {
+                let advanced = section.position_samples.saturating_add(frames as u64);
+                if section.looping && section.length_samples > 0 {
+                    section.position_samples = advanced % section.length_samples;
+                } else {
+                    section.position_samples = advanced.min(section.length_samples);
+                    if advanced >= section.length_samples {
+                        self.transport.stop();
+                        let _ = self.event_tx.push(EngineEvent::PlaybackStopped);
+                        section_ended = true;
+                    }
+                }
+                let _ = self.event_tx.push(EngineEvent::SectionPlaybackPosition {
+                    section_id: section.section_id,
+                    position_samples: section.position_samples,
+                });
+            }
+        }
+        if section_ended {
+            self.active_section = None;
+            self.transport
+                .set_audio_length(self.arrangement_audio_length);
+        }
 
         // Discontinuous jump NOT already handled by the loop-boundary
         // split (auto-stop at project end, loop region moved behind
@@ -429,6 +375,11 @@ impl AudioEngine {
             return;
         }
 
+        if let Some(section) = self.active_section {
+            self.process_section_multitrack(output, frames, channels, section);
+            return;
+        }
+
         let pos = self.transport.position();
         if let Some((loop_start, loop_end)) = self.transport.active_loop_region() {
             if pos < loop_end && pos + frames as u64 > loop_end {
@@ -439,6 +390,7 @@ impl AudioEngine {
                     pos,
                     first,
                     channels,
+                    self.transport.active_loop_region(),
                 );
                 // Kill anything sounding across the boundary, then
                 // continue sample-accurately from the loop start.
@@ -451,13 +403,68 @@ impl AudioEngine {
                         loop_start,
                         rest,
                         channels,
+                        self.transport.active_loop_region(),
                     );
                 }
                 self.split_wrap_handled = true;
                 return;
             }
         }
-        self.render_multitrack_segment(output, pos, frames, channels);
+        self.render_multitrack_segment(
+            output,
+            pos,
+            frames,
+            channels,
+            self.transport.active_loop_region(),
+        );
+    }
+
+    fn process_section_multitrack(
+        &mut self,
+        output: &mut [f32],
+        frames: usize,
+        channels: usize,
+        section: ActiveSectionPlayback,
+    ) {
+        for track in &mut self.tracks {
+            std::mem::swap(
+                &mut track.playback_source,
+                &mut track.section_playback_source,
+            );
+        }
+
+        let mut rendered_frames = 0usize;
+        let mut local_position = section.position_samples.min(section.length_samples);
+        while rendered_frames < frames && local_position < section.length_samples {
+            let available = (section.length_samples - local_position) as usize;
+            let segment_frames = available.min(frames - rendered_frames);
+            let start = rendered_frames * channels;
+            let end = (rendered_frames + segment_frames) * channels;
+            self.render_multitrack_segment(
+                &mut output[start..end],
+                local_position,
+                segment_frames,
+                channels,
+                None,
+            );
+            rendered_frames += segment_frames;
+            local_position += segment_frames as u64;
+            if rendered_frames < frames && section.looping {
+                for track in &mut self.tracks {
+                    track.flush_notes();
+                }
+                local_position = 0;
+            } else if local_position >= section.length_samples {
+                break;
+            }
+        }
+
+        for track in &mut self.tracks {
+            std::mem::swap(
+                &mut track.playback_source,
+                &mut track.section_playback_source,
+            );
+        }
     }
 
     fn render_multitrack_segment(
@@ -466,6 +473,7 @@ impl AudioEngine {
         pos: u64,
         frames: usize,
         channels: usize,
+        loop_region: Option<(u64, u64)>,
     ) {
         let has_track_solo = any_solo(&self.tracks);
         let has_bus_solo = any_solo(&self.buses);
@@ -509,7 +517,6 @@ impl AudioEngine {
             };
             let (auto_gain, auto_pan) = track.apply_automation(beat);
 
-            let loop_region = self.transport.active_loop_region();
             let rendered = if track.instrument.is_some() {
                 let tempo_map = TempoMap::new(self.transport.bpm(), self.sample_rate);
                 track.render_instrument(pos, frames, channels, &tempo_map)
@@ -517,15 +524,20 @@ impl AudioEngine {
                 track.render(pos, frames, channels, loop_region)
             };
 
-            if rendered {
-                track.process_effects(frames, channels);
-                if self.spectrum_track == Some(track.id) {
-                    push_spectrum(
-                        &mut self.spectrum_tx,
-                        &track.mix_buffer[..frames * channels],
-                        channels,
-                    );
-                }
+            // Always run the shared device chain. A silent new Section stops
+            // source material while already-produced effect tails continue.
+            track.process_effects(frames, channels);
+            let rendered = rendered
+                || track.mix_buffer[..frames * channels]
+                    .iter()
+                    .any(|sample| *sample != 0.0);
+
+            if rendered && self.spectrum_track == Some(track.id) {
+                push_spectrum(
+                    &mut self.spectrum_tx,
+                    &track.mix_buffer[..frames * channels],
+                    channels,
+                );
             }
 
             if !rendered {
@@ -616,54 +628,6 @@ impl AudioEngine {
                 peak_l: track_peak_l,
                 peak_r: track_peak_r,
             });
-        }
-    }
-
-    fn process_audition(&mut self, output: &mut [f32], frames: usize, channels: usize) {
-        let mut had_voice = self.audition.active.is_some() || self.audition.has_outgoing();
-        let mut start_offset = 0;
-        let queued_ready = self.audition.queued.as_ref().is_some_and(|queued| {
-            if !self.transport.is_playing() {
-                return true;
-            }
-            let block_start = self.transport.position();
-            queued.target_position < block_start.saturating_add(frames as u64)
-        });
-        if queued_ready {
-            let queued = self.audition.queued.take().expect("queued audition exists");
-            if self.transport.is_playing() {
-                start_offset = queued
-                    .target_position
-                    .saturating_sub(self.transport.position())
-                    .min(frames as u64) as usize;
-            }
-            self.audition.start(
-                queued.audio,
-                audition_fade_frames(self.sample_rate),
-                queued.looped,
-            );
-            had_voice = true;
-            let _ = self.event_tx.push(EngineEvent::AuditionStarted);
-        }
-        let gain = self.audition.gain;
-        for slot in self.audition.outgoing.iter_mut() {
-            if slot.as_mut().is_some_and(|voice| {
-                render_audition_voice(voice, output, frames, channels, gain, 0)
-            }) {
-                *slot = None;
-            }
-        }
-        if self.audition.active.as_mut().is_some_and(|voice| {
-            render_audition_voice(voice, output, frames, channels, gain, start_offset)
-        }) {
-            self.audition.active = None;
-        }
-        if had_voice
-            && self.audition.active.is_none()
-            && !self.audition.has_outgoing()
-            && self.audition.queued.is_none()
-        {
-            let _ = self.event_tx.push(EngineEvent::AuditionStopped);
         }
     }
 
@@ -824,100 +788,16 @@ impl AudioEngine {
                 .map(|track| track.playback_source.as_ref()),
             samples_per_beat,
         );
-        if total > 0 {
-            self.transport.set_audio_length(Some(total));
-        } else if self.audio.is_none() {
-            // Only clear audio length if no legacy audio is loaded
-            self.transport.set_audio_length(None);
-        }
-    }
-}
-
-const AUDITION_FADE_MS: usize = 5;
-
-fn audition_fade_frames(sample_rate: u32) -> usize {
-    ((sample_rate as usize * AUDITION_FADE_MS) / 1_000).max(1)
-}
-
-fn next_audition_boundary(position: u64, bpm: f64, sample_rate: u32, beats: u64) -> u64 {
-    if bpm <= 0.0 || sample_rate == 0 {
-        return position;
-    }
-    let boundary_frames = sample_rate as f64 * 60.0 / bpm * beats.max(1) as f64;
-    let boundary_index = (position as f64 / boundary_frames).floor() + 1.0;
-    (boundary_index * boundary_frames).round() as u64
-}
-
-/// Mix one RAW audition voice. Returns true once its source or fade is done.
-fn render_audition_voice(
-    voice: &mut AuditionVoice,
-    output: &mut [f32],
-    frames: usize,
-    channels: usize,
-    bus_gain: f32,
-    output_frame_offset: usize,
-) -> bool {
-    let audio_channels = voice.audio.num_channels();
-    let audio_frames = voice.audio.num_frames();
-    if audio_channels == 0 || audio_frames == 0 || channels == 0 {
-        return true;
-    }
-
-    let render_frames = frames.saturating_sub(output_frame_offset);
-    for frame in 0..render_frames {
-        let mut source = voice.position as usize;
-        if source >= audio_frames {
-            if !voice.looped {
-                return true;
-            }
-            let crossfade_frames = voice.fade_in_frames.min(audio_frames / 2);
-            source = crossfade_frames;
-            voice.position = source as u64;
-        }
-        let attack = if source < voice.fade_in_frames {
-            (source + 1) as f32 / voice.fade_in_frames as f32
+        self.arrangement_audio_length = if total > 0 {
+            Some(total)
         } else {
-            1.0
+            self.audio.as_ref().map(|audio| audio.num_frames() as u64)
         };
-        let remaining_source = audio_frames.saturating_sub(source + 1);
-        let natural_release = if voice.looped {
-            1.0
-        } else {
-            (remaining_source as f32 / voice.fade_in_frames as f32).clamp(0.0, 1.0)
-        };
-        let commanded_release = match voice.fade_out_remaining {
-            Some(remaining) => {
-                let envelope = remaining.saturating_sub(1) as f32 / voice.fade_in_frames as f32;
-                voice.fade_out_remaining = Some(remaining.saturating_sub(1));
-                envelope
-            }
-            None => 1.0,
-        };
-        let envelope = attack.min(natural_release) * commanded_release * bus_gain;
-        let crossfade_frames = voice.fade_in_frames.min(audio_frames / 2);
-        let crossfade_offset = source.saturating_sub(audio_frames - crossfade_frames);
-        for ch in 0..channels {
-            let source_channel = ch.min(audio_channels - 1);
-            let sample = if voice.looped
-                && crossfade_frames > 0
-                && source >= audio_frames - crossfade_frames
-            {
-                let head_gain = crossfade_offset as f32 / crossfade_frames as f32;
-                let tail_gain = 1.0 - head_gain;
-                voice.audio.sample(source_channel, source) * tail_gain
-                    + voice.audio.sample(source_channel, crossfade_offset) * head_gain
-            } else {
-                voice.audio.sample(source_channel, source)
-            };
-            output[(output_frame_offset + frame) * channels + ch] += sample * envelope;
-        }
-        voice.position = voice.position.saturating_add(1);
-        if voice.fade_out_remaining == Some(0) {
-            return true;
+        if self.active_section.is_none() {
+            self.transport
+                .set_audio_length(self.arrangement_audio_length);
         }
     }
-
-    !voice.looped && voice.position as usize >= audio_frames
 }
 
 /// Stream a block to the UI spectrum analyser as mono samples.
@@ -950,3 +830,7 @@ mod stuck_note_tests;
 #[cfg(test)]
 #[path = "engine_mute_event_tests.rs"]
 mod mute_event_tests;
+
+#[cfg(test)]
+#[path = "engine_section_playback_tests.rs"]
+mod section_playback_tests;

--- a/crates/vibez-engine/src/engine_audition.rs
+++ b/crates/vibez-engine/src/engine_audition.rs
@@ -1,0 +1,249 @@
+use std::sync::Arc;
+
+use rtrb::Producer;
+use vibez_core::audio_buffer::DecodedAudio;
+
+use crate::events::EngineEvent;
+use crate::transport::Transport;
+
+/// How many replaced voices can fade out simultaneously. With tiny
+/// audio buffers a retrigger can arrive before the previous ~5ms fade
+/// finishes; a couple of fixed slots absorb the overlap without
+/// clicking or allocating on the audio thread.
+const AUDITION_OUTGOING_VOICES: usize = 3;
+const AUDITION_FADE_MS: usize = 5;
+
+/// Dedicated Browser signal path mixed after project master processing.
+pub(super) struct AuditionBus {
+    pub(super) active: Option<AuditionVoice>,
+    outgoing: [Option<AuditionVoice>; AUDITION_OUTGOING_VOICES],
+    pub(super) queued: Option<QueuedAudition>,
+    pub(super) gain: f32,
+}
+
+pub(super) struct AuditionVoice {
+    audio: Arc<DecodedAudio>,
+    position: u64,
+    fade_in_frames: usize,
+    fade_out_remaining: Option<usize>,
+    looped: bool,
+}
+
+pub(super) struct QueuedAudition {
+    audio: Arc<DecodedAudio>,
+    target_position: u64,
+    looped: bool,
+}
+
+impl AuditionBus {
+    pub(super) fn new() -> Self {
+        Self {
+            active: None,
+            outgoing: std::array::from_fn(|_| None),
+            queued: None,
+            gain: 1.0,
+        }
+    }
+
+    pub(super) fn start(&mut self, audio: Arc<DecodedAudio>, fade_frames: usize, looped: bool) {
+        self.queued = None;
+        self.stop_active(fade_frames);
+        self.active = Some(AuditionVoice {
+            audio,
+            position: 0,
+            fade_in_frames: fade_frames,
+            fade_out_remaining: None,
+            looped,
+        });
+    }
+
+    pub(super) fn queue(
+        &mut self,
+        audio: Arc<DecodedAudio>,
+        target_position: u64,
+        fade_frames: usize,
+        looped: bool,
+    ) {
+        self.stop_active(fade_frames);
+        self.queued = Some(QueuedAudition {
+            audio,
+            target_position,
+            looped,
+        });
+    }
+
+    pub(super) fn stop(&mut self, fade_frames: usize) {
+        self.queued = None;
+        self.stop_active(fade_frames);
+    }
+
+    fn stop_active(&mut self, fade_frames: usize) {
+        if let Some(mut active) = self.active.take() {
+            if active.position > 0 {
+                active.fade_out_remaining = Some(fade_frames);
+                // Prefer a free slot; when a rapid retrigger burst has
+                // every slot fading, replace the voice closest to done
+                // (the smallest possible click).
+                let slot = self
+                    .outgoing
+                    .iter_mut()
+                    .min_by_key(|slot| {
+                        slot.as_ref()
+                            .map_or(0, |voice| voice.fade_out_remaining.unwrap_or(0))
+                    })
+                    .expect("outgoing slots are non-empty");
+                *slot = Some(active);
+            }
+        }
+    }
+
+    pub(super) fn has_outgoing(&self) -> bool {
+        self.outgoing.iter().any(Option::is_some)
+    }
+
+    pub(super) fn set_looped(&mut self, looped: bool) {
+        if let Some(active) = self.active.as_mut() {
+            active.looped = looped;
+        }
+        if let Some(queued) = self.queued.as_mut() {
+            queued.looped = looped;
+        }
+    }
+
+    pub(super) fn process(
+        &mut self,
+        output: &mut [f32],
+        frames: usize,
+        channels: usize,
+        transport: &Transport,
+        sample_rate: u32,
+        event_tx: &mut Producer<EngineEvent>,
+    ) {
+        let mut had_voice = self.active.is_some() || self.has_outgoing();
+        let mut start_offset = 0;
+        let queued_ready = self.queued.as_ref().is_some_and(|queued| {
+            if !transport.is_playing() {
+                return true;
+            }
+            let block_start = transport.position();
+            queued.target_position < block_start.saturating_add(frames as u64)
+        });
+        if queued_ready {
+            let queued = self.queued.take().expect("queued audition exists");
+            if transport.is_playing() {
+                start_offset = queued
+                    .target_position
+                    .saturating_sub(transport.position())
+                    .min(frames as u64) as usize;
+            }
+            self.start(
+                queued.audio,
+                audition_fade_frames(sample_rate),
+                queued.looped,
+            );
+            had_voice = true;
+            let _ = event_tx.push(EngineEvent::AuditionStarted);
+        }
+        let gain = self.gain;
+        for slot in self.outgoing.iter_mut() {
+            if slot.as_mut().is_some_and(|voice| {
+                render_audition_voice(voice, output, frames, channels, gain, 0)
+            }) {
+                *slot = None;
+            }
+        }
+        if self.active.as_mut().is_some_and(|voice| {
+            render_audition_voice(voice, output, frames, channels, gain, start_offset)
+        }) {
+            self.active = None;
+        }
+        if had_voice && self.active.is_none() && !self.has_outgoing() && self.queued.is_none() {
+            let _ = event_tx.push(EngineEvent::AuditionStopped);
+        }
+    }
+}
+
+pub(super) fn audition_fade_frames(sample_rate: u32) -> usize {
+    ((sample_rate as usize * AUDITION_FADE_MS) / 1_000).max(1)
+}
+
+pub(super) fn next_audition_boundary(position: u64, bpm: f64, sample_rate: u32, beats: u64) -> u64 {
+    if bpm <= 0.0 || sample_rate == 0 {
+        return position;
+    }
+    let boundary_frames = sample_rate as f64 * 60.0 / bpm * beats.max(1) as f64;
+    let boundary_index = (position as f64 / boundary_frames).floor() + 1.0;
+    (boundary_index * boundary_frames).round() as u64
+}
+
+/// Mix one RAW audition voice. Returns true once its source or fade is done.
+fn render_audition_voice(
+    voice: &mut AuditionVoice,
+    output: &mut [f32],
+    frames: usize,
+    channels: usize,
+    bus_gain: f32,
+    output_frame_offset: usize,
+) -> bool {
+    let audio_channels = voice.audio.num_channels();
+    let audio_frames = voice.audio.num_frames();
+    if audio_channels == 0 || audio_frames == 0 || channels == 0 {
+        return true;
+    }
+
+    let render_frames = frames.saturating_sub(output_frame_offset);
+    for frame in 0..render_frames {
+        let mut source = voice.position as usize;
+        if source >= audio_frames {
+            if !voice.looped {
+                return true;
+            }
+            let crossfade_frames = voice.fade_in_frames.min(audio_frames / 2);
+            source = crossfade_frames;
+            voice.position = source as u64;
+        }
+        let attack = if source < voice.fade_in_frames {
+            (source + 1) as f32 / voice.fade_in_frames as f32
+        } else {
+            1.0
+        };
+        let remaining_source = audio_frames.saturating_sub(source + 1);
+        let natural_release = if voice.looped {
+            1.0
+        } else {
+            (remaining_source as f32 / voice.fade_in_frames as f32).clamp(0.0, 1.0)
+        };
+        let commanded_release = match voice.fade_out_remaining {
+            Some(remaining) => {
+                let envelope = remaining.saturating_sub(1) as f32 / voice.fade_in_frames as f32;
+                voice.fade_out_remaining = Some(remaining.saturating_sub(1));
+                envelope
+            }
+            None => 1.0,
+        };
+        let envelope = attack.min(natural_release) * commanded_release * bus_gain;
+        let crossfade_frames = voice.fade_in_frames.min(audio_frames / 2);
+        let crossfade_offset = source.saturating_sub(audio_frames - crossfade_frames);
+        for ch in 0..channels {
+            let source_channel = ch.min(audio_channels - 1);
+            let sample = if voice.looped
+                && crossfade_frames > 0
+                && source >= audio_frames - crossfade_frames
+            {
+                let head_gain = crossfade_offset as f32 / crossfade_frames as f32;
+                let tail_gain = 1.0 - head_gain;
+                voice.audio.sample(source_channel, source) * tail_gain
+                    + voice.audio.sample(source_channel, crossfade_offset) * head_gain
+            } else {
+                voice.audio.sample(source_channel, source)
+            };
+            output[(output_frame_offset + frame) * channels + ch] += sample * envelope;
+        }
+        voice.position = voice.position.saturating_add(1);
+        if voice.fade_out_remaining == Some(0) {
+            return true;
+        }
+    }
+
+    !voice.looped && voice.position as usize >= audio_frames
+}

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -14,6 +14,9 @@ impl AudioEngine {
                 }
                 EngineCommand::Stop => {
                     self.transport.stop();
+                    self.active_section = None;
+                    self.transport
+                        .set_audio_length(self.arrangement_audio_length);
                     for track in &mut self.tracks {
                         track.flush_notes();
                     }
@@ -29,13 +32,67 @@ impl AudioEngine {
                     self.transport.set_bpm(bpm);
                     self.recalculate_audio_length();
                 }
+                EngineCommand::LaunchSection(mut prepared) => {
+                    let section_id = prepared.section_id;
+                    let length_samples = if self.transport.bpm() > 0.0 {
+                        (prepared.length_beats * self.sample_rate as f64 * 60.0
+                            / self.transport.bpm())
+                        .round()
+                        .max(1.0) as u64
+                    } else {
+                        1
+                    };
+                    let looping = prepared.looping;
+                    for track in &mut self.tracks {
+                        track.flush_notes();
+                    }
+                    for incoming in prepared.tracks_mut() {
+                        if let Some(track) = self
+                            .tracks
+                            .iter_mut()
+                            .find(|track| track.id == incoming.track_id)
+                        {
+                            std::mem::swap(
+                                &mut track.section_playback_source,
+                                &mut incoming.source,
+                            );
+                        }
+                    }
+                    let effective_at_samples = self.transport.position();
+                    self.active_section = Some(ActiveSectionPlayback {
+                        section_id,
+                        position_samples: 0,
+                        length_samples,
+                        looping,
+                    });
+                    self.transport.set_audio_length(None);
+                    if !self.transport.is_playing() {
+                        self.transport.play();
+                        let _ = self.event_tx.push(EngineEvent::PlaybackStarted);
+                    }
+                    let event = EngineEvent::SectionTransitioned {
+                        section_id,
+                        effective_at_samples,
+                        retired: prepared,
+                    };
+                    if let Err(rtrb::PushError::Full(event)) = self.event_tx.push(event) {
+                        // Never destroy Vec/Arc owners in the callback. Losing this
+                        // rare event leaks one retired source rather than glitching.
+                        std::mem::forget(event);
+                    }
+                }
                 EngineCommand::LoadAudio(audio) => {
                     let len = audio.num_frames() as u64;
                     self.audio = Some(audio);
-                    self.transport.set_audio_length(Some(len));
+                    self.arrangement_audio_length = Some(len);
+                    if self.active_section.is_none() {
+                        self.transport.set_audio_length(Some(len));
+                    }
                 }
                 EngineCommand::UnloadAudio => {
                     self.audio = None;
+                    self.arrangement_audio_length = None;
+                    self.active_section = None;
                     self.transport.set_audio_length(None);
                     self.transport.stop();
                     let _ = self.event_tx.push(EngineEvent::PlaybackStopped);

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -81,6 +81,55 @@ impl AudioEngine {
                         std::mem::forget(event);
                     }
                 }
+                EngineCommand::RefreshSection(mut prepared) => {
+                    let section_id = prepared.section_id;
+                    let mut applied = false;
+                    if let Some(active) = self
+                        .active_section
+                        .as_mut()
+                        .filter(|active| active.section_id == section_id)
+                    {
+                        let length_samples = if self.transport.bpm() > 0.0 {
+                            (prepared.length_beats * self.sample_rate as f64 * 60.0
+                                / self.transport.bpm())
+                            .round()
+                            .max(1.0) as u64
+                        } else {
+                            1
+                        };
+                        active.length_samples = length_samples;
+                        active.looping = prepared.looping;
+                        active.position_samples = if active.looping {
+                            active.position_samples % length_samples
+                        } else {
+                            active.position_samples.min(length_samples)
+                        };
+                        for track in &mut self.tracks {
+                            track.flush_notes();
+                        }
+                        for incoming in prepared.tracks_mut() {
+                            if let Some(track) = self
+                                .tracks
+                                .iter_mut()
+                                .find(|track| track.id == incoming.track_id)
+                            {
+                                std::mem::swap(
+                                    &mut track.section_playback_source,
+                                    &mut incoming.source,
+                                );
+                            }
+                        }
+                        applied = true;
+                    }
+                    let event = EngineEvent::SectionSourceRefreshed {
+                        section_id,
+                        applied,
+                        retired: prepared,
+                    };
+                    if let Err(rtrb::PushError::Full(event)) = self.event_tx.push(event) {
+                        std::mem::forget(event);
+                    }
+                }
                 EngineCommand::LoadAudio(audio) => {
                     let len = audio.num_frames() as u64;
                     self.audio = Some(audio);

--- a/crates/vibez-engine/src/engine_section_playback_tests.rs
+++ b/crates/vibez-engine/src/engine_section_playback_tests.rs
@@ -1,0 +1,426 @@
+//! Section playback regression tests. These exercise the public command/event
+//! boundary so the source-switch implementation remains replaceable.
+
+use super::*;
+
+use std::sync::{Arc, Mutex};
+
+use vibez_core::audio_buffer::DecodedAudio;
+use vibez_core::effect::EffectType;
+use vibez_core::id::{ClipId, EffectId, SectionId, TrackId};
+use vibez_core::midi::{InstrumentKind, MidiNote};
+
+use crate::playback_source::{
+    EngineClip, EngineNoteClip, PreparedPlaybackSource, PreparedSectionPlaybackSource,
+};
+
+struct NoteLogInstrument(Arc<Mutex<Vec<(bool, u8)>>>);
+
+struct TailEffect {
+    memory: f32,
+}
+
+impl vibez_dsp::effect::AudioEffect for TailEffect {
+    fn effect_type(&self) -> EffectType {
+        EffectType::Gain
+    }
+
+    fn param_descriptors(&self) -> &'static [vibez_core::effect::ParamDescriptor] {
+        &[]
+    }
+
+    fn set_param(&mut self, _index: usize, _value: f32) -> bool {
+        false
+    }
+
+    fn get_param(&self, _index: usize) -> f32 {
+        0.0
+    }
+
+    fn process(&mut self, buffer: &mut [f32], _channels: usize) {
+        for sample in buffer {
+            if *sample != 0.0 {
+                self.memory = *sample;
+            } else {
+                self.memory *= 0.5;
+                *sample = self.memory;
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        self.memory = 0.0;
+    }
+}
+
+impl vibez_instruments::Instrument for NoteLogInstrument {
+    fn instrument_kind(&self) -> InstrumentKind {
+        InstrumentKind::SubtractiveSynth
+    }
+
+    fn param_descriptors(&self) -> &'static [vibez_core::effect::ParamDescriptor] {
+        &[]
+    }
+
+    fn set_param(&mut self, _index: usize, _value: f32) -> bool {
+        false
+    }
+
+    fn get_param(&self, _index: usize) -> f32 {
+        0.0
+    }
+
+    fn note_on(&mut self, pitch: u8, _velocity: u8) {
+        self.0.lock().unwrap().push((true, pitch));
+    }
+
+    fn note_off(&mut self, pitch: u8) {
+        self.0.lock().unwrap().push((false, pitch));
+    }
+
+    fn render(&mut self, _buffer: &mut [f32], _channels: usize) {}
+
+    fn reset(&mut self) {}
+}
+
+fn constant_audio(frames: usize, value: f32) -> Arc<DecodedAudio> {
+    Arc::new(DecodedAudio {
+        channels: vec![vec![value; frames], vec![value; frames]],
+        sample_rate: 44_100,
+    })
+}
+
+#[test]
+fn resident_section_switches_immediately_and_returns_the_displaced_source() {
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let section_id = SectionId::new();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                section_id,
+                4.0,
+                true,
+                vec![(
+                    track_id,
+                    PreparedPlaybackSource::new(
+                        vec![EngineClip {
+                            id: ClipId::new(),
+                            audio: constant_audio(16, 0.25),
+                            position: 0,
+                            source_offset: 0,
+                            duration: 16,
+                            loop_enabled: false,
+                            loop_start: 0,
+                            loop_end: 0,
+                        }],
+                        Vec::new(),
+                        Vec::new(),
+                    ),
+                )],
+            ),
+        )))
+        .unwrap();
+
+    let mut output = [0.0; 8];
+    engine.process(&mut output, 2);
+
+    assert!(engine.transport().is_playing());
+    assert!(output.iter().all(|sample| *sample > 0.0));
+
+    let transition = std::iter::from_fn(|| events.pop().ok()).find_map(|event| match event {
+        EngineEvent::SectionTransitioned {
+            section_id: actual,
+            effective_at_samples,
+            retired,
+        } => Some((actual, effective_at_samples, retired)),
+        _ => None,
+    });
+    let (actual, effective_at_samples, retired) = transition.expect("transition event");
+    assert_eq!(actual, section_id);
+    assert_eq!(effective_at_samples, 0);
+    assert_eq!(retired.tracks().len(), 1);
+    assert!(retired.tracks()[0].source.clips.is_empty());
+}
+
+#[test]
+fn section_wraps_at_its_shortened_boundary_inside_one_callback() {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    let audio = Arc::new(DecodedAudio {
+        channels: vec![vec![0.1, 0.2, 0.3, 0.4, 0.9, 0.9]],
+        sample_rate: 8,
+    });
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                SectionId::new(),
+                1.0,
+                true,
+                vec![(
+                    track_id,
+                    PreparedPlaybackSource::new(
+                        vec![EngineClip {
+                            id: ClipId::new(),
+                            audio,
+                            position: 0,
+                            source_offset: 0,
+                            duration: 6,
+                            loop_enabled: false,
+                            loop_start: 0,
+                            loop_end: 0,
+                        }],
+                        Vec::new(),
+                        Vec::new(),
+                    ),
+                )],
+            ),
+        )))
+        .unwrap();
+
+    // 8 Hz at 120 BPM is four samples per beat, so this callback crosses the
+    // shortened one-beat boundary after frame four.
+    let mut output = [0.0; 6];
+    engine.process(&mut output, 1);
+
+    assert!((output[0] - output[4]).abs() < f32::EPSILON);
+    assert!((output[1] - output[5]).abs() < f32::EPSILON);
+    assert_ne!(output[2], output[4]);
+}
+
+#[test]
+fn arrangement_loop_does_not_wrap_section_engine_time() {
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let section_id = SectionId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::SetArrangementLoopRegion { start: 0, end: 2 })
+        .unwrap();
+    commands
+        .push(EngineCommand::SetArrangementLoop(true))
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                section_id,
+                4.0,
+                true,
+                vec![(track_id, PreparedPlaybackSource::default())],
+            ),
+        )))
+        .unwrap();
+
+    engine.process(&mut [0.0; 3], 1);
+
+    assert_eq!(engine.transport().position(), 3);
+    assert!(
+        std::iter::from_fn(|| events.pop().ok()).any(|event| matches!(
+            event,
+            EngineEvent::SectionPlaybackPosition {
+                section_id: actual,
+                position_samples: 3,
+            } if actual == section_id
+        ))
+    );
+}
+
+#[test]
+fn non_looping_section_returns_to_arrangement_source_after_ending() {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    engine.process(&mut [], 1);
+    engine.tracks[0].playback_source = Box::new(PreparedPlaybackSource::new(
+        vec![EngineClip {
+            id: ClipId::new(),
+            audio: constant_audio(16, 0.75),
+            position: 0,
+            source_offset: 0,
+            duration: 16,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        }],
+        Vec::new(),
+        Vec::new(),
+    ));
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                SectionId::new(),
+                1.0,
+                false,
+                vec![(
+                    track_id,
+                    PreparedPlaybackSource::new(
+                        vec![EngineClip {
+                            id: ClipId::new(),
+                            audio: constant_audio(4, 0.25),
+                            position: 0,
+                            source_offset: 0,
+                            duration: 4,
+                            loop_enabled: false,
+                            loop_start: 0,
+                            loop_end: 0,
+                        }],
+                        Vec::new(),
+                        Vec::new(),
+                    ),
+                )],
+            ),
+        )))
+        .unwrap();
+
+    let mut section_output = [0.0; 4];
+    engine.process(&mut section_output, 1);
+    assert!(section_output.iter().all(|sample| *sample == 0.25));
+    assert!(!engine.transport().is_playing());
+
+    commands.push(EngineCommand::Seek(0)).unwrap();
+    commands.push(EngineCommand::Play).unwrap();
+    let mut arrangement_output = [0.0; 1];
+    engine.process(&mut arrangement_output, 1);
+
+    assert_eq!(arrangement_output, [0.75]);
+}
+
+#[test]
+fn switching_sections_releases_notes_from_the_previous_source() {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let note_events = Arc::new(Mutex::new(Vec::new()));
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands
+        .push(EngineCommand::AddMidiTrack(track_id, "MIDI".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::SetPluginInstrument {
+            track_id,
+            instrument: Box::new(NoteLogInstrument(Arc::clone(&note_events))),
+        })
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                SectionId::new(),
+                4.0,
+                true,
+                vec![(
+                    track_id,
+                    PreparedPlaybackSource::new(
+                        Vec::new(),
+                        vec![EngineNoteClip {
+                            id: ClipId::new(),
+                            position_beats: 0.0,
+                            duration_beats: 4.0,
+                            notes: vec![MidiNote {
+                                pitch: 60,
+                                velocity: 100,
+                                start_beat: 0.0,
+                                duration_beats: 4.0,
+                            }],
+                            loop_enabled: false,
+                            loop_start_beats: 0.0,
+                            loop_end_beats: 0.0,
+                        }],
+                        Vec::new(),
+                    ),
+                )],
+            ),
+        )))
+        .unwrap();
+    let mut output = [0.0; 1];
+    engine.process(&mut output, 1);
+    assert!(note_events.lock().unwrap().contains(&(true, 60)));
+
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                SectionId::new(),
+                4.0,
+                true,
+                vec![(track_id, PreparedPlaybackSource::default())],
+            ),
+        )))
+        .unwrap();
+    engine.process(&mut output, 1);
+
+    assert!(note_events.lock().unwrap().contains(&(false, 60)));
+}
+
+#[test]
+fn absent_track_stops_source_content_without_resetting_effect_tail() {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::AddPluginEffect {
+            track_id,
+            effect_id: EffectId::new(),
+            effect: Box::new(TailEffect { memory: 0.0 }),
+            position: None,
+        })
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                SectionId::new(),
+                4.0,
+                true,
+                vec![(
+                    track_id,
+                    PreparedPlaybackSource::new(
+                        vec![EngineClip {
+                            id: ClipId::new(),
+                            audio: constant_audio(1, 1.0),
+                            position: 0,
+                            source_offset: 0,
+                            duration: 1,
+                            loop_enabled: false,
+                            loop_start: 0,
+                            loop_end: 0,
+                        }],
+                        Vec::new(),
+                        Vec::new(),
+                    ),
+                )],
+            ),
+        )))
+        .unwrap();
+    let mut source = [0.0; 1];
+    engine.process(&mut source, 1);
+    assert!(source[0] > 0.0);
+
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                SectionId::new(),
+                4.0,
+                true,
+                vec![(track_id, PreparedPlaybackSource::default())],
+            ),
+        )))
+        .unwrap();
+    let mut silence_with_tail = [0.0; 2];
+    engine.process(&mut silence_with_tail, 1);
+
+    assert!(silence_with_tail.iter().all(|sample| *sample > 0.0));
+    assert!(silence_with_tail[0] < source[0]);
+    assert!(silence_with_tail[1] < silence_with_tail[0]);
+}

--- a/crates/vibez-engine/src/engine_section_playback_tests.rs
+++ b/crates/vibez-engine/src/engine_section_playback_tests.rs
@@ -147,6 +147,62 @@ fn resident_section_switches_immediately_and_returns_the_displaced_source() {
 }
 
 #[test]
+fn refreshing_the_active_section_changes_content_without_restarting_its_playhead() {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let section_id = SectionId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+
+    let source = |value| {
+        Box::new(PreparedSectionPlaybackSource::new(
+            section_id,
+            4.0,
+            true,
+            vec![(
+                track_id,
+                PreparedPlaybackSource::new(
+                    vec![EngineClip {
+                        id: ClipId::new(),
+                        audio: constant_audio(32, value),
+                        position: 0,
+                        source_offset: 0,
+                        duration: 32,
+                        loop_enabled: false,
+                        loop_start: 0,
+                        loop_end: 0,
+                    }],
+                    Vec::new(),
+                    Vec::new(),
+                ),
+            )],
+        ))
+    };
+
+    commands
+        .push(EngineCommand::LaunchSection(source(0.25)))
+        .unwrap();
+    let mut before = [0.0; 4];
+    engine.process(&mut before, 1);
+    assert_eq!(before, [0.25; 4]);
+
+    commands
+        .push(EngineCommand::RefreshSection(source(0.75)))
+        .unwrap();
+    let mut after = [0.0; 4];
+    engine.process(&mut after, 1);
+
+    assert_eq!(after, [0.75; 4]);
+    let position = engine
+        .active_section
+        .expect("Section remains active")
+        .position_samples;
+    assert_eq!(position, 8, "refresh preserves the four elapsed samples");
+}
+
+#[test]
 fn section_wraps_at_its_shortened_boundary_inside_one_callback() {
     let (mut engine, mut commands, _events) = AudioEngine::new();
     let track_id = TrackId::new();

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -1,4 +1,6 @@
-use vibez_core::id::TrackId;
+use vibez_core::id::{SectionId, TrackId};
+
+use crate::playback_source::PreparedSectionPlaybackSource;
 
 /// Events sent from the audio engine back to the UI thread (via rtrb).
 ///
@@ -41,7 +43,7 @@ impl<T: ?Sized> std::fmt::Debug for DisposalCell<T> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub enum EngineEvent {
     /// A device removed from the audio graph, handed back so the UI
     /// thread performs the teardown. Plugin destructors run dlclose
@@ -79,6 +81,20 @@ pub enum EngineEvent {
         effective_at_samples: u64,
     },
 
+    /// A resident Section became active at this exact transport sample.
+    /// `retired` carries displaced sources to the UI thread for destruction.
+    SectionTransitioned {
+        section_id: SectionId,
+        effective_at_samples: u64,
+        retired: Box<PreparedSectionPlaybackSource>,
+    },
+
+    /// Current engine-owned local Section playhead.
+    SectionPlaybackPosition {
+        section_id: SectionId,
+        position_samples: u64,
+    },
+
     /// Playback has started (transport entered playing state).
     PlaybackStarted,
 
@@ -91,6 +107,99 @@ pub enum EngineEvent {
     AuditionQueued,
     /// Audition crossed its requested boundary and began rendering.
     AuditionStarted,
+}
+
+impl PartialEq for EngineEvent {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::DisposeEffect(left), Self::DisposeEffect(right)) => left == right,
+            (Self::DisposeInstrument(left), Self::DisposeInstrument(right)) => left == right,
+            (Self::PlaybackPosition(left), Self::PlaybackPosition(right)) => left == right,
+            (
+                Self::Metering {
+                    peak_l: left_peak_l,
+                    peak_r: left_peak_r,
+                    rms_l: left_rms_l,
+                    rms_r: left_rms_r,
+                },
+                Self::Metering {
+                    peak_l: right_peak_l,
+                    peak_r: right_peak_r,
+                    rms_l: right_rms_l,
+                    rms_r: right_rms_r,
+                },
+            ) => {
+                left_peak_l == right_peak_l
+                    && left_peak_r == right_peak_r
+                    && left_rms_l == right_rms_l
+                    && left_rms_r == right_rms_r
+            }
+            (
+                Self::TrackMeter {
+                    track_id: left_track,
+                    peak_l: left_peak_l,
+                    peak_r: left_peak_r,
+                },
+                Self::TrackMeter {
+                    track_id: right_track,
+                    peak_l: right_peak_l,
+                    peak_r: right_peak_r,
+                },
+            ) => {
+                left_track == right_track
+                    && left_peak_l == right_peak_l
+                    && left_peak_r == right_peak_r
+            }
+            (
+                Self::TrackMuteChanged {
+                    track_id: left_track,
+                    muted: left_muted,
+                    effective_at_samples: left_effective,
+                },
+                Self::TrackMuteChanged {
+                    track_id: right_track,
+                    muted: right_muted,
+                    effective_at_samples: right_effective,
+                },
+            ) => {
+                left_track == right_track
+                    && left_muted == right_muted
+                    && left_effective == right_effective
+            }
+            (
+                Self::SectionTransitioned {
+                    section_id: left_section,
+                    effective_at_samples: left_effective,
+                    retired: left_retired,
+                },
+                Self::SectionTransitioned {
+                    section_id: right_section,
+                    effective_at_samples: right_effective,
+                    retired: right_retired,
+                },
+            ) => {
+                left_section == right_section
+                    && left_effective == right_effective
+                    && std::ptr::eq(left_retired.as_ref(), right_retired.as_ref())
+            }
+            (
+                Self::SectionPlaybackPosition {
+                    section_id: left_section,
+                    position_samples: left_position,
+                },
+                Self::SectionPlaybackPosition {
+                    section_id: right_section,
+                    position_samples: right_position,
+                },
+            ) => left_section == right_section && left_position == right_position,
+            (Self::PlaybackStarted, Self::PlaybackStarted)
+            | (Self::PlaybackStopped, Self::PlaybackStopped)
+            | (Self::AuditionStopped, Self::AuditionStopped)
+            | (Self::AuditionQueued, Self::AuditionQueued)
+            | (Self::AuditionStarted, Self::AuditionStarted) => true,
+            _ => false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -139,8 +248,14 @@ mod tests {
             .unwrap();
         producer.push(EngineEvent::PlaybackStopped).unwrap();
 
-        assert_eq!(consumer.pop().unwrap(), EngineEvent::PlaybackStarted);
-        assert_eq!(consumer.pop().unwrap(), EngineEvent::PlaybackPosition(512));
+        assert!(matches!(
+            consumer.pop().unwrap(),
+            EngineEvent::PlaybackStarted
+        ));
+        assert!(matches!(
+            consumer.pop().unwrap(),
+            EngineEvent::PlaybackPosition(512)
+        ));
 
         match consumer.pop().unwrap() {
             EngineEvent::Metering {
@@ -157,7 +272,10 @@ mod tests {
             other => panic!("expected Metering, got {other:?}"),
         }
 
-        assert_eq!(consumer.pop().unwrap(), EngineEvent::PlaybackStopped);
+        assert!(matches!(
+            consumer.pop().unwrap(),
+            EngineEvent::PlaybackStopped
+        ));
     }
 
     #[test]
@@ -188,16 +306,13 @@ mod tests {
     }
 
     #[test]
-    fn event_debug_and_clone() {
+    fn event_debug() {
         let event = EngineEvent::Metering {
             peak_l: 1.0,
             peak_r: 0.0,
             rms_l: 0.5,
             rms_r: 0.5,
         };
-        let cloned = event.clone();
-        assert_eq!(event, cloned);
-
         let debug = format!("{event:?}");
         assert!(debug.contains("Metering"));
     }

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -89,6 +89,15 @@ pub enum EngineEvent {
         retired: Box<PreparedSectionPlaybackSource>,
     },
 
+    /// A Section source refresh was consumed by the engine. `applied` is
+    /// false when that Section stopped or changed before the command arrived.
+    /// In both cases `retired` returns ownership to the UI thread.
+    SectionSourceRefreshed {
+        section_id: SectionId,
+        applied: bool,
+        retired: Box<PreparedSectionPlaybackSource>,
+    },
+
     /// Current engine-owned local Section playhead.
     SectionPlaybackPosition {
         section_id: SectionId,
@@ -192,6 +201,22 @@ impl PartialEq for EngineEvent {
                     position_samples: right_position,
                 },
             ) => left_section == right_section && left_position == right_position,
+            (
+                Self::SectionSourceRefreshed {
+                    section_id: left_section,
+                    applied: left_applied,
+                    retired: left_retired,
+                },
+                Self::SectionSourceRefreshed {
+                    section_id: right_section,
+                    applied: right_applied,
+                    retired: right_retired,
+                },
+            ) => {
+                left_section == right_section
+                    && left_applied == right_applied
+                    && std::ptr::eq(left_retired.as_ref(), right_retired.as_ref())
+            }
             (Self::PlaybackStarted, Self::PlaybackStarted)
             | (Self::PlaybackStopped, Self::PlaybackStopped)
             | (Self::AuditionStopped, Self::AuditionStopped)

--- a/crates/vibez-engine/src/lib.rs
+++ b/crates/vibez-engine/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod engine;
+mod engine_audition;
 pub mod events;
 pub mod metering;
 pub mod mixer;

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -26,6 +26,10 @@ pub struct EngineTrack {
     /// Time-based content feeding this shared channel strip. It is prepared
     /// outside the callback before any future source switch.
     pub playback_source: Box<PreparedPlaybackSource>,
+    /// Resident Perform source. The engine swaps this pointer with
+    /// `playback_source` only around Section rendering, preserving Arrange as
+    /// the editable source while sharing the exact same renderer.
+    pub section_playback_source: Box<PreparedPlaybackSource>,
     pub gain: f32,
     pub pan: f32,
     pub mute: bool,
@@ -61,6 +65,7 @@ impl EngineTrack {
         Self {
             id,
             playback_source: Box::new(playback_source),
+            section_playback_source: Box::new(PreparedPlaybackSource::default()),
             gain: DEFAULT_TRACK_GAIN,
             pan: DEFAULT_TRACK_PAN,
             mute: false,

--- a/crates/vibez-engine/src/playback_source.rs
+++ b/crates/vibez-engine/src/playback_source.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::automation::AutomationLane;
-use vibez_core::id::ClipId;
+use vibez_core::id::{ClipId, SectionId, TrackId};
 use vibez_core::midi::MidiNote;
 
 /// A resident audio clip on a prepared timeline.
@@ -68,6 +68,66 @@ pub struct PreparedPlaybackSource {
     pub clips: Vec<EngineClip>,
     pub note_clips: Vec<EngineNoteClip>,
     pub automation: Vec<AutomationLane>,
+}
+
+/// One Project Track's resident content for a prepared Section.
+pub struct PreparedTrackPlaybackSource {
+    pub track_id: TrackId,
+    pub source: Box<PreparedPlaybackSource>,
+}
+
+/// A complete, resident Section source prepared outside the audio callback.
+///
+/// The engine swaps each boxed track source in place. The same owner is then
+/// returned through an engine event carrying the displaced sources, so no
+/// source allocation or destruction occurs on the real-time thread.
+pub struct PreparedSectionPlaybackSource {
+    pub section_id: SectionId,
+    pub length_beats: f64,
+    pub looping: bool,
+    tracks: Vec<PreparedTrackPlaybackSource>,
+}
+
+impl PreparedSectionPlaybackSource {
+    pub fn new(
+        section_id: SectionId,
+        length_beats: f64,
+        looping: bool,
+        tracks: Vec<(TrackId, PreparedPlaybackSource)>,
+    ) -> Self {
+        Self {
+            section_id,
+            length_beats,
+            looping,
+            tracks: tracks
+                .into_iter()
+                .map(|(track_id, source)| PreparedTrackPlaybackSource {
+                    track_id,
+                    source: Box::new(source),
+                })
+                .collect(),
+        }
+    }
+
+    pub fn tracks(&self) -> &[PreparedTrackPlaybackSource] {
+        &self.tracks
+    }
+
+    pub(crate) fn tracks_mut(&mut self) -> &mut [PreparedTrackPlaybackSource] {
+        &mut self.tracks
+    }
+}
+
+impl std::fmt::Debug for PreparedSectionPlaybackSource {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedSectionPlaybackSource")
+            .field("section_id", &self.section_id)
+            .field("length_beats", &self.length_beats)
+            .field("looping", &self.looping)
+            .field("track_count", &self.tracks.len())
+            .finish()
+    }
 }
 
 impl PreparedPlaybackSource {

--- a/crates/vibez-engine/src/transport.rs
+++ b/crates/vibez-engine/src/transport.rs
@@ -153,6 +153,16 @@ impl Transport {
 
         self.position
     }
+
+    /// Advance engine time without applying Arrangement loop or length
+    /// boundaries. Perform Sections own their local playback boundary while
+    /// active, but effective event timestamps must keep moving forward.
+    pub(crate) fn advance_unbounded(&mut self, frames: u64) -> u64 {
+        if self.playing {
+            self.position = self.position.saturating_add(frames);
+        }
+        self.position
+    }
 }
 
 impl Default for Transport {

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -3,6 +3,7 @@
 use iced::Task;
 
 use vibez_core::effect::EffectType;
+use vibez_core::id::SectionId;
 use vibez_engine::commands::EngineCommand;
 use vibez_engine::events::EngineEvent;
 use vibez_plugin_host::gui::PluginGuiKey;
@@ -29,7 +30,30 @@ fn apply_track_mute_request(
     Some(track_name)
 }
 
+fn prepare_playing_section_refresh(
+    perform: &crate::domains::perform::PerformState,
+    project_tracks: &[crate::state::ProjectTrack],
+    changed_section: SectionId,
+) -> Option<vibez_engine::playback_source::PreparedSectionPlaybackSource> {
+    (perform.playing_section == Some(changed_section))
+        .then(|| perform.sections.by_id(changed_section))
+        .flatten()
+        .map(|section| section.prepare_playback_source(project_tracks))
+}
+
 impl App {
+    /// Refresh resident content only when the edited Section is still the one
+    /// the engine reports as active. Selection remains intentionally separate.
+    pub(super) fn refresh_playing_section_after_edit(&mut self, section_id: SectionId) {
+        if let Some(prepared) = prepare_playing_section_refresh(
+            &self.state.perform,
+            &self.state.project_tracks.tracks,
+            section_id,
+        ) {
+            self.send_command(EngineCommand::RefreshSection(Box::new(prepared)));
+        }
+    }
+
     /// Apply cross-domain effects requested by Perform without giving the
     /// Perform interaction slice ownership of Project Track state.
     pub(super) fn apply_perform_action(&mut self, action: crate::domains::perform::PerformAction) {
@@ -68,6 +92,9 @@ impl App {
                 self.send_command(EngineCommand::LaunchSection(Box::new(prepared)));
                 self.state.status_text = "Launching Section…".into();
             }
+        }
+        if let Some(section_id) = action.section_content_changed {
+            self.refresh_playing_section_after_edit(section_id);
         }
     }
 
@@ -584,6 +611,11 @@ impl App {
                             self.state.perform.section_playhead_samples = position_samples;
                         }
                     }
+                    EngineEvent::SectionSourceRefreshed {
+                        section_id: _,
+                        applied: _,
+                        retired,
+                    } => drop(retired),
                 }
             }
         }
@@ -747,5 +779,30 @@ mod perform_action_tests {
         assert_eq!(name, None);
         assert!(state.project.history.undo.is_empty());
         assert!(engine.0.is_empty());
+    }
+
+    #[test]
+    fn section_refresh_is_prepared_only_for_the_currently_playing_section() {
+        let mut state = AppState::default();
+        let playing = crate::domains::perform::Section::new(0);
+        let playing_id = playing.id;
+        let other = crate::domains::perform::Section::new(1);
+        let other_id = other.id;
+        Arc::make_mut(&mut state.perform.sections).insert(playing);
+        Arc::make_mut(&mut state.perform.sections).insert(other);
+        state.perform.playing_section = Some(playing_id);
+
+        assert!(prepare_playing_section_refresh(
+            &state.perform,
+            &state.project_tracks.tracks,
+            playing_id,
+        )
+        .is_some());
+        assert!(prepare_playing_section_refresh(
+            &state.perform,
+            &state.project_tracks.tracks,
+            other_id,
+        )
+        .is_none());
     }
 }

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -57,6 +57,18 @@ impl App {
                 );
             }
         }
+        if let Some(section_id) = action.section_launch {
+            if let Some(prepared) = self
+                .state
+                .perform
+                .sections
+                .by_id(section_id)
+                .map(|section| section.prepare_playback_source(&self.state.project_tracks.tracks))
+            {
+                self.send_command(EngineCommand::LaunchSection(Box::new(prepared)));
+                self.state.status_text = "Launching Section…".into();
+            }
+        }
     }
 
     /// Route cross-domain effects requested by the arrangement domain.
@@ -507,6 +519,8 @@ impl App {
                     }
                     EngineEvent::PlaybackStopped => {
                         self.state.transport.playing = false;
+                        self.state.perform.playing_section = None;
+                        self.state.perform.section_playhead_samples = 0;
                     }
                     EngineEvent::PlaybackStarted => {
                         self.state.transport.playing = true;
@@ -551,6 +565,23 @@ impl App {
                     } => {
                         if let Some(track) = self.state.find_track_mut(track_id) {
                             track.mute = muted;
+                        }
+                    }
+                    EngineEvent::SectionTransitioned {
+                        section_id,
+                        effective_at_samples: _,
+                        retired,
+                    } => {
+                        self.state.perform.playing_section = Some(section_id);
+                        self.state.perform.section_playhead_samples = 0;
+                        drop(retired);
+                    }
+                    EngineEvent::SectionPlaybackPosition {
+                        section_id,
+                        position_samples,
+                    } => {
+                        if self.state.perform.playing_section == Some(section_id) {
+                            self.state.perform.section_playhead_samples = position_samples;
                         }
                     }
                 }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -723,6 +723,7 @@ impl App {
             self.state.status_text = "Section drop target no longer exists".into();
             return Task::none();
         }
+        self.refresh_playing_section_after_edit(section_id);
         self.state.arrangement.selected_track = Some(track_id);
         let beat = if self.state.transport.sample_rate > 0 && self.state.transport.bpm > 0.0 {
             position_samples as f64 * self.state.transport.bpm

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -161,6 +161,7 @@ mod views_devices;
 mod views_mixer;
 mod views_overlays;
 mod views_perform;
+mod views_perform_playhead;
 mod views_perform_sections;
 mod views_settings;
 mod views_settings_perform;

--- a/crates/vibez-ui/src/app/update_timeline.rs
+++ b/crates/vibez-ui/src/app/update_timeline.rs
@@ -15,6 +15,7 @@ impl App {
         &mut self,
         msg: AutomationMsg,
     ) -> AutomationAction {
+        let section_content_changed = msg.marks_dirty();
         let editing_section = self.state.view.workspace == Workspace::Perform
             && self.state.perform.selected_section.is_some();
         let action = if editing_section {
@@ -36,6 +37,11 @@ impl App {
         };
         if editing_section {
             self.state.perform.commit_selected_section_timeline();
+            if section_content_changed {
+                if let Some(section_id) = self.state.perform.selected_section {
+                    self.refresh_playing_section_after_edit(section_id);
+                }
+            }
         }
         action
     }
@@ -45,6 +51,7 @@ impl App {
         msg: ArrangementMsg,
         ctx: ArrangementCtx,
     ) -> ArrangementAction {
+        let section_content_changed = msg.marks_dirty();
         let editing_section = self.state.view.workspace == Workspace::Perform
             && self.state.perform.selected_section.is_some();
         if editing_section {
@@ -67,6 +74,11 @@ impl App {
                 ctx,
             );
             self.state.perform.commit_selected_section_timeline();
+            if section_content_changed {
+                if let Some(section_id) = self.state.perform.selected_section {
+                    self.refresh_playing_section_after_edit(section_id);
+                }
+            }
             if let Some(track_id) = self.state.perform.section_editor.editor().selected_track {
                 self.state.arrangement.selected_track = Some(track_id);
             }
@@ -87,6 +99,7 @@ impl App {
         msg: PianoRollMsg,
         ctx: PianoRollCtx,
     ) -> PianoRollAction {
+        let section_content_changed = msg.marks_dirty();
         let editing_section = self.state.view.workspace == Workspace::Perform
             && self.state.perform.selected_section.is_some();
         if editing_section {
@@ -110,6 +123,11 @@ impl App {
                 ctx,
             );
             self.state.perform.commit_selected_section_timeline();
+            if section_content_changed {
+                if let Some(section_id) = self.state.perform.selected_section {
+                    self.refresh_playing_section_after_edit(section_id);
+                }
+            }
             action
         } else {
             let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -375,6 +375,14 @@ impl App {
             || self.state.perform.selected_pad == Some(position);
         let playing =
             section.is_some_and(|section| self.state.perform.playing_section == Some(section.id));
+        let playhead_fraction = section.filter(|_| playing).map(|section| {
+            super::views_perform_playhead::section_playhead_fraction(
+                self.state.perform.section_playhead_samples,
+                section.length_beats,
+                self.state.transport.bpm,
+                self.state.transport.sample_rate,
+            )
+        });
         let pressed = self.state.perform.is_pad_pressed(position);
         let mute_track = (mode == PerformMode::TrackMutes)
             .then(|| {
@@ -553,7 +561,16 @@ impl App {
                 .align_x(iced::alignment::Horizontal::Right)
                 .align_y(iced::alignment::Vertical::Bottom)
                 .padding(8);
-                stack![select, launch].into()
+                if let Some(fraction) = playhead_fraction {
+                    stack![
+                        select,
+                        super::views_perform_playhead::pad_playhead(fraction),
+                        launch
+                    ]
+                    .into()
+                } else {
+                    stack![select, launch].into()
+                }
             }
             (PerformMode::Sections, None) if self.state.perform.duplicate_source.is_some() => {
                 mouse_area(pad)

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -1,7 +1,7 @@
 //! Perform workspace shell, Pad Surface, and shared Section Timeline Editor.
 
 use iced::widget::{
-    button, center, column, container, horizontal_space, mouse_area, pick_list, row, text,
+    button, center, column, container, horizontal_space, mouse_area, pick_list, row, stack, text,
     text_input, tooltip,
 };
 use iced::{Element, Length, Shadow, Theme, Vector};
@@ -373,6 +373,8 @@ impl App {
         let selected = section
             .is_some_and(|section| self.state.perform.selected_section == Some(section.id))
             || self.state.perform.selected_pad == Some(position);
+        let playing =
+            section.is_some_and(|section| self.state.perform.playing_section == Some(section.id));
         let pressed = self.state.perform.is_pad_pressed(position);
         let mute_track = (mode == PerformMode::TrackMutes)
             .then(|| {
@@ -385,7 +387,11 @@ impl App {
             PerformMode::Sections => match section {
                 Some(section) => (
                     section.name.clone(),
-                    format!("AVAILABLE · {:.0} BARS", section.length_beats / 4.0),
+                    format!(
+                        "{} · {:.0} BARS",
+                        if playing { "PLAYING" } else { "AVAILABLE" },
+                        section.length_beats / 4.0
+                    ),
                     th::track_color((ordinal - 1) as u8),
                     false,
                 ),
@@ -475,7 +481,7 @@ impl App {
                 iced::gradient::Linear::new(2.35)
                     .add_stop(
                         0.0,
-                        if pressed {
+                        if pressed || playing {
                             th::blend(th::accent_dim(), color, 0.35)
                         } else if muted {
                             th::blend(th::mute_active(), color, 0.28)
@@ -489,8 +495,10 @@ impl App {
                     .into(),
             ),
             border: iced::Border {
-                color: if pressed || selected {
+                color: if pressed || playing {
                     th::accent()
+                } else if selected {
+                    th::accent_dim()
                 } else if muted {
                     th::mute_active()
                 } else {
@@ -530,9 +538,23 @@ impl App {
             .into();
 
         match (mode, section) {
-            (PerformMode::Sections, Some(section)) => mouse_area(pad)
-                .on_press(Message::Perform(PerformMsg::SelectSection(section.id)))
-                .into(),
+            (PerformMode::Sections, Some(section)) => {
+                let select = mouse_area(pad)
+                    .on_press(Message::Perform(PerformMsg::SelectSection(section.id)));
+                let launch = container(perform_tool_button(
+                    icons::PLAY,
+                    "Launch Section",
+                    Message::Perform(PerformMsg::LaunchSection(section.id)),
+                    playing,
+                    false,
+                ))
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .align_x(iced::alignment::Horizontal::Right)
+                .align_y(iced::alignment::Vertical::Bottom)
+                .padding(8);
+                stack![select, launch].into()
+            }
             (PerformMode::Sections, None) if self.state.perform.duplicate_source.is_some() => {
                 mouse_area(pad)
                     .on_press(Message::Perform(PerformMsg::DuplicateSectionTo(

--- a/crates/vibez-ui/src/app/views_perform_playhead.rs
+++ b/crates/vibez-ui/src/app/views_perform_playhead.rs
@@ -1,0 +1,63 @@
+use iced::widget::{container, horizontal_space, row};
+use iced::{Element, Length, Theme};
+
+use crate::message::Message;
+use crate::theme as th;
+
+pub(super) fn section_playhead_fraction(
+    position_samples: u64,
+    length_beats: f64,
+    bpm: f64,
+    sample_rate: u32,
+) -> f32 {
+    let length_samples = if bpm > 0.0 {
+        (length_beats * f64::from(sample_rate.max(1)) * 60.0 / bpm)
+            .round()
+            .max(1.0)
+    } else {
+        1.0
+    };
+    (position_samples as f64 / length_samples).clamp(0.0, 1.0) as f32
+}
+
+pub(super) fn section_playhead_line(height: Length) -> Element<'static, Message> {
+    container(horizontal_space())
+        .width(Length::Fixed(2.0))
+        .height(height)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(th::playhead().into()),
+            shadow: iced::Shadow {
+                color: th::with_alpha(th::playhead(), 0.45),
+                offset: iced::Vector::ZERO,
+                blur_radius: 8.0,
+            },
+            ..Default::default()
+        })
+        .into()
+}
+
+pub(super) fn pad_playhead(fraction: f32) -> Element<'static, Message> {
+    let left = (fraction.clamp(0.0, 1.0) * 1_000.0).round() as u16;
+    let right = 1_000_u16.saturating_sub(left);
+    container(row![
+        horizontal_space().width(Length::FillPortion(left.max(1))),
+        section_playhead_line(Length::Fill),
+        horizontal_space().width(Length::FillPortion(right.max(1))),
+    ])
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .padding(5)
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn section_playhead_fraction_uses_engine_samples_and_section_length() {
+        assert_eq!(section_playhead_fraction(0, 4.0, 120.0, 48_000), 0.0);
+        assert!((section_playhead_fraction(48_000, 4.0, 120.0, 48_000) - 0.5).abs() < 0.001);
+        assert_eq!(section_playhead_fraction(120_000, 4.0, 120.0, 48_000), 1.0);
+    }
+}

--- a/crates/vibez-ui/src/app/views_perform_sections.rs
+++ b/crates/vibez-ui/src/app/views_perform_sections.rs
@@ -3,7 +3,8 @@
 use std::collections::HashSet;
 
 use iced::widget::{
-    button, canvas, center, column, container, horizontal_space, mouse_area, row, scrollable, text,
+    button, canvas, center, column, container, horizontal_space, mouse_area, row, scrollable,
+    stack, text,
 };
 use iced::{Element, Length, Theme};
 
@@ -453,12 +454,37 @@ impl App {
 
             let fixed_gutter =
                 column![ruler_gutter, gutters].width(Length::Fixed(SECTION_TRACK_GUTTER_WIDTH));
-            let timeline_content = container(column![ruler_marks, lanes])
+            let timeline_base: Element<'_, Message> = container(column![ruler_marks, lanes])
                 .width(Length::Fixed(timeline_width))
+                .height(Length::Fixed(content_height))
                 .style(|_theme: &Theme| container::Style {
                     background: Some(th::display_bg().into()),
                     ..Default::default()
-                });
+                })
+                .into();
+            let timeline_content: Element<'_, Message> =
+                if self.state.perform.playing_section == Some(section_id) {
+                    let fraction = super::views_perform_playhead::section_playhead_fraction(
+                        self.state.perform.section_playhead_samples,
+                        selected_section.length_beats,
+                        self.state.transport.bpm,
+                        self.state.transport.sample_rate,
+                    );
+                    let playhead = row![
+                        horizontal_space().width(Length::Fixed(timeline_width * fraction)),
+                        super::views_perform_playhead::section_playhead_line(Length::Fixed(
+                            content_height,
+                        )),
+                    ]
+                    .width(Length::Fixed(timeline_width))
+                    .height(Length::Fixed(content_height));
+                    stack![timeline_base, playhead]
+                        .width(Length::Fixed(timeline_width))
+                        .height(Length::Fixed(content_height))
+                        .into()
+                } else {
+                    timeline_base
+                };
             let scrolling_timeline = scrollable::Scrollable::with_direction(
                 timeline_content,
                 scrollable::Direction::Horizontal(

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -398,6 +398,7 @@ pub struct PerformAction {
     pub gesture: Option<PadGesture>,
     pub track_mute_request: Option<TrackMuteRequest>,
     pub section_launch: Option<SectionId>,
+    pub section_content_changed: Option<SectionId>,
 }
 
 impl PerformState {
@@ -490,6 +491,7 @@ impl PerformState {
                     && self.mode == PerformMode::Sections
                     && self.sections.by_id(id).is_some()
                 {
+                    self.select_section(id, ctx.selected_project_track);
                     return PerformAction {
                         section_launch: Some(id),
                         ..PerformAction::default()
@@ -574,6 +576,10 @@ impl PerformState {
                             sections::MIN_SECTION_LENGTH_BEATS,
                             sections::MAX_SECTION_LENGTH_BEATS,
                         );
+                        return PerformAction {
+                            section_content_changed: Some(id),
+                            ..PerformAction::default()
+                        };
                     }
                 }
             }
@@ -588,6 +594,10 @@ impl PerformState {
                 if ctx.workspace_visible {
                     if let Some(section) = Arc::make_mut(&mut self.sections).by_id_mut(id) {
                         section.looping = !section.looping;
+                        return PerformAction {
+                            section_content_changed: Some(id),
+                            ..PerformAction::default()
+                        };
                     }
                 }
             }
@@ -616,6 +626,10 @@ impl PerformState {
                         editor.selected_note_clip = None;
                     }
                     self.commit_selected_section_timeline();
+                    return PerformAction {
+                        section_content_changed: Some(section_id),
+                        ..PerformAction::default()
+                    };
                 }
             }
             PerformMsg::PreviousBank => {
@@ -678,6 +692,9 @@ impl PerformState {
                 } else {
                     None
                 };
+                if let Some(section_id) = section_launch {
+                    self.select_section(section_id, ctx.selected_project_track);
+                }
                 return PerformAction {
                     keyboard_consumed: true,
                     persist_settings: false,
@@ -690,6 +707,7 @@ impl PerformState {
                     }),
                     track_mute_request,
                     section_launch,
+                    section_content_changed: None,
                 };
             }
             PerformMsg::ComputerKeyReleased {

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -311,6 +311,9 @@ pub struct PerformState {
     pub editing_section_name: Option<SectionId>,
     pub section_name_edit: String,
     pub duplicate_source: Option<SectionId>,
+    /// Engine-owned playback truth mirrored from Section events.
+    pub playing_section: Option<SectionId>,
+    pub section_playhead_samples: u64,
     active_computer_keys: HashMap<String, (PadPosition, PadGestureSource)>,
     track_mute_slots: Vec<Option<TrackId>>,
 }
@@ -322,6 +325,7 @@ pub enum PerformMsg {
     BeginKeyRebind(PadPosition),
     CancelKeyRebind,
     SelectSection(SectionId),
+    LaunchSection(SectionId),
     CreateSectionAt(u16),
     BeginDuplicateSection(SectionId),
     CancelDuplicateSection,
@@ -393,6 +397,7 @@ pub struct PerformAction {
     pub persist_settings: bool,
     pub gesture: Option<PadGesture>,
     pub track_mute_request: Option<TrackMuteRequest>,
+    pub section_launch: Option<SectionId>,
 }
 
 impl PerformState {
@@ -478,6 +483,17 @@ impl PerformState {
             PerformMsg::SelectSection(id) => {
                 if ctx.workspace_visible {
                     self.select_section(id, ctx.selected_project_track);
+                }
+            }
+            PerformMsg::LaunchSection(id) => {
+                if ctx.workspace_visible
+                    && self.mode == PerformMode::Sections
+                    && self.sections.by_id(id).is_some()
+                {
+                    return PerformAction {
+                        section_launch: Some(id),
+                        ..PerformAction::default()
+                    };
                 }
             }
             PerformMsg::CreateSectionAt(slot) => {
@@ -656,6 +672,12 @@ impl PerformState {
                 let track_mute_request = (self.mode == PerformMode::TrackMutes)
                     .then(|| self.track_mute_request(position, ctx.project_tracks))
                     .flatten();
+                let section_launch = if self.mode == PerformMode::Sections {
+                    let slot = u16::from(self.banks.sections) * 16 + position.index() as u16;
+                    self.sections.at_slot(slot).map(|section| section.id)
+                } else {
+                    None
+                };
                 return PerformAction {
                     keyboard_consumed: true,
                     persist_settings: false,
@@ -667,6 +689,7 @@ impl PerformState {
                         occurred_at,
                     }),
                     track_mute_request,
+                    section_launch,
                 };
             }
             PerformMsg::ComputerKeyReleased {

--- a/crates/vibez-ui/src/domains/perform/sections.rs
+++ b/crates/vibez-ui/src/domains/perform/sections.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
 use vibez_core::id::{ClipId, LaneId, SectionId, TrackId};
+use vibez_engine::playback_source::{
+    EngineClip, EngineNoteClip, PreparedPlaybackSource, PreparedSectionPlaybackSource,
+};
 use vibez_project::SectionLaunchQuantization;
 
 use crate::domains::timeline_editor::TimelineEditorAdapter;
@@ -111,6 +114,56 @@ impl Section {
     /// playable boundary. Timeline content outside the boundary remains stored.
     pub fn contains_playable_beat(&self, beat: f64) -> bool {
         beat >= 0.0 && beat < self.length_beats
+    }
+
+    /// Resolve this Section into the engine's resident playback-source seam.
+    /// Every Project Track receives a source, including empty sources that
+    /// express intentional silence without resetting the shared channel.
+    pub fn prepare_playback_source(
+        &self,
+        project_tracks: &[crate::state::ProjectTrack],
+    ) -> PreparedSectionPlaybackSource {
+        let tracks = project_tracks
+            .iter()
+            .map(|track| {
+                let content = self.timeline.get(track.id);
+                let clips = content
+                    .into_iter()
+                    .flat_map(|content| content.clips.iter())
+                    .map(|clip| EngineClip {
+                        id: clip.id,
+                        audio: Arc::clone(&clip.audio),
+                        position: clip.position,
+                        source_offset: clip.source_offset,
+                        duration: clip.duration,
+                        loop_enabled: clip.loop_enabled,
+                        loop_start: clip.loop_start,
+                        loop_end: clip.loop_end,
+                    })
+                    .collect();
+                let note_clips = content
+                    .into_iter()
+                    .flat_map(|content| content.note_clips.iter())
+                    .map(|clip| EngineNoteClip {
+                        id: clip.id,
+                        position_beats: clip.position_beats,
+                        duration_beats: clip.duration_beats,
+                        notes: clip.notes.clone(),
+                        loop_enabled: clip.loop_enabled,
+                        loop_start_beats: clip.loop_start_beats,
+                        loop_end_beats: clip.loop_end_beats,
+                    })
+                    .collect();
+                let automation = content
+                    .map(|content| content.automation.clone())
+                    .unwrap_or_default();
+                (
+                    track.id,
+                    PreparedPlaybackSource::new(clips, note_clips, automation),
+                )
+            })
+            .collect();
+        PreparedSectionPlaybackSource::new(self.id, self.length_beats, self.looping, tracks)
     }
 }
 
@@ -325,6 +378,42 @@ mod tests {
             section.timeline.get(track_id).unwrap().note_clips[0].id,
             hidden_clip.id
         );
+    }
+
+    #[test]
+    fn playback_adapter_prepares_every_project_track_for_intentional_silence() {
+        let populated_id = TrackId::new();
+        let silent_id = TrackId::new();
+        let mut section = Section::new(0);
+        Arc::make_mut(&mut section.timeline)
+            .ensure(populated_id)
+            .note_clips
+            .push(UiNoteClip {
+                id: ClipId::new(),
+                name: "Pattern".into(),
+                position_beats: 0.0,
+                duration_beats: 4.0,
+                notes: Vec::new(),
+                selected_notes: Default::default(),
+                loop_enabled: false,
+                loop_start_beats: 0.0,
+                loop_end_beats: 0.0,
+            });
+        let tracks = [
+            crate::state::ProjectTrack::new(populated_id, "Drums".into(), 0),
+            crate::state::ProjectTrack::new(silent_id, "Bass".into(), 1),
+        ];
+
+        let prepared = section.prepare_playback_source(&tracks);
+
+        assert_eq!(prepared.section_id, section.id);
+        assert_eq!(prepared.tracks().len(), 2);
+        assert_eq!(prepared.tracks()[0].track_id, populated_id);
+        assert_eq!(prepared.tracks()[0].source.note_clips.len(), 1);
+        assert_eq!(prepared.tracks()[1].track_id, silent_id);
+        assert!(prepared.tracks()[1].source.clips.is_empty());
+        assert!(prepared.tracks()[1].source.note_clips.is_empty());
+        assert!(prepared.tracks()[1].source.automation.is_empty());
     }
 
     #[test]

--- a/crates/vibez-ui/src/domains/perform_tests.rs
+++ b/crates/vibez-ui/src/domains/perform_tests.rs
@@ -371,7 +371,7 @@ fn selecting_a_section_preserves_project_track_selection_and_resets_clip_focus()
 }
 
 #[test]
-fn keyboard_and_pointer_launch_match_while_selection_remains_independent() {
+fn keyboard_and_pointer_launch_select_the_target_then_allow_independent_selection() {
     let first = Section::new(0);
     let first_id = first.id;
     let second = Section::new(1);
@@ -386,6 +386,7 @@ fn keyboard_and_pointer_launch_match_while_selection_remains_independent() {
     };
 
     let pointer = state.update(PerformMsg::LaunchSection(first_id), &mut engine, ctx);
+    assert_eq!(state.selected_section, Some(first_id));
     let keyboard = state.update(
         PerformMsg::ComputerKeyPressed {
             key: ComputerKey::Digit1,
@@ -395,6 +396,7 @@ fn keyboard_and_pointer_launch_match_while_selection_remains_independent() {
         &mut engine,
         ctx,
     );
+    assert_eq!(state.selected_section, Some(first_id));
     let selection = state.update(PerformMsg::SelectSection(second_id), &mut engine, ctx);
 
     assert_eq!(pointer.section_launch, Some(first_id));
@@ -405,6 +407,27 @@ fn keyboard_and_pointer_launch_match_while_selection_remains_independent() {
         state.playing_section, None,
         "only engine events set playback truth"
     );
+}
+
+#[test]
+fn playback_affecting_section_edits_request_a_source_refresh() {
+    let section = Section::new(0);
+    let section_id = section.id;
+    let mut state = PerformState::default();
+    Arc::make_mut(&mut state.sections).insert(section);
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        ..PerformCtx::default()
+    };
+
+    let action = state.update(
+        PerformMsg::SetSectionLengthBeats(section_id, 8.0),
+        &mut engine,
+        ctx,
+    );
+
+    assert_eq!(action.section_content_changed, Some(section_id));
 }
 
 #[test]

--- a/crates/vibez-ui/src/domains/perform_tests.rs
+++ b/crates/vibez-ui/src/domains/perform_tests.rs
@@ -371,6 +371,43 @@ fn selecting_a_section_preserves_project_track_selection_and_resets_clip_focus()
 }
 
 #[test]
+fn keyboard_and_pointer_launch_match_while_selection_remains_independent() {
+    let first = Section::new(0);
+    let first_id = first.id;
+    let second = Section::new(1);
+    let second_id = second.id;
+    let mut state = PerformState::default();
+    Arc::make_mut(&mut state.sections).insert(first);
+    Arc::make_mut(&mut state.sections).insert(second);
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        ..PerformCtx::default()
+    };
+
+    let pointer = state.update(PerformMsg::LaunchSection(first_id), &mut engine, ctx);
+    let keyboard = state.update(
+        PerformMsg::ComputerKeyPressed {
+            key: ComputerKey::Digit1,
+            key_id: "1".into(),
+            occurred_at: Instant::now(),
+        },
+        &mut engine,
+        ctx,
+    );
+    let selection = state.update(PerformMsg::SelectSection(second_id), &mut engine, ctx);
+
+    assert_eq!(pointer.section_launch, Some(first_id));
+    assert_eq!(keyboard.section_launch, pointer.section_launch);
+    assert_eq!(selection.section_launch, None);
+    assert_eq!(state.selected_section, Some(second_id));
+    assert_eq!(
+        state.playing_section, None,
+        "only engine events set playback truth"
+    );
+}
+
+#[test]
 fn removing_track_content_only_changes_the_selected_section() {
     let tracks = project_tracks(1);
     let track_id = tracks[0].id;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,8 +108,9 @@ project persistence and undo. Each Section owns its properties and an
 independent `ArrangementTimeline` keyed by the same shared Project `TrackId`s;
 duplicating a Section remints every editable content identity while immutable
 decoded audio remains shared. `PerformMsg` changes that slice through the
-router and `EngineHandle`. Creating and editing Sections does not send engine
-commands yet—Section playback belongs to the later launch slice. Perform is a
+router and `EngineHandle`. A Section launch returns a semantic action; the
+router resolves the complete resident playback source and sends it to the
+engine without coupling the Perform interaction slice to engine storage. Perform is a
 sibling of Arrange and Mix in the shared shell, and all three retain their
 interaction state when producers switch between them. Track Mute pad slots
 retain stable `TrackId` assignments across
@@ -156,15 +157,15 @@ thin adapter that retains Arrange's Project Track/channel controls and
 implements `TimelineEditorAdapter` to resolve its editor. The editor never
 asks which workspace is active and contains no `Arrange | Section` branch.
 
-The selected Perform Section now provides that second adapter through a
+The selected Perform Section provides the editor adapter through a
 runtime-only `SectionTimelineEditor`. Selecting a Section resolves its
 persisted Timeline Content into the adapter while preserving the project-wide
 Project Track selection; clip and piano-roll selection remain local to the
 resolved Section editor. Every edit commits the adapter's copy-on-write
 Timeline Content back into the selected Section store for undo and project
-persistence. Until the Section playback source lands, a discarding engine
-handle prevents shared editor synchronization commands from mutating the
-audible Arrange source.
+persistence. Section authoring still uses a discarding engine handle so edits
+to a selected, non-playing Section cannot mutate either resident audio source;
+a launch prepares a fresh resident adapter from canonical Section content.
 
 Every horizontal editor surface uses `TimelineGeometry` for beat-to-pixel,
 pixel-to-beat, fitted viewport, visible-range, and beat-width conversions.
@@ -223,20 +224,32 @@ flowchart LR
 
 `EngineTrack` is the shared project channel strip: it owns the instrument,
 effects, sends, gain/pan, mute/solo, meters, and preallocated render scratch.
-Time-based Arrange content is now a separate `PreparedPlaybackSource` behind
-one owned pointer. `ArrangementPlaybackSource` is the first adapter and the
-same source renderer feeds the existing channel path, so there is no second
-clip, note, automation, instrument, or effect implementation. Prepared sources
-contain decoded clip `Arc`s and expose no loader or I/O API. Card 10 supplies
-the Section adapter and the first pointer transfer; the callback must exchange
-prepared ownership only and return superseded ownership for disposal outside
-the real-time thread rather than dropping it there.
+Time-based content is a separate `PreparedPlaybackSource` behind an owned
+pointer. `ArrangementPlaybackSource` and the active Section adapter feed the
+same channel renderer, so there is no second clip, note, automation,
+instrument, effect, or send implementation. A complete
+`PreparedSectionPlaybackSource` contains one resident source for every Project
+Track, including empty sources that mean intentional silence. It holds decoded
+clip `Arc`s and exposes no loader or I/O API.
+
+`EngineCommand::LaunchSection` swaps those prepared pointers into each shared
+channel at the next callback opportunity, resets the engine-owned local Section
+playhead, and emits a sample-timestamped `SectionTransitioned` event. The same
+command owner is returned in that event carrying the displaced sources, so
+their Vecs and Arcs are destroyed on the UI thread. The callback only swaps
+pointers: it never allocates, loads, locks, performs I/O, or drops a resident
+source. The UI sets playing-pad state only from engine events. Section loop
+wraps split inside a callback at the playable boundary, flush sounding notes,
+and continue from local sample zero. Empty sources still run the shared device
+chain, allowing existing effect tails to decay naturally.
 
 ```mermaid
 flowchart LR
-    A["ArrangementPlaybackSource adapter"] --> P["PreparedPlaybackSource<br/>audio + note clips + automation"]
-    P -- "resident source pointer" --> C["EngineTrack channel strip<br/>instrument + effects + sends + mixer"]
+    A["Arrange adapter"] --> P["PreparedPlaybackSource<br/>audio + note clips + automation"]
+    S["Section adapter<br/>one source per Project Track"] --> P
+    P -- "resident pointer swap" --> C["EngineTrack channel strip<br/>instrument + effects + sends + mixer"]
     C --> M["metering + master"]
+    C -- "timestamped transition + retired owners" --> U["UI mirror + off-thread drop"]
 ```
 
 ## Plugins (VST3 and CLAP)


### PR DESCRIPTION
## Summary

- adapt authored Sections into the Card 09 resident playback-source seam for every Project Track, including intentional empty sources
- launch Sections immediately from computer pads or a distinct pointer affordance while keeping editing selection independent
- keep Section playhead/playing-pad truth engine-owned, preserve shared channel devices and tails, release sounding notes on switches, and restore Arrange playback after stop or a non-looping end
- keep the callback switch path allocation-, lock-, I/O-, load-, and destruction-free by swapping prepared boxed sources and returning retired ownership to the UI thread

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -j 4 --workspace -- -D warnings`
- `cargo test -j 4 --workspace`
- focused TDD regressions cover immediate switching, shortened loop boundaries, Arrange-loop isolation, non-looping return to Arrange, silent absent tracks with continuing effect tails, and safe note release
- all changed Rust files remain below 1,000 lines

## Native dogfood

Exact commit `a73e6f6` was built and run from its dedicated target/worktree on isolated Xvfb display `:98`. `/proc` and the X11 window PID confirmed the branch executable. Pointer launch started Section 01; keyboard `2` then started Section 02 while Section 01 remained selected, confirming engine-driven playing state and independent editing selection. Evidence is in the dedicated Cargo target as `card10-xvfb-*.png`.

Audible sign-off with two contrasting authored Sections remains a human merge gate. Concise steps are included in the card delivery evidence and will be posted on this PR.

Card 10 only. Quantization/residency (Card 11), later Perform work, hardware cards, and the separate Arrange add-track/styling bug are out of scope.
