### PR TITLE
Perform: queue Sections on quantized boundaries

### DIFF
--- a/crates/vibez-core/src/lib.rs
+++ b/crates/vibez-core/src/lib.rs
@@ -6,5 +6,6 @@ pub mod effect;
 pub mod id;
 pub mod midi;
 pub mod onset;
+pub mod perform;
 pub mod time;
 pub mod track;

--- a/crates/vibez-core/src/perform.rs
+++ b/crates/vibez-core/src/perform.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+/// Musical boundary at which a resident Section launch becomes effective.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SectionLaunchQuantization {
+    Immediate,
+    OneBeat,
+    #[default]
+    OneBar,
+    EndOfSection,
+}
+
+impl SectionLaunchQuantization {
+    pub const ALL: [Self; 4] = [
+        Self::Immediate,
+        Self::OneBeat,
+        Self::OneBar,
+        Self::EndOfSection,
+    ];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Immediate => "Immediate",
+            Self::OneBeat => "1 Beat",
+            Self::OneBar => "1 Bar",
+            Self::EndOfSection => "End of Section",
+        }
+    }
+}
+
+impl std::fmt::Display for SectionLaunchQuantization {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.label())
+    }
+}

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -3,6 +3,7 @@ use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::effect::EffectType;
 use vibez_core::id::{ClipId, EffectId, TrackId};
 use vibez_core::midi::{InstrumentKind, MidiNote};
+use vibez_core::perform::SectionLaunchQuantization;
 use vibez_core::track::DrumPadState;
 use vibez_dsp::effect::AudioEffect;
 use vibez_instruments::Instrument;
@@ -34,6 +35,11 @@ pub enum EngineCommand {
     SetBpm(f64),
     /// Immediately activate a complete resident Section playback source.
     LaunchSection(Box<PreparedSectionPlaybackSource>),
+    /// Queue a complete resident Section for an engine-owned musical boundary.
+    QueueSection {
+        prepared: Box<PreparedSectionPlaybackSource>,
+        quantization: SectionLaunchQuantization,
+    },
     /// Replace the currently active Section's resident source in place.
     /// The engine preserves its local playhead and returns ownership of the
     /// displaced source through `SectionSourceRefreshed`.

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -16,7 +16,7 @@ use crate::metering;
 use crate::mixer::{
     any_solo, equal_power_pan, EffectSlot, EngineClip, EngineNoteClip, EngineTrack,
 };
-use crate::playback_source::calculate_total_length;
+use crate::playback_source::{calculate_total_length, PreparedSectionPlaybackSource};
 use crate::transport::Transport;
 
 /// Capacity of the UI spectrum-analyser sample ring: roughly a third
@@ -69,6 +69,10 @@ pub struct AudioEngine {
     /// for that block (segment-2 notes are legitimately sounding).
     split_wrap_handled: bool,
     active_section: Option<ActiveSectionPlayback>,
+    queued_section: Option<QueuedSectionPlayback>,
+    /// When a transition lands partway through the current callback, only
+    /// these frames advance the newly active Section's local playhead.
+    section_advance_override: Option<u64>,
     arrangement_audio_length: Option<u64>,
 }
 
@@ -78,6 +82,11 @@ struct ActiveSectionPlayback {
     position_samples: u64,
     length_samples: u64,
     looping: bool,
+}
+
+struct QueuedSectionPlayback {
+    prepared: Box<PreparedSectionPlaybackSource>,
+    effective_at_samples: u64,
 }
 
 impl AudioEngine {
@@ -106,6 +115,8 @@ impl AudioEngine {
             event_tx,
             split_wrap_handled: false,
             active_section: None,
+            queued_section: None,
+            section_advance_override: None,
             arrangement_audio_length: None,
         };
 
@@ -270,7 +281,11 @@ impl AudioEngine {
         let mut section_ended = false;
         if was_playing {
             if let Some(section) = self.active_section.as_mut() {
-                let advanced = section.position_samples.saturating_add(frames as u64);
+                let section_frames = self
+                    .section_advance_override
+                    .take()
+                    .unwrap_or(frames as u64);
+                let advanced = section.position_samples.saturating_add(section_frames);
                 if section.looping && section.length_samples > 0 {
                     section.position_samples = advanced % section.length_samples;
                 } else {
@@ -375,8 +390,8 @@ impl AudioEngine {
             return;
         }
 
-        if let Some(section) = self.active_section {
-            self.process_section_multitrack(output, frames, channels, section);
+        if self.active_section.is_some() {
+            self.process_section_multitrack(output, frames, channels);
             return;
         }
 
@@ -417,54 +432,6 @@ impl AudioEngine {
             channels,
             self.transport.active_loop_region(),
         );
-    }
-
-    fn process_section_multitrack(
-        &mut self,
-        output: &mut [f32],
-        frames: usize,
-        channels: usize,
-        section: ActiveSectionPlayback,
-    ) {
-        for track in &mut self.tracks {
-            std::mem::swap(
-                &mut track.playback_source,
-                &mut track.section_playback_source,
-            );
-        }
-
-        let mut rendered_frames = 0usize;
-        let mut local_position = section.position_samples.min(section.length_samples);
-        while rendered_frames < frames && local_position < section.length_samples {
-            let available = (section.length_samples - local_position) as usize;
-            let segment_frames = available.min(frames - rendered_frames);
-            let start = rendered_frames * channels;
-            let end = (rendered_frames + segment_frames) * channels;
-            self.render_multitrack_segment(
-                &mut output[start..end],
-                local_position,
-                segment_frames,
-                channels,
-                None,
-            );
-            rendered_frames += segment_frames;
-            local_position += segment_frames as u64;
-            if rendered_frames < frames && section.looping {
-                for track in &mut self.tracks {
-                    track.flush_notes();
-                }
-                local_position = 0;
-            } else if local_position >= section.length_samples {
-                break;
-            }
-        }
-
-        for track in &mut self.tracks {
-            std::mem::swap(
-                &mut track.playback_source,
-                &mut track.section_playback_source,
-            );
-        }
     }
 
     fn render_multitrack_segment(
@@ -819,6 +786,9 @@ fn push_spectrum(tx: &mut Producer<f32>, buffer: &[f32], channels: usize) {
 #[path = "engine_drain_commands.rs"]
 mod drain_commands;
 
+#[path = "engine_section_queue.rs"]
+mod section_queue;
+
 #[cfg(test)]
 #[path = "engine_tests.rs"]
 mod tests;
@@ -834,3 +804,7 @@ mod mute_event_tests;
 #[cfg(test)]
 #[path = "engine_section_playback_tests.rs"]
 mod section_playback_tests;
+
+#[cfg(test)]
+#[path = "engine_section_queue_tests.rs"]
+mod section_queue_tests;

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -14,6 +14,7 @@ impl AudioEngine {
                 }
                 EngineCommand::Stop => {
                     self.transport.stop();
+                    self.cancel_section_queue();
                     self.active_section = None;
                     self.transport
                         .set_audio_length(self.arrangement_audio_length);
@@ -29,58 +30,21 @@ impl AudioEngine {
                     }
                 }
                 EngineCommand::SetBpm(bpm) => {
-                    self.transport.set_bpm(bpm);
-                    self.recalculate_audio_length();
-                }
-                EngineCommand::LaunchSection(mut prepared) => {
-                    let section_id = prepared.section_id;
-                    let length_samples = if self.transport.bpm() > 0.0 {
-                        (prepared.length_beats * self.sample_rate as f64 * 60.0
-                            / self.transport.bpm())
-                        .round()
-                        .max(1.0) as u64
-                    } else {
-                        1
-                    };
-                    let looping = prepared.looping;
-                    for track in &mut self.tracks {
-                        track.flush_notes();
-                    }
-                    for incoming in prepared.tracks_mut() {
-                        if let Some(track) = self
-                            .tracks
-                            .iter_mut()
-                            .find(|track| track.id == incoming.track_id)
-                        {
-                            std::mem::swap(
-                                &mut track.section_playback_source,
-                                &mut incoming.source,
-                            );
-                        }
-                    }
-                    let effective_at_samples = self.transport.position();
-                    self.active_section = Some(ActiveSectionPlayback {
-                        section_id,
-                        position_samples: 0,
-                        length_samples,
-                        looping,
-                    });
-                    self.transport.set_audio_length(None);
-                    if !self.transport.is_playing() {
-                        self.transport.play();
-                        let _ = self.event_tx.push(EngineEvent::PlaybackStarted);
-                    }
-                    let event = EngineEvent::SectionTransitioned {
-                        section_id,
-                        effective_at_samples,
-                        retired: prepared,
-                    };
-                    if let Err(rtrb::PushError::Full(event)) = self.event_tx.push(event) {
-                        // Never destroy Vec/Arc owners in the callback. Losing this
-                        // rare event leaks one retired source rather than glitching.
-                        std::mem::forget(event);
+                    // V1 Perform holds one project tempo from the first
+                    // Section transition until transport stop.
+                    if self.active_section.is_none() {
+                        self.transport.set_bpm(bpm);
+                        self.recalculate_audio_length();
                     }
                 }
+                EngineCommand::LaunchSection(prepared) => {
+                    self.cancel_section_queue();
+                    self.activate_section(prepared, self.transport.position());
+                }
+                EngineCommand::QueueSection {
+                    prepared,
+                    quantization,
+                } => self.queue_section(prepared, quantization),
                 EngineCommand::RefreshSection(mut prepared) => {
                     let section_id = prepared.section_id;
                     let mut applied = false;

--- a/crates/vibez-engine/src/engine_section_queue.rs
+++ b/crates/vibez-engine/src/engine_section_queue.rs
@@ -1,0 +1,231 @@
+//! Resident Section queue ownership and sample-accurate callback switching.
+
+use super::*;
+use vibez_core::perform::SectionLaunchQuantization;
+
+impl AudioEngine {
+    pub(super) fn activate_section(
+        &mut self,
+        mut prepared: Box<PreparedSectionPlaybackSource>,
+        effective_at_samples: u64,
+    ) {
+        let section_id = prepared.section_id;
+        let length_samples = self.section_length_samples(prepared.length_beats);
+        let looping = prepared.looping;
+        for track in &mut self.tracks {
+            track.flush_notes();
+        }
+        for incoming in prepared.tracks_mut() {
+            if let Some(track) = self
+                .tracks
+                .iter_mut()
+                .find(|track| track.id == incoming.track_id)
+            {
+                std::mem::swap(&mut track.section_playback_source, &mut incoming.source);
+            }
+        }
+        self.active_section = Some(ActiveSectionPlayback {
+            section_id,
+            position_samples: 0,
+            length_samples,
+            looping,
+        });
+        self.transport.set_audio_length(None);
+        if !self.transport.is_playing() {
+            self.transport.play();
+            let _ = self.event_tx.push(EngineEvent::PlaybackStarted);
+        }
+        let event = EngineEvent::SectionTransitioned {
+            section_id,
+            effective_at_samples,
+            retired: prepared,
+        };
+        if let Err(rtrb::PushError::Full(event)) = self.event_tx.push(event) {
+            // Never destroy Vec/Arc owners in the callback. Losing this rare
+            // event leaks one retired source rather than glitching.
+            std::mem::forget(event);
+        }
+    }
+
+    pub(super) fn queue_section(
+        &mut self,
+        prepared: Box<PreparedSectionPlaybackSource>,
+        quantization: SectionLaunchQuantization,
+    ) {
+        let now = self.transport.position();
+        if quantization == SectionLaunchQuantization::Immediate
+            || self.active_section.is_none()
+            || !self.transport.is_playing()
+        {
+            self.cancel_section_queue();
+            self.activate_section(prepared, now);
+            return;
+        }
+
+        let effective_at_samples = match quantization {
+            SectionLaunchQuantization::Immediate => now,
+            SectionLaunchQuantization::OneBeat => self.next_grid_boundary(now, 1.0),
+            SectionLaunchQuantization::OneBar => self.next_grid_boundary(now, 4.0),
+            SectionLaunchQuantization::EndOfSection => self
+                .active_section
+                .map(|active| {
+                    now.saturating_add(
+                        active
+                            .length_samples
+                            .saturating_sub(active.position_samples),
+                    )
+                })
+                .unwrap_or(now),
+        };
+
+        if effective_at_samples <= now {
+            self.cancel_section_queue();
+            self.activate_section(prepared, now);
+            return;
+        }
+
+        let section_id = prepared.section_id;
+        let retired = self.queued_section.replace(QueuedSectionPlayback {
+            prepared,
+            effective_at_samples,
+        });
+        let event = EngineEvent::SectionQueued {
+            section_id,
+            effective_at_samples,
+            retired: retired.map(|queued| queued.prepared),
+        };
+        if let Err(rtrb::PushError::Full(event)) = self.event_tx.push(event) {
+            std::mem::forget(event);
+        }
+    }
+
+    pub(super) fn cancel_section_queue(&mut self) {
+        let Some(queued) = self.queued_section.take() else {
+            return;
+        };
+        let event = EngineEvent::SectionQueueCancelled {
+            retired: queued.prepared,
+        };
+        if let Err(rtrb::PushError::Full(event)) = self.event_tx.push(event) {
+            std::mem::forget(event);
+        }
+    }
+
+    pub(super) fn process_section_multitrack(
+        &mut self,
+        output: &mut [f32],
+        frames: usize,
+        channels: usize,
+    ) {
+        let block_start = self.transport.position();
+        let block_end = block_start.saturating_add(frames as u64);
+        let boundary = self
+            .queued_section
+            .as_ref()
+            .map(|queued| queued.effective_at_samples);
+
+        if boundary.is_some_and(|boundary| boundary <= block_start) {
+            let queued = self.queued_section.take().expect("queued Section");
+            self.activate_section(queued.prepared, block_start);
+        }
+
+        if let Some(boundary) =
+            boundary.filter(|boundary| *boundary > block_start && *boundary < block_end)
+        {
+            let frames_before = (boundary - block_start) as usize;
+            let old_section = self.active_section.expect("active Section");
+            self.render_section_frames(
+                &mut output[..frames_before * channels],
+                frames_before,
+                channels,
+                old_section,
+            );
+            let queued = self.queued_section.take().expect("queued Section");
+            self.activate_section(queued.prepared, boundary);
+            let frames_after = frames - frames_before;
+            let new_section = self.active_section.expect("active Section");
+            self.render_section_frames(
+                &mut output[frames_before * channels..],
+                frames_after,
+                channels,
+                new_section,
+            );
+            self.section_advance_override = Some(frames_after as u64);
+            return;
+        }
+
+        let section = self.active_section.expect("active Section");
+        self.render_section_frames(output, frames, channels, section);
+    }
+
+    fn render_section_frames(
+        &mut self,
+        output: &mut [f32],
+        frames: usize,
+        channels: usize,
+        section: ActiveSectionPlayback,
+    ) {
+        for track in &mut self.tracks {
+            std::mem::swap(
+                &mut track.playback_source,
+                &mut track.section_playback_source,
+            );
+        }
+
+        let mut rendered_frames = 0usize;
+        let mut local_position = section.position_samples.min(section.length_samples);
+        while rendered_frames < frames && local_position < section.length_samples {
+            let available = (section.length_samples - local_position) as usize;
+            let segment_frames = available.min(frames - rendered_frames);
+            let start = rendered_frames * channels;
+            let end = (rendered_frames + segment_frames) * channels;
+            self.render_multitrack_segment(
+                &mut output[start..end],
+                local_position,
+                segment_frames,
+                channels,
+                None,
+            );
+            rendered_frames += segment_frames;
+            local_position += segment_frames as u64;
+            if rendered_frames < frames && section.looping {
+                for track in &mut self.tracks {
+                    track.flush_notes();
+                }
+                local_position = 0;
+            } else if local_position >= section.length_samples {
+                break;
+            }
+        }
+
+        for track in &mut self.tracks {
+            std::mem::swap(
+                &mut track.playback_source,
+                &mut track.section_playback_source,
+            );
+        }
+    }
+
+    fn section_length_samples(&self, length_beats: f64) -> u64 {
+        if self.transport.bpm() > 0.0 {
+            (length_beats * self.sample_rate as f64 * 60.0 / self.transport.bpm())
+                .round()
+                .max(1.0) as u64
+        } else {
+            1
+        }
+    }
+
+    fn next_grid_boundary(&self, now: u64, beats: f64) -> u64 {
+        if self.transport.bpm() <= 0.0 {
+            return now;
+        }
+        let grid_samples = beats * self.sample_rate as f64 * 60.0 / self.transport.bpm();
+        if grid_samples <= 0.0 {
+            return now;
+        }
+        ((now as f64 / grid_samples).ceil() * grid_samples)
+            .round()
+            .max(now as f64) as u64
+    }
+}

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -1,0 +1,236 @@
+//! Quantized Section queueing regressions at the public command/event seam.
+
+use super::*;
+
+use std::sync::Arc;
+
+use vibez_core::audio_buffer::DecodedAudio;
+use vibez_core::id::{ClipId, SectionId, TrackId};
+use vibez_core::perform::SectionLaunchQuantization;
+
+use crate::playback_source::{EngineClip, PreparedPlaybackSource, PreparedSectionPlaybackSource};
+
+fn constant_audio(frames: usize, value: f32) -> Arc<DecodedAudio> {
+    Arc::new(DecodedAudio {
+        channels: vec![vec![value; frames]],
+        sample_rate: 8,
+    })
+}
+
+fn source(
+    section_id: SectionId,
+    track_id: TrackId,
+    length_beats: f64,
+    value: f32,
+) -> Box<PreparedSectionPlaybackSource> {
+    Box::new(PreparedSectionPlaybackSource::new(
+        section_id,
+        length_beats,
+        true,
+        vec![(
+            track_id,
+            PreparedPlaybackSource::new(
+                vec![EngineClip {
+                    id: ClipId::new(),
+                    audio: constant_audio(128, value),
+                    position: 0,
+                    source_offset: 0,
+                    duration: 128,
+                    loop_enabled: false,
+                    loop_start: 0,
+                    loop_end: 0,
+                }],
+                Vec::new(),
+                Vec::new(),
+            ),
+        )],
+    ))
+}
+
+fn playing_engine(
+    value: f32,
+    length_beats: f64,
+) -> (
+    AudioEngine,
+    rtrb::Producer<EngineCommand>,
+    rtrb::Consumer<EngineEvent>,
+    TrackId,
+) {
+    let (mut engine, mut commands, events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands.push(EngineCommand::SetBpm(120.0)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(source(
+            SectionId::new(),
+            track_id,
+            length_beats,
+            value,
+        )))
+        .unwrap();
+    let mut first_frame = [0.0];
+    engine.process(&mut first_frame, 1);
+    assert_eq!(first_frame, [value]);
+    (engine, commands, events, track_id)
+}
+
+fn transition_event(events: &mut rtrb::Consumer<EngineEvent>) -> Option<(SectionId, u64)> {
+    std::iter::from_fn(|| events.pop().ok()).find_map(|event| match event {
+        EngineEvent::SectionTransitioned {
+            section_id,
+            effective_at_samples,
+            ..
+        } => Some((section_id, effective_at_samples)),
+        _ => None,
+    })
+}
+
+#[test]
+fn one_beat_transition_lands_mid_buffer_with_engine_timestamp() {
+    let (mut engine, mut commands, mut events, track_id) = playing_engine(0.25, 8.0);
+    while events.pop().is_ok() {}
+    let next = SectionId::new();
+    commands
+        .push(EngineCommand::QueueSection {
+            prepared: source(next, track_id, 8.0, 0.75),
+            quantization: SectionLaunchQuantization::OneBeat,
+        })
+        .unwrap();
+
+    let mut output = [0.0; 6];
+    engine.process(&mut output, 1);
+
+    assert_eq!(output, [0.25, 0.25, 0.25, 0.75, 0.75, 0.75]);
+    assert_eq!(transition_event(&mut events), Some((next, 4)));
+}
+
+#[test]
+fn immediate_quantization_switches_at_the_callback_start() {
+    let (mut engine, mut commands, mut events, track_id) = playing_engine(0.25, 8.0);
+    while events.pop().is_ok() {}
+    let next = SectionId::new();
+    commands
+        .push(EngineCommand::QueueSection {
+            prepared: source(next, track_id, 8.0, 0.75),
+            quantization: SectionLaunchQuantization::Immediate,
+        })
+        .unwrap();
+
+    let mut output = [0.0; 3];
+    engine.process(&mut output, 1);
+
+    assert_eq!(output, [0.75; 3]);
+    assert_eq!(transition_event(&mut events), Some((next, 1)));
+}
+
+#[test]
+fn one_bar_and_end_of_section_use_their_exact_boundaries() {
+    for (quantization, expected_boundary) in [
+        (SectionLaunchQuantization::OneBar, 16),
+        (SectionLaunchQuantization::EndOfSection, 8),
+    ] {
+        let (mut engine, mut commands, mut events, track_id) = playing_engine(0.2, 2.0);
+        while events.pop().is_ok() {}
+        let next = SectionId::new();
+        commands
+            .push(EngineCommand::QueueSection {
+                prepared: source(next, track_id, 4.0, 0.8),
+                quantization,
+            })
+            .unwrap();
+
+        let mut output = [0.0; 18];
+        engine.process(&mut output, 1);
+
+        let old_frames = (expected_boundary - 1) as usize;
+        assert!(output[..old_frames]
+            .iter()
+            .all(|sample| (*sample - 0.2).abs() < f32::EPSILON));
+        assert!(output[old_frames..]
+            .iter()
+            .all(|sample| (*sample - 0.8).abs() < f32::EPSILON));
+        assert_eq!(
+            transition_event(&mut events),
+            Some((next, expected_boundary))
+        );
+    }
+}
+
+#[test]
+fn requeue_returns_stale_residency_and_only_latest_section_transitions() {
+    let (mut engine, mut commands, mut events, track_id) = playing_engine(0.1, 8.0);
+    while events.pop().is_ok() {}
+    let stale = SectionId::new();
+    let latest = SectionId::new();
+    commands
+        .push(EngineCommand::QueueSection {
+            prepared: source(stale, track_id, 8.0, 0.5),
+            quantization: SectionLaunchQuantization::OneBar,
+        })
+        .unwrap();
+    commands
+        .push(EngineCommand::QueueSection {
+            prepared: source(latest, track_id, 8.0, 0.9),
+            quantization: SectionLaunchQuantization::OneBeat,
+        })
+        .unwrap();
+
+    let mut output = [0.0; 6];
+    engine.process(&mut output, 1);
+
+    let queued: Vec<_> = std::iter::from_fn(|| events.pop().ok())
+        .filter_map(|event| match event {
+            EngineEvent::SectionQueued {
+                section_id,
+                effective_at_samples,
+                retired,
+            } => Some((
+                section_id,
+                effective_at_samples,
+                retired.map(|item| item.section_id),
+            )),
+            EngineEvent::SectionTransitioned {
+                section_id,
+                effective_at_samples,
+                ..
+            } => Some((section_id, effective_at_samples, None)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        queued,
+        vec![
+            (stale, 16, None),
+            (latest, 4, Some(stale)),
+            (latest, 4, None),
+        ]
+    );
+    assert!(output[3..]
+        .iter()
+        .all(|sample| (*sample - 0.9).abs() < f32::EPSILON));
+}
+
+#[test]
+fn perform_bpm_is_locked_and_live_mute_survives_transition() {
+    let (mut engine, mut commands, _events, track_id) = playing_engine(0.4, 8.0);
+    commands
+        .push(EngineCommand::SetTrackMute(track_id, true))
+        .unwrap();
+    commands.push(EngineCommand::SetBpm(140.0)).unwrap();
+    commands
+        .push(EngineCommand::QueueSection {
+            prepared: source(SectionId::new(), track_id, 8.0, 0.7),
+            quantization: SectionLaunchQuantization::OneBeat,
+        })
+        .unwrap();
+
+    let mut output = [1.0; 6];
+    engine.process(&mut output, 1);
+
+    assert_eq!(engine.transport().bpm(), 120.0);
+    assert!(engine.tracks()[0].mute);
+    assert_eq!(output, [0.0; 6]);
+}

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -81,6 +81,19 @@ pub enum EngineEvent {
         effective_at_samples: u64,
     },
 
+    /// A resident Section is queued for this exact transport sample.
+    /// Re-queueing returns the displaced resident owner for UI-thread drop.
+    SectionQueued {
+        section_id: SectionId,
+        effective_at_samples: u64,
+        retired: Option<Box<PreparedSectionPlaybackSource>>,
+    },
+
+    /// A queued resident owner was cancelled by transport stop.
+    SectionQueueCancelled {
+        retired: Box<PreparedSectionPlaybackSource>,
+    },
+
     /// A resident Section became active at this exact transport sample.
     /// `retired` carries displaced sources to the UI thread for destruction.
     SectionTransitioned {
@@ -175,6 +188,34 @@ impl PartialEq for EngineEvent {
                     && left_muted == right_muted
                     && left_effective == right_effective
             }
+            (
+                Self::SectionQueued {
+                    section_id: left_section,
+                    effective_at_samples: left_effective,
+                    retired: left_retired,
+                },
+                Self::SectionQueued {
+                    section_id: right_section,
+                    effective_at_samples: right_effective,
+                    retired: right_retired,
+                },
+            ) => {
+                left_section == right_section
+                    && left_effective == right_effective
+                    && match (left_retired, right_retired) {
+                        (Some(left), Some(right)) => std::ptr::eq(left.as_ref(), right.as_ref()),
+                        (None, None) => true,
+                        _ => false,
+                    }
+            }
+            (
+                Self::SectionQueueCancelled {
+                    retired: left_retired,
+                },
+                Self::SectionQueueCancelled {
+                    retired: right_retired,
+                },
+            ) => std::ptr::eq(left_retired.as_ref(), right_retired.as_ref()),
             (
                 Self::SectionTransitioned {
                     section_id: left_section,

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -6,6 +6,8 @@ use vibez_core::id::{SectionId, TrackId};
 use vibez_core::midi::NoteClipInfo;
 use vibez_core::track::{ClipInfo, TrackInfo};
 
+pub use vibez_core::perform::SectionLaunchQuantization;
+
 pub mod project_format_v1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -30,40 +32,6 @@ pub struct TimelineInfo {
     pub note_clips: Vec<NoteClipInfo>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub automation: Vec<TimelineAutomationInfo>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SectionLaunchQuantization {
-    Immediate,
-    OneBeat,
-    #[default]
-    OneBar,
-    EndOfSection,
-}
-
-impl SectionLaunchQuantization {
-    pub const ALL: [Self; 4] = [
-        Self::Immediate,
-        Self::OneBeat,
-        Self::OneBar,
-        Self::EndOfSection,
-    ];
-
-    pub const fn label(self) -> &'static str {
-        match self {
-            Self::Immediate => "Immediate",
-            Self::OneBeat => "1 Beat",
-            Self::OneBar => "1 Bar",
-            Self::EndOfSection => "End of Section",
-        }
-    }
-}
-
-impl std::fmt::Display for SectionLaunchQuantization {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(self.label())
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -42,6 +42,39 @@ fn prepare_playing_section_refresh(
 }
 
 impl App {
+    fn begin_section_residency(&mut self, section_id: SectionId) -> Task<Message> {
+        let Some(section) = self.state.perform.sections.by_id(section_id).cloned() else {
+            return Task::none();
+        };
+        let quantization = section.launch_quantization;
+        let track_ids: Vec<_> = self
+            .state
+            .project_tracks
+            .tracks
+            .iter()
+            .map(|track| track.id)
+            .collect();
+        let request_id = self.section_residency_request.begin();
+        let task = Task::perform(
+            async move {
+                let prepared = tokio::task::spawn_blocking(move || {
+                    section.prepare_playback_source_for_tracks(&track_ids)
+                })
+                .await
+                .expect("Section residency worker panicked");
+                crate::message::ResidentSection::new(Box::new(prepared))
+            },
+            move |resident| Message::SectionResidencyReady {
+                request_id,
+                section_id,
+                quantization,
+                resident,
+            },
+        );
+        self.state.status_text = "Preparing Section…".into();
+        self.section_residency_request.attach(task)
+    }
+
     /// Refresh resident content only when the edited Section is still the one
     /// the engine reports as active. Selection remains intentionally separate.
     pub(super) fn refresh_playing_section_after_edit(&mut self, section_id: SectionId) {
@@ -56,7 +89,11 @@ impl App {
 
     /// Apply cross-domain effects requested by Perform without giving the
     /// Perform interaction slice ownership of Project Track state.
-    pub(super) fn apply_perform_action(&mut self, action: crate::domains::perform::PerformAction) {
+    pub(super) fn apply_perform_action(
+        &mut self,
+        action: crate::domains::perform::PerformAction,
+    ) -> Task<Message> {
+        let mut tasks = Vec::new();
         if action.persist_settings {
             self.persist_ui_settings();
             self.state.status_text = "Perform key mapping saved".into();
@@ -82,20 +119,15 @@ impl App {
             }
         }
         if let Some(section_id) = action.section_launch {
-            if let Some(prepared) = self
-                .state
-                .perform
-                .sections
-                .by_id(section_id)
-                .map(|section| section.prepare_playback_source(&self.state.project_tracks.tracks))
-            {
-                self.send_command(EngineCommand::LaunchSection(Box::new(prepared)));
-                self.state.status_text = "Launching Section…".into();
-            }
+            tasks.push(self.begin_section_residency(section_id));
         }
         if let Some(section_id) = action.section_content_changed {
             self.refresh_playing_section_after_edit(section_id);
+            if self.state.perform.queued_section == Some(section_id) {
+                tasks.push(self.begin_section_residency(section_id));
+            }
         }
+        Task::batch(tasks)
     }
 
     /// Route cross-domain effects requested by the arrangement domain.
@@ -349,6 +381,10 @@ impl App {
             TransportAction::TempoChanged { old_bpm, new_bpm } => {
                 self.follow_tempo_change(old_bpm, new_bpm)
             }
+            TransportAction::TempoRejected => {
+                self.state.status_text = "Stop Perform playback to change BPM".into();
+                Task::none()
+            }
         }
     }
 
@@ -547,6 +583,8 @@ impl App {
                     EngineEvent::PlaybackStopped => {
                         self.state.transport.playing = false;
                         self.state.perform.playing_section = None;
+                        self.state.perform.queued_section = None;
+                        self.state.perform.pending_section_boundary_samples = None;
                         self.state.perform.section_playhead_samples = 0;
                     }
                     EngineEvent::PlaybackStarted => {
@@ -596,11 +634,30 @@ impl App {
                     }
                     EngineEvent::SectionTransitioned {
                         section_id,
-                        effective_at_samples: _,
+                        effective_at_samples,
                         retired,
                     } => {
                         self.state.perform.playing_section = Some(section_id);
+                        self.state.perform.queued_section = None;
+                        self.state.perform.pending_section_boundary_samples = None;
                         self.state.perform.section_playhead_samples = 0;
+                        self.state.status_text =
+                            format!("Section playing at sample {effective_at_samples}");
+                        drop(retired);
+                    }
+                    EngineEvent::SectionQueued {
+                        section_id,
+                        effective_at_samples,
+                        retired,
+                    } => {
+                        self.state.perform.queued_section = Some(section_id);
+                        self.state.perform.pending_section_boundary_samples =
+                            Some(effective_at_samples);
+                        drop(retired);
+                    }
+                    EngineEvent::SectionQueueCancelled { retired } => {
+                        self.state.perform.queued_section = None;
+                        self.state.perform.pending_section_boundary_samples = None;
                         drop(retired);
                     }
                     EngineEvent::SectionPlaybackPosition {

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -185,9 +185,9 @@ impl super::App {
                 self.state.perform.update(msg, &mut engine, ctx)
             };
             let keyboard_consumed = action.keyboard_consumed;
-            self.apply_perform_action(action);
+            let task = self.apply_perform_action(action);
             if keyboard_consumed {
-                return iced::Task::none();
+                return task;
             }
         }
 

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -159,6 +159,7 @@ mod views_devices;
 mod views_mixer;
 mod views_overlays;
 mod views_perform;
+mod views_perform_pads;
 mod views_perform_playhead;
 mod views_perform_sections;
 mod views_settings;

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -70,6 +70,8 @@ struct App {
     /// Bumped on every refresh start and on disconnect, so catalog pages
     /// fetched for a previous connection are dropped instead of reconciled.
     remote_catalog_request: tracked_request::TrackedRequest,
+    /// Cancellable preparation for the next resident Section launch.
+    section_residency_request: tracked_request::TrackedRequest,
     /// Catalog changes accumulated since the last reconcile flush; applied in
     /// batches so each page does not re-sort the whole catalog in update().
     remote_catalog_pending: Vec<crate::remote_provider::RemoteChange>,
@@ -324,6 +326,7 @@ impl App {
             pending_remote_audition: None,
             browser_import_request: Default::default(),
             remote_catalog_request: Default::default(),
+            section_residency_request: Default::default(),
             remote_catalog_pending: Vec::new(),
             midi_input,
             midi_input_ports: Vec::new(),

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -26,6 +26,7 @@ impl App {
         // Invalidate any Browser import still preparing (e.g. in its
         // WARP stage) so it cannot add a clip to the reset project.
         self.browser_import_request.cancel();
+        self.section_residency_request.cancel();
         self.stop_browser_audition();
         self.state.transport.playing = false;
         self.state.transport.position_samples = 0;

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -145,6 +145,15 @@ impl App {
             // only computes the cross-domain context, routes the
             // message, and applies the returned action.
             Message::Transport(msg) => {
+                let stops_perform = matches!(&msg, crate::domains::transport::TransportMsg::Stop)
+                    || matches!(
+                        &msg,
+                        crate::domains::transport::TransportMsg::TogglePlayback
+                            if self.state.transport.playing
+                    );
+                if stops_perform {
+                    self.section_residency_request.cancel();
+                }
                 let ctx = crate::domains::transport::TransportCtx {
                     total_duration_samples: self.state.total_duration_samples(),
                     time_selection: if self.state.arrangement.time_selection_active {
@@ -155,6 +164,8 @@ impl App {
                     } else {
                         None
                     },
+                    perform_tempo_locked: self.state.perform.playing_section.is_some()
+                        || self.state.perform.queued_section.is_some(),
                 };
                 let action = {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
@@ -229,7 +240,25 @@ impl App {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
                     self.state.perform.update(msg, &mut engine, ctx)
                 };
-                self.apply_perform_action(action);
+                return self.apply_perform_action(action);
+            }
+            Message::SectionResidencyReady {
+                request_id,
+                section_id,
+                quantization,
+                resident,
+            } => {
+                if self.section_residency_request.finish(request_id) {
+                    if let Some(prepared) = resident.take() {
+                        debug_assert_eq!(prepared.section_id, section_id);
+                        self.send_command(EngineCommand::QueueSection {
+                            prepared,
+                            quantization,
+                        });
+                        self.state.status_text =
+                            format!("Section ready · {}", quantization.label());
+                    }
+                }
             }
             Message::View(msg) => {
                 if matches!(&msg, ViewMsg::ToggleEditMenu) {

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -1,12 +1,11 @@
 //! Perform workspace shell, Pad Surface, and shared Section Timeline Editor.
 
 use iced::widget::{
-    button, center, column, container, horizontal_space, mouse_area, pick_list, row, stack, text,
-    text_input, tooltip,
+    button, center, column, container, horizontal_space, pick_list, row, text, text_input, tooltip,
 };
-use iced::{Element, Length, Shadow, Theme, Vector};
+use iced::{Element, Length, Theme};
 
-use crate::domains::perform::{PadPosition, PerformEditorFocus, PerformMode, PerformMsg, Section};
+use crate::domains::perform::{PerformMode, PerformMsg, Section};
 use crate::icons;
 use crate::message::Message;
 use crate::theme as th;
@@ -24,7 +23,7 @@ const SECTION_TOOLBAR_INLINE_MIN_WIDTH: f32 = 640.0;
 pub(super) const SECTION_TRACK_GUTTER_WIDTH: f32 = 112.0;
 pub(super) const SECTION_BAR_WIDTH: f32 = 160.0;
 
-fn perform_tool_button(
+pub(super) fn perform_tool_button(
     icon: char,
     tooltip_label: &'static str,
     message: Message,
@@ -92,75 +91,6 @@ fn perform_tool_button(
         .into()
 }
 
-fn perform_bank_button(
-    label: &'static str,
-    tooltip_label: &'static str,
-    message: PerformMsg,
-) -> Element<'static, Message> {
-    let control = button(
-        center(
-            text(label)
-                .font(PERFORM_TECH_STRONG)
-                .size(13)
-                .color(th::text_dim()),
-        )
-        .width(Length::Fill)
-        .height(Length::Fill),
-    )
-    .on_press(Message::Perform(message))
-    .width(Length::Fixed(20.0))
-    .height(Length::Fixed(20.0))
-    .padding(0)
-    .style(|_theme: &Theme, status| {
-        let engaged = matches!(status, button::Status::Hovered | button::Status::Pressed);
-        button::Style {
-            background: Some(
-                if engaged {
-                    th::bg_hover()
-                } else {
-                    th::bg_surface()
-                }
-                .into(),
-            ),
-            text_color: if matches!(status, button::Status::Pressed) {
-                th::accent()
-            } else {
-                th::text_dim()
-            },
-            border: iced::Border {
-                color: if engaged {
-                    th::accent_dim()
-                } else {
-                    th::border()
-                },
-                width: 1.0,
-                radius: 2.0.into(),
-            },
-            ..Default::default()
-        }
-    });
-    let hint = container(
-        text(tooltip_label)
-            .font(PERFORM_TECH)
-            .size(9)
-            .color(th::text()),
-    )
-    .padding([4, 6])
-    .style(|_theme: &Theme| container::Style {
-        background: Some(th::bg_elevated().into()),
-        border: iced::Border {
-            color: th::border_light(),
-            width: 1.0,
-            radius: 2.0.into(),
-        },
-        ..Default::default()
-    });
-    tooltip(control, hint, tooltip::Position::Bottom)
-        .gap(5)
-        .padding(0)
-        .into()
-}
-
 fn perform_mode_tab_width(surface_width: f32) -> f32 {
     ((surface_width - MODE_SELECTOR_INSET) / PerformMode::ALL.len() as f32)
         .clamp(MODE_TAB_MIN_WIDTH, MODE_TAB_MAX_WIDTH)
@@ -179,7 +109,7 @@ fn section_toolbar_stacks(section_width: f32) -> bool {
     section_width < SECTION_TOOLBAR_INLINE_MIN_WIDTH
 }
 
-fn perform_pad_grid_height(window_height: f32) -> f32 {
+pub(super) fn perform_pad_grid_height(window_height: f32) -> f32 {
     (window_height * 0.48).clamp(272.0, 480.0)
 }
 
@@ -350,348 +280,11 @@ impl App {
             .into()
     }
 
-    fn view_pad_surface(&self, surface_width: f32) -> Element<'_, Message> {
-        let mode = self.state.perform.mode;
-        let heading = column![
-            text("PERFORM SURFACE")
-                .font(PERFORM_LABEL)
-                .size(9)
-                .color(th::accent()),
-            text(mode.label().to_uppercase())
-                .font(PERFORM_DISPLAY)
-                .size(22)
-                .color(th::text())
-        ]
-        .spacing(5);
-        let (bank, origin) = match mode {
-            PerformMode::Sections => {
-                let pending = self
-                    .state
-                    .perform
-                    .pending_section_boundary_samples
-                    .map(|samples| {
-                        let beat = samples as f64 * self.state.transport.bpm
-                            / (self.state.transport.sample_rate as f64 * 60.0);
-                        format!(" · QUEUED @ BEAT {beat:.2}")
-                    })
-                    .unwrap_or_default();
-                (
-                    self.state.perform.banks.sections + 1,
-                    format!("ORDER TOP-LEFT{pending}"),
-                )
-            }
-            PerformMode::TrackMutes => (
-                self.state.perform.banks.track_mutes + 1,
-                "PROJECT TRACKS".to_string(),
-            ),
-            PerformMode::Instrument => (
-                self.state.perform.banks.instrument + 1,
-                "ORDER BOTTOM-LEFT".to_string(),
-            ),
-        };
-        let bank_navigation = row![
-            text(format!("BANK {bank}"))
-                .font(PERFORM_TECH_STRONG)
-                .size(9)
-                .color(th::blend(th::text_dim(), th::text(), 0.24)),
-            perform_bank_button("‹", "PREVIOUS BANK  [", PerformMsg::PreviousBank),
-            perform_bank_button("›", "NEXT BANK  ]", PerformMsg::NextBank),
-            text(format!("· {origin}"))
-                .font(PERFORM_TECH)
-                .size(9)
-                .color(th::blend(th::text_dim(), th::text(), 0.24)),
-        ]
-        .spacing(5)
-        .align_y(iced::Alignment::Center);
-        let header =
-            row![heading, horizontal_space(), bank_navigation,].align_y(iced::Alignment::End);
-
-        let pad_grid_height = perform_pad_grid_height(self.state.view.window_height);
-        let mut grid = column![]
-            .width(Length::Fill)
-            .height(Length::Fixed(pad_grid_height))
-            .spacing(8);
-        for row_index in 0..4 {
-            let mut pad_row = row![]
-                .width(Length::Fill)
-                .height(Length::FillPortion(1))
-                .spacing(8);
-            for position in PadPosition::ALL
-                .iter()
-                .copied()
-                .filter(|position| position.row == row_index)
-            {
-                pad_row = pad_row.push(self.view_perform_pad(position, mode));
-            }
-            grid = grid.push(pad_row);
-        }
-        let grid = center(grid)
-            .width(Length::Fill)
-            .height(Length::Fixed(pad_grid_height));
-
-        let surface = container(column![header, grid].spacing(12))
-            .width(Length::Fixed(surface_width))
-            .height(Length::Fill)
-            .padding(14)
-            .style(|_theme: &Theme| container::Style {
-                background: Some(th::perform_inset().into()),
-                border: iced::Border {
-                    color: th::border(),
-                    width: 1.0,
-                    radius: 0.0.into(),
-                },
-                ..Default::default()
-            });
-
-        mouse_area(surface)
-            .on_press(Message::Perform(PerformMsg::FocusEditor(
-                PerformEditorFocus::PadSurface,
-            )))
-            .into()
-    }
-
     fn view_perform_surface_splitter(&self) -> Element<'_, Message> {
         super::views_shell::horizontal_pane_splitter(
             self.state.view.perform_surface_resize_active,
             Message::View(crate::domains::view::ViewMsg::BeginPerformSurfaceResize),
         )
-    }
-
-    fn view_perform_pad(&self, position: PadPosition, mode: PerformMode) -> Element<'_, Message> {
-        let ordinal = u16::from(position.ordinal(mode))
-            + u16::from(self.state.perform.banks.for_mode(mode)) * 16;
-        let section = (mode == PerformMode::Sections)
-            .then(|| self.state.perform.sections.at_slot(ordinal - 1))
-            .flatten();
-        let selected = section
-            .is_some_and(|section| self.state.perform.selected_section == Some(section.id))
-            || self.state.perform.selected_pad == Some(position);
-        let playing =
-            section.is_some_and(|section| self.state.perform.playing_section == Some(section.id));
-        let queued =
-            section.is_some_and(|section| self.state.perform.queued_section == Some(section.id));
-        let playhead_fraction = section.filter(|_| playing).map(|section| {
-            super::views_perform_playhead::section_playhead_fraction(
-                self.state.perform.section_playhead_samples,
-                section.length_beats,
-                self.state.transport.bpm,
-                self.state.transport.sample_rate,
-            )
-        });
-        let pressed = self.state.perform.is_pad_pressed(position);
-        let mute_track = (mode == PerformMode::TrackMutes)
-            .then(|| {
-                self.state
-                    .perform
-                    .track_for_mute_pad(position, &self.state.project_tracks.tracks)
-            })
-            .flatten();
-        let (title, detail, color, muted) = match mode {
-            PerformMode::Sections => match section {
-                Some(section) => (
-                    section.name.clone(),
-                    format!(
-                        "{} · {:.0} BARS",
-                        if playing {
-                            "PLAYING"
-                        } else if queued {
-                            "QUEUED"
-                        } else {
-                            "AVAILABLE"
-                        },
-                        section.length_beats / 4.0
-                    ),
-                    th::track_color((ordinal - 1) as u8),
-                    false,
-                ),
-                None if self.state.perform.duplicate_source.is_some() => (
-                    "+ DUPLICATE".to_string(),
-                    "CHOOSE EMPTY SLOT".to_string(),
-                    th::track_color((ordinal - 1) as u8),
-                    false,
-                ),
-                None => (
-                    "+ SECTION".to_string(),
-                    "EMPTY".to_string(),
-                    th::track_color((ordinal - 1) as u8),
-                    false,
-                ),
-            },
-            PerformMode::TrackMutes => {
-                if let Some(track) = mute_track {
-                    (
-                        track.name.clone(),
-                        format!(
-                            "{} · {}",
-                            if track.kind.is_midi() {
-                                "MIDI"
-                            } else {
-                                "AUDIO"
-                            },
-                            if track.mute { "MUTED" } else { "LIVE" }
-                        ),
-                        th::track_color(track.color_index),
-                        track.mute,
-                    )
-                } else {
-                    (
-                        "—".to_string(),
-                        "NO PROJECT TRACK".to_string(),
-                        th::text_muted(),
-                        false,
-                    )
-                }
-            }
-            PerformMode::Instrument => (
-                "SELECT MIDI".to_string(),
-                "NO INSTRUMENT TARGET".to_string(),
-                th::track_color((ordinal - 1) as u8),
-                false,
-            ),
-        };
-        let number_color = th::blend(color, th::text(), 0.3);
-        let coordinate_color = th::blend(th::text_dim(), th::text(), 0.2);
-
-        let pad_face = container(
-            column![
-                row![
-                    text(format!("{ordinal:02}"))
-                        .font(PERFORM_TECH_STRONG)
-                        .size(11)
-                        .color(number_color),
-                    horizontal_space(),
-                    text(format!("R{} · C{}", position.row + 1, position.column + 1))
-                        .font(PERFORM_TECH)
-                        .size(9)
-                        .color(coordinate_color)
-                ],
-                center(text(title).font(PERFORM_DISPLAY).size(13).color(
-                    if mode == PerformMode::Sections {
-                        th::blend(th::text_dim(), th::text(), 0.22)
-                    } else {
-                        th::text()
-                    }
-                ))
-                .width(Length::Fill)
-                .height(Length::Fill),
-                text(detail).font(PERFORM_TECH).size(8).color(th::blend(
-                    th::text_dim(),
-                    th::text(),
-                    0.12
-                ))
-            ]
-            .height(Length::Fill),
-        )
-        .width(Length::Fill)
-        .height(Length::Fill)
-        .padding(8)
-        .style(move |_theme: &Theme| container::Style {
-            background: Some(
-                iced::gradient::Linear::new(2.35)
-                    .add_stop(
-                        0.0,
-                        if pressed || playing {
-                            th::blend(th::accent_dim(), color, 0.35)
-                        } else if queued {
-                            th::blend(th::accent_dim(), th::bg_hover(), 0.42)
-                        } else if muted {
-                            th::blend(th::mute_active(), color, 0.28)
-                        } else if selected {
-                            th::bg_hover()
-                        } else {
-                            th::perform_pad_highlight()
-                        },
-                    )
-                    .add_stop(1.0, th::perform_pad_lowlight())
-                    .into(),
-            ),
-            border: iced::Border {
-                color: if pressed || playing {
-                    th::accent()
-                } else if queued || selected {
-                    th::accent_dim()
-                } else if muted {
-                    th::mute_active()
-                } else {
-                    th::blend(th::border_light(), color, 0.38)
-                },
-                width: 1.0,
-                radius: 5.0.into(),
-            },
-            ..Default::default()
-        });
-
-        let pad: Element<'_, Message> = container(pad_face)
-            .width(Length::FillPortion(1))
-            .height(Length::Fill)
-            .padding(3)
-            .style(move |_theme: &Theme| container::Style {
-                background: Some(
-                    if pressed {
-                        th::blend(th::bg_dark(), color, 0.28)
-                    } else {
-                        th::bg_dark()
-                    }
-                    .into(),
-                ),
-                border: iced::Border {
-                    color: th::blend(th::border(), color, 0.3),
-                    width: 1.0,
-                    radius: 8.0.into(),
-                },
-                shadow: Shadow {
-                    color: th::perform_shadow(),
-                    offset: Vector::new(0.0, if pressed { 1.0 } else { 3.0 }),
-                    blur_radius: if pressed { 3.0 } else { 7.0 },
-                },
-                ..Default::default()
-            })
-            .into();
-
-        match (mode, section) {
-            (PerformMode::Sections, Some(section)) => {
-                let select = mouse_area(pad)
-                    .on_press(Message::Perform(PerformMsg::SelectSection(section.id)));
-                let launch = container(perform_tool_button(
-                    icons::PLAY,
-                    "Launch Section",
-                    Message::Perform(PerformMsg::LaunchSection(section.id)),
-                    playing,
-                    false,
-                ))
-                .width(Length::Fill)
-                .height(Length::Fill)
-                .align_x(iced::alignment::Horizontal::Right)
-                .align_y(iced::alignment::Vertical::Bottom)
-                .padding(8);
-                if let Some(fraction) = playhead_fraction {
-                    stack![
-                        select,
-                        super::views_perform_playhead::pad_playhead(fraction),
-                        launch
-                    ]
-                    .into()
-                } else {
-                    stack![select, launch].into()
-                }
-            }
-            (PerformMode::Sections, None) if self.state.perform.duplicate_source.is_some() => {
-                mouse_area(pad)
-                    .on_press(Message::Perform(PerformMsg::DuplicateSectionTo(
-                        ordinal - 1,
-                    )))
-                    .into()
-            }
-            (PerformMode::Sections, None) => mouse_area(pad)
-                .on_press(Message::Perform(PerformMsg::CreateSectionAt(ordinal - 1)))
-                .into(),
-            (PerformMode::TrackMutes, _) if mute_track.is_some() => mouse_area(pad)
-                .on_press(Message::Perform(PerformMsg::ToggleTrackMuteFromPad(
-                    position,
-                )))
-                .into(),
-            _ => pad,
-        }
     }
 
     pub(super) fn view_section_toolbar(

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -295,12 +295,30 @@ impl App {
         ]
         .spacing(5);
         let origin = match mode {
-            PerformMode::Sections => "ORDER · TOP-LEFT".to_string(),
+            PerformMode::Sections => {
+                let pending = self
+                    .state
+                    .perform
+                    .pending_section_boundary_samples
+                    .map(|samples| {
+                        let beat = samples as f64 * self.state.transport.bpm
+                            / (self.state.transport.sample_rate as f64 * 60.0);
+                        format!(" · QUEUED @ BEAT {beat:.2}")
+                    })
+                    .unwrap_or_default();
+                format!(
+                    "BANK {} · ORDER TOP-LEFT{pending} · [ ]",
+                    self.state.perform.banks.sections + 1
+                )
+            }
             PerformMode::TrackMutes => format!(
                 "BANK {} · PROJECT TRACKS · [ ]",
                 self.state.perform.banks.track_mutes + 1
             ),
-            PerformMode::Instrument => "ORDER · BOTTOM-LEFT".to_string(),
+            PerformMode::Instrument => format!(
+                "BANK {} · ORDER BOTTOM-LEFT · [ ]",
+                self.state.perform.banks.instrument + 1
+            ),
         };
         let header = row![
             heading,
@@ -375,6 +393,8 @@ impl App {
             || self.state.perform.selected_pad == Some(position);
         let playing =
             section.is_some_and(|section| self.state.perform.playing_section == Some(section.id));
+        let queued =
+            section.is_some_and(|section| self.state.perform.queued_section == Some(section.id));
         let playhead_fraction = section.filter(|_| playing).map(|section| {
             super::views_perform_playhead::section_playhead_fraction(
                 self.state.perform.section_playhead_samples,
@@ -397,7 +417,13 @@ impl App {
                     section.name.clone(),
                     format!(
                         "{} · {:.0} BARS",
-                        if playing { "PLAYING" } else { "AVAILABLE" },
+                        if playing {
+                            "PLAYING"
+                        } else if queued {
+                            "QUEUED"
+                        } else {
+                            "AVAILABLE"
+                        },
                         section.length_beats / 4.0
                     ),
                     th::track_color((ordinal - 1) as u8),
@@ -491,6 +517,8 @@ impl App {
                         0.0,
                         if pressed || playing {
                             th::blend(th::accent_dim(), color, 0.35)
+                        } else if queued {
+                            th::blend(th::accent_dim(), th::bg_hover(), 0.42)
                         } else if muted {
                             th::blend(th::mute_active(), color, 0.28)
                         } else if selected {
@@ -505,7 +533,7 @@ impl App {
             border: iced::Border {
                 color: if pressed || playing {
                     th::accent()
-                } else if selected {
+                } else if queued || selected {
                     th::accent_dim()
                 } else if muted {
                     th::mute_active()

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -92,6 +92,75 @@ fn perform_tool_button(
         .into()
 }
 
+fn perform_bank_button(
+    label: &'static str,
+    tooltip_label: &'static str,
+    message: PerformMsg,
+) -> Element<'static, Message> {
+    let control = button(
+        center(
+            text(label)
+                .font(PERFORM_TECH_STRONG)
+                .size(13)
+                .color(th::text_dim()),
+        )
+        .width(Length::Fill)
+        .height(Length::Fill),
+    )
+    .on_press(Message::Perform(message))
+    .width(Length::Fixed(20.0))
+    .height(Length::Fixed(20.0))
+    .padding(0)
+    .style(|_theme: &Theme, status| {
+        let engaged = matches!(status, button::Status::Hovered | button::Status::Pressed);
+        button::Style {
+            background: Some(
+                if engaged {
+                    th::bg_hover()
+                } else {
+                    th::bg_surface()
+                }
+                .into(),
+            ),
+            text_color: if matches!(status, button::Status::Pressed) {
+                th::accent()
+            } else {
+                th::text_dim()
+            },
+            border: iced::Border {
+                color: if engaged {
+                    th::accent_dim()
+                } else {
+                    th::border()
+                },
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            ..Default::default()
+        }
+    });
+    let hint = container(
+        text(tooltip_label)
+            .font(PERFORM_TECH)
+            .size(9)
+            .color(th::text()),
+    )
+    .padding([4, 6])
+    .style(|_theme: &Theme| container::Style {
+        background: Some(th::bg_elevated().into()),
+        border: iced::Border {
+            color: th::border_light(),
+            width: 1.0,
+            radius: 2.0.into(),
+        },
+        ..Default::default()
+    });
+    tooltip(control, hint, tooltip::Position::Bottom)
+        .gap(5)
+        .padding(0)
+        .into()
+}
+
 fn perform_mode_tab_width(surface_width: f32) -> f32 {
     ((surface_width - MODE_SELECTOR_INSET) / PerformMode::ALL.len() as f32)
         .clamp(MODE_TAB_MIN_WIDTH, MODE_TAB_MAX_WIDTH)
@@ -294,7 +363,7 @@ impl App {
                 .color(th::text())
         ]
         .spacing(5);
-        let origin = match mode {
+        let (bank, origin) = match mode {
             PerformMode::Sections => {
                 let pending = self
                     .state
@@ -306,30 +375,36 @@ impl App {
                         format!(" · QUEUED @ BEAT {beat:.2}")
                     })
                     .unwrap_or_default();
-                format!(
-                    "BANK {} · ORDER TOP-LEFT{pending} · [ ]",
-                    self.state.perform.banks.sections + 1
+                (
+                    self.state.perform.banks.sections + 1,
+                    format!("ORDER TOP-LEFT{pending}"),
                 )
             }
-            PerformMode::TrackMutes => format!(
-                "BANK {} · PROJECT TRACKS · [ ]",
-                self.state.perform.banks.track_mutes + 1
+            PerformMode::TrackMutes => (
+                self.state.perform.banks.track_mutes + 1,
+                "PROJECT TRACKS".to_string(),
             ),
-            PerformMode::Instrument => format!(
-                "BANK {} · ORDER BOTTOM-LEFT · [ ]",
-                self.state.perform.banks.instrument + 1
+            PerformMode::Instrument => (
+                self.state.perform.banks.instrument + 1,
+                "ORDER BOTTOM-LEFT".to_string(),
             ),
         };
-        let header = row![
-            heading,
-            horizontal_space(),
-            text(origin).font(PERFORM_TECH).size(9).color(th::blend(
-                th::text_dim(),
-                th::text(),
-                0.24
-            ))
+        let bank_navigation = row![
+            text(format!("BANK {bank}"))
+                .font(PERFORM_TECH_STRONG)
+                .size(9)
+                .color(th::blend(th::text_dim(), th::text(), 0.24)),
+            perform_bank_button("‹", "PREVIOUS BANK  [", PerformMsg::PreviousBank),
+            perform_bank_button("›", "NEXT BANK  ]", PerformMsg::NextBank),
+            text(format!("· {origin}"))
+                .font(PERFORM_TECH)
+                .size(9)
+                .color(th::blend(th::text_dim(), th::text(), 0.24)),
         ]
-        .align_y(iced::Alignment::End);
+        .spacing(5)
+        .align_y(iced::Alignment::Center);
+        let header =
+            row![heading, horizontal_space(), bank_navigation,].align_y(iced::Alignment::End);
 
         let pad_grid_height = perform_pad_grid_height(self.state.view.window_height);
         let mut grid = column![]

--- a/crates/vibez-ui/src/app/views_perform_pads.rs
+++ b/crates/vibez-ui/src/app/views_perform_pads.rs
@@ -1,0 +1,423 @@
+//! Pad Surface rendering for the Perform workspace.
+
+use iced::widget::{
+    button, center, column, container, horizontal_space, mouse_area, row, stack, text, tooltip,
+};
+use iced::{Element, Length, Shadow, Theme, Vector};
+
+use crate::domains::perform::{PadPosition, PerformEditorFocus, PerformMode, PerformMsg};
+use crate::icons;
+use crate::message::Message;
+use crate::theme as th;
+use crate::typography::{PERFORM_DISPLAY, PERFORM_LABEL, PERFORM_TECH, PERFORM_TECH_STRONG};
+
+use super::views_perform::{perform_pad_grid_height, perform_tool_button};
+use super::*;
+
+fn perform_bank_button(
+    label: &'static str,
+    tooltip_label: &'static str,
+    message: PerformMsg,
+) -> Element<'static, Message> {
+    let control = button(
+        center(
+            text(label)
+                .font(PERFORM_TECH_STRONG)
+                .size(13)
+                .color(th::text_dim()),
+        )
+        .width(Length::Fill)
+        .height(Length::Fill),
+    )
+    .on_press(Message::Perform(message))
+    .width(Length::Fixed(20.0))
+    .height(Length::Fixed(20.0))
+    .padding(0)
+    .style(|_theme: &Theme, status| {
+        let engaged = matches!(status, button::Status::Hovered | button::Status::Pressed);
+        button::Style {
+            background: Some(
+                if engaged {
+                    th::bg_hover()
+                } else {
+                    th::bg_surface()
+                }
+                .into(),
+            ),
+            text_color: if matches!(status, button::Status::Pressed) {
+                th::accent()
+            } else {
+                th::text_dim()
+            },
+            border: iced::Border {
+                color: if engaged {
+                    th::accent_dim()
+                } else {
+                    th::border()
+                },
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            ..Default::default()
+        }
+    });
+    let hint = container(
+        text(tooltip_label)
+            .font(PERFORM_TECH)
+            .size(9)
+            .color(th::text()),
+    )
+    .padding([4, 6])
+    .style(|_theme: &Theme| container::Style {
+        background: Some(th::bg_elevated().into()),
+        border: iced::Border {
+            color: th::border_light(),
+            width: 1.0,
+            radius: 2.0.into(),
+        },
+        ..Default::default()
+    });
+    tooltip(control, hint, tooltip::Position::Bottom)
+        .gap(5)
+        .padding(0)
+        .into()
+}
+
+impl App {
+    pub(super) fn view_pad_surface(&self, surface_width: f32) -> Element<'_, Message> {
+        let mode = self.state.perform.mode;
+        let heading = column![
+            text("PERFORM SURFACE")
+                .font(PERFORM_LABEL)
+                .size(9)
+                .color(th::accent()),
+            text(mode.label().to_uppercase())
+                .font(PERFORM_DISPLAY)
+                .size(22)
+                .color(th::text())
+        ]
+        .spacing(5);
+        let (bank, origin) = match mode {
+            PerformMode::Sections => {
+                let pending = self
+                    .state
+                    .perform
+                    .pending_section_boundary_samples
+                    .map(|samples| {
+                        let beat = samples as f64 * self.state.transport.bpm
+                            / (self.state.transport.sample_rate as f64 * 60.0);
+                        format!(" · QUEUED @ BEAT {beat:.2}")
+                    })
+                    .unwrap_or_default();
+                (
+                    self.state.perform.banks.sections + 1,
+                    format!("ORDER TOP-LEFT{pending}"),
+                )
+            }
+            PerformMode::TrackMutes => (
+                self.state.perform.banks.track_mutes + 1,
+                "PROJECT TRACKS".to_string(),
+            ),
+            PerformMode::Instrument => (
+                self.state.perform.banks.instrument + 1,
+                "ORDER BOTTOM-LEFT".to_string(),
+            ),
+        };
+        let bank_navigation = row![
+            text(format!("BANK {bank}"))
+                .font(PERFORM_TECH_STRONG)
+                .size(9)
+                .color(th::blend(th::text_dim(), th::text(), 0.24)),
+            perform_bank_button("‹", "PREVIOUS BANK  [", PerformMsg::PreviousBank),
+            perform_bank_button("›", "NEXT BANK  ]", PerformMsg::NextBank),
+            text(format!("· {origin}"))
+                .font(PERFORM_TECH)
+                .size(9)
+                .color(th::blend(th::text_dim(), th::text(), 0.24)),
+        ]
+        .spacing(5)
+        .align_y(iced::Alignment::Center);
+        let header =
+            row![heading, horizontal_space(), bank_navigation,].align_y(iced::Alignment::End);
+
+        let pad_grid_height = perform_pad_grid_height(self.state.view.window_height);
+        let mut grid = column![]
+            .width(Length::Fill)
+            .height(Length::Fixed(pad_grid_height))
+            .spacing(8);
+        for row_index in 0..4 {
+            let mut pad_row = row![]
+                .width(Length::Fill)
+                .height(Length::FillPortion(1))
+                .spacing(8);
+            for position in PadPosition::ALL
+                .iter()
+                .copied()
+                .filter(|position| position.row == row_index)
+            {
+                pad_row = pad_row.push(self.view_perform_pad(position, mode));
+            }
+            grid = grid.push(pad_row);
+        }
+        let grid = center(grid)
+            .width(Length::Fill)
+            .height(Length::Fixed(pad_grid_height));
+
+        let surface = container(column![header, grid].spacing(12))
+            .width(Length::Fixed(surface_width))
+            .height(Length::Fill)
+            .padding(14)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::perform_inset().into()),
+                border: iced::Border {
+                    color: th::border(),
+                    width: 1.0,
+                    radius: 0.0.into(),
+                },
+                ..Default::default()
+            });
+
+        mouse_area(surface)
+            .on_press(Message::Perform(PerformMsg::FocusEditor(
+                PerformEditorFocus::PadSurface,
+            )))
+            .into()
+    }
+
+    fn view_perform_pad(&self, position: PadPosition, mode: PerformMode) -> Element<'_, Message> {
+        let ordinal = u16::from(position.ordinal(mode))
+            + u16::from(self.state.perform.banks.for_mode(mode)) * 16;
+        let section = (mode == PerformMode::Sections)
+            .then(|| self.state.perform.sections.at_slot(ordinal - 1))
+            .flatten();
+        let selected = section
+            .is_some_and(|section| self.state.perform.selected_section == Some(section.id))
+            || self.state.perform.selected_pad == Some(position);
+        let playing =
+            section.is_some_and(|section| self.state.perform.playing_section == Some(section.id));
+        let queued =
+            section.is_some_and(|section| self.state.perform.queued_section == Some(section.id));
+        let playhead_fraction = section.filter(|_| playing).map(|section| {
+            super::views_perform_playhead::section_playhead_fraction(
+                self.state.perform.section_playhead_samples,
+                section.length_beats,
+                self.state.transport.bpm,
+                self.state.transport.sample_rate,
+            )
+        });
+        let pressed = self.state.perform.is_pad_pressed(position);
+        let mute_track = (mode == PerformMode::TrackMutes)
+            .then(|| {
+                self.state
+                    .perform
+                    .track_for_mute_pad(position, &self.state.project_tracks.tracks)
+            })
+            .flatten();
+        let (title, detail, color, muted) = match mode {
+            PerformMode::Sections => match section {
+                Some(section) => (
+                    section.name.clone(),
+                    format!(
+                        "{} · {:.0} BARS",
+                        if playing {
+                            "PLAYING"
+                        } else if queued {
+                            "QUEUED"
+                        } else {
+                            "AVAILABLE"
+                        },
+                        section.length_beats / 4.0
+                    ),
+                    th::track_color((ordinal - 1) as u8),
+                    false,
+                ),
+                None if self.state.perform.duplicate_source.is_some() => (
+                    "+ DUPLICATE".to_string(),
+                    "CHOOSE EMPTY SLOT".to_string(),
+                    th::track_color((ordinal - 1) as u8),
+                    false,
+                ),
+                None => (
+                    "+ SECTION".to_string(),
+                    "EMPTY".to_string(),
+                    th::track_color((ordinal - 1) as u8),
+                    false,
+                ),
+            },
+            PerformMode::TrackMutes => {
+                if let Some(track) = mute_track {
+                    (
+                        track.name.clone(),
+                        format!(
+                            "{} · {}",
+                            if track.kind.is_midi() {
+                                "MIDI"
+                            } else {
+                                "AUDIO"
+                            },
+                            if track.mute { "MUTED" } else { "LIVE" }
+                        ),
+                        th::track_color(track.color_index),
+                        track.mute,
+                    )
+                } else {
+                    (
+                        "—".to_string(),
+                        "NO PROJECT TRACK".to_string(),
+                        th::text_muted(),
+                        false,
+                    )
+                }
+            }
+            PerformMode::Instrument => (
+                "SELECT MIDI".to_string(),
+                "NO INSTRUMENT TARGET".to_string(),
+                th::track_color((ordinal - 1) as u8),
+                false,
+            ),
+        };
+        let number_color = th::blend(color, th::text(), 0.3);
+        let coordinate_color = th::blend(th::text_dim(), th::text(), 0.2);
+
+        let pad_face = container(
+            column![
+                row![
+                    text(format!("{ordinal:02}"))
+                        .font(PERFORM_TECH_STRONG)
+                        .size(11)
+                        .color(number_color),
+                    horizontal_space(),
+                    text(format!("R{} · C{}", position.row + 1, position.column + 1))
+                        .font(PERFORM_TECH)
+                        .size(9)
+                        .color(coordinate_color)
+                ],
+                center(text(title).font(PERFORM_DISPLAY).size(13).color(
+                    if mode == PerformMode::Sections {
+                        th::blend(th::text_dim(), th::text(), 0.22)
+                    } else {
+                        th::text()
+                    }
+                ))
+                .width(Length::Fill)
+                .height(Length::Fill),
+                text(detail).font(PERFORM_TECH).size(8).color(th::blend(
+                    th::text_dim(),
+                    th::text(),
+                    0.12
+                ))
+            ]
+            .height(Length::Fill),
+        )
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .padding(8)
+        .style(move |_theme: &Theme| container::Style {
+            background: Some(
+                iced::gradient::Linear::new(2.35)
+                    .add_stop(
+                        0.0,
+                        if pressed || playing {
+                            th::blend(th::accent_dim(), color, 0.35)
+                        } else if queued {
+                            th::blend(th::accent_dim(), th::bg_hover(), 0.42)
+                        } else if muted {
+                            th::blend(th::mute_active(), color, 0.28)
+                        } else if selected {
+                            th::bg_hover()
+                        } else {
+                            th::perform_pad_highlight()
+                        },
+                    )
+                    .add_stop(1.0, th::perform_pad_lowlight())
+                    .into(),
+            ),
+            border: iced::Border {
+                color: if pressed || playing {
+                    th::accent()
+                } else if queued || selected {
+                    th::accent_dim()
+                } else if muted {
+                    th::mute_active()
+                } else {
+                    th::blend(th::border_light(), color, 0.38)
+                },
+                width: 1.0,
+                radius: 5.0.into(),
+            },
+            ..Default::default()
+        });
+
+        let pad: Element<'_, Message> = container(pad_face)
+            .width(Length::FillPortion(1))
+            .height(Length::Fill)
+            .padding(3)
+            .style(move |_theme: &Theme| container::Style {
+                background: Some(
+                    if pressed {
+                        th::blend(th::bg_dark(), color, 0.28)
+                    } else {
+                        th::bg_dark()
+                    }
+                    .into(),
+                ),
+                border: iced::Border {
+                    color: th::blend(th::border(), color, 0.3),
+                    width: 1.0,
+                    radius: 8.0.into(),
+                },
+                shadow: Shadow {
+                    color: th::perform_shadow(),
+                    offset: Vector::new(0.0, if pressed { 1.0 } else { 3.0 }),
+                    blur_radius: if pressed { 3.0 } else { 7.0 },
+                },
+                ..Default::default()
+            })
+            .into();
+
+        match (mode, section) {
+            (PerformMode::Sections, Some(section)) => {
+                let select = mouse_area(pad)
+                    .on_press(Message::Perform(PerformMsg::SelectSection(section.id)));
+                let launch = container(perform_tool_button(
+                    icons::PLAY,
+                    "Launch Section",
+                    Message::Perform(PerformMsg::LaunchSection(section.id)),
+                    playing,
+                    false,
+                ))
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .align_x(iced::alignment::Horizontal::Right)
+                .align_y(iced::alignment::Vertical::Bottom)
+                .padding(8);
+                if let Some(fraction) = playhead_fraction {
+                    stack![
+                        select,
+                        super::views_perform_playhead::pad_playhead(fraction),
+                        launch
+                    ]
+                    .into()
+                } else {
+                    stack![select, launch].into()
+                }
+            }
+            (PerformMode::Sections, None) if self.state.perform.duplicate_source.is_some() => {
+                mouse_area(pad)
+                    .on_press(Message::Perform(PerformMsg::DuplicateSectionTo(
+                        ordinal - 1,
+                    )))
+                    .into()
+            }
+            (PerformMode::Sections, None) => mouse_area(pad)
+                .on_press(Message::Perform(PerformMsg::CreateSectionAt(ordinal - 1)))
+                .into(),
+            (PerformMode::TrackMutes, _) if mute_track.is_some() => mouse_area(pad)
+                .on_press(Message::Perform(PerformMsg::ToggleTrackMuteFromPad(
+                    position,
+                )))
+                .into(),
+            _ => pad,
+        }
+    }
+}

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -661,15 +661,19 @@ impl PerformState {
                 if ctx.workspace_visible {
                     match self.mode {
                         PerformMode::Sections => {
-                            let last_bank = self
+                            let last_reachable_bank = self
                                 .sections
                                 .sections
                                 .iter()
                                 .map(|section| section.slot / 16)
                                 .max()
+                                .map(|bank| u8::try_from(bank.saturating_add(1)).unwrap_or(u8::MAX))
                                 .unwrap_or(0);
-                            self.banks.sections =
-                                self.banks.sections.saturating_add(1).min(last_bank as u8);
+                            self.banks.sections = self
+                                .banks
+                                .sections
+                                .saturating_add(1)
+                                .min(last_reachable_bank);
                         }
                         PerformMode::TrackMutes => {
                             let last_bank = self.track_mute_slots.len().saturating_sub(1) / 16;

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -274,8 +274,8 @@ pub enum PerformEditorFocus {
     SectionConstruction,
 }
 
-/// Per-mode bank cursors are UI interaction state. Navigation is added by a
-/// later card; Card 02 establishes the ownership boundary only.
+/// Per-mode bank cursors are UI interaction state. Bracket navigation updates
+/// only the active mode's cursor and never touches engine playback.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct PerformBanks {
     pub sections: u8,
@@ -313,6 +313,8 @@ pub struct PerformState {
     pub duplicate_source: Option<SectionId>,
     /// Engine-owned playback truth mirrored from Section events.
     pub playing_section: Option<SectionId>,
+    pub queued_section: Option<SectionId>,
+    pub pending_section_boundary_samples: Option<u64>,
     pub section_playhead_samples: u64,
     active_computer_keys: HashMap<String, (PadPosition, PadGestureSource)>,
     track_mute_slots: Vec<Option<TrackId>>,
@@ -540,6 +542,14 @@ impl PerformState {
                     if self.duplicate_source == Some(id) {
                         self.duplicate_source = None;
                     }
+                    let last_bank = self
+                        .sections
+                        .sections
+                        .iter()
+                        .map(|section| section.slot / 16)
+                        .max()
+                        .unwrap_or(0);
+                    self.banks.sections = self.banks.sections.min(last_bank as u8);
                 }
             }
             PerformMsg::StartEditingSectionName(id) => {
@@ -633,18 +643,53 @@ impl PerformState {
                 }
             }
             PerformMsg::PreviousBank => {
-                if ctx.workspace_visible && self.mode == PerformMode::TrackMutes {
-                    self.banks.track_mutes = self.banks.track_mutes.saturating_sub(1);
+                if ctx.workspace_visible {
+                    match self.mode {
+                        PerformMode::Sections => {
+                            self.banks.sections = self.banks.sections.saturating_sub(1)
+                        }
+                        PerformMode::TrackMutes => {
+                            self.banks.track_mutes = self.banks.track_mutes.saturating_sub(1)
+                        }
+                        PerformMode::Instrument => {
+                            self.banks.instrument = self.banks.instrument.saturating_sub(1)
+                        }
+                    }
                 }
             }
             PerformMsg::NextBank => {
-                if ctx.workspace_visible && self.mode == PerformMode::TrackMutes {
-                    let last_bank = self.track_mute_slots.len().saturating_sub(1) / 16;
-                    self.banks.track_mutes = self
-                        .banks
-                        .track_mutes
-                        .saturating_add(1)
-                        .min(last_bank as u8);
+                if ctx.workspace_visible {
+                    match self.mode {
+                        PerformMode::Sections => {
+                            let last_bank = self
+                                .sections
+                                .sections
+                                .iter()
+                                .map(|section| section.slot / 16)
+                                .max()
+                                .unwrap_or(0);
+                            self.banks.sections =
+                                self.banks.sections.saturating_add(1).min(last_bank as u8);
+                        }
+                        PerformMode::TrackMutes => {
+                            let last_bank = self.track_mute_slots.len().saturating_sub(1) / 16;
+                            self.banks.track_mutes = self
+                                .banks
+                                .track_mutes
+                                .saturating_add(1)
+                                .min(last_bank as u8);
+                        }
+                        PerformMode::Instrument => {
+                            let playable = ctx
+                                .project_tracks
+                                .iter()
+                                .filter(|track| track.kind.is_midi() && track.has_instrument)
+                                .count();
+                            let last_bank = playable.saturating_sub(1) / 16;
+                            self.banks.instrument =
+                                self.banks.instrument.saturating_add(1).min(last_bank as u8);
+                        }
+                    }
                 }
             }
             PerformMsg::ToggleTrackMuteFromPad(position) => {

--- a/crates/vibez-ui/src/domains/perform/sections.rs
+++ b/crates/vibez-ui/src/domains/perform/sections.rs
@@ -123,10 +123,18 @@ impl Section {
         &self,
         project_tracks: &[crate::state::ProjectTrack],
     ) -> PreparedSectionPlaybackSource {
-        let tracks = project_tracks
+        let track_ids: Vec<_> = project_tracks.iter().map(|track| track.id).collect();
+        self.prepare_playback_source_for_tracks(&track_ids)
+    }
+
+    pub fn prepare_playback_source_for_tracks(
+        &self,
+        project_track_ids: &[TrackId],
+    ) -> PreparedSectionPlaybackSource {
+        let tracks = project_track_ids
             .iter()
-            .map(|track| {
-                let content = self.timeline.get(track.id);
+            .map(|track_id| {
+                let content = self.timeline.get(*track_id);
                 let clips = content
                     .into_iter()
                     .flat_map(|content| content.clips.iter())
@@ -158,7 +166,7 @@ impl Section {
                     .map(|content| content.automation.clone())
                     .unwrap_or_default();
                 (
-                    track.id,
+                    *track_id,
                     PreparedPlaybackSource::new(clips, note_clips, automation),
                 )
             })

--- a/crates/vibez-ui/src/domains/perform_tests.rs
+++ b/crates/vibez-ui/src/domains/perform_tests.rs
@@ -684,3 +684,27 @@ fn sections_and_track_mutes_remember_independent_banks() {
     assert_eq!(state.banks.track_mutes, 1);
     assert!(engine.0.is_empty(), "bank changes never touch playback");
 }
+
+#[test]
+fn full_first_section_bank_can_open_an_empty_bank_and_create_section_seventeen() {
+    let mut state = PerformState::default();
+    for slot in 0..16 {
+        Arc::make_mut(&mut state.sections).insert(Section::new(slot));
+    }
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        project_tracks: &[],
+        selected_project_track: None,
+    };
+
+    state.update(PerformMsg::NextBank, &mut engine, ctx);
+    assert_eq!(state.banks.sections, 1, "] should expose empty bank 2");
+
+    state.update(PerformMsg::CreateSectionAt(16), &mut engine, ctx);
+    assert!(state.sections.at_slot(16).is_some());
+
+    state.update(PerformMsg::PreviousBank, &mut engine, ctx);
+    assert_eq!(state.banks.sections, 0);
+    assert!(engine.0.is_empty(), "bank changes never touch playback");
+}

--- a/crates/vibez-ui/src/domains/perform_tests.rs
+++ b/crates/vibez-ui/src/domains/perform_tests.rs
@@ -407,6 +407,8 @@ fn keyboard_and_pointer_launch_select_the_target_then_allow_independent_selectio
         state.playing_section, None,
         "only engine events set playback truth"
     );
+    assert_eq!(state.queued_section, None);
+    assert_eq!(state.pending_section_boundary_samples, None);
 }
 
 #[test]
@@ -646,4 +648,39 @@ fn track_slots_survive_deletion_and_fill_without_scrambling_other_pads() {
             .map(|track| track.id),
         Some(second_id)
     );
+}
+
+#[test]
+fn sections_and_track_mutes_remember_independent_banks() {
+    let tracks = project_tracks(18);
+    let mut state = PerformState::default();
+    Arc::make_mut(&mut state.sections).insert(Section::new(0));
+    Arc::make_mut(&mut state.sections).insert(Section::new(16));
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        project_tracks: &tracks,
+        selected_project_track: None,
+    };
+
+    state.update(PerformMsg::NextBank, &mut engine, ctx);
+    assert_eq!(state.banks.sections, 1);
+
+    state.update(
+        PerformMsg::SelectMode(PerformMode::TrackMutes),
+        &mut engine,
+        ctx,
+    );
+    state.update(PerformMsg::NextBank, &mut engine, ctx);
+    assert_eq!(state.banks.track_mutes, 1);
+
+    state.update(
+        PerformMsg::SelectMode(PerformMode::Sections),
+        &mut engine,
+        ctx,
+    );
+    state.update(PerformMsg::PreviousBank, &mut engine, ctx);
+    assert_eq!(state.banks.sections, 0);
+    assert_eq!(state.banks.track_mutes, 1);
+    assert!(engine.0.is_empty(), "bank changes never touch playback");
 }

--- a/crates/vibez-ui/src/domains/transport.rs
+++ b/crates/vibez-ui/src/domains/transport.rs
@@ -45,6 +45,8 @@ pub struct TransportCtx {
     pub total_duration_samples: u64,
     /// Active time selection in beats, if any (loop-enable copies it).
     pub time_selection: Option<(f64, f64)>,
+    /// Perform holds one project BPM until its Section transport stops.
+    pub perform_tempo_locked: bool,
 }
 
 /// Cross-domain effects the transport cannot perform itself. The
@@ -59,6 +61,7 @@ pub enum TransportAction {
         old_bpm: f64,
         new_bpm: f64,
     },
+    TempoRejected,
 }
 
 impl TransportState {
@@ -123,6 +126,10 @@ impl TransportState {
                 TransportAction::None
             }
             TransportMsg::BpmSubmit => match self.bpm_text.parse::<f64>() {
+                Ok(_) if ctx.perform_tempo_locked => {
+                    self.bpm_text = format!("{:.0}", self.bpm);
+                    TransportAction::TempoRejected
+                }
                 Ok(bpm) => self.set_bpm(bpm, engine),
                 Err(_) => {
                     self.bpm_text = format!("{:.0}", self.bpm);
@@ -130,6 +137,10 @@ impl TransportState {
                 }
             },
             TransportMsg::NudgeBpm(delta) => {
+                if ctx.perform_tempo_locked {
+                    self.bpm_text = format!("{:.0}", self.bpm);
+                    return TransportAction::TempoRejected;
+                }
                 let bpm = self.bpm + delta;
                 self.set_bpm(bpm, engine)
             }
@@ -263,12 +274,34 @@ mod tests {
     }
 
     #[test]
+    fn perform_playback_rejects_bpm_submit() {
+        let mut t = transport();
+        t.bpm_text = "140".into();
+        let mut engine = RecordingEngine::default();
+
+        let action = t.update(
+            TransportMsg::BpmSubmit,
+            &mut engine,
+            TransportCtx {
+                perform_tempo_locked: true,
+                ..TransportCtx::default()
+            },
+        );
+
+        assert_eq!(t.bpm, 120.0);
+        assert_eq!(t.bpm_text, "120");
+        assert_eq!(action, TransportAction::TempoRejected);
+        assert!(engine.0.is_empty());
+    }
+
+    #[test]
     fn seek_clamps_and_requests_selection_clear() {
         let mut t = transport();
         let mut engine = RecordingEngine::default();
         let ctx = TransportCtx {
             total_duration_samples: 1000,
             time_selection: None,
+            ..TransportCtx::default()
         };
         let action = t.update(TransportMsg::Seek(2.0), &mut engine, ctx);
         assert_eq!(t.position_samples, 1000);
@@ -298,6 +331,7 @@ mod tests {
         let ctx = TransportCtx {
             total_duration_samples: 0,
             time_selection: Some((4.0, 8.0)),
+            ..TransportCtx::default()
         };
         t.update(TransportMsg::ToggleArrangementLoop, &mut engine, ctx);
         assert!(t.loop_enabled);

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -12,6 +12,35 @@ use vibez_plugin_host::PluginId;
 use vibez_project::project_format_v1::SaveObservation;
 use vibez_project::{Project, TimelineLocation};
 
+/// Cloneable UI-message holder for one prepared, uniquely-owned Section.
+/// The router takes the box exactly once before sending it to the engine.
+#[derive(Clone)]
+pub struct ResidentSection(
+    Arc<
+        std::sync::Mutex<Option<Box<vibez_engine::playback_source::PreparedSectionPlaybackSource>>>,
+    >,
+);
+
+impl ResidentSection {
+    pub fn new(
+        prepared: Box<vibez_engine::playback_source::PreparedSectionPlaybackSource>,
+    ) -> Self {
+        Self(Arc::new(std::sync::Mutex::new(Some(prepared))))
+    }
+
+    pub fn take(
+        &self,
+    ) -> Option<Box<vibez_engine::playback_source::PreparedSectionPlaybackSource>> {
+        self.0.lock().ok()?.take()
+    }
+}
+
+impl std::fmt::Debug for ResidentSection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ResidentSection")
+    }
+}
+
 use crate::state::{
     AuditionImportInput, AuditionMode, SampleBrowserEntry, SampleBrowserFolder, SettingsTab,
     UndoGestureId,
@@ -242,6 +271,12 @@ pub enum Message {
     Project(crate::domains::project::ProjectMsg),
     Automation(crate::domains::automation::AutomationMsg),
     Perform(crate::domains::perform::PerformMsg),
+    SectionResidencyReady {
+        request_id: u64,
+        section_id: SectionId,
+        quantization: vibez_core::perform::SectionLaunchQuantization,
+        resident: ResidentSection,
+    },
     KeyboardInput {
         event: iced::keyboard::Event,
         occurred_at: std::time::Instant,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,8 +103,9 @@ in the router layer as iced Tasks in topic modules under
 math happens in the domains. Replaceable router work uses one `TrackedRequest`
 lifecycle for monotonic tokens, stale-result rejection, cancellation, optional
 iced task abortion, and abort-on-drop. Remote import, Remote materialization,
-Browser import preparation, and Remote catalog refresh keep separate tracker
-instances but do not duplicate request IDs, generations, or abort handles.
+Browser import preparation, Remote catalog refresh, and Section residency keep
+separate tracker instances but do not duplicate request IDs, generations, or
+abort handles.
 
 Perform follows the same boundary. `PerformState` owns runtime-only mode, bank,
 selection, and editor-focus state alongside an `Arc<SectionStore>` that enters
@@ -113,9 +114,11 @@ independent `ArrangementTimeline` keyed by the same shared Project `TrackId`s;
 duplicating a Section remints every editable content identity while immutable
 decoded audio remains shared. `PerformMsg` changes that slice through the
 router and `EngineHandle`. A Section launch returns a semantic action; the
-router resolves the complete resident playback source and sends it to the
-engine without coupling the Perform interaction slice to engine storage. Perform is a
-sibling of Arrange and Mix in the shared shell, and all three retain their
+router prepares the complete playback source on a cancellable background task,
+then sends only the resident owner and launch policy to the engine. A newer
+launch cancels and invalidates stale residency work without coupling the
+Perform interaction slice to engine storage. Perform is a sibling of Arrange
+and Mix in the shared shell, and all three retain their
 interaction state when producers switch between them. Track Mute pad slots
 retain stable `TrackId` assignments across
 track additions and deletions. A pad press resolves inside Perform to a narrow
@@ -236,16 +239,20 @@ instrument, effect, or send implementation. A complete
 Track, including empty sources that mean intentional silence. It holds decoded
 clip `Arc`s and exposes no loader or I/O API.
 
-`EngineCommand::LaunchSection` swaps those prepared pointers into each shared
-channel at the next callback opportunity, resets the engine-owned local Section
-playhead, and emits a sample-timestamped `SectionTransitioned` event. The same
-command owner is returned in that event carrying the displaced sources, so
-their Vecs and Arcs are destroyed on the UI thread. The callback only swaps
-pointers: it never allocates, loads, locks, performs I/O, or drops a resident
-source. The UI sets playing-pad state only from engine events. Section loop
-wraps split inside a callback at the playable boundary, flush sounding notes,
-and continue from local sample zero. Empty sources still run the shared device
-chain, allowing existing effect tails to decay naturally.
+`EngineCommand::LaunchSection` retains the immediate Card 10 path.
+`EngineCommand::QueueSection` transfers a prepared owner plus its Immediate,
+beat, bar, or end-of-Section policy. The engine computes and owns the pending
+absolute sample boundary, returns displaced queued owners to the UI thread, and
+splits rendering when that boundary falls partway through a callback. Only then
+does it swap the resident pointers, reset the local Section playhead, and emit a
+sample-timestamped `SectionTransitioned` event. `SectionQueued` is likewise the
+only source of queued-pad and pending-boundary UI state. The callback never
+loads, locks, performs I/O, or drops a resident source. Section loop wraps split
+inside a callback at the playable boundary, flush sounding notes, and continue
+from local sample zero. Empty sources still run the shared device chain,
+allowing existing effect tails to decay naturally. Live Project Track mutes
+remain channel state across transitions, and the engine plus Transport domain
+hold one Project BPM until Perform playback stops.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Card 11 — Queue Sections with Quantized Transitions

### Outcome
- prepares Section residency through the shared cancellable TrackedRequest mechanism from Card 25
- queues Immediate, 1 Beat, 1 Bar, and End of Section policies in the engine
- swaps resident sources exactly at engine-owned boundaries, including mid-callback, and reports sample timestamps
- drives PLAYING, QUEUED, and pending-boundary UI state only from engine events
- adds independent bracket-key banks for Sections, Track Mutes, and the retained Instrument shell
- locks project BPM throughout Perform playback and preserves live Track mute state across transitions

### Ownership and RT safety
- UI/background code prepares decoded clip owners before QueueSection is sent
- requeue aborts stale UI work and returns displaced resident owners for UI-thread destruction
- the callback swaps pointers only; no loading, locks, I/O, or resident-owner drops
- the Card 10 immediate LaunchSection and playing-Section refresh seams remain intact

### TDD and verification
- red/green engine coverage for all four policies, mid-buffer output and timestamp, stale requeue retirement/latest-wins, BPM lock, and mute persistence
- red/green UI coverage for independent banks/no engine commands, engine-event playback truth, BPM rejection, and shared request cancellation/stale-result behavior
- 148 vibez-engine tests pass
- 283 vibez-ui tests pass
- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace --all-targets with -D warnings passes when allowing only three pre-existing origin/dev Rust 1.96 lints
- cargo test --workspace
- git diff --check

Strict all-target Clippy without those allowances remains red on unchanged origin/dev files: host_context.rs, engine_section_playback_tests.rs, and ui_settings.rs. None are touched here. All touched Rust files remain under 1000 lines.

### Exact-branch native dogfood
- executable, cwd, PID, and X11 window all verified against this worktree and target on Xvfb only
- created two Sections; first changed to PLAYING only after its engine event
- queued the second at 1 Bar; pad changed to QUEUED and header displayed the engine-reported absolute beat boundary
- the isolated Xvfb audio backend runs callbacks faster than wall clock and floods position events, so it is not accepted as timing/audibility evidence; deterministic engine tests cover exact switching and the real native audio pass remains the human gate

### Manual sign-off
1. Prepare two contrasting looping Sections and set the second to 1 Bar.
2. Launch the first, then launch the second mid-bar. Confirm the second says QUEUED with a pending beat and becomes PLAYING exactly on the bar.
3. Repeat with Immediate, 1 Beat, and End of Section.
4. Mute a Track before a transition and confirm it stays muted afterward until reversed.
5. While Perform plays, try typing and nudging BPM; it must remain unchanged. Stop, then confirm BPM edits work.
6. Create a Section in slot 17, use ] to reach bank 2 and [ to return, switch modes, and confirm each mode remembers its own bank without interrupting playback.

Out of scope and intentionally absent: Instrument performance behavior, recording, Capture, Card 12+, and the separate Arrange add-track styling bug.