### PR TITLE
feat(perform): play instrument targets from pads

### DIFF
--- a/crates/vibez-engine/src/engine_section_playback_tests.rs
+++ b/crates/vibez-engine/src/engine_section_playback_tests.rs
@@ -419,6 +419,62 @@ fn switching_sections_releases_notes_from_the_previous_source() {
 }
 
 #[test]
+fn live_instrument_note_releases_after_a_section_transition() {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let note_events = Arc::new(Mutex::new(Vec::new()));
+    commands
+        .push(EngineCommand::AddMidiTrack(track_id, "MIDI".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::SetPluginInstrument {
+            track_id,
+            instrument: Box::new(NoteLogInstrument(Arc::clone(&note_events))),
+        })
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                SectionId::new(),
+                4.0,
+                true,
+                vec![(track_id, PreparedPlaybackSource::default())],
+            ),
+        )))
+        .unwrap();
+    commands
+        .push(EngineCommand::ExternalNoteOn {
+            track_id,
+            pitch: 48,
+            velocity: 100,
+        })
+        .unwrap();
+    let mut output = [0.0; 1];
+    engine.process(&mut output, 1);
+
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                SectionId::new(),
+                4.0,
+                true,
+                vec![(track_id, PreparedPlaybackSource::default())],
+            ),
+        )))
+        .unwrap();
+    engine.process(&mut output, 1);
+    commands
+        .push(EngineCommand::ExternalNoteOff {
+            track_id,
+            pitch: 48,
+        })
+        .unwrap();
+    engine.process(&mut output, 1);
+
+    assert_eq!(*note_events.lock().unwrap(), vec![(true, 48), (false, 48)]);
+}
+
+#[test]
 fn absent_track_stops_source_content_without_resetting_effect_tail() {
     let (mut engine, mut commands, _events) = AudioEngine::new();
     let track_id = TrackId::new();

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -96,7 +96,7 @@ impl App {
         let mut tasks = Vec::new();
         if action.persist_settings {
             self.persist_ui_settings();
-            self.state.status_text = "Perform key mapping saved".into();
+            self.state.status_text = "Perform settings saved".into();
         }
         if let Some(request) = action.track_mute_request {
             let pre_edit_snapshot = self.take_snapshot();
@@ -116,6 +116,19 @@ impl App {
                     "{} {track_name}",
                     if request.muted { "Muted" } else { "Unmuted" }
                 );
+            }
+        }
+        if let Some(track_id) = action.select_project_track {
+            self.state.arrangement.selected_track = Some(track_id);
+            if self.state.perform.selected_section.is_some() {
+                self.state
+                    .perform
+                    .section_editor
+                    .editor_mut()
+                    .selected_track = Some(track_id);
+            }
+            if let Some(track) = self.state.find_track(track_id) {
+                self.state.status_text = format!("Instrument Target: {}", track.name);
             }
         }
         if let Some(section_id) = action.section_launch {
@@ -533,7 +546,7 @@ impl App {
         let has_instrument = self
             .state
             .find_track(track_id)
-            .map(|t| t.instrument_kind.is_some())
+            .map(|track| track.is_playable_midi_target())
             .unwrap_or(false);
         if !has_instrument {
             return;

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -58,7 +58,9 @@ pub(crate) fn keyboard_input_message(
         // A release must clear a press that began before focus moved into a
         // text field. Unpaired releases are harmless in the adapter.
         iced::keyboard::Event::KeyReleased { .. } => true,
-        iced::keyboard::Event::ModifiersChanged(_) => false,
+        iced::keyboard::Event::ModifiersChanged(modifiers) => {
+            status == iced::event::Status::Ignored || !modifiers.shift()
+        }
     };
     should_forward.then(|| Message::KeyboardInput {
         event,
@@ -141,7 +143,12 @@ impl super::App {
                 {
                     (Some(PerformMsg::CancelKeyRebind), None)
                 } else if let Some(computer_key) = computer_key_from_physical(physical_key) {
-                    if modifiers.is_empty() || self.state.perform.key_rebind_target.is_some() {
+                    if modifiers.is_empty()
+                        || (self.state.perform.instrument_target_overlay
+                            && self.state.perform.mode == PerformMode::Instrument
+                            && modifiers == iced::keyboard::Modifiers::SHIFT)
+                        || self.state.perform.key_rebind_target.is_some()
+                    {
                         (
                             Some(PerformMsg::ComputerKeyPressed {
                                 key: computer_key,
@@ -171,7 +178,10 @@ impl super::App {
                     None,
                 )
             }
-            iced::keyboard::Event::ModifiersChanged(_) => return iced::Task::none(),
+            iced::keyboard::Event::ModifiersChanged(modifiers) => (
+                Some(PerformMsg::SetInstrumentTargetOverlay(modifiers.shift())),
+                None,
+            ),
         };
 
         if let Some(msg) = perform_msg {
@@ -572,6 +582,27 @@ mod tests {
             keyboard_input_message(event, iced::event::Status::Ignored),
             Some(Message::KeyboardInput { .. })
         ));
+    }
+
+    #[test]
+    fn uncaptured_shift_changes_reach_the_instrument_target_overlay() {
+        use iced::keyboard::{Event, Modifiers};
+
+        assert!(matches!(
+            keyboard_input_message(
+                Event::ModifiersChanged(Modifiers::SHIFT),
+                iced::event::Status::Ignored,
+            ),
+            Some(Message::KeyboardInput {
+                event: Event::ModifiersChanged(modifiers),
+                ..
+            }) if modifiers.shift()
+        ));
+        assert!(keyboard_input_message(
+            Event::ModifiersChanged(Modifiers::SHIFT),
+            iced::event::Status::Captured,
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use iced::{Subscription, Task, Theme};
 
 use crate::domains::browser::BrowserMsg;
+use crate::domains::perform::PerformMsg;
 use crate::domains::view::ViewMsg;
 use rtrb::{Consumer, Producer};
 use vibez_audio_io::audio_stream::AudioOutputStream;
@@ -522,6 +523,9 @@ impl App {
                 iced::Event::Window(iced::window::Event::Resized(size)) => Some(Message::View(
                     ViewMsg::WindowResized(size.width, size.height),
                 )),
+                iced::Event::Window(iced::window::Event::Unfocused) => {
+                    Some(Message::Perform(PerformMsg::WindowUnfocused))
+                }
                 _ => None,
             }),
         ])

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -266,6 +266,9 @@ impl App {
             ..Default::default()
         };
         state.perform.input_mapping = ui_settings.perform_input_mapping.clone();
+        state
+            .perform
+            .set_fixed_computer_velocity(ui_settings.fixed_computer_velocity);
 
         // Themes: scan the user's .vzt collection, then restore the
         // saved selection (built-in name or user theme name).

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -219,6 +219,7 @@ impl App {
     pub(super) fn persist_ui_settings(&mut self) {
         let settings = UiSettings {
             perform_input_mapping: self.state.perform.input_mapping.clone(),
+            fixed_computer_velocity: self.state.perform.fixed_computer_velocity(),
             sample_library_roots: self.state.browser.roots.clone(),
             sample_browser_open: self.state.browser.open,
             sample_browser_width: self.state.browser.dock_width,

--- a/crates/vibez-ui/src/app/views_perform_pads.rs
+++ b/crates/vibez-ui/src/app/views_perform_pads.rs
@@ -198,18 +198,43 @@ impl App {
                 selected_text_color: th::accent(),
                 selected_background: th::bg_hover().into(),
             });
+            let target_overlay = self.state.perform.instrument_target_overlay;
+            let range_or_bank = if target_overlay {
+                format!("TARGET BANK {bank}")
+            } else {
+                let low = crate::widgets::piano_roll::pitch_name(
+                    self.state.perform.instrument_pitch(PadPosition::ALL[12]),
+                );
+                let high = crate::widgets::piano_roll::pitch_name(
+                    self.state.perform.instrument_pitch(PadPosition::ALL[3]),
+                );
+                format!(
+                    "OCTAVE {:+} · {low}–{high}",
+                    self.state.perform.instrument_octave()
+                )
+            };
+            let previous_hint = if target_overlay {
+                "PREVIOUS TARGET BANK"
+            } else {
+                "OCTAVE DOWN  ["
+            };
+            let next_hint = if target_overlay {
+                "NEXT TARGET BANK"
+            } else {
+                "OCTAVE UP  ]"
+            };
             let target_navigation = row![
                 text("INSTRUMENT TARGET")
                     .font(PERFORM_LABEL)
                     .size(8)
                     .color(th::text_muted()),
                 horizontal_space(),
-                text(format!("TARGET BANK {bank}"))
+                text(range_or_bank)
                     .font(PERFORM_TECH_STRONG)
                     .size(8)
                     .color(th::blend(th::text_dim(), th::text(), 0.24)),
-                perform_bank_button("‹", "PREVIOUS TARGET BANK  [", PerformMsg::PreviousBank),
-                perform_bank_button("›", "NEXT TARGET BANK  ]", PerformMsg::NextBank),
+                perform_bank_button("‹", previous_hint, PerformMsg::PreviousBank),
+                perform_bank_button("›", next_hint, PerformMsg::NextBank),
             ]
             .spacing(5)
             .align_y(iced::Alignment::Center);
@@ -286,8 +311,13 @@ impl App {
     }
 
     fn view_perform_pad(&self, position: PadPosition, mode: PerformMode) -> Element<'_, Message> {
-        let ordinal = u16::from(position.ordinal(mode))
-            + u16::from(self.state.perform.banks.for_mode(mode)) * 16;
+        let visible_bank =
+            if mode == PerformMode::Instrument && !self.state.perform.instrument_target_overlay {
+                0
+            } else {
+                self.state.perform.banks.for_mode(mode)
+            };
+        let ordinal = u16::from(position.ordinal(mode)) + u16::from(visible_bank) * 16;
         let section = (mode == PerformMode::Sections)
             .then(|| self.state.perform.sections.at_slot(ordinal - 1))
             .flatten();
@@ -406,7 +436,7 @@ impl App {
                 }
             }
             PerformMode::Instrument => {
-                let pitch = 35 + position.ordinal(PerformMode::Instrument);
+                let pitch = self.state.perform.instrument_pitch(position);
                 (
                     crate::widgets::piano_roll::pitch_name(pitch),
                     selected_instrument

--- a/crates/vibez-ui/src/app/views_perform_pads.rs
+++ b/crates/vibez-ui/src/app/views_perform_pads.rs
@@ -137,21 +137,7 @@ impl App {
                 "ORDER BOTTOM-LEFT".to_string(),
             ),
         };
-        let bank_navigation = row![
-            text(format!("BANK {bank}"))
-                .font(PERFORM_TECH_STRONG)
-                .size(9)
-                .color(th::blend(th::text_dim(), th::text(), 0.24)),
-            perform_bank_button("‹", "PREVIOUS BANK  [", PerformMsg::PreviousBank),
-            perform_bank_button("›", "NEXT BANK  ]", PerformMsg::NextBank),
-            text(format!("· {origin}"))
-                .font(PERFORM_TECH)
-                .size(9)
-                .color(th::blend(th::text_dim(), th::text(), 0.24)),
-        ]
-        .spacing(5)
-        .align_y(iced::Alignment::Center);
-        let target_selector = (mode == PerformMode::Instrument).then(|| {
+        let header: Element<'_, Message> = if mode == PerformMode::Instrument {
             let targets: Vec<_> = self
                 .state
                 .project_tracks
@@ -169,18 +155,91 @@ impl App {
                     .find(|target| target.track_id == selected)
                     .cloned()
             });
-            pick_list(targets, selected, |target| {
+            let selector = pick_list(targets, selected, |target| {
                 Message::Perform(PerformMsg::SelectInstrumentTarget(target.track_id))
             })
-            .placeholder("Select Instrument Target")
-            .width(Length::Fixed(170.0))
+            .placeholder("CHOOSE PLAYABLE MIDI TARGET")
+            .width(Length::Fill)
+            .padding([5, 8])
             .text_size(10)
-        });
-        let mut header = row![heading, horizontal_space()].align_y(iced::Alignment::End);
-        if let Some(selector) = target_selector {
-            header = header.push(selector);
-        }
-        let header = header.push(bank_navigation);
+            .style(|_theme: &Theme, status| {
+                let engaged = matches!(
+                    status,
+                    pick_list::Status::Hovered | pick_list::Status::Opened
+                );
+                pick_list::Style {
+                    text_color: th::text(),
+                    placeholder_color: th::text_dim(),
+                    handle_color: if engaged {
+                        th::accent()
+                    } else {
+                        th::text_dim()
+                    },
+                    background: th::perform_pad_lowlight().into(),
+                    border: iced::Border {
+                        color: if engaged {
+                            th::accent_dim()
+                        } else {
+                            th::border_light()
+                        },
+                        width: 1.0,
+                        radius: 3.0.into(),
+                    },
+                }
+            })
+            .menu_style(|_theme: &Theme| iced::widget::overlay::menu::Style {
+                background: th::bg_elevated().into(),
+                border: iced::Border {
+                    color: th::border_light(),
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                text_color: th::text(),
+                selected_text_color: th::accent(),
+                selected_background: th::bg_hover().into(),
+            });
+            let target_navigation = row![
+                text("INSTRUMENT TARGET")
+                    .font(PERFORM_LABEL)
+                    .size(8)
+                    .color(th::text_muted()),
+                horizontal_space(),
+                text(format!("TARGET BANK {bank}"))
+                    .font(PERFORM_TECH_STRONG)
+                    .size(8)
+                    .color(th::blend(th::text_dim(), th::text(), 0.24)),
+                perform_bank_button("‹", "PREVIOUS TARGET BANK  [", PerformMsg::PreviousBank),
+                perform_bank_button("›", "NEXT TARGET BANK  ]", PerformMsg::NextBank),
+            ]
+            .spacing(5)
+            .align_y(iced::Alignment::Center);
+            let target_panel = column![target_navigation, selector]
+                .spacing(4)
+                .width(Length::Fill);
+
+            row![heading, target_panel]
+                .spacing(20)
+                .align_y(iced::Alignment::End)
+                .into()
+        } else {
+            let bank_navigation = row![
+                text(format!("BANK {bank}"))
+                    .font(PERFORM_TECH_STRONG)
+                    .size(9)
+                    .color(th::blend(th::text_dim(), th::text(), 0.24)),
+                perform_bank_button("‹", "PREVIOUS BANK  [", PerformMsg::PreviousBank),
+                perform_bank_button("›", "NEXT BANK  ]", PerformMsg::NextBank),
+                text(format!("· {origin}"))
+                    .font(PERFORM_TECH)
+                    .size(9)
+                    .color(th::blend(th::text_dim(), th::text(), 0.24)),
+            ]
+            .spacing(5)
+            .align_y(iced::Alignment::Center);
+            row![heading, horizontal_space(), bank_navigation]
+                .align_y(iced::Alignment::End)
+                .into()
+        };
 
         let pad_grid_height = perform_pad_grid_height(self.state.view.window_height);
         let mut grid = column![]

--- a/crates/vibez-ui/src/app/views_perform_pads.rs
+++ b/crates/vibez-ui/src/app/views_perform_pads.rs
@@ -1,7 +1,8 @@
 //! Pad Surface rendering for the Perform workspace.
 
 use iced::widget::{
-    button, center, column, container, horizontal_space, mouse_area, row, stack, text, tooltip,
+    button, center, column, container, horizontal_space, mouse_area, pick_list, row, stack, text,
+    tooltip,
 };
 use iced::{Element, Length, Shadow, Theme, Vector};
 
@@ -10,9 +11,22 @@ use crate::icons;
 use crate::message::Message;
 use crate::theme as th;
 use crate::typography::{PERFORM_DISPLAY, PERFORM_LABEL, PERFORM_TECH, PERFORM_TECH_STRONG};
+use vibez_core::id::TrackId;
 
 use super::views_perform::{perform_pad_grid_height, perform_tool_button};
 use super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InstrumentTargetOption {
+    track_id: TrackId,
+    label: String,
+}
+
+impl std::fmt::Display for InstrumentTargetOption {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.label)
+    }
+}
 
 fn perform_bank_button(
     label: &'static str,
@@ -137,8 +151,36 @@ impl App {
         ]
         .spacing(5)
         .align_y(iced::Alignment::Center);
-        let header =
-            row![heading, horizontal_space(), bank_navigation,].align_y(iced::Alignment::End);
+        let target_selector = (mode == PerformMode::Instrument).then(|| {
+            let targets: Vec<_> = self
+                .state
+                .project_tracks
+                .tracks
+                .iter()
+                .filter(|track| track.is_playable_midi_target())
+                .map(|track| InstrumentTargetOption {
+                    track_id: track.id,
+                    label: track.name.clone(),
+                })
+                .collect();
+            let selected = self.state.arrangement.selected_track.and_then(|selected| {
+                targets
+                    .iter()
+                    .find(|target| target.track_id == selected)
+                    .cloned()
+            });
+            pick_list(targets, selected, |target| {
+                Message::Perform(PerformMsg::SelectInstrumentTarget(target.track_id))
+            })
+            .placeholder("Select Instrument Target")
+            .width(Length::Fixed(170.0))
+            .text_size(10)
+        });
+        let mut header = row![heading, horizontal_space()].align_y(iced::Alignment::End);
+        if let Some(selector) = target_selector {
+            header = header.push(selector);
+        }
+        let header = header.push(bank_navigation);
 
         let pad_grid_height = perform_pad_grid_height(self.state.view.window_height);
         let mut grid = column![]
@@ -213,6 +255,24 @@ impl App {
                     .track_for_mute_pad(position, &self.state.project_tracks.tracks)
             })
             .flatten();
+        let instrument_target = (mode == PerformMode::Instrument
+            && self.state.perform.instrument_target_overlay)
+            .then(|| {
+                self.state
+                    .perform
+                    .track_for_instrument_target_pad(position, &self.state.project_tracks.tracks)
+            })
+            .flatten();
+        let selected_instrument = self.state.arrangement.selected_track.and_then(|track_id| {
+            self.state
+                .project_tracks
+                .tracks
+                .iter()
+                .find(|track| track.id == track_id && track.is_playable_midi_target())
+        });
+        let selected = selected
+            || instrument_target
+                .is_some_and(|track| self.state.arrangement.selected_track == Some(track.id));
         let (title, detail, color, muted) = match mode {
             PerformMode::Sections => match section {
                 Some(section) => (
@@ -269,12 +329,36 @@ impl App {
                     )
                 }
             }
-            PerformMode::Instrument => (
-                "SELECT MIDI".to_string(),
-                "NO INSTRUMENT TARGET".to_string(),
-                th::track_color((ordinal - 1) as u8),
-                false,
-            ),
+            PerformMode::Instrument if self.state.perform.instrument_target_overlay => {
+                if let Some(track) = instrument_target {
+                    (
+                        track.name.clone(),
+                        "SELECT INSTRUMENT TARGET".to_string(),
+                        th::track_color(track.color_index),
+                        false,
+                    )
+                } else {
+                    (
+                        "—".to_string(),
+                        "NO PLAYABLE MIDI TARGET".to_string(),
+                        th::text_muted(),
+                        false,
+                    )
+                }
+            }
+            PerformMode::Instrument => {
+                let pitch = 35 + position.ordinal(PerformMode::Instrument);
+                (
+                    crate::widgets::piano_roll::pitch_name(pitch),
+                    selected_instrument
+                        .map(|track| track.name.clone())
+                        .unwrap_or_else(|| "NO INSTRUMENT TARGET".to_string()),
+                    selected_instrument
+                        .map(|track| th::track_color(track.color_index))
+                        .unwrap_or_else(|| th::track_color((ordinal - 1) as u8)),
+                    false,
+                )
+            }
         };
         let number_color = th::blend(color, th::text(), 0.3);
         let coordinate_color = th::blend(th::text_dim(), th::text(), 0.2);
@@ -417,6 +501,14 @@ impl App {
                     position,
                 )))
                 .into(),
+            (PerformMode::Instrument, _) if instrument_target.is_some() => {
+                let track_id = instrument_target.expect("checked target").id;
+                mouse_area(pad)
+                    .on_press(Message::Perform(PerformMsg::SelectInstrumentTarget(
+                        track_id,
+                    )))
+                    .into()
+            }
             _ => pad,
         }
     }

--- a/crates/vibez-ui/src/app/views_settings_perform.rs
+++ b/crates/vibez-ui/src/app/views_settings_perform.rs
@@ -1,6 +1,6 @@
 //! Global Perform input preferences.
 
-use iced::widget::{button, column, container, row, text};
+use iced::widget::{button, column, container, row, slider, text};
 use iced::{Element, Length, Theme};
 
 use crate::domains::perform::{PadPosition, PerformMsg};
@@ -17,6 +17,24 @@ impl App {
         )
         .size(11)
         .color(th::text_dim());
+        let velocity = self.state.perform.fixed_computer_velocity();
+        let velocity_control = column![
+            row![
+                text("Fixed computer-key velocity")
+                    .size(12)
+                    .color(th::text()),
+                iced::widget::horizontal_space(),
+                text(format!("{velocity}")).size(12).color(th::accent())
+            ],
+            slider(1..=127, velocity, |value| {
+                Message::Perform(PerformMsg::SetFixedComputerVelocity(value))
+            })
+            .step(1_u8),
+            text("Applies immediately to Instrument pads and is remembered globally.")
+                .size(10)
+                .color(th::text_dim())
+        ]
+        .spacing(5);
 
         let mut grid = column![].spacing(6);
         for row_index in 0..4 {
@@ -128,6 +146,7 @@ impl App {
         column![
             title,
             hint,
+            velocity_control,
             container(grid).width(Length::Fill).padding([6, 0]),
             text(status).size(10).color(th::text_dim()),
             container(column![])

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -384,6 +384,7 @@ pub enum PerformMsg {
         key_id: String,
         occurred_at: Instant,
     },
+    WindowUnfocused,
 }
 
 impl PerformMsg {
@@ -904,6 +905,17 @@ impl PerformState {
                     ..PerformAction::default()
                 };
             }
+            PerformMsg::WindowUnfocused => {
+                self.instrument_target_overlay = false;
+                for (_, (_, _, instrument_note)) in self.active_computer_keys.drain() {
+                    if let Some(note) = instrument_note {
+                        engine.send(vibez_engine::commands::EngineCommand::ExternalNoteOff {
+                            track_id: note.track_id,
+                            pitch: note.pitch,
+                        });
+                    }
+                }
+            }
         }
         PerformAction::default()
     }
@@ -970,3 +982,7 @@ impl PerformState {
 #[cfg(test)]
 #[path = "perform_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "perform_focus_tests.rs"]
+mod focus_tests;

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -274,6 +274,10 @@ struct ActiveInstrumentNote {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ComputerKeyVelocity(u8);
 
+const INSTRUMENT_BASE_PITCH: u8 = 35;
+const MIN_INSTRUMENT_OCTAVE: i8 = -3;
+const MAX_INSTRUMENT_OCTAVE: i8 = 6;
+
 impl Default for ComputerKeyVelocity {
     fn default() -> Self {
         Self(100)
@@ -289,8 +293,9 @@ pub enum PerformEditorFocus {
     SectionConstruction,
 }
 
-/// Per-mode bank cursors are UI interaction state. Bracket navigation updates
-/// only the active mode's cursor and never touches engine playback.
+/// Per-mode bank cursors are UI interaction state. Instrument target banks are
+/// paged only while its target overlay is visible; normal Instrument bracket
+/// navigation changes the separate octave range instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct PerformBanks {
     pub sections: u8,
@@ -309,8 +314,8 @@ impl PerformBanks {
 }
 
 /// Perform state combines project-owned Sections with runtime interaction.
-/// Input mapping, mode, banks, focus, and edit buffers remain global/runtime;
-/// only the Section store enters project persistence and undo.
+/// Input mapping, mode, banks, Instrument octave, focus, and edit buffers remain
+/// global/runtime; only the Section store enters project persistence and undo.
 #[derive(Default)]
 pub struct PerformState {
     pub mode: PerformMode,
@@ -320,6 +325,7 @@ pub struct PerformState {
     pub input_mapping: PerformInputMapping,
     pub key_rebind_target: Option<PadPosition>,
     pub instrument_target_overlay: bool,
+    instrument_octave: i8,
     computer_key_velocity: ComputerKeyVelocity,
     pub sections: Arc<SectionStore>,
     pub selected_section: Option<SectionId>,
@@ -693,7 +699,14 @@ impl PerformState {
                             self.banks.track_mutes = self.banks.track_mutes.saturating_sub(1)
                         }
                         PerformMode::Instrument => {
-                            self.banks.instrument = self.banks.instrument.saturating_sub(1)
+                            if self.instrument_target_overlay {
+                                self.banks.instrument = self.banks.instrument.saturating_sub(1);
+                            } else {
+                                self.instrument_octave = self
+                                    .instrument_octave
+                                    .saturating_sub(1)
+                                    .max(MIN_INSTRUMENT_OCTAVE);
+                            }
                         }
                     }
                 }
@@ -725,14 +738,21 @@ impl PerformState {
                                 .min(last_bank as u8);
                         }
                         PerformMode::Instrument => {
-                            let playable = ctx
-                                .project_tracks
-                                .iter()
-                                .filter(|track| track.is_playable_midi_target())
-                                .count();
-                            let last_bank = playable.saturating_sub(1) / 16;
-                            self.banks.instrument =
-                                self.banks.instrument.saturating_add(1).min(last_bank as u8);
+                            if self.instrument_target_overlay {
+                                let playable = ctx
+                                    .project_tracks
+                                    .iter()
+                                    .filter(|track| track.is_playable_midi_target())
+                                    .count();
+                                let last_bank = playable.saturating_sub(1) / 16;
+                                self.banks.instrument =
+                                    self.banks.instrument.saturating_add(1).min(last_bank as u8);
+                            } else {
+                                self.instrument_octave = self
+                                    .instrument_octave
+                                    .saturating_add(1)
+                                    .min(MAX_INSTRUMENT_OCTAVE);
+                            }
                         }
                     }
                 }
@@ -813,7 +833,7 @@ impl PerformState {
                             .find(|track| track.id == track_id && track.is_playable_midi_target())
                             .map(|_| ActiveInstrumentNote {
                                 track_id,
-                                pitch: 35 + position.ordinal(PerformMode::Instrument),
+                                pitch: self.instrument_pitch(position),
                             })
                     })
                 } else {
@@ -896,6 +916,15 @@ impl PerformState {
 
     pub const fn fixed_computer_velocity(&self) -> u8 {
         self.computer_key_velocity.0
+    }
+
+    pub const fn instrument_octave(&self) -> i8 {
+        self.instrument_octave
+    }
+
+    pub fn instrument_pitch(&self, position: PadPosition) -> u8 {
+        let base = i16::from(INSTRUMENT_BASE_PITCH + position.ordinal(PerformMode::Instrument));
+        (base + i16::from(self.instrument_octave) * 12).clamp(0, 127) as u8
     }
 
     pub fn set_fixed_computer_velocity(&mut self, velocity: u8) {

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -265,6 +265,21 @@ pub struct PadGesture {
     pub occurred_at: Instant,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ActiveInstrumentNote {
+    track_id: TrackId,
+    pitch: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ComputerKeyVelocity(u8);
+
+impl Default for ComputerKeyVelocity {
+    fn default() -> Self {
+        Self(100)
+    }
+}
+
 /// Which part of Perform owns keyboard/editor focus. This remains runtime UI
 /// state and is deliberately not persisted in the project document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -304,6 +319,8 @@ pub struct PerformState {
     pub editor_focus: PerformEditorFocus,
     pub input_mapping: PerformInputMapping,
     pub key_rebind_target: Option<PadPosition>,
+    pub instrument_target_overlay: bool,
+    computer_key_velocity: ComputerKeyVelocity,
     pub sections: Arc<SectionStore>,
     pub selected_section: Option<SectionId>,
     pub section_editor: SectionTimelineEditor,
@@ -316,7 +333,8 @@ pub struct PerformState {
     pub queued_section: Option<SectionId>,
     pub pending_section_boundary_samples: Option<u64>,
     pub section_playhead_samples: u64,
-    active_computer_keys: HashMap<String, (PadPosition, PadGestureSource)>,
+    active_computer_keys:
+        HashMap<String, (PadPosition, PadGestureSource, Option<ActiveInstrumentNote>)>,
     track_mute_slots: Vec<Option<TrackId>>,
 }
 
@@ -348,6 +366,9 @@ pub enum PerformMsg {
     PreviousBank,
     NextBank,
     ToggleTrackMuteFromPad(PadPosition),
+    SetInstrumentTargetOverlay(bool),
+    SelectInstrumentTarget(TrackId),
+    SetFixedComputerVelocity(u8),
     ComputerKeyPressed {
         key: ComputerKey,
         key_id: String,
@@ -399,6 +420,7 @@ pub struct PerformAction {
     pub persist_settings: bool,
     pub gesture: Option<PadGesture>,
     pub track_mute_request: Option<TrackMuteRequest>,
+    pub select_project_track: Option<TrackId>,
     pub section_launch: Option<SectionId>,
     pub section_content_changed: Option<SectionId>,
 }
@@ -433,6 +455,12 @@ impl PerformState {
 
         let last_bank = self.track_mute_slots.len().saturating_sub(1) / 16;
         self.banks.track_mutes = self.banks.track_mutes.min(last_bank as u8);
+        let playable_targets = tracks
+            .iter()
+            .filter(|track| track.is_playable_midi_target())
+            .count();
+        let last_instrument_bank = playable_targets.saturating_sub(1) / 16;
+        self.banks.instrument = self.banks.instrument.min(last_instrument_bank as u8);
     }
 
     fn track_mute_request(
@@ -459,10 +487,23 @@ impl PerformState {
         tracks.iter().find(|track| track.id == track_id)
     }
 
+    pub fn track_for_instrument_target_pad<'a>(
+        &self,
+        position: PadPosition,
+        tracks: &'a [ProjectTrack],
+    ) -> Option<&'a ProjectTrack> {
+        let slot = usize::from(self.banks.instrument) * 16
+            + usize::from(position.ordinal(PerformMode::Instrument) - 1);
+        tracks
+            .iter()
+            .filter(|track| track.is_playable_midi_target())
+            .nth(slot)
+    }
+
     pub fn update(
         &mut self,
         msg: PerformMsg,
-        _engine: &mut impl EngineHandle,
+        engine: &mut impl EngineHandle,
         ctx: PerformCtx<'_>,
     ) -> PerformAction {
         self.sync_track_mute_slots(ctx.project_tracks);
@@ -687,7 +728,7 @@ impl PerformState {
                             let playable = ctx
                                 .project_tracks
                                 .iter()
-                                .filter(|track| track.kind.is_midi() && track.has_instrument)
+                                .filter(|track| track.is_playable_midi_target())
                                 .count();
                             let last_bank = playable.saturating_sub(1) / 16;
                             self.banks.instrument =
@@ -703,6 +744,31 @@ impl PerformState {
                         ..PerformAction::default()
                     };
                 }
+            }
+            PerformMsg::SetInstrumentTargetOverlay(visible) => {
+                if ctx.workspace_visible || !visible {
+                    self.instrument_target_overlay = visible;
+                }
+            }
+            PerformMsg::SelectInstrumentTarget(track_id) => {
+                if ctx.workspace_visible
+                    && ctx
+                        .project_tracks
+                        .iter()
+                        .any(|track| track.id == track_id && track.is_playable_midi_target())
+                {
+                    return PerformAction {
+                        select_project_track: Some(track_id),
+                        ..PerformAction::default()
+                    };
+                }
+            }
+            PerformMsg::SetFixedComputerVelocity(velocity) => {
+                self.computer_key_velocity = ComputerKeyVelocity(velocity.clamp(1, 127));
+                return PerformAction {
+                    persist_settings: true,
+                    ..PerformAction::default()
+                };
             }
             PerformMsg::ComputerKeyPressed {
                 key,
@@ -731,7 +797,37 @@ impl PerformState {
                     return PerformAction::default();
                 };
                 let source = PadGestureSource::ComputerKeyboard { key };
-                self.active_computer_keys.insert(key_id, (position, source));
+                let selected_instrument_target = (self.mode == PerformMode::Instrument
+                    && self.instrument_target_overlay)
+                    .then(|| {
+                        self.track_for_instrument_target_pad(position, ctx.project_tracks)
+                            .map(|track| track.id)
+                    })
+                    .flatten();
+                let instrument_note = if self.mode == PerformMode::Instrument
+                    && !self.instrument_target_overlay
+                {
+                    ctx.selected_project_track.and_then(|track_id| {
+                        ctx.project_tracks
+                            .iter()
+                            .find(|track| track.id == track_id && track.is_playable_midi_target())
+                            .map(|_| ActiveInstrumentNote {
+                                track_id,
+                                pitch: 35 + position.ordinal(PerformMode::Instrument),
+                            })
+                    })
+                } else {
+                    None
+                };
+                if let Some(note) = instrument_note {
+                    engine.send(vibez_engine::commands::EngineCommand::ExternalNoteOn {
+                        track_id: note.track_id,
+                        pitch: note.pitch,
+                        velocity: self.computer_key_velocity.0,
+                    });
+                }
+                self.active_computer_keys
+                    .insert(key_id, (position, source, instrument_note));
                 let track_mute_request = (self.mode == PerformMode::TrackMutes)
                     .then(|| self.track_mute_request(position, ctx.project_tracks))
                     .flatten();
@@ -755,6 +851,7 @@ impl PerformState {
                         occurred_at,
                     }),
                     track_mute_request,
+                    select_project_track: selected_instrument_target,
                     section_launch,
                     section_content_changed: None,
                 };
@@ -763,9 +860,17 @@ impl PerformState {
                 key_id,
                 occurred_at,
             } => {
-                let Some((position, source)) = self.active_computer_keys.remove(&key_id) else {
+                let Some((position, source, instrument_note)) =
+                    self.active_computer_keys.remove(&key_id)
+                else {
                     return PerformAction::default();
                 };
+                if let Some(note) = instrument_note {
+                    engine.send(vibez_engine::commands::EngineCommand::ExternalNoteOff {
+                        track_id: note.track_id,
+                        pitch: note.pitch,
+                    });
+                }
                 return PerformAction {
                     keyboard_consumed: true,
                     persist_settings: false,
@@ -786,7 +891,15 @@ impl PerformState {
     pub fn is_pad_pressed(&self, position: PadPosition) -> bool {
         self.active_computer_keys
             .values()
-            .any(|(pressed, _)| *pressed == position)
+            .any(|(pressed, _, _)| *pressed == position)
+    }
+
+    pub const fn fixed_computer_velocity(&self) -> u8 {
+        self.computer_key_velocity.0
+    }
+
+    pub fn set_fixed_computer_velocity(&mut self, velocity: u8) {
+        self.computer_key_velocity = ComputerKeyVelocity(velocity.clamp(1, 127));
     }
 
     fn select_section(&mut self, id: SectionId, selected_track: Option<TrackId>) {

--- a/crates/vibez-ui/src/domains/perform_focus_tests.rs
+++ b/crates/vibez-ui/src/domains/perform_focus_tests.rs
@@ -1,0 +1,61 @@
+use super::super::test_support::RecordingEngine;
+use super::*;
+
+#[test]
+fn window_focus_loss_releases_all_held_instrument_notes_and_clears_overlay() {
+    let tracks = vec![playable_midi_track("Drums")];
+    let mut state = PerformState {
+        mode: PerformMode::Instrument,
+        ..PerformState::default()
+    };
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        project_tracks: &tracks,
+        selected_project_track: Some(tracks[0].id),
+    };
+    let at = Instant::now();
+
+    for (key, key_id) in [(ComputerKey::Z, "z"), (ComputerKey::X, "x")] {
+        state.update(
+            PerformMsg::ComputerKeyPressed {
+                key,
+                key_id: key_id.into(),
+                occurred_at: at,
+            },
+            &mut engine,
+            ctx,
+        );
+    }
+    state.update(
+        PerformMsg::SetInstrumentTargetOverlay(true),
+        &mut engine,
+        ctx,
+    );
+
+    state.update(PerformMsg::WindowUnfocused, &mut engine, ctx);
+
+    assert!(!state.is_pad_pressed(PadPosition { row: 3, column: 0 }));
+    assert!(!state.is_pad_pressed(PadPosition { row: 3, column: 1 }));
+    assert!(!state.instrument_target_overlay);
+    assert_eq!(engine.0.len(), 4);
+    let mut note_offs = engine
+        .0
+        .iter()
+        .filter_map(|command| match command {
+            vibez_engine::commands::EngineCommand::ExternalNoteOff { track_id, pitch } => {
+                Some((*track_id, *pitch))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    note_offs.sort_by_key(|(_, pitch)| *pitch);
+    assert_eq!(note_offs, [(tracks[0].id, 36), (tracks[0].id, 37)]);
+}
+
+fn playable_midi_track(name: &str) -> ProjectTrack {
+    let mut track = ProjectTrack::new(TrackId::new(), name.into(), 0);
+    track.kind = vibez_core::midi::TrackKind::Midi;
+    track.has_instrument = true;
+    track
+}

--- a/crates/vibez-ui/src/domains/perform_tests.rs
+++ b/crates/vibez-ui/src/domains/perform_tests.rs
@@ -181,7 +181,7 @@ fn one_hold_produces_exactly_one_press_and_release() {
 }
 
 #[test]
-fn instrument_pad_hold_plays_and_releases_the_selected_target() {
+fn instrument_pad_hold_uses_the_selected_target_and_octave() {
     let tracks = vec![playable_midi_track("Drums")];
     let mut state = PerformState {
         mode: PerformMode::Instrument,
@@ -195,6 +195,7 @@ fn instrument_pad_hold_plays_and_releases_the_selected_target() {
     };
     let at = Instant::now();
 
+    state.update(PerformMsg::NextBank, &mut engine, ctx);
     state.update(
         PerformMsg::ComputerKeyPressed {
             key: ComputerKey::Z,
@@ -218,19 +219,44 @@ fn instrument_pad_hold_plays_and_releases_the_selected_target() {
         [
             vibez_engine::commands::EngineCommand::ExternalNoteOn {
                 track_id,
-                pitch: 36,
+                pitch: 48,
                 velocity: 100,
             },
             vibez_engine::commands::EngineCommand::ExternalNoteOff {
                 track_id: released_track,
-                pitch: 36,
+                pitch: 48,
             },
         ] if *track_id == tracks[0].id && *released_track == tracks[0].id
     ));
 }
 
 #[test]
-fn held_note_release_stays_paired_when_the_target_and_mode_change() {
+fn instrument_octave_navigation_stays_inside_the_midi_range() {
+    let mut state = PerformState {
+        mode: PerformMode::Instrument,
+        ..PerformState::default()
+    };
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        ..PerformCtx::default()
+    };
+
+    for _ in 0..12 {
+        state.update(PerformMsg::NextBank, &mut engine, ctx);
+    }
+    assert_eq!(state.instrument_octave(), 6);
+    assert_eq!(state.instrument_pitch(PadPosition::ALL[3]), 123);
+
+    for _ in 0..12 {
+        state.update(PerformMsg::PreviousBank, &mut engine, ctx);
+    }
+    assert_eq!(state.instrument_octave(), -3);
+    assert_eq!(state.instrument_pitch(PadPosition::ALL[12]), 0);
+}
+
+#[test]
+fn held_note_release_stays_paired_when_range_target_and_mode_change() {
     let tracks = vec![playable_midi_track("Drums"), playable_midi_track("Surge")];
     let mut state = PerformState {
         mode: PerformMode::Instrument,
@@ -251,6 +277,14 @@ fn held_note_release_stays_paired_when_the_target_and_mode_change() {
             selected_project_track: Some(tracks[0].id),
         },
     );
+    state.update(
+        PerformMsg::NextBank,
+        &mut engine,
+        PerformCtx {
+            workspace_visible: true,
+            ..PerformCtx::default()
+        },
+    );
     state.mode = PerformMode::Sections;
     state.update(
         PerformMsg::ComputerKeyReleased {
@@ -268,10 +302,14 @@ fn held_note_release_stays_paired_when_the_target_and_mode_change() {
     assert!(matches!(
         engine.0.as_slice(),
         [
-            vibez_engine::commands::EngineCommand::ExternalNoteOn { track_id, .. },
+            vibez_engine::commands::EngineCommand::ExternalNoteOn {
+                track_id,
+                pitch: 36,
+                ..
+            },
             vibez_engine::commands::EngineCommand::ExternalNoteOff {
                 track_id: released_track,
-                ..
+                pitch: 36,
             }
         ] if *track_id == tracks[0].id && *released_track == tracks[0].id
     ));
@@ -877,7 +915,7 @@ fn track_slots_survive_deletion_and_fill_without_scrambling_other_pads() {
 }
 
 #[test]
-fn each_perform_mode_remembers_its_own_bank() {
+fn each_perform_mode_remembers_its_own_navigation_state() {
     let mut tracks = project_tracks(18);
     for track in &mut tracks {
         track.kind = vibez_core::midi::TrackKind::Midi;
@@ -910,6 +948,14 @@ fn each_perform_mode_remembers_its_own_bank() {
         ctx,
     );
     state.update(PerformMsg::NextBank, &mut engine, ctx);
+    assert_eq!(state.instrument_octave(), 1);
+    assert_eq!(state.banks.instrument, 0);
+    state.update(
+        PerformMsg::SetInstrumentTargetOverlay(true),
+        &mut engine,
+        ctx,
+    );
+    state.update(PerformMsg::NextBank, &mut engine, ctx);
     assert_eq!(state.banks.instrument, 1);
 
     state.update(
@@ -921,6 +967,7 @@ fn each_perform_mode_remembers_its_own_bank() {
     assert_eq!(state.banks.sections, 0);
     assert_eq!(state.banks.track_mutes, 1);
     assert_eq!(state.banks.instrument, 1);
+    assert_eq!(state.instrument_octave(), 1);
     assert!(engine.0.is_empty(), "bank changes never touch playback");
 }
 

--- a/crates/vibez-ui/src/domains/perform_tests.rs
+++ b/crates/vibez-ui/src/domains/perform_tests.rs
@@ -7,6 +7,13 @@ fn project_tracks(count: usize) -> Vec<ProjectTrack> {
         .collect()
 }
 
+fn playable_midi_track(name: &str) -> ProjectTrack {
+    let mut track = ProjectTrack::new(TrackId::new(), name.into(), 0);
+    track.kind = vibez_core::midi::TrackKind::Midi;
+    track.has_instrument = true;
+    track
+}
+
 #[test]
 fn exposes_exactly_the_three_settled_v1_modes() {
     assert_eq!(
@@ -171,6 +178,225 @@ fn one_hold_produces_exactly_one_press_and_release() {
     assert!(extra_release.gesture.is_none());
     assert!(!state.is_pad_pressed(position));
     assert!(engine.0.is_empty());
+}
+
+#[test]
+fn instrument_pad_hold_plays_and_releases_the_selected_target() {
+    let tracks = vec![playable_midi_track("Drums")];
+    let mut state = PerformState {
+        mode: PerformMode::Instrument,
+        ..PerformState::default()
+    };
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        project_tracks: &tracks,
+        selected_project_track: Some(tracks[0].id),
+    };
+    let at = Instant::now();
+
+    state.update(
+        PerformMsg::ComputerKeyPressed {
+            key: ComputerKey::Z,
+            key_id: "z".into(),
+            occurred_at: at,
+        },
+        &mut engine,
+        ctx,
+    );
+    state.update(
+        PerformMsg::ComputerKeyReleased {
+            key_id: "z".into(),
+            occurred_at: at,
+        },
+        &mut engine,
+        ctx,
+    );
+
+    assert!(matches!(
+        engine.0.as_slice(),
+        [
+            vibez_engine::commands::EngineCommand::ExternalNoteOn {
+                track_id,
+                pitch: 36,
+                velocity: 100,
+            },
+            vibez_engine::commands::EngineCommand::ExternalNoteOff {
+                track_id: released_track,
+                pitch: 36,
+            },
+        ] if *track_id == tracks[0].id && *released_track == tracks[0].id
+    ));
+}
+
+#[test]
+fn held_note_release_stays_paired_when_the_target_and_mode_change() {
+    let tracks = vec![playable_midi_track("Drums"), playable_midi_track("Surge")];
+    let mut state = PerformState {
+        mode: PerformMode::Instrument,
+        ..PerformState::default()
+    };
+    let mut engine = RecordingEngine::default();
+    let at = Instant::now();
+    state.update(
+        PerformMsg::ComputerKeyPressed {
+            key: ComputerKey::Z,
+            key_id: "z".into(),
+            occurred_at: at,
+        },
+        &mut engine,
+        PerformCtx {
+            workspace_visible: true,
+            project_tracks: &tracks,
+            selected_project_track: Some(tracks[0].id),
+        },
+    );
+    state.mode = PerformMode::Sections;
+    state.update(
+        PerformMsg::ComputerKeyReleased {
+            key_id: "z".into(),
+            occurred_at: at,
+        },
+        &mut engine,
+        PerformCtx {
+            workspace_visible: true,
+            project_tracks: &tracks,
+            selected_project_track: Some(tracks[1].id),
+        },
+    );
+
+    assert!(matches!(
+        engine.0.as_slice(),
+        [
+            vibez_engine::commands::EngineCommand::ExternalNoteOn { track_id, .. },
+            vibez_engine::commands::EngineCommand::ExternalNoteOff {
+                track_id: released_track,
+                ..
+            }
+        ] if *track_id == tracks[0].id && *released_track == tracks[0].id
+    ));
+}
+
+#[test]
+fn shift_overlay_selects_only_playable_midi_targets_in_bottom_left_order() {
+    let mut tracks = project_tracks(1);
+    let first = playable_midi_track("Drums");
+    let first_id = first.id;
+    tracks.push(first);
+    let mut uninstrumented = playable_midi_track("Empty MIDI");
+    uninstrumented.has_instrument = false;
+    tracks.push(uninstrumented);
+    let second = playable_midi_track("Dexed");
+    let second_id = second.id;
+    tracks.push(second);
+    let mut state = PerformState {
+        mode: PerformMode::Instrument,
+        ..PerformState::default()
+    };
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        project_tracks: &tracks,
+        selected_project_track: Some(first_id),
+    };
+
+    state.update(
+        PerformMsg::SetInstrumentTargetOverlay(true),
+        &mut engine,
+        ctx,
+    );
+    let action = state.update(
+        PerformMsg::ComputerKeyPressed {
+            key: ComputerKey::X,
+            key_id: "x".into(),
+            occurred_at: Instant::now(),
+        },
+        &mut engine,
+        ctx,
+    );
+
+    assert_eq!(action.select_project_track, Some(second_id));
+    assert!(engine.0.is_empty(), "target selection must not play a note");
+}
+
+#[test]
+fn shift_release_clears_the_overlay_after_focus_leaves_perform() {
+    let mut state = PerformState::default();
+    let mut engine = RecordingEngine::default();
+    state.update(
+        PerformMsg::SetInstrumentTargetOverlay(true),
+        &mut engine,
+        PerformCtx {
+            workspace_visible: true,
+            ..PerformCtx::default()
+        },
+    );
+
+    state.update(
+        PerformMsg::SetInstrumentTargetOverlay(false),
+        &mut engine,
+        PerformCtx {
+            workspace_visible: false,
+            ..PerformCtx::default()
+        },
+    );
+
+    assert!(!state.instrument_target_overlay);
+}
+
+#[test]
+fn on_screen_target_selection_retargets_the_project_track() {
+    let tracks = vec![playable_midi_track("Surge")];
+    let mut state = PerformState {
+        mode: PerformMode::Instrument,
+        ..PerformState::default()
+    };
+    let mut engine = RecordingEngine::default();
+
+    let action = state.update(
+        PerformMsg::SelectInstrumentTarget(tracks[0].id),
+        &mut engine,
+        PerformCtx {
+            workspace_visible: true,
+            project_tracks: &tracks,
+            selected_project_track: None,
+        },
+    );
+
+    assert_eq!(action.select_project_track, Some(tracks[0].id));
+    assert!(engine.0.is_empty());
+}
+
+#[test]
+fn changing_fixed_velocity_persists_and_affects_the_next_note_immediately() {
+    let tracks = vec![playable_midi_track("Drums")];
+    let mut state = PerformState {
+        mode: PerformMode::Instrument,
+        ..PerformState::default()
+    };
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        project_tracks: &tracks,
+        selected_project_track: Some(tracks[0].id),
+    };
+
+    let setting = state.update(PerformMsg::SetFixedComputerVelocity(73), &mut engine, ctx);
+    state.update(
+        PerformMsg::ComputerKeyPressed {
+            key: ComputerKey::Z,
+            key_id: "z".into(),
+            occurred_at: Instant::now(),
+        },
+        &mut engine,
+        ctx,
+    );
+
+    assert!(setting.persist_settings);
+    assert!(matches!(
+        engine.0.as_slice(),
+        [vibez_engine::commands::EngineCommand::ExternalNoteOn { velocity: 73, .. }]
+    ));
 }
 
 #[test]
@@ -651,8 +877,12 @@ fn track_slots_survive_deletion_and_fill_without_scrambling_other_pads() {
 }
 
 #[test]
-fn sections_and_track_mutes_remember_independent_banks() {
-    let tracks = project_tracks(18);
+fn each_perform_mode_remembers_its_own_bank() {
+    let mut tracks = project_tracks(18);
+    for track in &mut tracks {
+        track.kind = vibez_core::midi::TrackKind::Midi;
+        track.has_instrument = true;
+    }
     let mut state = PerformState::default();
     Arc::make_mut(&mut state.sections).insert(Section::new(0));
     Arc::make_mut(&mut state.sections).insert(Section::new(16));
@@ -675,6 +905,14 @@ fn sections_and_track_mutes_remember_independent_banks() {
     assert_eq!(state.banks.track_mutes, 1);
 
     state.update(
+        PerformMsg::SelectMode(PerformMode::Instrument),
+        &mut engine,
+        ctx,
+    );
+    state.update(PerformMsg::NextBank, &mut engine, ctx);
+    assert_eq!(state.banks.instrument, 1);
+
+    state.update(
         PerformMsg::SelectMode(PerformMode::Sections),
         &mut engine,
         ctx,
@@ -682,6 +920,7 @@ fn sections_and_track_mutes_remember_independent_banks() {
     state.update(PerformMsg::PreviousBank, &mut engine, ctx);
     assert_eq!(state.banks.sections, 0);
     assert_eq!(state.banks.track_mutes, 1);
+    assert_eq!(state.banks.instrument, 1);
     assert!(engine.0.is_empty(), "bank changes never touch playback");
 }
 

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -235,6 +235,10 @@ pub struct ProjectTrack {
 pub type UiTrack = ProjectTrack;
 
 impl ProjectTrack {
+    pub fn is_playable_midi_target(&self) -> bool {
+        self.kind.is_midi() && self.has_instrument
+    }
+
     pub fn new(id: TrackId, name: String, color_index: u8) -> Self {
         Self {
             id,

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 pub struct UiSettings {
     #[serde(default)]
     pub perform_input_mapping: crate::domains::perform::PerformInputMapping,
+    #[serde(default = "default_fixed_computer_velocity")]
+    pub fixed_computer_velocity: u8,
     #[serde(default)]
     pub sample_library_roots: Vec<PathBuf>,
     #[serde(default = "default_sample_browser_open")]
@@ -55,6 +57,7 @@ impl Default for UiSettings {
     fn default() -> Self {
         Self {
             perform_input_mapping: crate::domains::perform::PerformInputMapping::default(),
+            fixed_computer_velocity: default_fixed_computer_velocity(),
             sample_library_roots: Vec::new(),
             sample_browser_open: default_sample_browser_open(),
             sample_browser_width: default_sample_browser_width(),
@@ -102,6 +105,10 @@ impl UiSettings {
 
 fn default_sample_browser_open() -> bool {
     true
+}
+
+const fn default_fixed_computer_velocity() -> u8 {
+    100
 }
 
 fn default_media_cache_budget_bytes() -> u64 {
@@ -292,6 +299,20 @@ mod tests {
             loaded.input_mapping_key(PadPosition::ALL[0]),
             ComputerKey::Y
         );
+    }
+
+    #[test]
+    fn fixed_computer_velocity_defaults_and_roundtrips_globally() {
+        let old: UiSettings = serde_json::from_str("{}").unwrap();
+        assert_eq!(old.fixed_computer_velocity, 100);
+
+        let settings = UiSettings {
+            fixed_computer_velocity: 73,
+            ..UiSettings::default()
+        };
+        let loaded: UiSettings =
+            serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
+        assert_eq!(loaded.fixed_computer_velocity, 73);
     }
 
     #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,6 +138,8 @@ Each held key remembers its original Track and pitch so target changes, mode
 changes, and Section transitions cannot redirect its note-off. The Shift target
 overlay and on-screen selector update the same selection used by the Section
 overview, while per-mode target banks remain runtime interaction state.
+Window focus loss drains all held computer keys through matching note-offs and
+clears the Shift overlay so OS-level focus changes cannot leave a note sounding.
 Widget-captured presses are not forwarded, so text fields suppress pad input.
 The mapping and fixed computer-key velocity (default 100) persist in the user's
 `ui.json` settings and are absent from the project document and undo snapshots.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,11 +130,17 @@ computer-key adapter maps physical key codes through the global
 `PerformInputMapping`, suppresses auto-repeat, pairs releases with the original
 press, and emits a timestamped `PadGesture` containing Pad Position, state,
 optional velocity, and source identity. The domain consumes the gesture
-synchronously to mirror pressed state in the Pad Surface; later musical slices
-consume the same gesture action without deriving input from rendered state or
-the 60 fps engine-event pump. Widget-captured presses are not forwarded, so
-text fields suppress pad input. The mapping persists in the user's `ui.json`
-settings and is absent from the project document and undo snapshots.
+synchronously to mirror pressed state in the Pad Surface. Instrument mode also
+resolves the project-wide selected Track through the playable MIDI Project
+Track filter and sends paired live note commands through `EngineHandle`,
+without deriving input from rendered state or the 60 fps engine-event pump.
+Each held key remembers its original Track and pitch so target changes, mode
+changes, and Section transitions cannot redirect its note-off. The Shift target
+overlay and on-screen selector update the same selection used by the Section
+overview, while per-mode target banks remain runtime interaction state.
+Widget-captured presses are not forwarded, so text fields suppress pad input.
+The mapping and fixed computer-key velocity (default 100) persist in the user's
+`ui.json` settings and are absent from the project document and undo snapshots.
 
 Track mute commands become authoritative when the audio callback drains them.
 The engine emits `EngineEvent::TrackMuteChanged` with the effective state and


### PR DESCRIPTION
## Summary

- play Perform Instrument pads directly through the engine command path with paired note-on/off state
- share the project-wide selected playable MIDI track between the Shift target overlay, on-screen picker, Section editor, and unmatched MIDI input
- add independent Instrument banking, bottom-left pitch/target order, and globally persisted fixed computer-key velocity
- keep held notes paired across target changes, mode changes, and queued Section transitions

## Verification

- full workspace test suite passed (UI 292 tests; engine 151 tests; remaining crates and doc tests passed)
- workspace Clippy passed with `-D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/dev...HEAD`
- exact-head isolated Xvfb/null-sink dogfood recorded under `/home/alexander/Code/Apps/vibez-targets/card-12/card12-dogfood/evidence`
  - built-in Subtractive Synth, Dexed VST3, and Surge XT VST3 all produced non-silent pad audio
  - Shift retargeting and the on-screen target picker both exercised
  - velocity changed from 100 to 64 immediately and remained 64 after a full app restart
  - Section 02 launched at sample 85,355 while Bass C2 remained held across the queued one-bar transition, then released to digital silence without a stuck note

## Scope

- Card 12 only; Cards 13, 14, and 28 remain out of scope
- no merge requested
