### PR TITLE
refactor(ui): unify tracked async requests

### DIFF
--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -16,10 +16,6 @@ fn queue_latest_remote_audition(slot: &mut Option<DropboxEntry>, entry: DropboxE
     *slot = Some(entry);
 }
 
-pub(super) fn remote_import_result_is_current(current: u64, result: u64) -> bool {
-    current == result
-}
-
 pub(super) fn remote_catalog_page_task(
     client: Arc<DropboxClient>,
     checkpoint: Option<String>,
@@ -74,7 +70,7 @@ pub(super) fn seed_remote_availability(
 
 impl App {
     pub(super) fn remote_import_active(&self) -> bool {
-        self.remote_import_in_flight.is_some()
+        self.remote_import_request.is_active()
     }
 
     pub(super) fn reseed_remote_availability(&mut self) {
@@ -112,7 +108,7 @@ impl App {
         &self,
         next_checkpoint: Option<String>,
     ) -> Task<Message> {
-        let generation = self.remote_catalog_generation;
+        let generation = self.remote_catalog_request.current().unwrap_or(0);
         let snapshot = self.state.browser.remote.catalog.clone();
         Task::perform(
             async move {
@@ -162,19 +158,10 @@ impl App {
         target: BrowserImportTarget,
         treatment: crate::state::AuditionImportInput,
     ) -> Task<Message> {
-        if let Some(handle) = self.remote_import_abort.take() {
-            handle.abort();
-        }
-        if let Some(handle) = self.remote_materialization_abort.take() {
-            handle.abort();
-            self.remote_materialization_request_id =
-                self.remote_materialization_request_id.saturating_add(1);
-        }
+        self.remote_materialization_request.cancel();
         self.remote_audition_cache_lease = None;
         let maintenance = self.media_cache_maintenance_task();
-        self.remote_import_request_id = self.remote_import_request_id.saturating_add(1);
-        let request_id = self.remote_import_request_id;
-        self.remote_import_in_flight = Some(request_id);
+        let request_id = self.remote_import_request.begin();
         self.state.browser.remote.availability.insert(
             entry.path_lower.clone(),
             if self
@@ -198,8 +185,7 @@ impl App {
                 result,
             },
         );
-        let (task, handle) = task.abortable();
-        self.remote_import_abort = Some(handle);
+        let task = self.remote_import_request.attach(task);
         Task::batch([task, maintenance])
     }
 
@@ -236,14 +222,14 @@ impl App {
                 };
             return Task::none();
         };
-        self.remote_catalog_generation = self.remote_catalog_generation.wrapping_add(1);
+        let generation = self.remote_catalog_request.begin();
         self.remote_catalog_pending.clear();
         self.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Refreshing;
         self.state.browser.remote.refresh_pages = 0;
         self.state.browser.remote.refresh_items = self.state.browser.remote.catalog.entries.len();
         self.state.status_text = "Refreshing Remote catalog…".into();
         let checkpoint = self.state.browser.remote.catalog.checkpoint.clone();
-        remote_catalog_page_task(client, checkpoint, 0, self.remote_catalog_generation)
+        remote_catalog_page_task(client, checkpoint, 0, generation)
     }
 
     pub(super) fn start_remote_audition(
@@ -262,14 +248,10 @@ impl App {
             self.state.status_text = "Remote Audition queued behind active import".into();
             return Task::none();
         }
-        if let Some(handle) = self.remote_materialization_abort.take() {
-            handle.abort();
-        }
+        self.remote_materialization_request.cancel();
         self.remote_audition_cache_lease = None;
         let maintenance = self.media_cache_maintenance_task();
-        self.remote_materialization_request_id =
-            self.remote_materialization_request_id.saturating_add(1);
-        let request_id = self.remote_materialization_request_id;
+        let request_id = self.remote_materialization_request.begin();
         let cached = self
             .dropbox_cache
             .is_cached(&entry.path_lower, entry.rev.as_deref());
@@ -284,6 +266,7 @@ impl App {
             self.state
                 .browser
                 .fail_waveform_load(&source, "Reconnect Required · uncached Remote media".into());
+            self.remote_materialization_request.finish(request_id);
             return Task::none();
         }
 
@@ -325,8 +308,7 @@ impl App {
                 result,
             },
         );
-        let (task, handle) = task.abortable();
-        self.remote_materialization_abort = Some(handle);
+        let task = self.remote_materialization_request.attach(task);
         Task::batch([task, maintenance])
     }
 
@@ -388,12 +370,5 @@ mod tests {
             pending.as_ref().map(|entry| entry.path_lower.as_str()),
             Some("/winner.wav")
         );
-    }
-
-    #[test]
-    fn cancelled_or_superseded_remote_import_results_cannot_create_project_media() {
-        assert!(remote_import_result_is_current(7, 7));
-        assert!(!remote_import_result_is_current(8, 7));
-        assert!(!remote_import_result_is_current(9, 7));
     }
 }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -466,8 +466,8 @@ impl App {
             AuditionMode::Warp => format!("Preparing WARP import: {name}"),
         };
         let retained_target = target.clone();
-        let generation = self.browser_import_generation;
-        Task::perform(
+        let generation = self.browser_import_request.begin();
+        let task = Task::perform(
             prepare_browser_import_audio_async(target, treatment, raw, source, project_bpm),
             move |result| match result {
                 Ok((audio, original_audio, source)) => Message::BrowserImportPrepared {
@@ -483,7 +483,8 @@ impl App {
                 },
                 Err(error) => Message::BrowserSampleDecodeError(error),
             },
-        )
+        );
+        self.browser_import_request.attach(task)
     }
 
     pub(super) fn apply_browser_import_prepared(

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -59,22 +59,17 @@ struct App {
     dropbox_settings: DropboxSettings,
     dropbox_cache: DropboxCache,
     dropbox_client: Option<Arc<DropboxClient>>,
-    remote_materialization_abort: Option<iced::task::Handle>,
-    remote_import_abort: Option<iced::task::Handle>,
-    remote_import_request_id: u64,
-    remote_materialization_request_id: u64,
+    remote_materialization_request: tracked_request::TrackedRequest,
+    remote_import_request: tracked_request::TrackedRequest,
     remote_audition_cache_lease: Option<vibez_dropbox::CacheLease>,
-    /// Request id of the active Remote import, if any. Completions for any
-    /// other generation must not clear it or release the queued audition.
-    remote_import_in_flight: Option<u64>,
     pending_remote_audition: Option<DropboxEntry>,
     /// Generation for the whole Browser import pipeline (local and
     /// remote). Bumped on cancellation and project reset so an
     /// in-flight WARP preparation cannot land a clip afterwards.
-    browser_import_generation: u64,
+    browser_import_request: tracked_request::TrackedRequest,
     /// Bumped on every refresh start and on disconnect, so catalog pages
     /// fetched for a previous connection are dropped instead of reconciled.
-    remote_catalog_generation: u64,
+    remote_catalog_request: tracked_request::TrackedRequest,
     /// Catalog changes accumulated since the last reconcile flush; applied in
     /// batches so each page does not re-sort the whole catalog in update().
     remote_catalog_pending: Vec<crate::remote_provider::RemoteChange>,
@@ -134,6 +129,7 @@ mod audio_tasks;
 mod bounce;
 mod keyboard;
 mod local_watcher;
+mod tracked_request;
 
 use async_helpers::*;
 pub(crate) use audio_tasks::*;
@@ -321,15 +317,12 @@ impl App {
             dropbox_settings,
             dropbox_cache,
             dropbox_client,
-            remote_materialization_abort: None,
-            remote_import_abort: None,
-            remote_import_request_id: 0,
-            remote_materialization_request_id: 0,
+            remote_materialization_request: Default::default(),
+            remote_import_request: Default::default(),
             remote_audition_cache_lease: None,
-            remote_import_in_flight: None,
             pending_remote_audition: None,
-            browser_import_generation: 0,
-            remote_catalog_generation: 0,
+            browser_import_request: Default::default(),
+            remote_catalog_request: Default::default(),
             remote_catalog_pending: Vec::new(),
             midi_input,
             midi_input_ports: Vec::new(),

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -25,7 +25,7 @@ impl App {
     pub(super) fn clear_project_runtime(&mut self) {
         // Invalidate any Browser import still preparing (e.g. in its
         // WARP stage) so it cannot add a clip to the reset project.
-        self.browser_import_generation = self.browser_import_generation.wrapping_add(1);
+        self.browser_import_request.cancel();
         self.stop_browser_audition();
         self.state.transport.playing = false;
         self.state.transport.position_samples = 0;
@@ -197,16 +197,8 @@ impl App {
     }
 
     pub(super) fn reset_to_new_project(&mut self) {
-        if let Some(handle) = self.remote_import_abort.take() {
-            handle.abort();
-            self.remote_import_request_id = self.remote_import_request_id.saturating_add(1);
-            self.remote_import_in_flight = None;
-        }
-        if let Some(handle) = self.remote_materialization_abort.take() {
-            handle.abort();
-            self.remote_materialization_request_id =
-                self.remote_materialization_request_id.saturating_add(1);
-        }
+        self.remote_import_request.cancel();
+        self.remote_materialization_request.cancel();
         self.remote_audition_cache_lease = None;
         let _ = self.dropbox_cache.set_policy(self.dropbox_cache.policy());
         self.clear_project_runtime();

--- a/crates/vibez-ui/src/app/tracked_request.rs
+++ b/crates/vibez-ui/src/app/tracked_request.rs
@@ -1,0 +1,123 @@
+use iced::Task;
+
+/// One router-owned async request lifecycle.
+///
+/// Tokens reject stale completions. Replacing/cancelling a request aborts any
+/// attached task, and dropping the tracker aborts its active task as well.
+#[derive(Default)]
+pub(super) struct TrackedRequest {
+    generation: u64,
+    active: Option<u64>,
+    abort: Option<Box<dyn FnOnce()>>,
+}
+
+impl TrackedRequest {
+    pub fn begin(&mut self) -> u64 {
+        self.abort_current();
+        self.generation = self.generation.wrapping_add(1);
+        self.active = Some(self.generation);
+        self.generation
+    }
+
+    pub fn attach<Message: 'static>(&mut self, task: Task<Message>) -> Task<Message> {
+        if let Some(abort) = self.abort.take() {
+            abort();
+        }
+        let (task, handle) = task.abortable();
+        self.abort = Some(Box::new(move || handle.abort()));
+        task
+    }
+
+    pub fn is_current(&self, token: u64) -> bool {
+        self.active == Some(token)
+    }
+
+    pub fn current(&self) -> Option<u64> {
+        self.active
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active.is_some()
+    }
+
+    pub fn finish(&mut self, token: u64) -> bool {
+        if !self.is_current(token) {
+            return false;
+        }
+        self.active = None;
+        self.abort = None;
+        true
+    }
+
+    pub fn cancel(&mut self) {
+        self.abort_current();
+        self.generation = self.generation.wrapping_add(1);
+        self.active = None;
+    }
+
+    fn abort_current(&mut self) {
+        if let Some(abort) = self.abort.take() {
+            abort();
+        }
+        self.active = None;
+    }
+
+    #[cfg(test)]
+    fn attach_abort_probe(&mut self, probe: std::sync::Arc<std::sync::atomic::AtomicBool>) {
+        self.abort = Some(Box::new(move || {
+            probe.store(true, std::sync::atomic::Ordering::SeqCst)
+        }));
+    }
+}
+
+impl Drop for TrackedRequest {
+    fn drop(&mut self) {
+        self.abort_current();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TrackedRequest;
+
+    #[test]
+    fn replacement_rejects_the_previous_token_and_finish_clears_activity() {
+        let mut request = TrackedRequest::default();
+        let first = request.begin();
+        let probe = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        request.attach_abort_probe(std::sync::Arc::clone(&probe));
+        assert!(request.is_current(first));
+        assert!(request.is_active());
+
+        let second = request.begin();
+        assert!(probe.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(!request.is_current(first));
+        assert!(request.is_current(second));
+        assert!(!request.finish(first));
+        assert!(request.finish(second));
+        assert!(!request.is_active());
+    }
+
+    #[test]
+    fn cancellation_invalidates_the_current_token() {
+        let mut request = TrackedRequest::default();
+        let token = request.begin();
+
+        request.cancel();
+
+        assert!(!request.is_current(token));
+        assert!(!request.is_active());
+    }
+
+    #[test]
+    fn drop_aborts_attached_work() {
+        let probe = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let mut request = TrackedRequest::default();
+            request.begin();
+            request.attach_abort_probe(std::sync::Arc::clone(&probe));
+        }
+
+        assert!(probe.load(std::sync::atomic::Ordering::SeqCst));
+    }
+}

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -294,11 +294,7 @@ impl App {
     }
 
     pub(super) fn on_stop_browser_preview(&mut self) -> Task<Message> {
-        if let Some(handle) = self.remote_materialization_abort.take() {
-            handle.abort();
-            self.remote_materialization_request_id =
-                self.remote_materialization_request_id.saturating_add(1);
-        }
+        self.remote_materialization_request.cancel();
         self.remote_audition_cache_lease = None;
         self.state.browser.remote.preview_in_progress = false;
         self.stop_browser_audition();
@@ -311,11 +307,7 @@ impl App {
     pub(super) fn on_toggle_audition_enabled(&mut self) -> Task<Message> {
         let enabled = self.state.browser.toggle_audition_enabled();
         let maintenance = if !enabled {
-            if let Some(handle) = self.remote_materialization_abort.take() {
-                handle.abort();
-                self.remote_materialization_request_id =
-                    self.remote_materialization_request_id.saturating_add(1);
-            }
+            self.remote_materialization_request.cancel();
             self.remote_audition_cache_lease = None;
             self.stop_browser_audition();
             self.media_cache_maintenance_task()
@@ -418,13 +410,9 @@ impl App {
     }
 
     pub(super) fn on_escape_pressed(&mut self) -> Task<Message> {
-        // Escape abandons any pending browser import at whatever stage
-        // it is in. The fetch/decode stage is covered by the abort
-        // handle below, but the WARP-preparation stage has no handle
-        // (remote_import_in_flight is already cleared), so only this
-        // generation bump stops BrowserImportPrepared from landing a
-        // clip after the user cancelled.
-        self.browser_import_generation = self.browser_import_generation.wrapping_add(1);
+        // Escape abandons any pending browser import at whatever stage it is
+        // in; the shared tracker aborts attached work and rejects late output.
+        self.browser_import_request.cancel();
         if self.state.browser.audition_playing
             || self.state.browser.audition_loading
             || self.state.browser.audition_queued
@@ -432,11 +420,7 @@ impl App {
             self.stop_browser_audition();
             self.state.status_text = "Audition stopped".into();
         } else if self.remote_import_active() {
-            if let Some(handle) = self.remote_import_abort.take() {
-                handle.abort();
-            }
-            self.remote_import_request_id = self.remote_import_request_id.saturating_add(1);
-            self.remote_import_in_flight = None;
+            self.remote_import_request.cancel();
             self.state.status_text = "Remote import cancelled; no project media added".into();
             let maintenance = self.media_cache_maintenance_task();
             if let Some(entry) = self.pending_remote_audition.take() {
@@ -634,8 +618,8 @@ impl App {
         name: String,
         source: MediaSourceRef,
     ) -> Task<Message> {
-        // The active import's own completion has already cleared
-        // `remote_import_in_flight` (RemoteImportReady). A remote
+        // The active import's own completion has already finished its
+        // TrackedRequest (RemoteImportReady). A remote
         // source decoded while another import is still running (e.g.
         // a dropped staged copy) must not run its cleanup or release
         // the queued audition.
@@ -674,15 +658,13 @@ impl App {
             String,
         >,
     ) -> Task<Message> {
-        if !dropbox_io::remote_import_result_is_current(self.remote_import_request_id, request_id) {
+        if !self.remote_import_request.finish(request_id) {
             // Staging copies are content-addressed, so a superseding
             // import of the same bytes shares this exact file;
             // deleting it here would break that import's next save.
             // The startup staging sweep owns orphan cleanup.
             return Task::none();
         }
-        self.remote_import_abort = None;
-        self.remote_import_in_flight = None;
         match result {
             Ok((audio, name, source)) => self.update(Message::BrowserSampleDecoded(
                 target, treatment, audio, name, source,
@@ -700,7 +682,7 @@ impl App {
         generation: u64,
         payload: crate::message::PreparedBrowserImport,
     ) -> Task<Message> {
-        if generation != self.browser_import_generation {
+        if !self.browser_import_request.finish(generation) {
             return Task::none();
         }
         self.apply_browser_import_prepared(target, payload)

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -51,7 +51,7 @@ impl App {
         // Invalidate any in-flight refresh so pages fetched for this
         // (possibly different) account cannot reconcile after a
         // reconnect.
-        self.remote_catalog_generation = self.remote_catalog_generation.wrapping_add(1);
+        self.remote_catalog_request.cancel();
         self.remote_catalog_pending.clear();
         self.dropbox_settings.clear_tokens();
         let _ = self.dropbox_settings.save();
@@ -77,7 +77,7 @@ impl App {
             crate::remote_provider::RemoteProviderError,
         >,
     ) -> Task<Message> {
-        if generation != self.remote_catalog_generation {
+        if !self.remote_catalog_request.is_current(generation) {
             return Task::none();
         }
         match result {
@@ -192,7 +192,7 @@ impl App {
         next_checkpoint: Option<String>,
         result: Result<(), String>,
     ) -> Task<Message> {
-        if generation != self.remote_catalog_generation {
+        if !self.remote_catalog_request.is_current(generation) {
             return Task::none();
         }
         match result {
@@ -347,10 +347,9 @@ impl App {
         source: MediaSourceRef,
         result: Result<crate::message::RemoteMaterializedSample, String>,
     ) -> Task<Message> {
-        if request_id != self.remote_materialization_request_id {
+        if !self.remote_materialization_request.finish(request_id) {
             return Task::none();
         }
-        self.remote_materialization_abort = None;
         self.state.browser.remote.preview_in_progress = false;
         let path_lower = match &source {
             MediaSourceRef::DropboxFile { path_lower, .. } => path_lower.clone(),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,7 +100,11 @@ the returned action, and the recorded engine commands.
 Anything asynchronous (file dialogs, decoding, saving, bounce renders) stays
 in the router layer as iced Tasks in topic modules under
 `crates/vibez-ui/src/app/`; the results come back as messages and the state
-math happens in the domains.
+math happens in the domains. Replaceable router work uses one `TrackedRequest`
+lifecycle for monotonic tokens, stale-result rejection, cancellation, optional
+iced task abortion, and abort-on-drop. Remote import, Remote materialization,
+Browser import preparation, and Remote catalog refresh keep separate tracker
+instances but do not duplicate request IDs, generations, or abort handles.
 
 Perform follows the same boundary. `PerformState` owns runtime-only mode, bank,
 selection, and editor-focus state alongside an `Arc<SectionStore>` that enters


### PR DESCRIPTION
## Summary

- introduce one router-owned `TrackedRequest` lifecycle for generation tokens, stale-result rejection, cancellation, attached-task abort, completion, and abort-on-drop
- migrate the four existing mechanisms: Remote import, Remote audition materialization, Browser import preparation, and Remote catalog refresh
- retain async work in the app router and preserve the existing domain-message boundaries without adding behavior or mixing Card 10 changes
- remove the duplicated request IDs, generations, abort handles, and in-flight bookkeeping

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -j 4 --workspace -- -D warnings`
- `cargo test -j 4 --workspace`
- unit regressions cover cancellation, generation replacement/stale rejection, completion, replacement abort, and abort on drop
- existing integration coverage exercises supported-format media decode/import, cancellation, project reopen, Remote materialization, and catalog reconciliation
- all changed Rust files remain below 1,000 lines

## Native dogfood

Exact commit `a01d230` was built and run from its dedicated target/worktree on isolated Xvfb display `:98`. `/proc` and the X11 window PID confirmed the branch executable. Startup reconciled the existing 383,533-entry Remote catalog, a copied project opened, saved an added Section, and reopened with that Section intact. Evidence is in the dedicated Cargo target as `card25-xvfb-*.png`.

Card 25 only. No Section playback/residency changes, new async behavior, hardware work, or Arrange add-track/styling changes are included.
