### PR TITLE
fix(browser): select visible Remote folders directly

### DIFF
--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -382,6 +382,7 @@ impl BrowserState {
                 self.remote.connection_expanded = !self.remote.connection_expanded;
             }
             BrowserMsg::SelectRemoteFolder(path) => {
+                self.mode = SampleBrowserMode::Remote;
                 self.remote.current_path = path;
                 if !self.remote.current_path.is_empty() {
                     self.remote

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -379,23 +379,123 @@ fn remote_navigation_cycles_folder_connection_and_everywhere_scopes() {
 }
 
 #[test]
+fn selecting_visible_remote_folder_from_local_activates_that_folder_in_one_click() {
+    let mut browser = BrowserState {
+        mode: SampleBrowserMode::Local,
+        search: "kick".into(),
+        search_scope: crate::state::BrowserSearchScope::Everywhere,
+        results_visible_limit: crate::state::BROWSER_RESULTS_PAGE_SIZE * 2,
+        selected_source: Some(MediaSourceRef::LocalFile {
+            path: PathBuf::from("/samples/kick.wav"),
+        }),
+        ..BrowserState::default()
+    };
+    browser.remote.catalog.entries = vec![
+        RemoteCatalogEntry {
+            provider_item_id: "/megalodon".into(),
+            path: "/Megalodon".into(),
+            parent_path: String::new(),
+            name: "Megalodon".into(),
+            is_folder: true,
+            revision: None,
+            size: None,
+            derived_metadata: None,
+        },
+        RemoteCatalogEntry {
+            provider_item_id: "/megalodon/drums".into(),
+            path: "/Megalodon/Drums".into(),
+            parent_path: "/megalodon".into(),
+            name: "Drums".into(),
+            is_folder: true,
+            revision: None,
+            size: None,
+            derived_metadata: None,
+        },
+    ];
+    browser.remote.rebuild_catalog_children();
+    browser.remote.expanded.insert("/megalodon".into());
+    assert_eq!(browser.remote.catalog_child_indices("").len(), 1);
+    assert_eq!(browser.remote.catalog_child_indices("/megalodon").len(), 1);
+
+    browser.update(BrowserMsg::SelectRemoteFolder("/megalodon/drums".into()));
+
+    assert_eq!(browser.mode, SampleBrowserMode::Remote);
+    assert_eq!(browser.remote.current_path, "/megalodon/drums");
+    assert!(browser.remote.expanded.contains("/megalodon"));
+    assert!(browser.remote.expanded.contains("/megalodon/drums"));
+    assert_eq!(
+        browser.search_scope,
+        crate::state::BrowserSearchScope::SelectedFolder
+    );
+    assert_eq!(browser.search, "kick");
+    assert_eq!(browser.remote.catalog.entries.len(), 2);
+    assert_eq!(
+        browser.results_visible_limit,
+        crate::state::BROWSER_RESULTS_PAGE_SIZE
+    );
+    assert!(browser.selected_source.is_none());
+}
+
+#[test]
+fn selecting_visible_remote_connection_from_local_activates_its_root_in_one_click() {
+    let mut browser = BrowserState {
+        mode: SampleBrowserMode::Local,
+        search: "snare".into(),
+        search_scope: crate::state::BrowserSearchScope::Everywhere,
+        results_visible_limit: crate::state::BROWSER_RESULTS_PAGE_SIZE * 2,
+        selected_source: Some(MediaSourceRef::DropboxFile {
+            path_lower: "/megalodon/snare.wav".into(),
+            display_path: "/Megalodon/Snare.wav".into(),
+            rev: Some("rev-7".into()),
+        }),
+        ..BrowserState::default()
+    };
+    browser.remote.current_path = "/megalodon".into();
+    browser.remote.selected_path = Some("/megalodon/snare.wav".into());
+    browser.remote.expanded.insert("/megalodon".into());
+
+    browser.update(BrowserMsg::SelectRemoteFolder(String::new()));
+
+    assert_eq!(browser.mode, SampleBrowserMode::Remote);
+    assert!(browser.remote.current_path.is_empty());
+    assert!(browser.remote.expanded.contains("/megalodon"));
+    assert_eq!(
+        browser.search_scope,
+        crate::state::BrowserSearchScope::SelectedFolder
+    );
+    assert_eq!(browser.search, "snare");
+    assert_eq!(
+        browser.results_visible_limit,
+        crate::state::BROWSER_RESULTS_PAGE_SIZE
+    );
+    assert!(browser.remote.selected_path.is_none());
+    assert!(browser.selected_source.is_none());
+}
+
+#[test]
 fn remote_place_and_connection_collapse_without_losing_navigation_state() {
     let mut browser = BrowserState::default();
     browser.remote.current_path = "/megalodon/drums".into();
     browser.remote.expanded.insert("/megalodon".into());
 
+    browser.update(BrowserMsg::ToggleRemoteFolder("/megalodon".into()));
     browser.update(BrowserMsg::ToggleRemoteConnection);
     browser.update(BrowserMsg::ToggleRemotePlace);
 
+    assert_eq!(browser.mode, SampleBrowserMode::Local);
     assert!(!browser.remote.connection_expanded);
     assert!(!browser.remote.place_expanded);
     assert_eq!(browser.remote.current_path, "/megalodon/drums");
-    assert!(browser.remote.expanded.contains("/megalodon"));
+    assert!(!browser.remote.expanded.contains("/megalodon"));
 
     browser.update(BrowserMsg::ToggleRemotePlace);
     browser.update(BrowserMsg::ToggleRemoteConnection);
+    browser.update(BrowserMsg::ToggleRemoteFolder("/megalodon".into()));
     assert!(browser.remote.place_expanded);
     assert!(browser.remote.connection_expanded);
+    assert!(browser.remote.expanded.contains("/megalodon"));
+    assert_eq!(browser.mode, SampleBrowserMode::Local);
+    assert_eq!(browser.remote.current_path, "/megalodon/drums");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- activate the Remote Place inside the existing `SelectRemoteFolder` domain transition
- cover one-click selection of both a visible Dropbox connection root and nested folder from Local results
- keep disclosure controls navigation-free and preserve query, scope, selection reset, catalog, and bounded-result behavior

This PR implements Browser Card 15 only. The corresponding Local-return defect remains isolated in Card 16.

## Diagnosis and TDD

The deterministic regression reproduced on fresh `origin/dev`: after `SelectRemoteFolder("/megalodon/drums")`, the exact path, expansion, selected-folder scope, selection reset, and results bound were correct, but `SampleBrowserMode` remained `Local`. The test was observed RED (`left: Local`, `right: Remote`) before the one-line fix and GREEN afterward.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace -j 4`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace -j 4`
- `git diff --check`
- exact-head Xvfb dogfood at `d9a111e`: from Local, one click on visible `Art` activated and highlighted that Remote folder with its children in Results; from Local, one click on `Alex’s Dropbox` activated and highlighted the connection root; the Art disclosure control collapsed without navigating

All Cargo commands used the lane target and shared global lock.