### PR TITLE
Fix looped MIDI loudness growth after bar 2

### DIFF
--- a/crates/vibez-engine/src/engine_stuck_note_tests.rs
+++ b/crates/vibez-engine/src/engine_stuck_note_tests.rs
@@ -12,6 +12,7 @@ type NoteEventLog = Arc<Mutex<Vec<(bool, u8)>>>;
 /// Instrument that records every note event it receives.
 struct SpyInstrument {
     events: NoteEventLog,
+    batch_render: bool,
 }
 
 impl vibez_instruments::Instrument for SpyInstrument {
@@ -35,6 +36,9 @@ impl vibez_instruments::Instrument for SpyInstrument {
     }
     fn render(&mut self, _buffer: &mut [f32], _channels: usize) {}
     fn reset(&mut self) {}
+    fn supports_batch_render(&self) -> bool {
+        self.batch_render
+    }
 }
 
 /// Engine with one MIDI track holding a held note (0..8 beats in
@@ -57,6 +61,7 @@ fn engine_with_held_note() -> (
             track_id: tid,
             instrument: Box::new(SpyInstrument {
                 events: Arc::clone(&events),
+                batch_render: false,
             }),
         })
         .unwrap();
@@ -129,6 +134,7 @@ fn run_scenario(
             track_id: tid,
             instrument: Box::new(SpyInstrument {
                 events: Arc::clone(&events),
+                batch_render: false,
             }),
         })
         .unwrap();
@@ -183,6 +189,86 @@ fn dogfood_clip_loop_one_bar_in_two_bar_clip() {
         "expected several note-ons: {events:?}"
     );
     assert_no_hanging_notes(&events);
+}
+
+fn looped_note_ons_per_bar(batch_render: bool) -> Vec<usize> {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let track_id = TrackId::new();
+    let clip_id = ClipId::new();
+    cmd_tx.push(EngineCommand::SetSampleRate(44_100)).unwrap();
+    cmd_tx
+        .push(EngineCommand::AddMidiTrack(track_id, "kick".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetPluginInstrument {
+            track_id,
+            instrument: Box::new(SpyInstrument {
+                events: Arc::clone(&events),
+                batch_render,
+            }),
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddNoteClip {
+            track_id,
+            clip_id,
+            position_beats: 0.0,
+            duration_beats: 16.0,
+            loop_enabled: true,
+            loop_start_beats: 0.0,
+            loop_end_beats: 4.0,
+        })
+        .unwrap();
+    for step in 0..8 {
+        cmd_tx
+            .push(EngineCommand::AddNote {
+                track_id,
+                clip_id,
+                note: MidiNote {
+                    pitch: 36,
+                    velocity: 100,
+                    start_beat: step as f64 * 0.5,
+                    duration_beats: 0.5,
+                },
+            })
+            .unwrap();
+    }
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    // At 44.1 kHz and 120 BPM, one four-beat bar is 88,200 frames. This
+    // production-rate boundary catches adjacent-frame retriggers that a tiny
+    // synthetic sample rate can mask through exact floating-point division.
+    let mut output = vec![0.0; 88_200 * 2];
+    let mut note_ons_per_bar = Vec::new();
+    for _ in 0..4 {
+        let before = events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(is_on, pitch)| *is_on && *pitch == 36)
+            .count();
+        engine.process(&mut output, 2);
+        let after = events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(is_on, pitch)| *is_on && *pitch == 36)
+            .count();
+        note_ons_per_bar.push(after - before);
+    }
+
+    note_ons_per_bar
+}
+
+#[test]
+fn built_in_instrument_note_loop_emits_each_note_once_across_four_bars() {
+    assert_eq!(looped_note_ons_per_bar(false), vec![8, 8, 8, 8]);
+}
+
+#[test]
+fn plugin_instrument_note_loop_emits_each_note_once_across_four_bars() {
+    assert_eq!(looped_note_ons_per_bar(true), vec![8, 8, 8, 8]);
 }
 
 #[test]

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -14,6 +14,11 @@ use vibez_instruments::Instrument;
 use crate::playback_source::{ArrangementPlaybackSource, PreparedPlaybackSource};
 pub use crate::playback_source::{EngineClip, EngineNoteClip};
 
+#[inline]
+fn crossed_beat(previous: f64, current: f64, event: f64) -> bool {
+    previous < event && event <= current
+}
+
 pub struct EffectSlot {
     pub id: EffectId,
     pub effect: Box<dyn AudioEffect>,
@@ -333,21 +338,20 @@ impl EngineTrack {
                         self.timed_note_offs.push((frame as u32, note.pitch));
                     }
                     for note in &clip.notes {
-                        let diff = effective_local - note.start_beat;
-                        if diff >= 0.0 && diff < beat_step {
+                        if note.start_beat >= clip.loop_start_beats
+                            && note.start_beat <= effective_local
+                        {
                             self.timed_note_ons
                                 .push((frame as u32, note.pitch, note.velocity));
                         }
                     }
                 } else {
                     for note in &clip.notes {
-                        let diff = effective_local - note.start_beat;
-                        if diff >= 0.0 && diff < beat_step {
+                        if crossed_beat(prev_effective_local, effective_local, note.start_beat) {
                             self.timed_note_ons
                                 .push((frame as u32, note.pitch, note.velocity));
                         }
-                        let end_diff = effective_local - note.end_beat();
-                        if end_diff >= 0.0 && end_diff < beat_step {
+                        if crossed_beat(prev_effective_local, effective_local, note.end_beat()) {
                             self.timed_note_offs.push((frame as u32, note.pitch));
                         }
                     }
@@ -473,19 +477,18 @@ impl EngineTrack {
                         note_offs.push(note.pitch);
                     }
                     for note in &clip.notes {
-                        let diff = effective_local - note.start_beat;
-                        if diff >= 0.0 && diff < beat_step {
+                        if note.start_beat >= clip.loop_start_beats
+                            && note.start_beat <= effective_local
+                        {
                             note_ons.push((note.pitch, note.velocity));
                         }
                     }
                 } else {
                     for note in &clip.notes {
-                        let diff = effective_local - note.start_beat;
-                        if diff >= 0.0 && diff < beat_step {
+                        if crossed_beat(prev_effective_local, effective_local, note.start_beat) {
                             note_ons.push((note.pitch, note.velocity));
                         }
-                        let end_diff = effective_local - note.end_beat();
-                        if end_diff >= 0.0 && end_diff < beat_step {
+                        if crossed_beat(prev_effective_local, effective_local, note.end_beat()) {
                             note_offs.push(note.pitch);
                         }
                     }


### PR DESCRIPTION
## Summary
- emit each looped MIDI note-on and note-off exactly once when its beat boundary is crossed
- apply the same boundary rule to built-in per-frame and plugin batch rendering
- add production-rate four-bar regressions for both rendering paths

## Root cause
At 44.1 kHz, the floating-point one-sample event window became true on two adjacent frames after the second one-bar wrap. Identical kicks were therefore triggered twice from bar 3 onward.

## Verification
- red: both paths reported note-ons per bar as [8, 8, 16, 16]
- green: both paths report [8, 8, 8, 8]
- exact HM BD 02.wav render: peak 0.41210467 and RMS 0.17934328 in every bar
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## Scope
Isolated Card 27 fix only. No Card 11, VST routing, Explorer, or UI changes. Not merged pending explicit approval and native playback sign-off.