### PR TITLE
fix(ui): create one track per shortcut press

### DIFF
--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -12,19 +12,20 @@ use crate::domains::view::ViewMsg;
 
 use crate::message::Message;
 
-#[derive(Default)]
 pub(crate) struct EdgeShortcutState {
-    pressed_keys: std::collections::HashSet<String>,
-    released_at: std::collections::HashMap<String, std::time::Instant>,
+    track_chord_armed: bool,
+}
+
+impl Default for EdgeShortcutState {
+    fn default() -> Self {
+        Self {
+            track_chord_armed: true,
+        }
+    }
 }
 
 impl EdgeShortcutState {
-    fn should_dispatch(
-        &mut self,
-        key_id: &str,
-        message: &Message,
-        occurred_at: std::time::Instant,
-    ) -> bool {
+    fn should_dispatch(&mut self, message: &Message) -> bool {
         let edge_triggered = matches!(
             message,
             Message::Arrangement(ArrangementMsg::AddTrack | ArrangementMsg::AddInstrumentTrack)
@@ -32,20 +33,13 @@ impl EdgeShortcutState {
         if !edge_triggered {
             return true;
         }
-
-        let release_gap = self
-            .released_at
-            .get(key_id)
-            .map(|released_at| occurred_at.saturating_duration_since(*released_at));
-        let synthetic_repeat =
-            release_gap.is_some_and(|gap| gap <= std::time::Duration::from_millis(30));
-        let first_press = self.pressed_keys.insert(key_id.to_owned());
-        first_press && !synthetic_repeat
+        std::mem::replace(&mut self.track_chord_armed, false)
     }
 
-    fn release(&mut self, key_id: &str, occurred_at: std::time::Instant) {
-        self.pressed_keys.remove(key_id);
-        self.released_at.insert(key_id.to_owned(), occurred_at);
+    fn observe_modifiers(&mut self, modifiers: iced::keyboard::Modifiers) {
+        if !modifiers.control() {
+            self.track_chord_armed = true;
+        }
     }
 }
 
@@ -135,7 +129,6 @@ impl super::App {
                 modifiers,
                 ..
             } => {
-                let edge_key_id = runtime_key_id(&key);
                 if self.state.perform.key_rebind_target.is_some()
                     && matches!(key, iced::keyboard::Key::Named(Named::Escape))
                 {
@@ -148,21 +141,21 @@ impl super::App {
                                 key_id: runtime_key_id(&key),
                                 occurred_at,
                             }),
-                            Some((key, modifiers, edge_key_id)),
+                            Some((key, modifiers)),
                         )
                     } else {
-                        (None, Some((key, modifiers, edge_key_id)))
+                        (None, Some((key, modifiers)))
                     }
                 } else if self.state.perform.key_rebind_target.is_some() {
                     self.state.status_text = "Perform keys must be letters or numbers".into();
                     return iced::Task::none();
                 } else {
-                    (None, Some((key, modifiers, edge_key_id)))
+                    (None, Some((key, modifiers)))
                 }
             }
-            iced::keyboard::Event::KeyReleased { key, .. } => {
+            iced::keyboard::Event::KeyReleased { key, modifiers, .. } => {
                 let key_id = runtime_key_id(&key);
-                self.edge_shortcuts.release(&key_id, occurred_at);
+                self.edge_shortcuts.observe_modifiers(modifiers);
                 (
                     Some(PerformMsg::ComputerKeyReleased {
                         key_id,
@@ -171,7 +164,10 @@ impl super::App {
                     None,
                 )
             }
-            iced::keyboard::Event::ModifiersChanged(_) => return iced::Task::none(),
+            iced::keyboard::Event::ModifiersChanged(modifiers) => {
+                self.edge_shortcuts.observe_modifiers(modifiers);
+                return iced::Task::none();
+            }
         };
 
         if let Some(msg) = perform_msg {
@@ -192,10 +188,10 @@ impl super::App {
         }
 
         fallback
-            .and_then(|(key, modifiers, key_id)| {
+            .and_then(|(key, modifiers)| {
                 let message = global_key_handler(key, modifiers)?;
                 self.edge_shortcuts
-                    .should_dispatch(&key_id, &message, occurred_at)
+                    .should_dispatch(&message)
                     .then_some(message)
             })
             .map_or_else(iced::Task::none, iced::Task::done)
@@ -446,34 +442,29 @@ mod tests {
     }
 
     #[test]
-    fn held_track_shortcut_dispatches_once_until_key_release() {
+    fn held_track_shortcut_dispatches_once_until_control_is_released() {
         let mut state = EdgeShortcutState::default();
         let add = Message::Arrangement(ArrangementMsg::AddInstrumentTrack);
-        let started = std::time::Instant::now();
 
-        assert!(state.should_dispatch("Character(\"T\")", &add, started));
-        assert!(!state.should_dispatch("Character(\"T\")", &add, started));
+        assert!(state.should_dispatch(&add));
+        assert!(!state.should_dispatch(&add));
 
-        // X11 auto-repeat is delivered as a synthetic release/press pair.
-        state.release(
-            "Character(\"T\")",
-            started + std::time::Duration::from_millis(500),
-        );
-        assert!(!state.should_dispatch(
-            "Character(\"T\")",
-            &add,
-            started + std::time::Duration::from_millis(501),
-        ));
+        // Repeated T release/press pairs keep the Ctrl chord held.
+        state.observe_modifiers(iced::keyboard::Modifiers::CTRL);
+        assert!(!state.should_dispatch(&add));
 
-        state.release(
-            "Character(\"T\")",
-            started + std::time::Duration::from_millis(900),
-        );
-        assert!(state.should_dispatch(
-            "Character(\"T\")",
-            &add,
-            started + std::time::Duration::from_millis(1_000),
-        ));
+        state.observe_modifiers(iced::keyboard::Modifiers::empty());
+        assert!(state.should_dispatch(&add));
+    }
+
+    #[test]
+    fn delayed_x11_repeat_does_not_duplicate_an_audio_track() {
+        let mut state = EdgeShortcutState::default();
+        let add = Message::Arrangement(ArrangementMsg::AddTrack);
+
+        assert!(state.should_dispatch(&add));
+        state.observe_modifiers(iced::keyboard::Modifiers::CTRL);
+        assert!(!state.should_dispatch(&add));
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -12,20 +12,19 @@ use crate::domains::view::ViewMsg;
 
 use crate::message::Message;
 
+#[derive(Default)]
 pub(crate) struct EdgeShortcutState {
-    track_chord_armed: bool,
-}
-
-impl Default for EdgeShortcutState {
-    fn default() -> Self {
-        Self {
-            track_chord_armed: true,
-        }
-    }
+    pressed_keys: std::collections::HashSet<String>,
+    released_at: std::collections::HashMap<String, std::time::Instant>,
 }
 
 impl EdgeShortcutState {
-    fn should_dispatch(&mut self, message: &Message) -> bool {
+    fn should_dispatch(
+        &mut self,
+        key_id: &str,
+        message: &Message,
+        occurred_at: std::time::Instant,
+    ) -> bool {
         let edge_triggered = matches!(
             message,
             Message::Arrangement(ArrangementMsg::AddTrack | ArrangementMsg::AddInstrumentTrack)
@@ -33,13 +32,20 @@ impl EdgeShortcutState {
         if !edge_triggered {
             return true;
         }
-        std::mem::replace(&mut self.track_chord_armed, false)
+
+        let release_gap = self
+            .released_at
+            .get(key_id)
+            .map(|released_at| occurred_at.saturating_duration_since(*released_at));
+        let synthetic_repeat =
+            release_gap.is_some_and(|gap| gap <= std::time::Duration::from_millis(30));
+        let first_press = self.pressed_keys.insert(key_id.to_owned());
+        first_press && !synthetic_repeat
     }
 
-    fn observe_modifiers(&mut self, modifiers: iced::keyboard::Modifiers) {
-        if !modifiers.control() {
-            self.track_chord_armed = true;
-        }
+    fn release(&mut self, key_id: &str, occurred_at: std::time::Instant) {
+        self.pressed_keys.remove(key_id);
+        self.released_at.insert(key_id.to_owned(), occurred_at);
     }
 }
 
@@ -129,6 +135,7 @@ impl super::App {
                 modifiers,
                 ..
             } => {
+                let edge_key_id = runtime_key_id(&key);
                 if self.state.perform.key_rebind_target.is_some()
                     && matches!(key, iced::keyboard::Key::Named(Named::Escape))
                 {
@@ -141,21 +148,21 @@ impl super::App {
                                 key_id: runtime_key_id(&key),
                                 occurred_at,
                             }),
-                            Some((key, modifiers)),
+                            Some((key, modifiers, edge_key_id)),
                         )
                     } else {
-                        (None, Some((key, modifiers)))
+                        (None, Some((key, modifiers, edge_key_id)))
                     }
                 } else if self.state.perform.key_rebind_target.is_some() {
                     self.state.status_text = "Perform keys must be letters or numbers".into();
                     return iced::Task::none();
                 } else {
-                    (None, Some((key, modifiers)))
+                    (None, Some((key, modifiers, edge_key_id)))
                 }
             }
-            iced::keyboard::Event::KeyReleased { key, modifiers, .. } => {
+            iced::keyboard::Event::KeyReleased { key, .. } => {
                 let key_id = runtime_key_id(&key);
-                self.edge_shortcuts.observe_modifiers(modifiers);
+                self.edge_shortcuts.release(&key_id, occurred_at);
                 (
                     Some(PerformMsg::ComputerKeyReleased {
                         key_id,
@@ -164,10 +171,7 @@ impl super::App {
                     None,
                 )
             }
-            iced::keyboard::Event::ModifiersChanged(modifiers) => {
-                self.edge_shortcuts.observe_modifiers(modifiers);
-                return iced::Task::none();
-            }
+            iced::keyboard::Event::ModifiersChanged(_) => return iced::Task::none(),
         };
 
         if let Some(msg) = perform_msg {
@@ -188,10 +192,10 @@ impl super::App {
         }
 
         fallback
-            .and_then(|(key, modifiers)| {
+            .and_then(|(key, modifiers, key_id)| {
                 let message = global_key_handler(key, modifiers)?;
                 self.edge_shortcuts
-                    .should_dispatch(&message)
+                    .should_dispatch(&key_id, &message, occurred_at)
                     .then_some(message)
             })
             .map_or_else(iced::Task::none, iced::Task::done)
@@ -442,29 +446,34 @@ mod tests {
     }
 
     #[test]
-    fn held_track_shortcut_dispatches_once_until_control_is_released() {
+    fn held_track_shortcut_dispatches_once_until_key_release() {
         let mut state = EdgeShortcutState::default();
         let add = Message::Arrangement(ArrangementMsg::AddInstrumentTrack);
+        let started = std::time::Instant::now();
 
-        assert!(state.should_dispatch(&add));
-        assert!(!state.should_dispatch(&add));
+        assert!(state.should_dispatch("Character(\"T\")", &add, started));
+        assert!(!state.should_dispatch("Character(\"T\")", &add, started));
 
-        // Repeated T release/press pairs keep the Ctrl chord held.
-        state.observe_modifiers(iced::keyboard::Modifiers::CTRL);
-        assert!(!state.should_dispatch(&add));
+        // X11 auto-repeat is delivered as a synthetic release/press pair.
+        state.release(
+            "Character(\"T\")",
+            started + std::time::Duration::from_millis(500),
+        );
+        assert!(!state.should_dispatch(
+            "Character(\"T\")",
+            &add,
+            started + std::time::Duration::from_millis(501),
+        ));
 
-        state.observe_modifiers(iced::keyboard::Modifiers::empty());
-        assert!(state.should_dispatch(&add));
-    }
-
-    #[test]
-    fn delayed_x11_repeat_does_not_duplicate_an_audio_track() {
-        let mut state = EdgeShortcutState::default();
-        let add = Message::Arrangement(ArrangementMsg::AddTrack);
-
-        assert!(state.should_dispatch(&add));
-        state.observe_modifiers(iced::keyboard::Modifiers::CTRL);
-        assert!(!state.should_dispatch(&add));
+        state.release(
+            "Character(\"T\")",
+            started + std::time::Duration::from_millis(900),
+        );
+        assert!(state.should_dispatch(
+            "Character(\"T\")",
+            &add,
+            started + std::time::Duration::from_millis(1_000),
+        ));
     }
 
     #[test]
@@ -563,5 +572,21 @@ mod tests {
             keyboard_input_message(event, iced::event::Status::Ignored),
             Some(Message::KeyboardInput { .. })
         ));
+    }
+
+    #[test]
+    fn repeated_t_taps_dispatch_while_control_stays_held() {
+        let mut state = EdgeShortcutState::default();
+        let add = Message::Arrangement(ArrangementMsg::AddTrack);
+        let started = std::time::Instant::now();
+
+        for tap in 0..4 {
+            let pressed_at = started + std::time::Duration::from_millis(tap * 300);
+            assert!(state.should_dispatch("Character(\"t\")", &add, pressed_at));
+            state.release(
+                "Character(\"t\")",
+                pressed_at + std::time::Duration::from_millis(100),
+            );
+        }
     }
 }

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -729,7 +729,10 @@ impl canvas::Program<Message> for TrackClipCanvas {
             // the piano roll's and won, deleting the clip while a
             // note was selected; it could even delete the whole track.
 
-            // -- Keyboard shortcuts (Ctrl+D/E/J/T) --
+            // -- Lane-local keyboard shortcuts (Ctrl+D/E/J) --
+            // Track creation is global and must not be handled here: this
+            // canvas is instantiated once per track, so one Ctrl+T event would
+            // otherwise publish one AddTrack message per existing lane.
             canvas::Event::Keyboard(iced::keyboard::Event::KeyPressed {
                 key: iced::keyboard::Key::Character(ref c),
                 modifiers,
@@ -755,19 +758,6 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 Some(Message::join_selected_clips()),
                             );
                         }
-                        "t" | "T" => {
-                            if modifiers.shift() {
-                                return (
-                                    canvas::event::Status::Captured,
-                                    Some(Message::Arrangement(ArrangementMsg::AddInstrumentTrack)),
-                                );
-                            } else {
-                                return (
-                                    canvas::event::Status::Captured,
-                                    Some(Message::Arrangement(ArrangementMsg::AddTrack)),
-                                );
-                            }
-                        }
                         _ => {}
                     }
                 }
@@ -782,6 +772,77 @@ impl canvas::Program<Message> for TrackClipCanvas {
         }
 
         (canvas::event::Status::Ignored, None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iced::keyboard::key::{Code, Physical};
+    use iced::keyboard::{Event, Key, Location, Modifiers};
+    use iced::{Point, Size};
+
+    fn empty_track_canvas() -> TrackClipCanvas {
+        let track_id = TrackId::new();
+        let track = ProjectTrack::new(track_id, "Track 1".into(), 0);
+        TrackClipCanvas::from_track(
+            &track,
+            &TrackTimelineContent::default(),
+            0.0,
+            1.0,
+            GridConfig::new(crate::state::SnapGrid::EIGHTH, true, false, 0),
+            0.0,
+            16.0,
+            44_100,
+            true,
+            Color::BLACK,
+            120.0,
+            track_id,
+            0,
+            1,
+            vec![track_id],
+            vec![false],
+            HashSet::new(),
+            false,
+            0.0,
+            0.0,
+            false,
+            0.0,
+            0.0,
+            None,
+            false,
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    fn per_track_canvas_ignores_global_track_creation_shortcuts() {
+        let canvas = empty_track_canvas();
+        let bounds = Rectangle::new(Point::ORIGIN, Size::new(800.0, 80.0));
+
+        for modifiers in [Modifiers::CTRL, Modifiers::CTRL | Modifiers::SHIFT] {
+            let event = canvas::Event::Keyboard(Event::KeyPressed {
+                key: Key::Character("t".into()),
+                modified_key: Key::Character("t".into()),
+                physical_key: Physical::Code(Code::KeyT),
+                location: Location::Standard,
+                modifiers,
+                text: None,
+            });
+            let mut state = ClipInteractionState::default();
+
+            let (status, message) = <TrackClipCanvas as canvas::Program<Message>>::update(
+                &canvas,
+                &mut state,
+                event,
+                bounds,
+                mouse::Cursor::Unavailable,
+            );
+
+            assert_eq!(status, canvas::event::Status::Ignored);
+            assert!(message.is_none());
+        }
     }
 }
 


### PR DESCRIPTION
## Outcome

Ctrl+T and Ctrl+Shift+T create exactly one Track per intentional T tap in Arrange and the Perform Section editor. Ctrl may stay held while T is tapped repeatedly: Track count grows 1, 2, 3, 4 instead of doubling or becoming permanently disarmed.

## Actual root cause

Track creation was owned twice: once by the global keyboard adapter and once by every per-track TrackClipCanvas. After the first Track existed, each canvas published its own AddTrack or AddInstrumentTrack message, so N existing Tracks created N more Tracks. The key-repeat diagnosis in PR #80 did not cover this captured per-canvas path.

The first commit in this PR then introduced a Ctrl-chord guard. That was also inconsistent: release ordering could leave the chord permanently disarmed, and holding Ctrl intentionally while tapping T could create only one Track. That commit is fully reverted in the final diff. The existing per-T-key repeat guard remains, and Track creation now has one UI owner.

## Scope

- remove Ctrl+T and Ctrl+Shift+T handling from per-track canvases
- retain lane-local clip shortcuts
- regression-test that every Track canvas ignores both global creation shortcuts
- regression-test four intentional T press/release cycles while Ctrl remains held
- no Track-domain, Arrange/Perform model, or Card 10 changes

## Evidence

- red-first held-Ctrl regression failed against the Ctrl-chord API and passes with per-T rearming
- exact branch native Xvfb: Ctrl held plus four T taps produced 4 Audio Tracks
- exact branch fresh native Xvfb: Ctrl+Shift held plus four T taps produced 4 MIDI Tracks
- per-track canvas regression passes for audio and MIDI creation shortcuts
- cargo fmt --all -- --check
- cargo check --workspace -j4
- cargo clippy --workspace -j4 -- -D warnings
- cargo test --workspace -j4 (274 UI tests)
- git diff --check

## Manual demo

1. Open an empty project in Arrange.
2. Hold Ctrl and tap T four times; the count must read 1, 2, 3, 4.
3. Start a fresh project, hold Ctrl+Shift, and tap T four times; the count must read 1, 2, 3, 4.
4. Repeat from the Perform Section editor; the same global Project Track list must grow by one per T tap.