### PR TITLE
Perform Card 13: add Full Level and 16 Levels

### DIFF
--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -120,7 +120,10 @@ impl App {
         }
         if let Some(track_id) = action.select_project_track {
             self.state.arrangement.selected_track = Some(track_id);
-            self.state.perform.sync_instrument_target(Some(track_id));
+            self.state.perform.sync_instrument_target_from_selection(
+                Some(track_id),
+                &self.state.project_tracks.tracks,
+            );
             if self.state.perform.selected_section.is_some() {
                 self.state
                     .perform

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -120,6 +120,7 @@ impl App {
         }
         if let Some(track_id) = action.select_project_track {
             self.state.arrangement.selected_track = Some(track_id);
+            self.state.perform.sync_instrument_target(Some(track_id));
             if self.state.perform.selected_section.is_some() {
                 self.state
                     .perform

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -160,6 +160,7 @@ mod views_devices;
 mod views_mixer;
 mod views_overlays;
 mod views_perform;
+mod views_perform_instrument;
 mod views_perform_pads;
 mod views_perform_playhead;
 mod views_perform_sections;

--- a/crates/vibez-ui/src/app/update_timeline.rs
+++ b/crates/vibez-ui/src/app/update_timeline.rs
@@ -62,7 +62,10 @@ impl App {
                     .section_editor
                     .editor_mut()
                     .selected_track = Some(*track_id);
-                self.state.perform.sync_instrument_target(Some(*track_id));
+                self.state.perform.sync_instrument_target_from_selection(
+                    Some(*track_id),
+                    &self.state.project_tracks.tracks,
+                );
                 return ArrangementAction::default();
             }
         }
@@ -83,9 +86,10 @@ impl App {
             if let Some(track_id) = self.state.perform.section_editor.editor().selected_track {
                 self.state.arrangement.selected_track = Some(track_id);
             }
-            self.state
-                .perform
-                .sync_instrument_target(self.state.arrangement.selected_track);
+            self.state.perform.sync_instrument_target_from_selection(
+                self.state.arrangement.selected_track,
+                &self.state.project_tracks.tracks,
+            );
             action
         } else {
             let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
@@ -95,9 +99,10 @@ impl App {
                 &mut engine,
                 ctx,
             );
-            self.state
-                .perform
-                .sync_instrument_target(self.state.arrangement.selected_track);
+            self.state.perform.sync_instrument_target_from_selection(
+                self.state.arrangement.selected_track,
+                &self.state.project_tracks.tracks,
+            );
             action
         }
     }

--- a/crates/vibez-ui/src/app/update_timeline.rs
+++ b/crates/vibez-ui/src/app/update_timeline.rs
@@ -62,6 +62,7 @@ impl App {
                     .section_editor
                     .editor_mut()
                     .selected_track = Some(*track_id);
+                self.state.perform.sync_instrument_target(Some(*track_id));
                 return ArrangementAction::default();
             }
         }
@@ -82,15 +83,22 @@ impl App {
             if let Some(track_id) = self.state.perform.section_editor.editor().selected_track {
                 self.state.arrangement.selected_track = Some(track_id);
             }
+            self.state
+                .perform
+                .sync_instrument_target(self.state.arrangement.selected_track);
             action
         } else {
             let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
-            self.state.arrangement.update(
+            let action = self.state.arrangement.update(
                 Arc::make_mut(&mut self.state.project_tracks),
                 msg,
                 &mut engine,
                 ctx,
-            )
+            );
+            self.state
+                .perform
+                .sync_instrument_target(self.state.arrangement.selected_track);
+            action
         }
     }
 

--- a/crates/vibez-ui/src/app/views_perform_instrument.rs
+++ b/crates/vibez-ui/src/app/views_perform_instrument.rs
@@ -1,0 +1,409 @@
+//! Instrument-mode controls for the Perform pad surface.
+
+use iced::widget::{
+    button, column, container, horizontal_space, pick_list, row, slider, text, vertical_space,
+};
+use iced::{Element, Length, Theme};
+
+use vibez_core::id::TrackId;
+
+use crate::domains::perform::{PerformMsg, SixteenLevelsParameter};
+use crate::message::Message;
+use crate::theme as th;
+use crate::typography::{PERFORM_LABEL, PERFORM_TECH, PERFORM_TECH_STRONG};
+
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InstrumentTargetOption {
+    track_id: TrackId,
+    label: String,
+}
+
+impl std::fmt::Display for InstrumentTargetOption {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.label)
+    }
+}
+
+fn rail_button(
+    label: &'static str,
+    state: String,
+    active: bool,
+    enabled: bool,
+    message: PerformMsg,
+) -> Element<'static, Message> {
+    let foreground = if !enabled {
+        th::text_muted()
+    } else if active {
+        th::accent()
+    } else {
+        th::text_dim()
+    };
+    let content = container(
+        column![
+            text(label).font(PERFORM_LABEL).size(8).color(foreground),
+            text(state)
+                .font(PERFORM_TECH_STRONG)
+                .size(8)
+                .color(foreground),
+        ]
+        .spacing(5),
+    )
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .align_x(iced::alignment::Horizontal::Left)
+    .align_y(iced::alignment::Vertical::Center);
+    let control = button(content)
+        .width(Length::FillPortion(1))
+        .height(Length::Fixed(50.0))
+        .padding([0, 8])
+        .style(move |_theme: &Theme, status| {
+            let engaged = matches!(status, button::Status::Hovered | button::Status::Pressed);
+            button::Style {
+                background: Some(
+                    if !enabled {
+                        th::bg_dark()
+                    } else if active {
+                        th::perform_active_surface()
+                    } else if engaged {
+                        th::bg_hover()
+                    } else {
+                        th::bg_surface()
+                    }
+                    .into(),
+                ),
+                text_color: foreground,
+                border: iced::Border {
+                    color: if active && enabled {
+                        th::accent_dim()
+                    } else {
+                        th::border()
+                    },
+                    width: 1.0,
+                    radius: 2.0.into(),
+                },
+                ..Default::default()
+            }
+        });
+    if enabled {
+        control.on_press(Message::Perform(message)).into()
+    } else {
+        control.into()
+    }
+}
+
+fn range_control<'a>(
+    label: String,
+    range: std::ops::RangeInclusive<i16>,
+    value: i16,
+    on_change: impl Fn(i16) -> Message + 'a,
+) -> Element<'a, Message> {
+    column![
+        text(label).font(PERFORM_TECH).size(8).color(th::text_dim()),
+        slider(range, value, on_change).step(1_i16),
+    ]
+    .spacing(3)
+    .into()
+}
+
+fn navigation_button(label: &'static str, message: PerformMsg) -> Element<'static, Message> {
+    button(
+        container(
+            text(label)
+                .font(PERFORM_TECH_STRONG)
+                .size(12)
+                .color(th::text_dim()),
+        )
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .align_x(iced::alignment::Horizontal::Center)
+        .align_y(iced::alignment::Vertical::Center),
+    )
+    .on_press(Message::Perform(message))
+    .width(Length::Fixed(25.0))
+    .height(Length::Fixed(22.0))
+    .padding(0)
+    .style(|_theme: &Theme, status| {
+        let engaged = matches!(status, button::Status::Hovered | button::Status::Pressed);
+        button::Style {
+            background: Some(
+                if engaged {
+                    th::bg_hover()
+                } else {
+                    th::bg_surface()
+                }
+                .into(),
+            ),
+            text_color: if engaged {
+                th::accent()
+            } else {
+                th::text_dim()
+            },
+            border: iced::Border {
+                color: if engaged {
+                    th::accent_dim()
+                } else {
+                    th::border()
+                },
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            ..Default::default()
+        }
+    })
+    .into()
+}
+
+impl App {
+    pub(super) fn view_instrument_control_rail(
+        &self,
+        bank: u8,
+        height: f32,
+    ) -> iced::widget::Container<'_, Message> {
+        let targets: Vec<_> = self
+            .state
+            .project_tracks
+            .tracks
+            .iter()
+            .filter(|track| track.is_playable_midi_target())
+            .map(|track| InstrumentTargetOption {
+                track_id: track.id,
+                label: track.name.clone(),
+            })
+            .collect();
+        let selected = self.state.perform.instrument_target().and_then(|selected| {
+            targets
+                .iter()
+                .find(|target| target.track_id == selected)
+                .cloned()
+        });
+        let selector = pick_list(targets, selected, |target| {
+            Message::Perform(PerformMsg::SelectInstrumentTarget(target.track_id))
+        })
+        .placeholder("CHOOSE MIDI TARGET")
+        .width(Length::Fill)
+        .padding([5, 7])
+        .text_size(9)
+        .style(|_theme: &Theme, status| {
+            let engaged = matches!(
+                status,
+                pick_list::Status::Hovered | pick_list::Status::Opened
+            );
+            pick_list::Style {
+                text_color: th::text(),
+                placeholder_color: th::text_dim(),
+                handle_color: if engaged {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                },
+                background: th::perform_pad_lowlight().into(),
+                border: iced::Border {
+                    color: if engaged {
+                        th::accent_dim()
+                    } else {
+                        th::border_light()
+                    },
+                    width: 1.0,
+                    radius: 2.0.into(),
+                },
+            }
+        })
+        .menu_style(|_theme: &Theme| iced::widget::overlay::menu::Style {
+            background: th::bg_elevated().into(),
+            border: iced::Border {
+                color: th::border_light(),
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            text_color: th::text(),
+            selected_text_color: th::accent(),
+            selected_background: th::bg_hover().into(),
+        });
+
+        let target_overlay = self.state.perform.instrument_target_overlay;
+        let range_or_bank = if target_overlay {
+            format!("TARGET BANK {bank}")
+        } else {
+            format!("OCTAVE {:+}", self.state.perform.instrument_octave())
+        };
+        let previous_hint = if target_overlay {
+            "TARGET ‹"
+        } else {
+            "OCTAVE ‹"
+        };
+        let next_hint = if target_overlay {
+            "TARGET ›"
+        } else {
+            "OCTAVE ›"
+        };
+        let navigation = row![
+            text(range_or_bank)
+                .font(PERFORM_TECH_STRONG)
+                .size(8)
+                .color(th::text_dim()),
+            horizontal_space(),
+            navigation_button("‹", PerformMsg::PreviousBank),
+            navigation_button("›", PerformMsg::NextBank),
+        ]
+        .spacing(4)
+        .align_y(iced::Alignment::Center);
+
+        let full_level_enabled = self.state.perform.full_level_enabled();
+        let full_level_available = self.state.perform.full_level_available();
+        let levels_enabled = self.state.perform.sixteen_levels_enabled();
+        let parameter = self.state.perform.sixteen_levels_parameter();
+        let range = self.state.perform.sixteen_levels_range();
+        let bounds = self.state.perform.sixteen_levels_bounds();
+        let choosing_source = self.state.perform.choosing_sixteen_levels_source();
+        let source = self
+            .state
+            .perform
+            .sixteen_levels_source_pitch()
+            .map(crate::widgets::piano_roll::pitch_name);
+        let toggles = row![
+            rail_button(
+                "FULL LEVEL",
+                if !full_level_available {
+                    "UNAVAILABLE"
+                } else if full_level_enabled {
+                    "VELOCITY 127"
+                } else {
+                    "OFF"
+                }
+                .into(),
+                full_level_enabled && full_level_available,
+                full_level_available,
+                PerformMsg::ToggleFullLevel,
+            ),
+            rail_button(
+                "16 LEVELS",
+                if choosing_source {
+                    "CHOOSE SOURCE".into()
+                } else if levels_enabled {
+                    parameter.to_string().to_uppercase()
+                } else {
+                    "OFF".into()
+                },
+                levels_enabled,
+                true,
+                PerformMsg::ToggleSixteenLevels,
+            ),
+        ]
+        .spacing(5);
+
+        let assignment = pick_list(
+            SixteenLevelsParameter::ALL.to_vec(),
+            Some(parameter),
+            |parameter| Message::Perform(PerformMsg::SelectSixteenLevelsParameter(parameter)),
+        )
+        .width(Length::Fill)
+        .padding([4, 7])
+        .text_size(9)
+        .style(|_theme: &Theme, status| {
+            let engaged = matches!(
+                status,
+                pick_list::Status::Hovered | pick_list::Status::Opened
+            );
+            pick_list::Style {
+                text_color: th::text(),
+                placeholder_color: th::text_dim(),
+                handle_color: if engaged {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                },
+                background: th::perform_pad_lowlight().into(),
+                border: iced::Border {
+                    color: if engaged {
+                        th::accent_dim()
+                    } else {
+                        th::border()
+                    },
+                    width: 1.0,
+                    radius: 2.0.into(),
+                },
+            }
+        })
+        .menu_style(|_theme: &Theme| iced::widget::overlay::menu::Style {
+            background: th::bg_elevated().into(),
+            border: iced::Border {
+                color: th::border_light(),
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            text_color: th::text(),
+            selected_text_color: th::accent(),
+            selected_background: th::bg_hover().into(),
+        });
+        let source_state = if choosing_source {
+            "PRESS A PAD".to_string()
+        } else if let Some(source) = source {
+            source
+        } else {
+            "PLAY A PAD".to_string()
+        };
+        let source_control = rail_button(
+            "SOURCE",
+            source_state,
+            choosing_source,
+            levels_enabled,
+            PerformMsg::ChooseSixteenLevelsSource,
+        );
+        let range_units = match parameter {
+            SixteenLevelsParameter::Pitch => "ST",
+            SixteenLevelsParameter::Velocity => "VEL",
+        };
+
+        container(
+            column![
+                text("INSTRUMENT TARGET")
+                    .font(PERFORM_LABEL)
+                    .size(8)
+                    .color(th::text_muted()),
+                selector,
+                navigation,
+                toggles,
+                column![
+                    text("16 LEVEL ASSIGNMENT")
+                        .font(PERFORM_LABEL)
+                        .size(8)
+                        .color(th::text_muted()),
+                    assignment,
+                ]
+                .spacing(3),
+                source_control,
+                range_control(
+                    format!("MIN {} {range_units}", range.minimum),
+                    bounds.minimum..=range.maximum,
+                    range.minimum,
+                    |value| Message::Perform(PerformMsg::SetSixteenLevelsMinimum(value)),
+                ),
+                range_control(
+                    format!("MAX {} {range_units}", range.maximum),
+                    range.minimum..=bounds.maximum,
+                    range.maximum,
+                    |value| Message::Perform(PerformMsg::SetSixteenLevelsMaximum(value)),
+                ),
+                vertical_space().height(Length::Fill),
+                text(format!("{previous_hint}  ·  {next_hint}"))
+                    .font(PERFORM_TECH)
+                    .size(7)
+                    .color(th::text_muted()),
+            ]
+            .spacing(7),
+        )
+        .height(Length::Fixed(height))
+        .padding(8)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_dark().into()),
+            border: iced::Border {
+                color: th::border(),
+                width: 1.0,
+                radius: 0.0.into(),
+            },
+            ..Default::default()
+        })
+    }
+}

--- a/crates/vibez-ui/src/app/views_perform_pads.rs
+++ b/crates/vibez-ui/src/app/views_perform_pads.rs
@@ -1,12 +1,14 @@
 //! Pad Surface rendering for the Perform workspace.
 
 use iced::widget::{
-    button, center, column, container, horizontal_space, mouse_area, pick_list, row, stack, text,
-    tooltip,
+    button, center, column, container, horizontal_space, mouse_area, pick_list, row, slider, stack,
+    text, tooltip,
 };
 use iced::{Element, Length, Shadow, Theme, Vector};
 
-use crate::domains::perform::{PadPosition, PerformEditorFocus, PerformMode, PerformMsg};
+use crate::domains::perform::{
+    PadPosition, PerformEditorFocus, PerformMode, PerformMsg, SixteenLevelsParameter,
+};
 use crate::icons;
 use crate::message::Message;
 use crate::theme as th;
@@ -97,7 +99,234 @@ fn perform_bank_button(
         .into()
 }
 
+fn instrument_toggle(
+    label: &'static str,
+    active: bool,
+    enabled: bool,
+    message: PerformMsg,
+) -> Element<'static, Message> {
+    let content = center(text(label).font(PERFORM_LABEL).size(9).color(if enabled {
+        if active {
+            th::accent()
+        } else {
+            th::text_dim()
+        }
+    } else {
+        th::text_muted()
+    }))
+    .width(Length::Fill)
+    .height(Length::Fill);
+    let control = button(content)
+        .width(Length::FillPortion(1))
+        .height(Length::Fixed(27.0))
+        .padding(0)
+        .style(move |_theme: &Theme, status| {
+            let engaged = matches!(status, button::Status::Hovered | button::Status::Pressed);
+            button::Style {
+                background: Some(
+                    if !enabled {
+                        th::bg_dark()
+                    } else if active {
+                        th::perform_active_surface()
+                    } else if engaged {
+                        th::bg_hover()
+                    } else {
+                        th::bg_surface()
+                    }
+                    .into(),
+                ),
+                text_color: if active && enabled {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                },
+                border: iced::Border {
+                    color: if active && enabled {
+                        th::accent_dim()
+                    } else {
+                        th::border()
+                    },
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                ..Default::default()
+            }
+        });
+    if enabled {
+        control.on_press(Message::Perform(message)).into()
+    } else {
+        control.into()
+    }
+}
+
 impl App {
+    fn view_instrument_controls(&self) -> Element<'_, Message> {
+        let full_level_enabled = self.state.perform.full_level_enabled();
+        let full_level_available = self.state.perform.full_level_available();
+        let levels_enabled = self.state.perform.sixteen_levels_enabled();
+        let parameter = self.state.perform.sixteen_levels_parameter();
+        let range = self.state.perform.sixteen_levels_range();
+        let bounds = self.state.perform.sixteen_levels_bounds();
+        let choosing_source = self.state.perform.choosing_sixteen_levels_source();
+        let source = self
+            .state
+            .perform
+            .sixteen_levels_source_pitch()
+            .map(crate::widgets::piano_roll::pitch_name);
+
+        let toggles = row![
+            instrument_toggle(
+                "FULL LEVEL",
+                full_level_enabled && full_level_available,
+                full_level_available,
+                PerformMsg::ToggleFullLevel,
+            ),
+            instrument_toggle(
+                "16 LEVELS",
+                levels_enabled,
+                true,
+                PerformMsg::ToggleSixteenLevels,
+            ),
+        ]
+        .spacing(5);
+
+        let assignment = pick_list(
+            SixteenLevelsParameter::ALL.to_vec(),
+            Some(parameter),
+            |parameter| Message::Perform(PerformMsg::SelectSixteenLevelsParameter(parameter)),
+        )
+        .width(Length::FillPortion(1))
+        .padding([4, 7])
+        .text_size(9)
+        .style(|_theme: &Theme, status| {
+            let engaged = matches!(
+                status,
+                pick_list::Status::Hovered | pick_list::Status::Opened
+            );
+            pick_list::Style {
+                text_color: th::text(),
+                placeholder_color: th::text_dim(),
+                handle_color: if engaged {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                },
+                background: th::perform_pad_lowlight().into(),
+                border: iced::Border {
+                    color: if engaged {
+                        th::accent_dim()
+                    } else {
+                        th::border()
+                    },
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+            }
+        });
+        let source_label = if choosing_source {
+            "CHOOSE SOURCE · PRESS PAD".to_string()
+        } else if let Some(source) = source {
+            format!("SOURCE · {source}")
+        } else {
+            "SOURCE · PLAY A PAD".to_string()
+        };
+        let source_button = button(
+            center(text(source_label).font(PERFORM_TECH_STRONG).size(8).color(
+                if choosing_source {
+                    th::accent()
+                } else {
+                    th::text_dim()
+                },
+            ))
+            .width(Length::Fill)
+            .height(Length::Fill),
+        )
+        .width(Length::FillPortion(2))
+        .height(Length::Fixed(27.0))
+        .padding(0)
+        .style(move |_theme: &Theme, status| button::Style {
+            background: Some(
+                if choosing_source {
+                    th::perform_active_surface()
+                } else if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                    th::bg_hover()
+                } else {
+                    th::bg_surface()
+                }
+                .into(),
+            ),
+            text_color: th::text_dim(),
+            border: iced::Border {
+                color: if choosing_source {
+                    th::accent_dim()
+                } else {
+                    th::border()
+                },
+                width: 1.0,
+                radius: 3.0.into(),
+            },
+            ..Default::default()
+        });
+        let source_button: Element<'_, Message> = if levels_enabled {
+            source_button
+                .on_press(Message::Perform(PerformMsg::ChooseSixteenLevelsSource))
+                .into()
+        } else {
+            source_button.into()
+        };
+
+        let range_units = match parameter {
+            SixteenLevelsParameter::Pitch => "ST",
+            SixteenLevelsParameter::Velocity => "VEL",
+        };
+        let minimum = row![
+            text(format!("MIN {} {range_units}", range.minimum))
+                .font(PERFORM_TECH)
+                .size(8)
+                .color(th::text_dim()),
+            slider(bounds.minimum..=range.maximum, range.minimum, |value| {
+                Message::Perform(PerformMsg::SetSixteenLevelsMinimum(value))
+            })
+            .step(1_i16),
+        ]
+        .spacing(6)
+        .align_y(iced::Alignment::Center)
+        .width(Length::FillPortion(1));
+        let maximum = row![
+            text(format!("MAX {} {range_units}", range.maximum))
+                .font(PERFORM_TECH)
+                .size(8)
+                .color(th::text_dim()),
+            slider(range.minimum..=bounds.maximum, range.maximum, |value| {
+                Message::Perform(PerformMsg::SetSixteenLevelsMaximum(value))
+            })
+            .step(1_i16),
+        ]
+        .spacing(6)
+        .align_y(iced::Alignment::Center)
+        .width(Length::FillPortion(1));
+
+        container(
+            column![
+                toggles,
+                row![assignment, source_button].spacing(5),
+                row![minimum, maximum].spacing(10)
+            ]
+            .spacing(5),
+        )
+        .padding([6, 7])
+        .style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_dark().into()),
+            border: iced::Border {
+                color: th::border(),
+                width: 1.0,
+                radius: 4.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
+    }
+
     pub(super) fn view_pad_surface(&self, surface_width: f32) -> Element<'_, Message> {
         let mode = self.state.perform.mode;
         let heading = column![
@@ -201,6 +430,16 @@ impl App {
             let target_overlay = self.state.perform.instrument_target_overlay;
             let range_or_bank = if target_overlay {
                 format!("TARGET BANK {bank}")
+            } else if self.state.perform.choosing_sixteen_levels_source() {
+                "16 LEVELS · CHOOSE SOURCE".to_string()
+            } else if self.state.perform.sixteen_levels_enabled() {
+                let range = self.state.perform.sixteen_levels_range();
+                format!(
+                    "16 LEVELS · {} {}–{}",
+                    self.state.perform.sixteen_levels_parameter(),
+                    range.minimum,
+                    range.maximum
+                )
             } else {
                 let low = crate::widgets::piano_roll::pitch_name(
                     self.state.perform.instrument_pitch(PadPosition::ALL[12]),
@@ -266,7 +505,13 @@ impl App {
                 .into()
         };
 
-        let pad_grid_height = perform_pad_grid_height(self.state.view.window_height);
+        let pad_grid_height = (perform_pad_grid_height(self.state.view.window_height)
+            - if mode == PerformMode::Instrument {
+                82.0
+            } else {
+                0.0
+            })
+        .max(200.0);
         let mut grid = column![]
             .width(Length::Fill)
             .height(Length::Fixed(pad_grid_height))
@@ -289,7 +534,12 @@ impl App {
             .width(Length::Fill)
             .height(Length::Fixed(pad_grid_height));
 
-        let surface = container(column![header, grid].spacing(12))
+        let content = if mode == PerformMode::Instrument {
+            column![header, self.view_instrument_controls(), grid].spacing(8)
+        } else {
+            column![header, grid].spacing(12)
+        };
+        let surface = container(content)
             .width(Length::Fixed(surface_width))
             .height(Length::Fill)
             .padding(14)
@@ -436,12 +686,25 @@ impl App {
                 }
             }
             PerformMode::Instrument => {
-                let pitch = self.state.perform.instrument_pitch(position);
+                let preview = self.state.perform.instrument_pad_preview(position);
+                let choosing_source = self.state.perform.choosing_sixteen_levels_source();
+                let levels_enabled = self.state.perform.sixteen_levels_enabled();
+                let parameter = self.state.perform.sixteen_levels_parameter();
+                let target = selected_instrument
+                    .map(|track| track.name.clone())
+                    .unwrap_or_else(|| "NO INSTRUMENT TARGET".to_string());
+                let detail = if choosing_source {
+                    format!("CHOOSE SOURCE · {target}")
+                } else if levels_enabled && parameter == SixteenLevelsParameter::Velocity {
+                    format!("VELOCITY {} · {target}", preview.velocity)
+                } else if levels_enabled {
+                    format!("PITCH LEVEL · {target}")
+                } else {
+                    target
+                };
                 (
-                    crate::widgets::piano_roll::pitch_name(pitch),
-                    selected_instrument
-                        .map(|track| track.name.clone())
-                        .unwrap_or_else(|| "NO INSTRUMENT TARGET".to_string()),
+                    crate::widgets::piano_roll::pitch_name(preview.pitch),
+                    detail,
                     selected_instrument
                         .map(|track| th::track_color(track.color_index))
                         .unwrap_or_else(|| th::track_color((ordinal - 1) as u8)),

--- a/crates/vibez-ui/src/app/views_perform_pads.rs
+++ b/crates/vibez-ui/src/app/views_perform_pads.rs
@@ -1,11 +1,12 @@
 //! Pad Surface rendering for the Perform workspace.
 
 use iced::widget::{
-    button, center, column, container, horizontal_space, mouse_area, pick_list, row, slider, stack,
-    text, tooltip,
+    button, center, column, container, horizontal_space, mouse_area, row, stack, text, tooltip,
 };
 use iced::{Element, Length, Shadow, Theme, Vector};
 
+use super::views_perform::{perform_pad_grid_height, perform_tool_button};
+use super::*;
 use crate::domains::perform::{
     PadPosition, PerformEditorFocus, PerformMode, PerformMsg, SixteenLevelsParameter,
 };
@@ -13,22 +14,6 @@ use crate::icons;
 use crate::message::Message;
 use crate::theme as th;
 use crate::typography::{PERFORM_DISPLAY, PERFORM_LABEL, PERFORM_TECH, PERFORM_TECH_STRONG};
-use vibez_core::id::TrackId;
-
-use super::views_perform::{perform_pad_grid_height, perform_tool_button};
-use super::*;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct InstrumentTargetOption {
-    track_id: TrackId,
-    label: String,
-}
-
-impl std::fmt::Display for InstrumentTargetOption {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(&self.label)
-    }
-}
 
 fn perform_bank_button(
     label: &'static str,
@@ -99,234 +84,7 @@ fn perform_bank_button(
         .into()
 }
 
-fn instrument_toggle(
-    label: &'static str,
-    active: bool,
-    enabled: bool,
-    message: PerformMsg,
-) -> Element<'static, Message> {
-    let content = center(text(label).font(PERFORM_LABEL).size(9).color(if enabled {
-        if active {
-            th::accent()
-        } else {
-            th::text_dim()
-        }
-    } else {
-        th::text_muted()
-    }))
-    .width(Length::Fill)
-    .height(Length::Fill);
-    let control = button(content)
-        .width(Length::FillPortion(1))
-        .height(Length::Fixed(27.0))
-        .padding(0)
-        .style(move |_theme: &Theme, status| {
-            let engaged = matches!(status, button::Status::Hovered | button::Status::Pressed);
-            button::Style {
-                background: Some(
-                    if !enabled {
-                        th::bg_dark()
-                    } else if active {
-                        th::perform_active_surface()
-                    } else if engaged {
-                        th::bg_hover()
-                    } else {
-                        th::bg_surface()
-                    }
-                    .into(),
-                ),
-                text_color: if active && enabled {
-                    th::accent()
-                } else {
-                    th::text_dim()
-                },
-                border: iced::Border {
-                    color: if active && enabled {
-                        th::accent_dim()
-                    } else {
-                        th::border()
-                    },
-                    width: 1.0,
-                    radius: 3.0.into(),
-                },
-                ..Default::default()
-            }
-        });
-    if enabled {
-        control.on_press(Message::Perform(message)).into()
-    } else {
-        control.into()
-    }
-}
-
 impl App {
-    fn view_instrument_controls(&self) -> Element<'_, Message> {
-        let full_level_enabled = self.state.perform.full_level_enabled();
-        let full_level_available = self.state.perform.full_level_available();
-        let levels_enabled = self.state.perform.sixteen_levels_enabled();
-        let parameter = self.state.perform.sixteen_levels_parameter();
-        let range = self.state.perform.sixteen_levels_range();
-        let bounds = self.state.perform.sixteen_levels_bounds();
-        let choosing_source = self.state.perform.choosing_sixteen_levels_source();
-        let source = self
-            .state
-            .perform
-            .sixteen_levels_source_pitch()
-            .map(crate::widgets::piano_roll::pitch_name);
-
-        let toggles = row![
-            instrument_toggle(
-                "FULL LEVEL",
-                full_level_enabled && full_level_available,
-                full_level_available,
-                PerformMsg::ToggleFullLevel,
-            ),
-            instrument_toggle(
-                "16 LEVELS",
-                levels_enabled,
-                true,
-                PerformMsg::ToggleSixteenLevels,
-            ),
-        ]
-        .spacing(5);
-
-        let assignment = pick_list(
-            SixteenLevelsParameter::ALL.to_vec(),
-            Some(parameter),
-            |parameter| Message::Perform(PerformMsg::SelectSixteenLevelsParameter(parameter)),
-        )
-        .width(Length::FillPortion(1))
-        .padding([4, 7])
-        .text_size(9)
-        .style(|_theme: &Theme, status| {
-            let engaged = matches!(
-                status,
-                pick_list::Status::Hovered | pick_list::Status::Opened
-            );
-            pick_list::Style {
-                text_color: th::text(),
-                placeholder_color: th::text_dim(),
-                handle_color: if engaged {
-                    th::accent()
-                } else {
-                    th::text_dim()
-                },
-                background: th::perform_pad_lowlight().into(),
-                border: iced::Border {
-                    color: if engaged {
-                        th::accent_dim()
-                    } else {
-                        th::border()
-                    },
-                    width: 1.0,
-                    radius: 3.0.into(),
-                },
-            }
-        });
-        let source_label = if choosing_source {
-            "CHOOSE SOURCE · PRESS PAD".to_string()
-        } else if let Some(source) = source {
-            format!("SOURCE · {source}")
-        } else {
-            "SOURCE · PLAY A PAD".to_string()
-        };
-        let source_button = button(
-            center(text(source_label).font(PERFORM_TECH_STRONG).size(8).color(
-                if choosing_source {
-                    th::accent()
-                } else {
-                    th::text_dim()
-                },
-            ))
-            .width(Length::Fill)
-            .height(Length::Fill),
-        )
-        .width(Length::FillPortion(2))
-        .height(Length::Fixed(27.0))
-        .padding(0)
-        .style(move |_theme: &Theme, status| button::Style {
-            background: Some(
-                if choosing_source {
-                    th::perform_active_surface()
-                } else if matches!(status, button::Status::Hovered | button::Status::Pressed) {
-                    th::bg_hover()
-                } else {
-                    th::bg_surface()
-                }
-                .into(),
-            ),
-            text_color: th::text_dim(),
-            border: iced::Border {
-                color: if choosing_source {
-                    th::accent_dim()
-                } else {
-                    th::border()
-                },
-                width: 1.0,
-                radius: 3.0.into(),
-            },
-            ..Default::default()
-        });
-        let source_button: Element<'_, Message> = if levels_enabled {
-            source_button
-                .on_press(Message::Perform(PerformMsg::ChooseSixteenLevelsSource))
-                .into()
-        } else {
-            source_button.into()
-        };
-
-        let range_units = match parameter {
-            SixteenLevelsParameter::Pitch => "ST",
-            SixteenLevelsParameter::Velocity => "VEL",
-        };
-        let minimum = row![
-            text(format!("MIN {} {range_units}", range.minimum))
-                .font(PERFORM_TECH)
-                .size(8)
-                .color(th::text_dim()),
-            slider(bounds.minimum..=range.maximum, range.minimum, |value| {
-                Message::Perform(PerformMsg::SetSixteenLevelsMinimum(value))
-            })
-            .step(1_i16),
-        ]
-        .spacing(6)
-        .align_y(iced::Alignment::Center)
-        .width(Length::FillPortion(1));
-        let maximum = row![
-            text(format!("MAX {} {range_units}", range.maximum))
-                .font(PERFORM_TECH)
-                .size(8)
-                .color(th::text_dim()),
-            slider(range.minimum..=bounds.maximum, range.maximum, |value| {
-                Message::Perform(PerformMsg::SetSixteenLevelsMaximum(value))
-            })
-            .step(1_i16),
-        ]
-        .spacing(6)
-        .align_y(iced::Alignment::Center)
-        .width(Length::FillPortion(1));
-
-        container(
-            column![
-                toggles,
-                row![assignment, source_button].spacing(5),
-                row![minimum, maximum].spacing(10)
-            ]
-            .spacing(5),
-        )
-        .padding([6, 7])
-        .style(|_theme: &Theme| container::Style {
-            background: Some(th::bg_dark().into()),
-            border: iced::Border {
-                color: th::border(),
-                width: 1.0,
-                radius: 4.0.into(),
-            },
-            ..Default::default()
-        })
-        .into()
-    }
-
     pub(super) fn view_pad_surface(&self, surface_width: f32) -> Element<'_, Message> {
         let mode = self.state.perform.mode;
         let heading = column![
@@ -367,124 +125,16 @@ impl App {
             ),
         };
         let header: Element<'_, Message> = if mode == PerformMode::Instrument {
-            let targets: Vec<_> = self
-                .state
-                .project_tracks
-                .tracks
-                .iter()
-                .filter(|track| track.is_playable_midi_target())
-                .map(|track| InstrumentTargetOption {
-                    track_id: track.id,
-                    label: track.name.clone(),
-                })
-                .collect();
-            let selected = self.state.arrangement.selected_track.and_then(|selected| {
-                targets
-                    .iter()
-                    .find(|target| target.track_id == selected)
-                    .cloned()
-            });
-            let selector = pick_list(targets, selected, |target| {
-                Message::Perform(PerformMsg::SelectInstrumentTarget(target.track_id))
-            })
-            .placeholder("CHOOSE PLAYABLE MIDI TARGET")
-            .width(Length::Fill)
-            .padding([5, 8])
-            .text_size(10)
-            .style(|_theme: &Theme, status| {
-                let engaged = matches!(
-                    status,
-                    pick_list::Status::Hovered | pick_list::Status::Opened
-                );
-                pick_list::Style {
-                    text_color: th::text(),
-                    placeholder_color: th::text_dim(),
-                    handle_color: if engaged {
-                        th::accent()
-                    } else {
-                        th::text_dim()
-                    },
-                    background: th::perform_pad_lowlight().into(),
-                    border: iced::Border {
-                        color: if engaged {
-                            th::accent_dim()
-                        } else {
-                            th::border_light()
-                        },
-                        width: 1.0,
-                        radius: 3.0.into(),
-                    },
-                }
-            })
-            .menu_style(|_theme: &Theme| iced::widget::overlay::menu::Style {
-                background: th::bg_elevated().into(),
-                border: iced::Border {
-                    color: th::border_light(),
-                    width: 1.0,
-                    radius: 3.0.into(),
-                },
-                text_color: th::text(),
-                selected_text_color: th::accent(),
-                selected_background: th::bg_hover().into(),
-            });
-            let target_overlay = self.state.perform.instrument_target_overlay;
-            let range_or_bank = if target_overlay {
-                format!("TARGET BANK {bank}")
-            } else if self.state.perform.choosing_sixteen_levels_source() {
-                "16 LEVELS · CHOOSE SOURCE".to_string()
-            } else if self.state.perform.sixteen_levels_enabled() {
-                let range = self.state.perform.sixteen_levels_range();
-                format!(
-                    "16 LEVELS · {} {}–{}",
-                    self.state.perform.sixteen_levels_parameter(),
-                    range.minimum,
-                    range.maximum
-                )
-            } else {
-                let low = crate::widgets::piano_roll::pitch_name(
-                    self.state.perform.instrument_pitch(PadPosition::ALL[12]),
-                );
-                let high = crate::widgets::piano_roll::pitch_name(
-                    self.state.perform.instrument_pitch(PadPosition::ALL[3]),
-                );
-                format!(
-                    "OCTAVE {:+} · {low}–{high}",
-                    self.state.perform.instrument_octave()
-                )
-            };
-            let previous_hint = if target_overlay {
-                "PREVIOUS TARGET BANK"
-            } else {
-                "OCTAVE DOWN  ["
-            };
-            let next_hint = if target_overlay {
-                "NEXT TARGET BANK"
-            } else {
-                "OCTAVE UP  ]"
-            };
-            let target_navigation = row![
-                text("INSTRUMENT TARGET")
-                    .font(PERFORM_LABEL)
-                    .size(8)
-                    .color(th::text_muted()),
+            row![
+                heading,
                 horizontal_space(),
-                text(range_or_bank)
-                    .font(PERFORM_TECH_STRONG)
-                    .size(8)
+                text("16 PAD INSTRUMENT · HOLD SHIFT FOR TARGETS")
+                    .font(PERFORM_TECH)
+                    .size(9)
                     .color(th::blend(th::text_dim(), th::text(), 0.24)),
-                perform_bank_button("‹", previous_hint, PerformMsg::PreviousBank),
-                perform_bank_button("›", next_hint, PerformMsg::NextBank),
             ]
-            .spacing(5)
-            .align_y(iced::Alignment::Center);
-            let target_panel = column![target_navigation, selector]
-                .spacing(4)
-                .width(Length::Fill);
-
-            row![heading, target_panel]
-                .spacing(20)
-                .align_y(iced::Alignment::End)
-                .into()
+            .align_y(iced::Alignment::End)
+            .into()
         } else {
             let bank_navigation = row![
                 text(format!("BANK {bank}"))
@@ -505,13 +155,7 @@ impl App {
                 .into()
         };
 
-        let pad_grid_height = (perform_pad_grid_height(self.state.view.window_height)
-            - if mode == PerformMode::Instrument {
-                82.0
-            } else {
-                0.0
-            })
-        .max(200.0);
+        let pad_grid_height = perform_pad_grid_height(self.state.view.window_height);
         let mut grid = column![]
             .width(Length::Fill)
             .height(Length::Fixed(pad_grid_height))
@@ -535,7 +179,17 @@ impl App {
             .height(Length::Fixed(pad_grid_height));
 
         let content = if mode == PerformMode::Instrument {
-            column![header, self.view_instrument_controls(), grid].spacing(8)
+            let rail_width = (surface_width * 0.3).clamp(154.0, 176.0);
+            column![
+                header,
+                row![
+                    grid,
+                    self.view_instrument_control_rail(bank, pad_grid_height)
+                        .width(Length::Fixed(rail_width))
+                ]
+                .spacing(10)
+            ]
+            .spacing(12)
         } else {
             column![header, grid].spacing(12)
         };
@@ -602,7 +256,7 @@ impl App {
                     .track_for_instrument_target_pad(position, &self.state.project_tracks.tracks)
             })
             .flatten();
-        let selected_instrument = self.state.arrangement.selected_track.and_then(|track_id| {
+        let selected_instrument = self.state.perform.instrument_target().and_then(|track_id| {
             self.state
                 .project_tracks
                 .tracks
@@ -611,7 +265,7 @@ impl App {
         });
         let selected = selected
             || instrument_target
-                .is_some_and(|track| self.state.arrangement.selected_track == Some(track.id));
+                .is_some_and(|track| self.state.perform.instrument_target() == Some(track.id));
         let (title, detail, color, muted) = match mode {
             PerformMode::Sections => match section {
                 Some(section) => (

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -14,7 +14,10 @@ use vibez_project::SectionLaunchQuantization;
 use super::EngineHandle;
 use crate::state::ProjectTrack;
 
+mod instrument;
 mod sections;
+pub use instrument::SixteenLevelsParameter;
+use instrument::{ActiveInstrumentNote, InstrumentPerformanceState};
 pub use sections::{Section, SectionStore, SectionTimelineEditor, TimelineContentLocation};
 
 /// The three Perform Modes exposed in V1. Macros stays absent until its
@@ -265,25 +268,6 @@ pub struct PadGesture {
     pub occurred_at: Instant,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ActiveInstrumentNote {
-    track_id: TrackId,
-    pitch: u8,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ComputerKeyVelocity(u8);
-
-const INSTRUMENT_BASE_PITCH: u8 = 35;
-const MIN_INSTRUMENT_OCTAVE: i8 = -3;
-const MAX_INSTRUMENT_OCTAVE: i8 = 6;
-
-impl Default for ComputerKeyVelocity {
-    fn default() -> Self {
-        Self(100)
-    }
-}
-
 /// Which part of Perform owns keyboard/editor focus. This remains runtime UI
 /// state and is deliberately not persisted in the project document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -314,8 +298,9 @@ impl PerformBanks {
 }
 
 /// Perform state combines project-owned Sections with runtime interaction.
-/// Input mapping, mode, banks, Instrument octave, focus, and edit buffers remain
-/// global/runtime; only the Section store enters project persistence and undo.
+/// Input mapping, mode, banks, live Instrument controls, focus, and edit buffers
+/// remain global/runtime; only the Section store enters project persistence and
+/// undo.
 #[derive(Default)]
 pub struct PerformState {
     pub mode: PerformMode,
@@ -325,8 +310,7 @@ pub struct PerformState {
     pub input_mapping: PerformInputMapping,
     pub key_rebind_target: Option<PadPosition>,
     pub instrument_target_overlay: bool,
-    instrument_octave: i8,
-    computer_key_velocity: ComputerKeyVelocity,
+    instrument: InstrumentPerformanceState,
     pub sections: Arc<SectionStore>,
     pub selected_section: Option<SectionId>,
     pub section_editor: SectionTimelineEditor,
@@ -375,6 +359,12 @@ pub enum PerformMsg {
     SetInstrumentTargetOverlay(bool),
     SelectInstrumentTarget(TrackId),
     SetFixedComputerVelocity(u8),
+    ToggleFullLevel,
+    ToggleSixteenLevels,
+    SelectSixteenLevelsParameter(SixteenLevelsParameter),
+    SetSixteenLevelsMinimum(i16),
+    SetSixteenLevelsMaximum(i16),
+    ChooseSixteenLevelsSource,
     ComputerKeyPressed {
         key: ComputerKey,
         key_id: String,
@@ -514,6 +504,7 @@ impl PerformState {
         ctx: PerformCtx<'_>,
     ) -> PerformAction {
         self.sync_track_mute_slots(ctx.project_tracks);
+        self.sync_instrument_target(ctx.selected_project_track);
         match msg {
             PerformMsg::SelectMode(mode) => {
                 if ctx.workspace_visible {
@@ -703,10 +694,7 @@ impl PerformState {
                             if self.instrument_target_overlay {
                                 self.banks.instrument = self.banks.instrument.saturating_sub(1);
                             } else {
-                                self.instrument_octave = self
-                                    .instrument_octave
-                                    .saturating_sub(1)
-                                    .max(MIN_INSTRUMENT_OCTAVE);
+                                self.shift_instrument_octave(-1);
                             }
                         }
                     }
@@ -749,10 +737,7 @@ impl PerformState {
                                 self.banks.instrument =
                                     self.banks.instrument.saturating_add(1).min(last_bank as u8);
                             } else {
-                                self.instrument_octave = self
-                                    .instrument_octave
-                                    .saturating_add(1)
-                                    .min(MAX_INSTRUMENT_OCTAVE);
+                                self.shift_instrument_octave(1);
                             }
                         }
                     }
@@ -778,6 +763,9 @@ impl PerformState {
                         .iter()
                         .any(|track| track.id == track_id && track.is_playable_midi_target())
                 {
+                    if ctx.selected_project_track != Some(track_id) {
+                        self.sync_instrument_target(Some(track_id));
+                    }
                     return PerformAction {
                         select_project_track: Some(track_id),
                         ..PerformAction::default()
@@ -785,11 +773,41 @@ impl PerformState {
                 }
             }
             PerformMsg::SetFixedComputerVelocity(velocity) => {
-                self.computer_key_velocity = ComputerKeyVelocity(velocity.clamp(1, 127));
+                self.set_fixed_computer_velocity(velocity);
                 return PerformAction {
                     persist_settings: true,
                     ..PerformAction::default()
                 };
+            }
+            PerformMsg::ToggleFullLevel => {
+                if ctx.workspace_visible && self.mode == PerformMode::Instrument {
+                    self.toggle_full_level();
+                }
+            }
+            PerformMsg::ToggleSixteenLevels => {
+                if ctx.workspace_visible && self.mode == PerformMode::Instrument {
+                    self.toggle_sixteen_levels();
+                }
+            }
+            PerformMsg::SelectSixteenLevelsParameter(parameter) => {
+                if ctx.workspace_visible && self.mode == PerformMode::Instrument {
+                    self.select_sixteen_levels_parameter(parameter);
+                }
+            }
+            PerformMsg::SetSixteenLevelsMinimum(minimum) => {
+                if ctx.workspace_visible && self.mode == PerformMode::Instrument {
+                    self.set_sixteen_levels_minimum(minimum);
+                }
+            }
+            PerformMsg::SetSixteenLevelsMaximum(maximum) => {
+                if ctx.workspace_visible && self.mode == PerformMode::Instrument {
+                    self.set_sixteen_levels_maximum(maximum);
+                }
+            }
+            PerformMsg::ChooseSixteenLevelsSource => {
+                if ctx.workspace_visible && self.mode == PerformMode::Instrument {
+                    self.begin_choosing_sixteen_levels_source();
+                }
             }
             PerformMsg::ComputerKeyPressed {
                 key,
@@ -825,18 +843,20 @@ impl PerformState {
                             .map(|track| track.id)
                     })
                     .flatten();
+                if let Some(track_id) = selected_instrument_target {
+                    self.sync_instrument_target(Some(track_id));
+                }
                 let instrument_note = if self.mode == PerformMode::Instrument
                     && !self.instrument_target_overlay
                 {
-                    ctx.selected_project_track.and_then(|track_id| {
-                        ctx.project_tracks
-                            .iter()
-                            .find(|track| track.id == track_id && track.is_playable_midi_target())
-                            .map(|_| ActiveInstrumentNote {
-                                track_id,
-                                pitch: self.instrument_pitch(position),
+                    let velocity = self.fixed_computer_velocity();
+                    ctx.selected_project_track
+                        .filter(|track_id| {
+                            ctx.project_tracks.iter().any(|track| {
+                                track.id == *track_id && track.is_playable_midi_target()
                             })
-                    })
+                        })
+                        .map(|track_id| self.resolve_instrument_note(position, velocity, track_id))
                 } else {
                     None
                 };
@@ -844,7 +864,7 @@ impl PerformState {
                     engine.send(vibez_engine::commands::EngineCommand::ExternalNoteOn {
                         track_id: note.track_id,
                         pitch: note.pitch,
-                        velocity: self.computer_key_velocity.0,
+                        velocity: note.velocity,
                     });
                 }
                 self.active_computer_keys
@@ -924,23 +944,6 @@ impl PerformState {
         self.active_computer_keys
             .values()
             .any(|(pressed, _, _)| *pressed == position)
-    }
-
-    pub const fn fixed_computer_velocity(&self) -> u8 {
-        self.computer_key_velocity.0
-    }
-
-    pub const fn instrument_octave(&self) -> i8 {
-        self.instrument_octave
-    }
-
-    pub fn instrument_pitch(&self, position: PadPosition) -> u8 {
-        let base = i16::from(INSTRUMENT_BASE_PITCH + position.ordinal(PerformMode::Instrument));
-        (base + i16::from(self.instrument_octave) * 12).clamp(0, 127) as u8
-    }
-
-    pub fn set_fixed_computer_velocity(&mut self, velocity: u8) {
-        self.computer_key_velocity = ComputerKeyVelocity(velocity.clamp(1, 127));
     }
 
     fn select_section(&mut self, id: SectionId, selected_track: Option<TrackId>) {

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -504,7 +504,7 @@ impl PerformState {
         ctx: PerformCtx<'_>,
     ) -> PerformAction {
         self.sync_track_mute_slots(ctx.project_tracks);
-        self.sync_instrument_target(ctx.selected_project_track);
+        self.sync_instrument_target_from_selection(ctx.selected_project_track, ctx.project_tracks);
         match msg {
             PerformMsg::SelectMode(mode) => {
                 if ctx.workspace_visible {
@@ -850,7 +850,7 @@ impl PerformState {
                     && !self.instrument_target_overlay
                 {
                     let velocity = self.fixed_computer_velocity();
-                    ctx.selected_project_track
+                    self.instrument_target()
                         .filter(|track_id| {
                             ctx.project_tracks.iter().any(|track| {
                                 track.id == *track_id && track.is_playable_midi_target()

--- a/crates/vibez-ui/src/domains/perform/instrument.rs
+++ b/crates/vibez-ui/src/domains/perform/instrument.rs
@@ -4,6 +4,8 @@ use std::fmt;
 
 use vibez_core::id::TrackId;
 
+use crate::state::ProjectTrack;
+
 use super::{PadPosition, PerformMode, PerformState};
 
 const INSTRUMENT_BASE_PITCH: u8 = 35;
@@ -173,6 +175,25 @@ pub(super) struct InstrumentPerformanceState {
 }
 
 impl PerformState {
+    pub(crate) const fn instrument_target(&self) -> Option<TrackId> {
+        self.instrument.target
+    }
+
+    pub(crate) fn sync_instrument_target_from_selection(
+        &mut self,
+        selected: Option<TrackId>,
+        project_tracks: &[ProjectTrack],
+    ) {
+        let playable_target = selected.filter(|track_id| {
+            project_tracks
+                .iter()
+                .any(|track| track.id == *track_id && track.is_playable_midi_target())
+        });
+        if playable_target.is_some() {
+            self.sync_instrument_target(playable_target);
+        }
+    }
+
     pub(crate) fn sync_instrument_target(&mut self, target: Option<TrackId>) {
         if self.instrument.target != target {
             self.instrument.target = target;

--- a/crates/vibez-ui/src/domains/perform/instrument.rs
+++ b/crates/vibez-ui/src/domains/perform/instrument.rs
@@ -1,0 +1,363 @@
+//! Instrument-mode note transformation and live performance controls.
+
+use std::fmt;
+
+use vibez_core::id::TrackId;
+
+use super::{PadPosition, PerformMode, PerformState};
+
+const INSTRUMENT_BASE_PITCH: u8 = 35;
+const MIN_INSTRUMENT_OCTAVE: i8 = -3;
+const MAX_INSTRUMENT_OCTAVE: i8 = 6;
+const LEVEL_COUNT: i16 = 16;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ActiveInstrumentNote {
+    pub(super) track_id: TrackId,
+    pub(super) pitch: u8,
+    pub(super) velocity: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ComputerKeyVelocity(pub(super) u8);
+
+impl Default for ComputerKeyVelocity {
+    fn default() -> Self {
+        Self(100)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SixteenLevelsParameter {
+    #[default]
+    Pitch,
+    Velocity,
+}
+
+impl SixteenLevelsParameter {
+    pub const ALL: [Self; 2] = [Self::Pitch, Self::Velocity];
+
+    fn descriptor(self) -> &'static SixteenLevelsParameterDescriptor {
+        SIXTEEN_LEVELS_PARAMETERS
+            .iter()
+            .find(|descriptor| descriptor.parameter == self)
+            .expect("every 16 Levels parameter has a descriptor")
+    }
+}
+
+impl fmt::Display for SixteenLevelsParameter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.descriptor().label)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SixteenLevelsRange {
+    pub minimum: i16,
+    pub maximum: i16,
+}
+
+impl SixteenLevelsRange {
+    fn value_at(self, position: PadPosition) -> i16 {
+        let index = i16::from(position.ordinal(PerformMode::Instrument) - 1);
+        let span = self.maximum - self.minimum;
+        self.minimum + (span * index + (LEVEL_COUNT - 1) / 2) / (LEVEL_COUNT - 1)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InstrumentPadPreview {
+    pub pitch: u8,
+    pub velocity: u8,
+}
+
+type ApplyParameter = fn(InstrumentPadPreview, i16) -> InstrumentPadPreview;
+
+struct SixteenLevelsParameterDescriptor {
+    parameter: SixteenLevelsParameter,
+    label: &'static str,
+    bounds: SixteenLevelsRange,
+    default_range: SixteenLevelsRange,
+    owns_velocity: bool,
+    apply: ApplyParameter,
+}
+
+const SIXTEEN_LEVELS_PARAMETERS: [SixteenLevelsParameterDescriptor; 2] = [
+    SixteenLevelsParameterDescriptor {
+        parameter: SixteenLevelsParameter::Pitch,
+        label: "Pitch",
+        bounds: SixteenLevelsRange {
+            minimum: -48,
+            maximum: 48,
+        },
+        default_range: SixteenLevelsRange {
+            minimum: 0,
+            maximum: 15,
+        },
+        owns_velocity: false,
+        apply: apply_pitch,
+    },
+    SixteenLevelsParameterDescriptor {
+        parameter: SixteenLevelsParameter::Velocity,
+        label: "Velocity",
+        bounds: SixteenLevelsRange {
+            minimum: 1,
+            maximum: 127,
+        },
+        default_range: SixteenLevelsRange {
+            minimum: 8,
+            maximum: 127,
+        },
+        owns_velocity: true,
+        apply: apply_velocity,
+    },
+];
+
+fn apply_pitch(note: InstrumentPadPreview, value: i16) -> InstrumentPadPreview {
+    InstrumentPadPreview {
+        pitch: (i16::from(note.pitch) + value).clamp(0, 127) as u8,
+        ..note
+    }
+}
+
+fn apply_velocity(note: InstrumentPadPreview, value: i16) -> InstrumentPadPreview {
+    InstrumentPadPreview {
+        velocity: value.clamp(1, 127) as u8,
+        ..note
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SixteenLevelsAssignment {
+    parameter: SixteenLevelsParameter,
+    range: SixteenLevelsRange,
+}
+
+impl Default for SixteenLevelsAssignment {
+    fn default() -> Self {
+        let parameter = SixteenLevelsParameter::default();
+        Self {
+            parameter,
+            range: parameter.descriptor().default_range,
+        }
+    }
+}
+
+impl SixteenLevelsAssignment {
+    fn map(
+        self,
+        source_pitch: u8,
+        input_velocity: u8,
+        position: PadPosition,
+    ) -> InstrumentPadPreview {
+        let descriptor = self.parameter.descriptor();
+        let note = InstrumentPadPreview {
+            pitch: source_pitch,
+            velocity: input_velocity,
+        };
+        (descriptor.apply)(note, self.range.value_at(position))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(super) struct InstrumentPerformanceState {
+    octave: i8,
+    computer_key_velocity: ComputerKeyVelocity,
+    full_level: bool,
+    sixteen_levels_enabled: bool,
+    sixteen_levels: SixteenLevelsAssignment,
+    source_pitch: Option<u8>,
+    last_played_pitch: Option<u8>,
+    choosing_source: bool,
+    target: Option<TrackId>,
+}
+
+impl PerformState {
+    pub(crate) fn sync_instrument_target(&mut self, target: Option<TrackId>) {
+        if self.instrument.target != target {
+            self.instrument.target = target;
+            self.clear_instrument_source();
+        }
+    }
+
+    pub(super) fn clear_instrument_source(&mut self) {
+        self.instrument.source_pitch = None;
+        self.instrument.last_played_pitch = None;
+        self.instrument.choosing_source = self.instrument.sixteen_levels_enabled;
+    }
+
+    pub(super) fn shift_instrument_octave(&mut self, amount: i8) {
+        self.instrument.octave = self
+            .instrument
+            .octave
+            .saturating_add(amount)
+            .clamp(MIN_INSTRUMENT_OCTAVE, MAX_INSTRUMENT_OCTAVE);
+    }
+
+    pub(super) fn toggle_full_level(&mut self) {
+        if self.full_level_available() {
+            self.instrument.full_level = !self.instrument.full_level;
+        }
+    }
+
+    pub(super) fn toggle_sixteen_levels(&mut self) {
+        self.instrument.sixteen_levels_enabled = !self.instrument.sixteen_levels_enabled;
+        if self.instrument.sixteen_levels_enabled {
+            self.instrument.source_pitch = self.instrument.last_played_pitch;
+            self.instrument.choosing_source = self.instrument.source_pitch.is_none();
+        } else {
+            self.instrument.choosing_source = false;
+        }
+    }
+
+    pub(super) fn select_sixteen_levels_parameter(&mut self, parameter: SixteenLevelsParameter) {
+        if self.instrument.sixteen_levels.parameter != parameter {
+            self.instrument.sixteen_levels = SixteenLevelsAssignment {
+                parameter,
+                range: parameter.descriptor().default_range,
+            };
+        }
+    }
+
+    pub(super) fn set_sixteen_levels_minimum(&mut self, minimum: i16) {
+        let descriptor = self.instrument.sixteen_levels.parameter.descriptor();
+        self.instrument.sixteen_levels.range.minimum = minimum
+            .clamp(descriptor.bounds.minimum, descriptor.bounds.maximum)
+            .min(self.instrument.sixteen_levels.range.maximum);
+    }
+
+    pub(super) fn set_sixteen_levels_maximum(&mut self, maximum: i16) {
+        let descriptor = self.instrument.sixteen_levels.parameter.descriptor();
+        self.instrument.sixteen_levels.range.maximum = maximum
+            .clamp(descriptor.bounds.minimum, descriptor.bounds.maximum)
+            .max(self.instrument.sixteen_levels.range.minimum);
+    }
+
+    pub(super) fn begin_choosing_sixteen_levels_source(&mut self) {
+        if self.instrument.sixteen_levels_enabled {
+            self.instrument.choosing_source = true;
+        }
+    }
+
+    pub(super) fn resolve_instrument_note(
+        &mut self,
+        position: PadPosition,
+        input_velocity: u8,
+        track_id: TrackId,
+    ) -> ActiveInstrumentNote {
+        self.sync_instrument_target(Some(track_id));
+        let pitch = self.instrument_pitch(position);
+        let input_velocity = input_velocity.clamp(1, 127);
+        let velocity = if self.full_level_effective() {
+            127
+        } else {
+            input_velocity
+        };
+
+        let preview = if self.instrument.sixteen_levels_enabled {
+            if let (false, Some(source_pitch)) = (
+                self.instrument.choosing_source,
+                self.instrument.source_pitch,
+            ) {
+                self.instrument
+                    .sixteen_levels
+                    .map(source_pitch, velocity, position)
+            } else {
+                self.instrument.source_pitch = Some(pitch);
+                self.instrument.last_played_pitch = Some(pitch);
+                self.instrument.choosing_source = false;
+                InstrumentPadPreview { pitch, velocity }
+            }
+        } else {
+            self.instrument.last_played_pitch = Some(pitch);
+            InstrumentPadPreview { pitch, velocity }
+        };
+
+        ActiveInstrumentNote {
+            track_id,
+            pitch: preview.pitch,
+            velocity: preview.velocity,
+        }
+    }
+
+    pub fn instrument_pad_preview(&self, position: PadPosition) -> InstrumentPadPreview {
+        let pitch = self.instrument_pitch(position);
+        let velocity = if self.full_level_effective() {
+            127
+        } else {
+            self.fixed_computer_velocity()
+        };
+        if self.instrument.sixteen_levels_enabled && !self.instrument.choosing_source {
+            if let Some(source_pitch) = self.instrument.source_pitch {
+                return self
+                    .instrument
+                    .sixteen_levels
+                    .map(source_pitch, velocity, position);
+            }
+        }
+        InstrumentPadPreview { pitch, velocity }
+    }
+
+    pub const fn fixed_computer_velocity(&self) -> u8 {
+        self.instrument.computer_key_velocity.0
+    }
+
+    pub const fn instrument_octave(&self) -> i8 {
+        self.instrument.octave
+    }
+
+    pub fn instrument_pitch(&self, position: PadPosition) -> u8 {
+        let base = i16::from(INSTRUMENT_BASE_PITCH + position.ordinal(PerformMode::Instrument));
+        (base + i16::from(self.instrument.octave) * 12).clamp(0, 127) as u8
+    }
+
+    pub fn set_fixed_computer_velocity(&mut self, velocity: u8) {
+        self.instrument.computer_key_velocity = ComputerKeyVelocity(velocity.clamp(1, 127));
+    }
+
+    pub const fn full_level_enabled(&self) -> bool {
+        self.instrument.full_level
+    }
+
+    pub fn full_level_available(&self) -> bool {
+        !(self.instrument.sixteen_levels_enabled
+            && self
+                .instrument
+                .sixteen_levels
+                .parameter
+                .descriptor()
+                .owns_velocity)
+    }
+
+    pub fn full_level_effective(&self) -> bool {
+        self.instrument.full_level && self.full_level_available()
+    }
+
+    pub const fn sixteen_levels_enabled(&self) -> bool {
+        self.instrument.sixteen_levels_enabled
+    }
+
+    pub const fn sixteen_levels_parameter(&self) -> SixteenLevelsParameter {
+        self.instrument.sixteen_levels.parameter
+    }
+
+    pub const fn sixteen_levels_range(&self) -> SixteenLevelsRange {
+        self.instrument.sixteen_levels.range
+    }
+
+    pub fn sixteen_levels_bounds(&self) -> SixteenLevelsRange {
+        self.instrument.sixteen_levels.parameter.descriptor().bounds
+    }
+
+    pub const fn sixteen_levels_source_pitch(&self) -> Option<u8> {
+        self.instrument.source_pitch
+    }
+
+    pub const fn choosing_sixteen_levels_source(&self) -> bool {
+        self.instrument.choosing_source
+    }
+}
+
+#[cfg(test)]
+#[path = "instrument_tests.rs"]
+mod tests;

--- a/crates/vibez-ui/src/domains/perform/instrument_tests.rs
+++ b/crates/vibez-ui/src/domains/perform/instrument_tests.rs
@@ -139,6 +139,56 @@ fn choose_source_and_target_changes_have_an_explicit_lifecycle() {
 }
 
 #[test]
+fn selecting_a_non_playable_track_preserves_the_last_instrument_target_and_source() {
+    let mut first_instrument = ProjectTrack::new(TrackId::new(), "Keys".into(), 0);
+    first_instrument.kind = vibez_core::midi::TrackKind::Midi;
+    first_instrument.has_instrument = true;
+    let audio_track = ProjectTrack::new(TrackId::new(), "Vocal".into(), 1);
+    let mut second_instrument = ProjectTrack::new(TrackId::new(), "Bass".into(), 2);
+    second_instrument.kind = vibez_core::midi::TrackKind::Midi;
+    second_instrument.has_instrument = true;
+    let tracks = vec![first_instrument, audio_track, second_instrument];
+    let mut state = PerformState::default();
+
+    state.sync_instrument_target_from_selection(Some(tracks[0].id), &tracks);
+    assert_eq!(state.instrument_target(), Some(tracks[0].id));
+    state.resolve_instrument_note(position(4), 70, tracks[0].id);
+    state.toggle_sixteen_levels();
+    assert_eq!(state.sixteen_levels_source_pitch(), Some(40));
+
+    state.sync_instrument_target_from_selection(Some(tracks[1].id), &tracks);
+    assert_eq!(state.instrument_target(), Some(tracks[0].id));
+    assert_eq!(state.sixteen_levels_source_pitch(), Some(40));
+    assert!(!state.choosing_sixteen_levels_source());
+
+    state.mode = PerformMode::Instrument;
+    let mut engine = RecordingEngine::default();
+    state.update(
+        PerformMsg::ComputerKeyPressed {
+            key: ComputerKey::Z,
+            key_id: "z".into(),
+            occurred_at: std::time::Instant::now(),
+        },
+        &mut engine,
+        PerformCtx {
+            workspace_visible: true,
+            project_tracks: &tracks,
+            selected_project_track: Some(tracks[1].id),
+        },
+    );
+    assert!(matches!(
+        engine.0.last(),
+        Some(vibez_engine::commands::EngineCommand::ExternalNoteOn { track_id, .. })
+            if *track_id == tracks[0].id
+    ));
+
+    state.sync_instrument_target_from_selection(Some(tracks[2].id), &tracks);
+    assert_eq!(state.instrument_target(), Some(tracks[2].id));
+    assert_eq!(state.sixteen_levels_source_pitch(), None);
+    assert!(state.choosing_sixteen_levels_source());
+}
+
+#[test]
 fn range_edits_apply_to_the_next_note_immediately() {
     let track_id = TrackId::new();
     let mut state = PerformState::default();

--- a/crates/vibez-ui/src/domains/perform/instrument_tests.rs
+++ b/crates/vibez-ui/src/domains/perform/instrument_tests.rs
@@ -1,0 +1,251 @@
+use super::super::{ComputerKey, PerformCtx, PerformMsg};
+use super::*;
+use crate::domains::test_support::RecordingEngine;
+use crate::state::ProjectTrack;
+
+fn position(level: u8) -> PadPosition {
+    PadPosition::ALL
+        .into_iter()
+        .find(|position| position.ordinal(PerformMode::Instrument) == level + 1)
+        .expect("level maps to a Pad Position")
+}
+
+#[test]
+fn descriptors_distribute_values_without_parameter_specific_pad_logic() {
+    let pitch = SixteenLevelsParameter::Pitch.descriptor();
+    let velocity = SixteenLevelsParameter::Velocity.descriptor();
+
+    let pitch_values = (0..16)
+        .map(|level| pitch.default_range.value_at(position(level)))
+        .collect::<Vec<_>>();
+    assert_eq!(pitch_values, (0..16).collect::<Vec<_>>());
+
+    let velocity_values = (0..16)
+        .map(|level| velocity.default_range.value_at(position(level)))
+        .collect::<Vec<_>>();
+    assert_eq!(velocity_values.first(), Some(&8));
+    assert_eq!(velocity_values.last(), Some(&127));
+    assert!(velocity_values
+        .windows(2)
+        .all(|pair| matches!(pair[1] - pair[0], 7 | 8)));
+
+    let input = InstrumentPadPreview {
+        pitch: 60,
+        velocity: 41,
+    };
+    assert_eq!(
+        (pitch.apply)(input, 7),
+        InstrumentPadPreview {
+            pitch: 67,
+            velocity: 41
+        }
+    );
+    assert_eq!(
+        (velocity.apply)(input, 99),
+        InstrumentPadPreview {
+            pitch: 60,
+            velocity: 99
+        }
+    );
+}
+
+#[test]
+fn full_level_is_reversible_and_does_not_rewrite_mapping_or_sections() {
+    let track_id = TrackId::new();
+    let mut state = PerformState::default();
+    let mapping = state.input_mapping.clone();
+    let sections = std::sync::Arc::clone(&state.sections);
+
+    let normal = state.resolve_instrument_note(position(0), 23, track_id);
+    state.toggle_full_level();
+    let full = state.resolve_instrument_note(position(1), 23, track_id);
+    state.toggle_full_level();
+    let restored = state.resolve_instrument_note(position(2), 23, track_id);
+
+    assert_eq!(normal.velocity, 23);
+    assert_eq!(full.velocity, 127);
+    assert_eq!(restored.velocity, 23);
+    assert_eq!(state.input_mapping, mapping);
+    assert!(std::sync::Arc::ptr_eq(&state.sections, &sections));
+}
+
+#[test]
+fn pitch_levels_preserve_velocity_and_coexist_with_full_level() {
+    let track_id = TrackId::new();
+    let mut state = PerformState::default();
+    let source = state.resolve_instrument_note(position(0), 44, track_id);
+    assert_eq!(source.pitch, 36);
+
+    state.toggle_sixteen_levels();
+    let high = state.resolve_instrument_note(position(15), 57, track_id);
+    assert_eq!((high.pitch, high.velocity), (51, 57));
+
+    state.toggle_full_level();
+    let middle = state.resolve_instrument_note(position(7), 19, track_id);
+    assert_eq!((middle.pitch, middle.velocity), (43, 127));
+    assert!(state.full_level_available());
+}
+
+#[test]
+fn velocity_levels_own_velocity_and_make_full_level_unavailable() {
+    let track_id = TrackId::new();
+    let mut state = PerformState::default();
+    state.resolve_instrument_note(position(4), 31, track_id);
+    state.toggle_full_level();
+    state.select_sixteen_levels_parameter(SixteenLevelsParameter::Velocity);
+    state.toggle_sixteen_levels();
+
+    assert!(state.full_level_enabled());
+    assert!(!state.full_level_available());
+    assert!(!state.full_level_effective());
+    state.toggle_full_level();
+    assert!(
+        state.full_level_enabled(),
+        "disabled control ignores toggles"
+    );
+
+    let low = state.resolve_instrument_note(position(0), 2, track_id);
+    let high = state.resolve_instrument_note(position(15), 2, track_id);
+    assert_eq!((low.pitch, low.velocity), (40, 8));
+    assert_eq!((high.pitch, high.velocity), (40, 127));
+}
+
+#[test]
+fn choose_source_and_target_changes_have_an_explicit_lifecycle() {
+    let first_target = TrackId::new();
+    let second_target = TrackId::new();
+    let mut state = PerformState::default();
+
+    state.sync_instrument_target(Some(first_target));
+    state.toggle_sixteen_levels();
+    assert!(state.choosing_sixteen_levels_source());
+    assert_eq!(state.sixteen_levels_source_pitch(), None);
+
+    let chosen = state.resolve_instrument_note(position(6), 70, first_target);
+    assert_eq!(chosen.pitch, 42);
+    assert_eq!(state.sixteen_levels_source_pitch(), Some(42));
+    assert!(!state.choosing_sixteen_levels_source());
+
+    state.begin_choosing_sixteen_levels_source();
+    state.resolve_instrument_note(position(2), 70, first_target);
+    assert_eq!(state.sixteen_levels_source_pitch(), Some(38));
+
+    state.sync_instrument_target(Some(second_target));
+    assert_eq!(state.sixteen_levels_source_pitch(), None);
+    assert!(state.choosing_sixteen_levels_source());
+    let newly_chosen = state.resolve_instrument_note(position(10), 70, second_target);
+    assert_eq!(newly_chosen.pitch, 46);
+    assert_eq!(newly_chosen.track_id, second_target);
+}
+
+#[test]
+fn range_edits_apply_to_the_next_note_immediately() {
+    let track_id = TrackId::new();
+    let mut state = PerformState::default();
+    state.resolve_instrument_note(position(0), 64, track_id);
+    state.toggle_sixteen_levels();
+    state.set_sixteen_levels_minimum(-12);
+    state.set_sixteen_levels_maximum(12);
+
+    let pitch_low = state.resolve_instrument_note(position(0), 64, track_id);
+    let pitch_high = state.resolve_instrument_note(position(15), 64, track_id);
+    assert_eq!((pitch_low.pitch, pitch_high.pitch), (24, 48));
+
+    state.select_sixteen_levels_parameter(SixteenLevelsParameter::Velocity);
+    state.set_sixteen_levels_minimum(20);
+    state.set_sixteen_levels_maximum(80);
+    let velocity_low = state.resolve_instrument_note(position(0), 3, track_id);
+    let velocity_high = state.resolve_instrument_note(position(15), 120, track_id);
+    assert_eq!((velocity_low.velocity, velocity_high.velocity), (20, 80));
+}
+
+#[test]
+fn range_edits_clamp_to_descriptor_bounds_and_never_cross() {
+    let mut state = PerformState::default();
+    state.set_sixteen_levels_minimum(500);
+    assert_eq!(
+        state.sixteen_levels_range(),
+        SixteenLevelsRange {
+            minimum: 15,
+            maximum: 15
+        }
+    );
+    state.set_sixteen_levels_maximum(-500);
+    assert_eq!(state.sixteen_levels_range().maximum, 15);
+
+    state.select_sixteen_levels_parameter(SixteenLevelsParameter::Velocity);
+    state.set_sixteen_levels_minimum(-1);
+    state.set_sixteen_levels_maximum(500);
+    assert_eq!(
+        state.sixteen_levels_range(),
+        SixteenLevelsRange {
+            minimum: 1,
+            maximum: 127
+        }
+    );
+}
+
+#[test]
+fn perform_messages_send_transformed_notes_through_the_existing_engine_path() {
+    let mut track = ProjectTrack::new(TrackId::new(), "Drums".into(), 0);
+    track.kind = vibez_core::midi::TrackKind::Midi;
+    track.has_instrument = true;
+    let tracks = vec![track];
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        project_tracks: &tracks,
+        selected_project_track: Some(tracks[0].id),
+    };
+    let mut state = PerformState {
+        mode: PerformMode::Instrument,
+        ..PerformState::default()
+    };
+    let mut engine = RecordingEngine::default();
+    let now = std::time::Instant::now();
+
+    state.update(PerformMsg::ToggleFullLevel, &mut engine, ctx);
+    state.update(
+        PerformMsg::ComputerKeyPressed {
+            key: ComputerKey::Z,
+            key_id: "z".into(),
+            occurred_at: now,
+        },
+        &mut engine,
+        ctx,
+    );
+    state.update(
+        PerformMsg::ComputerKeyReleased {
+            key_id: "z".into(),
+            occurred_at: now,
+        },
+        &mut engine,
+        ctx,
+    );
+    state.update(PerformMsg::ToggleSixteenLevels, &mut engine, ctx);
+    state.update(
+        PerformMsg::ComputerKeyPressed {
+            key: ComputerKey::Digit4,
+            key_id: "4".into(),
+            occurred_at: now,
+        },
+        &mut engine,
+        ctx,
+    );
+
+    assert!(matches!(
+        engine.0.as_slice(),
+        [
+            vibez_engine::commands::EngineCommand::ExternalNoteOn {
+                pitch: 36,
+                velocity: 127,
+                ..
+            },
+            vibez_engine::commands::EngineCommand::ExternalNoteOff { pitch: 36, .. },
+            vibez_engine::commands::EngineCommand::ExternalNoteOn {
+                pitch: 51,
+                velocity: 127,
+                ..
+            },
+        ]
+    ));
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -144,6 +144,16 @@ Widget-captured presses are not forwarded, so text fields suppress pad input.
 The mapping and fixed computer-key velocity (default 100) persist in the user's
 `ui.json` settings and are absent from the project document and undo snapshots.
 
+Instrument Pad Gestures resolve through one live note-transform boundary before
+they become paired engine note commands. Full Level supplies the effective
+velocity there for every input adapter. A 16 Levels Assignment combines one
+remembered source pitch, one generic sixteen-step range, and a data descriptor
+whose apply function owns either pitch or velocity; adding a future parameter
+does not add branches to Pad Surface semantics. The held-note record retains the
+resolved Track and pitch, so changing a range, assignment, or Instrument Target
+cannot redirect its eventual note-off. These controls and their source memory
+are runtime performance state rather than project content.
+
 Track mute commands become authoritative when the audio callback drains them.
 The engine emits `EngineEvent::TrackMuteChanged` with the effective state and
 absolute transport sample; the UI mirrors that result into the shared Project


### PR DESCRIPTION
## Summary

- add Full Level as a reversible effective-velocity transform shared by Instrument input adapters
- add data-driven Pitch and Velocity 16 Levels assignments with editable ranges
- add remembered/chooseable source lifecycle that clears when the Instrument Target changes
- add integrated Perform controls and per-pad pitch/velocity feedback
- document the live note-transform architecture

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace -j 4` (307 vibez-ui tests, 151 engine tests, complete workspace and doc tests)
- strict workspace Clippy passes for this change with three known Rust 1.96 baseline lints in untouched files explicitly allowed (`unnecessary_cast`, `replace_box`, `items_after_test_module`)
- isolated Xvfb + Pulse null-sink dogfood: Full Level, Pitch and Velocity assignments, live range edits, Source reassignment, and target-change clearing
- velocity pads 1 and 16 produced distinct recorded audio peaks (-29.30 dB vs -4.87 dB)

## Scope

Card 13 only. Note Repeat, Swing, and recording remain out of scope.

Do not merge without Alex’s explicit approval.