### PR TITLE
Fix VST3 instruments as MIDI clip sources

### DIFF
--- a/crates/vibez-plugin-host/examples/scan_dir.rs
+++ b/crates/vibez-plugin-host/examples/scan_dir.rs
@@ -21,7 +21,7 @@ fn main() {
     let settings = PluginSettings {
         extra_scan_paths: vec![dir],
         scan_default_paths: false,
-        cache: Vec::new(),
+        ..PluginSettings::default()
     };
 
     if sandboxed {
@@ -49,7 +49,7 @@ fn main() {
         let single = PluginSettings {
             extra_scan_paths: vec![path.clone()],
             scan_default_paths: false,
-            cache: Vec::new(),
+            ..PluginSettings::default()
         };
         // scan_plugins only walks directories, so scan the parent dir
         // trick doesn't isolate; call the per-format scanners directly.

--- a/crates/vibez-plugin-host/src/settings.rs
+++ b/crates/vibez-plugin-host/src/settings.rs
@@ -4,12 +4,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::info::PluginInfo;
 
+const CURRENT_CACHE_REVISION: u32 = 1;
+
 /// Plugin host settings, persisted to `~/.config/vibez/plugins.json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginSettings {
     pub extra_scan_paths: Vec<PathBuf>,
     pub scan_default_paths: bool,
     pub cache: Vec<PluginInfo>,
+    #[serde(default)]
+    pub cache_revision: u32,
 }
 
 impl Default for PluginSettings {
@@ -18,11 +22,20 @@ impl Default for PluginSettings {
             extra_scan_paths: Vec::new(),
             scan_default_paths: true,
             cache: Vec::new(),
+            cache_revision: CURRENT_CACHE_REVISION,
         }
     }
 }
 
 impl PluginSettings {
+    pub fn cache_needs_refresh(&self) -> bool {
+        self.cache_revision < CURRENT_CACHE_REVISION
+    }
+
+    pub fn mark_cache_refreshed(&mut self) {
+        self.cache_revision = CURRENT_CACHE_REVISION;
+    }
+
     /// Path to the settings JSON file.
     pub fn settings_path() -> PathBuf {
         dirs::config_dir()
@@ -48,5 +61,27 @@ impl PluginSettings {
         }
         let json = serde_json::to_string_pretty(self).map_err(std::io::Error::other)?;
         std::fs::write(&path, json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PluginSettings;
+
+    #[test]
+    fn legacy_catalog_requests_exactly_one_refresh() {
+        let legacy = r#"{
+            "extra_scan_paths": [],
+            "scan_default_paths": true,
+            "cache": []
+        }"#;
+        let mut settings: PluginSettings = serde_json::from_str(legacy).unwrap();
+
+        assert!(settings.cache_needs_refresh());
+
+        settings.mark_cache_refreshed();
+        let saved = serde_json::to_string(&settings).unwrap();
+        let reloaded: PluginSettings = serde_json::from_str(&saved).unwrap();
+        assert!(!reloaded.cache_needs_refresh());
     }
 }

--- a/crates/vibez-plugin-host/src/vst3_host/instance.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/instance.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
 
 use vibez_core::effect::ParamDescriptor;
+use vst3::Steinberg::Vst::{
+    Event as VstEvent, Event__type0 as VstEventData, NoteOffEvent, NoteOnEvent,
+};
 
 use crate::buffer::AudioBufferAdapter;
 use crate::instance::PluginInstance;
@@ -344,7 +347,129 @@ struct NoteEvent {
     is_on: bool,
     pitch: u8,
     velocity: u8,
+    frame_offset: u32,
 }
+
+// ── Live IEventList (input) ──
+// Stack-allocated for each process() call. The VST3 processor reads this
+// COM object synchronously and must not retain it after process() returns.
+
+#[repr(C)]
+struct EventListVtbl {
+    query_interface: unsafe extern "system" fn(
+        *mut std::ffi::c_void,
+        *const u8,
+        *mut *mut std::ffi::c_void,
+    ) -> i32,
+    add_ref: unsafe extern "system" fn(*mut std::ffi::c_void) -> u32,
+    release: unsafe extern "system" fn(*mut std::ffi::c_void) -> u32,
+    get_event_count: unsafe extern "system" fn(*mut std::ffi::c_void) -> i32,
+    get_event: unsafe extern "system" fn(*mut std::ffi::c_void, i32, *mut VstEvent) -> i32,
+    add_event: unsafe extern "system" fn(*mut std::ffi::c_void, *mut VstEvent) -> i32,
+}
+
+#[repr(C)]
+struct LiveEventList<'a> {
+    vtbl: *const EventListVtbl,
+    events: &'a [NoteEvent],
+}
+
+impl<'a> LiveEventList<'a> {
+    fn new(events: &'a [NoteEvent]) -> Self {
+        Self {
+            vtbl: &LIVE_EVENT_LIST_VTBL,
+            events,
+        }
+    }
+
+    fn event_count(&self) -> usize {
+        self.events.len()
+    }
+
+    fn event(&self, index: usize) -> Option<VstEvent> {
+        self.events.get(index).map(vst_event)
+    }
+
+    fn as_raw_mut(&mut self) -> *mut std::ffi::c_void {
+        self as *mut Self as *mut std::ffi::c_void
+    }
+}
+
+fn vst_event(event: &NoteEvent) -> VstEvent {
+    let sample_offset = event.frame_offset.min(i32::MAX as u32) as i32;
+    if event.is_on {
+        VstEvent {
+            busIndex: 0,
+            sampleOffset: sample_offset,
+            ppqPosition: 0.0,
+            flags: 0,
+            r#type: vst3::Steinberg::Vst::Event_::EventTypes_::kNoteOnEvent as u16,
+            __field0: VstEventData {
+                noteOn: NoteOnEvent {
+                    channel: 0,
+                    pitch: event.pitch as i16,
+                    tuning: 0.0,
+                    velocity: event.velocity as f32 / 127.0,
+                    length: 0,
+                    noteId: -1,
+                },
+            },
+        }
+    } else {
+        VstEvent {
+            busIndex: 0,
+            sampleOffset: sample_offset,
+            ppqPosition: 0.0,
+            flags: 0,
+            r#type: vst3::Steinberg::Vst::Event_::EventTypes_::kNoteOffEvent as u16,
+            __field0: VstEventData {
+                noteOff: NoteOffEvent {
+                    channel: 0,
+                    pitch: event.pitch as i16,
+                    velocity: event.velocity as f32 / 127.0,
+                    noteId: -1,
+                    tuning: 0.0,
+                },
+            },
+        }
+    }
+}
+
+unsafe extern "system" fn event_list_count(this: *mut std::ffi::c_void) -> i32 {
+    unsafe { (*(this as *const LiveEventList<'_>)).event_count() as i32 }
+}
+
+unsafe extern "system" fn event_list_get(
+    this: *mut std::ffi::c_void,
+    index: i32,
+    event: *mut VstEvent,
+) -> i32 {
+    if index < 0 || event.is_null() {
+        return 1;
+    }
+    let Some(value) = (unsafe { &*(this as *const LiveEventList<'_>) }).event(index as usize)
+    else {
+        return 1;
+    };
+    unsafe { *event = value };
+    0
+}
+
+unsafe extern "system" fn event_list_add(
+    _this: *mut std::ffi::c_void,
+    _event: *mut VstEvent,
+) -> i32 {
+    1
+}
+
+static LIVE_EVENT_LIST_VTBL: EventListVtbl = EventListVtbl {
+    query_interface: pc_query_interface,
+    add_ref: pc_add_ref,
+    release: pc_release,
+    get_event_count: event_list_count,
+    get_event: event_list_get,
+    add_event: event_list_add,
+};
 
 // VST3 IComponent IID: {E831FF31-F2D5-4301-928E-BBEE25697802}
 const ICOMPONENT_IID: [u8; 16] = crate::vst3_tuid([
@@ -877,6 +1002,12 @@ impl PluginInstance for Vst3PluginInstance {
             queues: live_queues.as_ptr(),
             len: live_queues.len(),
         };
+        // EngineTrack submits note-offs before note-ons to keep its active-note
+        // mask correct. VST3 requires chronological input; at one offset,
+        // release before retrigger. Unstable sorting allocates no scratch buffer.
+        self.note_events
+            .sort_unstable_by_key(|event| (event.frame_offset, event.is_on));
+        let mut live_events = LiveEventList::new(&self.note_events);
 
         let mut process_data = ProcessDataRaw {
             process_mode: 0,
@@ -892,7 +1023,7 @@ impl PluginInstance for Vst3PluginInstance {
                 &live_changes as *const LiveParamChanges as *mut std::ffi::c_void
             },
             output_parameter_changes: param_changes_stub(),
-            input_events: std::ptr::null_mut(),
+            input_events: live_events.as_raw_mut(),
             output_events: std::ptr::null_mut(),
             process_context: std::ptr::null_mut(),
         };
@@ -927,6 +1058,7 @@ impl PluginInstance for Vst3PluginInstance {
             is_on: true,
             pitch,
             velocity,
+            frame_offset: 0,
         });
     }
 
@@ -935,6 +1067,25 @@ impl PluginInstance for Vst3PluginInstance {
             is_on: false,
             pitch,
             velocity: 0,
+            frame_offset: 0,
+        });
+    }
+
+    fn note_on_at(&mut self, pitch: u8, velocity: u8, frame_offset: u32) {
+        self.note_events.push(NoteEvent {
+            is_on: true,
+            pitch,
+            velocity,
+            frame_offset,
+        });
+    }
+
+    fn note_off_at(&mut self, pitch: u8, frame_offset: u32) {
+        self.note_events.push(NoteEvent {
+            is_on: false,
+            pitch,
+            velocity: 0,
+            frame_offset,
         });
     }
 
@@ -1112,6 +1263,8 @@ unsafe fn connect_component_and_controller(
 
 #[cfg(test)]
 mod tests {
+    use vst3::Steinberg::Vst::Event_::EventTypes_::{kNoteOffEvent, kNoteOnEvent};
+
     /// Hand-written IIDs must match the SDK-generated constants in the
     /// vst3 crate. A single wrong byte makes every plugin reject the
     /// queryInterface call (a 0x3F-for-0x3D typo in IAudioProcessor
@@ -1140,5 +1293,47 @@ mod tests {
             super::IAUDIOPROCESSOR_IID,
             vst3::Steinberg::Vst::IAudioProcessor_iid,
         );
+    }
+
+    #[test]
+    fn live_event_list_exposes_timed_clip_notes_to_vst3() {
+        let mut events = vec![
+            super::NoteEvent {
+                is_on: false,
+                pitch: 64,
+                velocity: 0,
+                frame_offset: 91,
+            },
+            super::NoteEvent {
+                is_on: true,
+                pitch: 64,
+                velocity: 96,
+                frame_offset: 17,
+            },
+        ];
+        events.sort_unstable_by_key(|event| (event.frame_offset, event.is_on));
+        let mut list = super::LiveEventList::new(&events);
+
+        assert_eq!(list.event_count(), 2);
+
+        let raw = list.as_raw_mut();
+        let vtbl = unsafe { (*raw.cast::<super::LiveEventList<'_>>()).vtbl };
+        assert_eq!(unsafe { ((*vtbl).get_event_count)(raw) }, 2);
+        let mut via_vtable = unsafe { std::mem::zeroed() };
+        assert_eq!(unsafe { ((*vtbl).get_event)(raw, 0, &mut via_vtable) }, 0);
+        assert_eq!(via_vtable.sampleOffset, 17);
+
+        let note_on = list.event(0).expect("note-on event");
+        assert_eq!(note_on.r#type, kNoteOnEvent as u16);
+        assert_eq!(note_on.sampleOffset, 17);
+        let note_on = unsafe { note_on.__field0.noteOn };
+        assert_eq!(note_on.pitch, 64);
+        assert!((note_on.velocity - 96.0 / 127.0).abs() < f32::EPSILON);
+
+        let note_off = list.event(1).expect("note-off event");
+        assert_eq!(note_off.r#type, kNoteOffEvent as u16);
+        assert_eq!(note_off.sampleOffset, 91);
+        let note_off = unsafe { note_off.__field0.noteOff };
+        assert_eq!(note_off.pitch, 64);
     }
 }

--- a/crates/vibez-plugin-host/src/vst3_host/scanner.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/scanner.rs
@@ -98,6 +98,30 @@ fn scan_vst3_inner(path: &Path) -> Result<Vec<PluginInfo>, String> {
         unsafe extern "system" fn(*mut std::ffi::c_void, i32, *mut PClassInfoRaw) -> i32;
     let get_class_info: GetClassInfoFn = unsafe { std::mem::transmute(*vtbl_ptr.add(5)) };
 
+    // PClassInfo2 carries the VST3 subcategory string that distinguishes
+    // instruments from effects. The base PClassInfo has no equivalent field.
+    type QueryInterfaceFn = unsafe extern "system" fn(
+        *mut std::ffi::c_void,
+        *const u8,
+        *mut *mut std::ffi::c_void,
+    ) -> i32;
+    let query_interface: QueryInterfaceFn = unsafe { std::mem::transmute(*vtbl_ptr) };
+    let mut factory2: *mut std::ffi::c_void = std::ptr::null_mut();
+    let has_factory2 = unsafe {
+        query_interface(
+            factory_ptr,
+            vst3::Steinberg::IPluginFactory2_iid.as_ptr().cast(),
+            &mut factory2,
+        ) == 0
+            && !factory2.is_null()
+    };
+    type GetClassInfo2Fn =
+        unsafe extern "system" fn(*mut std::ffi::c_void, i32, *mut PClassInfo2Raw) -> i32;
+    let get_class_info2: Option<GetClassInfo2Fn> = has_factory2.then(|| unsafe {
+        let factory2_vtbl = *(factory2 as *const *const *const std::ffi::c_void);
+        std::mem::transmute(*factory2_vtbl.add(7))
+    });
+
     let mut results = Vec::new();
 
     for i in 0..count {
@@ -124,7 +148,17 @@ fn scan_vst3_inner(path: &Path) -> Result<Vec<PluginInfo>, String> {
             continue;
         }
 
-        let category = PluginCategory::Effect;
+        let (category, vendor) = get_class_info2
+            .and_then(|get_class_info2| {
+                let mut info2 = PClassInfo2Raw::zeroed();
+                (unsafe { get_class_info2(factory2, i as i32, &mut info2) } == 0).then(|| {
+                    (
+                        category_from_subcategories(&cstr_from_fixed(&info2.subcategories)),
+                        cstr_from_fixed(&info2.vendor),
+                    )
+                })
+            })
+            .unwrap_or((PluginCategory::Effect, String::new()));
 
         results.push(PluginInfo {
             id: PluginId {
@@ -132,15 +166,20 @@ fn scan_vst3_inner(path: &Path) -> Result<Vec<PluginInfo>, String> {
                 uid,
             },
             name: name.clone(),
-            vendor: String::new(),
+            vendor,
             category,
             format: PluginFormat::Vst3,
             path: path.to_path_buf(),
         });
     }
 
-    // Release factory
+    // Release the queried IPluginFactory2 reference, then the base factory.
     type ReleaseFn = unsafe extern "system" fn(*mut std::ffi::c_void) -> u32;
+    if has_factory2 {
+        let factory2_vtbl = unsafe { *(factory2 as *const *const *const std::ffi::c_void) };
+        let release_factory2: ReleaseFn = unsafe { std::mem::transmute(*factory2_vtbl.add(2)) };
+        unsafe { release_factory2(factory2) };
+    }
     let release: ReleaseFn = unsafe { std::mem::transmute(*vtbl_ptr.add(2)) };
     unsafe { release(factory_ptr) };
 
@@ -169,6 +208,27 @@ impl PClassInfoRaw {
             category: [0; 32],
             name: [0; 64],
         }
+    }
+}
+
+/// Raw PClassInfo2 matching the VST3 C layout. Its subcategories are the only
+/// portable way for a host to distinguish an instrument from an insert effect.
+#[repr(C)]
+struct PClassInfo2Raw {
+    cid: [u8; 16],
+    cardinality: i32,
+    category: [u8; 32],
+    name: [u8; 64],
+    class_flags: u32,
+    subcategories: [u8; 128],
+    vendor: [u8; 64],
+    version: [u8; 64],
+    sdk_version: [u8; 64],
+}
+
+impl PClassInfo2Raw {
+    fn zeroed() -> Self {
+        unsafe { std::mem::zeroed() }
     }
 }
 
@@ -224,4 +284,51 @@ pub(crate) fn find_vst3_module(bundle_path: &Path) -> Result<std::path::PathBuf,
 fn cstr_from_fixed(buf: &[u8]) -> String {
     let bytes: Vec<u8> = buf.iter().take_while(|&&b| b != 0).copied().collect();
     String::from_utf8_lossy(&bytes).to_string()
+}
+
+fn category_from_subcategories(subcategories: &str) -> PluginCategory {
+    let mut is_effect = false;
+    let mut is_instrument = false;
+    for category in subcategories.split('|') {
+        match category.trim() {
+            "Fx" => is_effect = true,
+            "Instrument" => is_instrument = true,
+            _ => {}
+        }
+    }
+    match (is_effect, is_instrument) {
+        (true, true) => PluginCategory::Both,
+        (_, true) => PluginCategory::Instrument,
+        _ => PluginCategory::Effect,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vst3_instrument_subcategories_select_the_track_instrument_slot() {
+        assert_eq!(
+            category_from_subcategories("Instrument|Synth"),
+            PluginCategory::Instrument
+        );
+        assert_eq!(
+            category_from_subcategories("Instrument|Sampler"),
+            PluginCategory::Instrument
+        );
+        assert_eq!(
+            category_from_subcategories("Fx|Instrument"),
+            PluginCategory::Both
+        );
+    }
+
+    #[test]
+    fn vst3_effect_subcategories_remain_effects() {
+        assert_eq!(
+            category_from_subcategories("Fx|Reverb"),
+            PluginCategory::Effect
+        );
+        assert_eq!(category_from_subcategories(""), PluginCategory::Effect);
+    }
 }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -358,6 +358,11 @@ impl App {
         } else {
             Task::none()
         };
+        let plugin_catalog_startup_task = if app.state.plugin_settings.cache_needs_refresh() {
+            Task::done(Message::ScanPlugins)
+        } else {
+            Task::none()
+        };
 
         // Staged Project Media copies are content-addressed and shared, so
         // saves and aborted imports never delete them eagerly; this sweep
@@ -381,7 +386,12 @@ impl App {
 
         (
             app,
-            Task::batch([local_startup_task, remote_startup_task, open_task]),
+            Task::batch([
+                local_startup_task,
+                remote_startup_task,
+                plugin_catalog_startup_task,
+                open_task,
+            ]),
         )
     }
 

--- a/crates/vibez-ui/src/app/plugins.rs
+++ b/crates/vibez-ui/src/app/plugins.rs
@@ -37,6 +37,7 @@ impl App {
     ) -> Task<Message> {
         let count = report.plugins.len();
         self.state.plugin_settings.cache = report.plugins;
+        self.state.plugin_settings.mark_cache_refreshed();
         self.state.plugin_scan_in_progress = false;
         self.state.plugin_scan_status = if report.failed.is_empty() {
             format!("Found {count} plugins")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -262,14 +262,20 @@ Third-party plugins are the least trustworthy code in the process, so they
 are handled in three stages:
 
 1. **Scanning** runs in a separate `vibez-plugin-scan` subprocess. A plugin
-   that crashes during a scan kills the subprocess, not vibez.
+   that crashes during a scan kills the subprocess, not vibez. VST3 scanning
+   reads `IPluginFactory2::getClassInfo2` subcategories so `Instrument`
+   components enter the Track instrument slot while `Fx` components remain
+   inserts.
 2. **Loading** is two-phase: a background thread does the `dlopen` and
    factory lookup, then the UI thread finishes initialization. The UI-thread
    phase is mandatory because JUCE-based plugins bind their message loop to
    the initializing thread.
 3. **Running**: the audio thread processes the plugin like any built-in
    effect; the UI thread pumps plugin GUI run loops on the 60 fps tick and
-   captures plugin state for saving.
+   captures plugin state for saving. VST3 instruments receive the engine's
+   timed note queue through a callback-lifetime `IEventList`; events are sorted
+   by sample offset and preserve within-block note-on/note-off timing before
+   `IAudioProcessor::process` runs.
 
 ## Projects, undo, and warping
 


### PR DESCRIPTION
## Card 26 — Route MIDI Clips to VST3 Instruments

### Outcome
- reads VST3 PClassInfo2 subcategories so Instrument components enter the Track instrument slot and Fx components remain inserts
- exposes queued note-on/note-off events to IAudioProcessor::process through a callback-lifetime IEventList
- preserves within-block frame offsets and orders note-off before same-offset retriggers
- automatically refreshes legacy plugin catalogs once, so existing installs receive the corrected VST3 classifications without a hidden manual rescan
- leaves CLAP, built-in instruments, VST3 effects, plugin state, and Perform Card 11 untouched

### Root cause and follow-up
The first native sign-off failed because the persisted pre-fix catalog still classified Dexed, Surge XT, and Vital VST3 as Effects. The live trace proved the UI therefore inserted Dexed and Surge as effect devices; MIDI never reached an instrument. Fresh scanning already classified all three correctly.

A versioned plugin catalog now requests one sandboxed startup refresh when scanner semantics change, persists the current revision after completion, and does not rescan on subsequent launches.

### TDD and verification
- red: scanner had no category contract and every VST3 was hard-coded Effect
- red: VST3 process inputEvents was null and timed note offsets were not stored
- red: a legacy catalog had no way to request and remember exactly one migration refresh
- green: complete workspace suite, strict workspace Clippy, format, and diff checks
- isolated legacy-catalog startup migrated Dexed, Surge XT, and Vital from Effect to Instrument, populated their vendors, and left the catalog byte-identical on a second launch
- direct installed-plugin probes produced non-zero audio from timed MIDI: Dexed peak 0.13078251; Surge XT peak 0.33702826

### Manual sign-off
1. Start this exact branch with the existing pre-fix catalog; wait for the automatic scan to finish.
2. Remove any Dexed or Surge devices previously added as effects.
3. Add Dexed VST3 and Surge XT VST3 again; verify each occupies the instrument card.
4. Play an authored MIDI clip and confirm each selected VST3 is audible.
5. Add a VST3 effect separately and confirm it remains an insert.

The large VST3 instance module remains intentionally local per the canonical refactoring guide; this PR does not split its unsafe FFI contract.