### PR TITLE
Perform Card 30: add live MIDI clip Swing

### DIFF
--- a/crates/vibez-core/src/midi.rs
+++ b/crates/vibez-core/src/midi.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::id::{ClipId, TrackId};
+use crate::perform::GrooveGrid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct MidiNote {
@@ -34,6 +35,8 @@ pub struct NoteClipInfo {
     pub loop_start_beats: f64,
     #[serde(default)]
     pub loop_end_beats: f64,
+    #[serde(default)]
+    pub groove_grid: GrooveGrid,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -79,6 +82,7 @@ impl TrackKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::perform::GrooveGrid;
 
     #[test]
     fn midi_note_frequency() {
@@ -129,6 +133,7 @@ mod tests {
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
+            groove_grid: GrooveGrid::Sixteenth,
             notes: vec![
                 MidiNote {
                     pitch: 60,
@@ -149,6 +154,27 @@ mod tests {
         assert_eq!(loaded.name, "Pattern 1");
         assert_eq!(loaded.notes.len(), 2);
         assert_eq!(loaded.notes[0].pitch, 60);
+        assert_eq!(loaded.groove_grid, GrooveGrid::Sixteenth);
+    }
+
+    #[test]
+    fn legacy_note_clip_defaults_the_groove_grid_to_off() {
+        let clip = NoteClipInfo {
+            id: ClipId::new(),
+            track_id: TrackId::new(),
+            name: "Legacy".into(),
+            position_beats: 0.0,
+            duration_beats: 4.0,
+            notes: Vec::new(),
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+            groove_grid: GrooveGrid::Off,
+        };
+        let mut json = serde_json::to_value(clip).unwrap();
+        json.as_object_mut().unwrap().remove("groove_grid");
+        let loaded: NoteClipInfo = serde_json::from_value(json).unwrap();
+        assert_eq!(loaded.groove_grid, GrooveGrid::Off);
     }
 
     #[test]

--- a/crates/vibez-core/src/perform.rs
+++ b/crates/vibez-core/src/perform.rs
@@ -1,5 +1,71 @@
 use serde::{Deserialize, Serialize};
 
+/// Opt-in playback grid for non-destructive MIDI clip Swing.
+///
+/// `Off` deliberately remains the default: Vibez never guesses the rhythmic
+/// intent of freely recorded notes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GrooveGrid {
+    #[default]
+    Off,
+    Eighth,
+    Sixteenth,
+}
+
+impl GrooveGrid {
+    pub const ALL: [Self; 3] = [Self::Off, Self::Eighth, Self::Sixteenth];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Off => "Off",
+            Self::Eighth => "1/8",
+            Self::Sixteenth => "1/16",
+        }
+    }
+
+    /// Map one clip-local beat through the MPC2000XL pair shape.
+    ///
+    /// Pair endpoints stay fixed and the straight midpoint moves to the
+    /// nearest 96 PPQN Swing tick. Interpolating either side maps human timing
+    /// without a tolerance window and cannot reorder events.
+    pub fn map_beat(self, beat: f64, swing: SwingAmount) -> f64 {
+        let pair_ticks = match self {
+            Self::Off => return beat,
+            Self::Eighth => GrooveProfile::MPC2000XL_PPQN,
+            Self::Sixteenth => GrooveProfile::MPC2000XL_PPQN / 2,
+        };
+        let pair_beats = pair_ticks as f64 / GrooveProfile::MPC2000XL_PPQN as f64;
+        let pair_start = (beat / pair_beats).floor() * pair_beats;
+        let phase = beat - pair_start;
+        let midpoint = pair_beats / 2.0;
+        let swung_ticks = (pair_ticks as f64 * swing.get() as f64).round();
+        let swung_midpoint = swung_ticks / GrooveProfile::MPC2000XL_PPQN as f64;
+
+        if phase <= midpoint {
+            pair_start + phase / midpoint * swung_midpoint
+        } else {
+            pair_start
+                + swung_midpoint
+                + (phase - midpoint) / midpoint * (pair_beats - swung_midpoint)
+        }
+    }
+
+    pub const fn pair_beats(self) -> Option<f64> {
+        match self {
+            Self::Off => None,
+            Self::Eighth => Some(1.0),
+            Self::Sixteenth => Some(0.5),
+        }
+    }
+}
+
+impl std::fmt::Display for GrooveGrid {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.label())
+    }
+}
+
 /// Immutable timing-model identity used to interpret Project Swing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum GrooveProfile {
@@ -187,6 +253,38 @@ impl std::fmt::Display for NoteRepeatRate {
 #[cfg(test)]
 mod groove_tests {
     use super::*;
+
+    #[test]
+    fn groove_grid_maps_the_midpoint_to_the_96_ppqn_swing_tick() {
+        assert!(
+            (GrooveGrid::Sixteenth.map_beat(0.25, SwingAmount::new(0.66)) - 32.0 / 96.0).abs()
+                < 1e-9
+        );
+        assert!(
+            (GrooveGrid::Eighth.map_beat(0.5, SwingAmount::new(0.56)) - 54.0 / 96.0).abs() < 1e-9
+        );
+    }
+
+    #[test]
+    fn groove_grid_maps_human_timing_monotonically_without_a_tolerance() {
+        let swing = SwingAmount::new(0.66);
+        let mapped =
+            [0.0, 0.125, 0.25, 0.375, 0.5].map(|beat| GrooveGrid::Sixteenth.map_beat(beat, swing));
+        assert_eq!(mapped[0], 0.0);
+        assert!((mapped[1] - 16.0 / 96.0).abs() < 1e-9);
+        assert!((mapped[2] - 32.0 / 96.0).abs() < 1e-9);
+        assert!((mapped[3] - 40.0 / 96.0).abs() < 1e-9);
+        assert_eq!(mapped[4], 0.5);
+        assert!(mapped.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+
+    #[test]
+    fn groove_grid_off_is_an_identity_map() {
+        assert_eq!(
+            GrooveGrid::Off.map_beat(0.371, SwingAmount::new(0.75)),
+            0.371
+        );
+    }
 
     #[test]
     fn mpc2000xl_profile_has_a_stable_persisted_identity() {

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -4,7 +4,7 @@ use vibez_core::effect::EffectType;
 use vibez_core::id::{ClipId, EffectId, TrackId};
 use vibez_core::midi::{InstrumentKind, MidiNote};
 use vibez_core::perform::SectionLaunchQuantization;
-use vibez_core::perform::{NoteRepeatRate, SwingAmount, SwingOffset};
+use vibez_core::perform::{GrooveGrid, NoteRepeatRate, SwingAmount, SwingOffset};
 use vibez_core::track::DrumPadState;
 use vibez_dsp::effect::AudioEffect;
 use vibez_instruments::Instrument;
@@ -34,8 +34,7 @@ pub enum EngineCommand {
     Seek(u64),
     /// Change the project tempo.
     SetBpm(f64),
-    /// Set Project Swing for generated events. Existing clip playback is
-    /// deliberately unaffected.
+    /// Set Project Swing for generated events and opted-in MIDI clips.
     SetProjectSwing(SwingAmount),
     /// Immediately activate a complete resident Section playback source.
     LaunchSection(Box<PreparedSectionPlaybackSource>),
@@ -114,7 +113,7 @@ pub enum EngineCommand {
     /// Set the solo state for a track.
     SetTrackSolo(TrackId, bool),
     /// Set the optional Project Track Swing adjustment used by generated
-    /// events on this channel.
+    /// events and opted-in MIDI clips on this channel.
     SetTrackSwingOffset(TrackId, Option<SwingOffset>),
 
     // -- Busses (return channels) --
@@ -175,6 +174,11 @@ pub enum EngineCommand {
         clip_id: ClipId,
         duration_beats: f64,
     },
+    SetNoteClipGrooveGrid {
+        track_id: TrackId,
+        clip_id: ClipId,
+        groove_grid: GrooveGrid,
+    },
     AddNoteClip {
         track_id: TrackId,
         clip_id: ClipId,
@@ -183,6 +187,7 @@ pub enum EngineCommand {
         loop_enabled: bool,
         loop_start_beats: f64,
         loop_end_beats: f64,
+        groove_grid: GrooveGrid,
     },
     RemoveNoteClip(TrackId, ClipId),
     /// Move a note clip to a new beat position on the timeline.

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -917,6 +917,10 @@ mod mute_event_tests;
 mod note_repeat_tests;
 
 #[cfg(test)]
+#[path = "engine_clip_groove_tests.rs"]
+mod clip_groove_tests;
+
+#[cfg(test)]
 #[path = "engine_section_playback_tests.rs"]
 mod section_playback_tests;
 

--- a/crates/vibez-engine/src/engine_clip_groove_tests.rs
+++ b/crates/vibez-engine/src/engine_clip_groove_tests.rs
@@ -1,0 +1,255 @@
+//! Deterministic render-read fixtures for opt-in MIDI clip Groove.
+
+use super::*;
+use std::sync::{Arc, Mutex};
+use vibez_core::id::{ClipId, TrackId};
+use vibez_core::midi::{InstrumentKind, MidiNote};
+use vibez_core::perform::{GrooveGrid, SwingAmount, SwingOffset};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TimedEvent {
+    On(u32, u8),
+    Off(u32, u8),
+}
+
+struct TimedSpy {
+    events: Arc<Mutex<Vec<TimedEvent>>>,
+}
+
+impl vibez_instruments::Instrument for TimedSpy {
+    fn instrument_kind(&self) -> InstrumentKind {
+        InstrumentKind::SubtractiveSynth
+    }
+
+    fn param_descriptors(&self) -> &'static [vibez_core::effect::ParamDescriptor] {
+        &[]
+    }
+
+    fn set_param(&mut self, _index: usize, _value: f32) -> bool {
+        false
+    }
+
+    fn get_param(&self, _index: usize) -> f32 {
+        0.0
+    }
+
+    fn note_on(&mut self, pitch: u8, _velocity: u8) {
+        self.events.lock().unwrap().push(TimedEvent::On(0, pitch));
+    }
+
+    fn note_off(&mut self, pitch: u8) {
+        self.events.lock().unwrap().push(TimedEvent::Off(0, pitch));
+    }
+
+    fn note_on_at(&mut self, pitch: u8, _velocity: u8, frame_offset: u32) {
+        self.events
+            .lock()
+            .unwrap()
+            .push(TimedEvent::On(frame_offset, pitch));
+    }
+
+    fn note_off_at(&mut self, pitch: u8, frame_offset: u32) {
+        self.events
+            .lock()
+            .unwrap()
+            .push(TimedEvent::Off(frame_offset, pitch));
+    }
+
+    fn render(&mut self, _buffer: &mut [f32], _channels: usize) {}
+
+    fn reset(&mut self) {}
+
+    fn supports_batch_render(&self) -> bool {
+        true
+    }
+}
+
+fn render_events(
+    grid: GrooveGrid,
+    swing: SwingAmount,
+    track_offset: Option<SwingOffset>,
+    duration_beats: f64,
+    looping: bool,
+    loop_end_beats: f64,
+    notes: &[MidiNote],
+    frames: usize,
+) -> Vec<TimedEvent> {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let clip_id = ClipId::new();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    commands.push(EngineCommand::SetSampleRate(96)).unwrap();
+    commands.push(EngineCommand::SetBpm(60.0)).unwrap();
+    commands
+        .push(EngineCommand::SetProjectSwing(swing))
+        .unwrap();
+    commands
+        .push(EngineCommand::AddMidiTrack(track_id, "Groove probe".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::SetPluginInstrument {
+            track_id,
+            instrument: Box::new(TimedSpy {
+                events: Arc::clone(&events),
+            }),
+        })
+        .unwrap();
+    if let Some(offset) = track_offset {
+        commands
+            .push(EngineCommand::SetTrackSwingOffset(track_id, Some(offset)))
+            .unwrap();
+    }
+    commands
+        .push(EngineCommand::AddNoteClip {
+            track_id,
+            clip_id,
+            position_beats: 0.0,
+            duration_beats,
+            loop_enabled: looping,
+            loop_start_beats: 0.0,
+            loop_end_beats,
+            groove_grid: grid,
+        })
+        .unwrap();
+    for note in notes {
+        commands
+            .push(EngineCommand::AddNote {
+                track_id,
+                clip_id,
+                note: *note,
+            })
+            .unwrap();
+    }
+    commands.push(EngineCommand::Play).unwrap();
+    engine.process(&mut vec![0.0; frames * 2], 2);
+    let rendered = events.lock().unwrap().clone();
+    rendered
+}
+
+fn midpoint_note(start_beat: f64) -> MidiNote {
+    MidiNote {
+        pitch: 42,
+        velocity: 100,
+        start_beat,
+        duration_beats: 0.05,
+    }
+}
+
+#[test]
+fn opted_in_clip_midpoints_match_the_mpc_96_ppqn_ticks() {
+    for (grid, midpoint, fixtures) in [
+        (
+            GrooveGrid::Sixteenth,
+            0.25,
+            [(0.50, 24), (0.56, 27), (0.66, 32), (0.75, 36)],
+        ),
+        (
+            GrooveGrid::Eighth,
+            0.5,
+            [(0.50, 48), (0.56, 54), (0.66, 63), (0.75, 72)],
+        ),
+    ] {
+        for (swing, expected_tick) in fixtures {
+            let events = render_events(
+                grid,
+                SwingAmount::new(swing),
+                None,
+                1.0,
+                false,
+                0.0,
+                &[midpoint_note(midpoint)],
+                96,
+            );
+            assert!(
+                events.contains(&TimedEvent::On(expected_tick, 42)),
+                "{events:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn looped_clip_reuses_its_local_grid_without_baking_absolute_positions() {
+    let events = render_events(
+        GrooveGrid::Sixteenth,
+        SwingAmount::new(0.66),
+        None,
+        1.0,
+        true,
+        0.5,
+        &[midpoint_note(0.25)],
+        96,
+    );
+    let onsets: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            TimedEvent::On(frame, 42) => Some(*frame),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(onsets, vec![32, 80]);
+}
+
+#[test]
+fn shortened_clip_drops_an_onset_mapped_past_its_boundary() {
+    let events = render_events(
+        GrooveGrid::Sixteenth,
+        SwingAmount::new(0.75),
+        None,
+        0.3,
+        false,
+        0.0,
+        &[midpoint_note(0.25)],
+        96,
+    );
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, TimedEvent::On(..))));
+}
+
+#[test]
+fn mapped_note_off_is_clamped_to_the_next_same_pitch_onset() {
+    let events = render_events(
+        GrooveGrid::Sixteenth,
+        SwingAmount::new(0.66),
+        None,
+        1.0,
+        false,
+        0.0,
+        &[
+            MidiNote {
+                pitch: 42,
+                velocity: 100,
+                start_beat: 0.25,
+                duration_beats: 0.4,
+            },
+            MidiNote {
+                pitch: 42,
+                velocity: 100,
+                start_beat: 0.5,
+                duration_beats: 0.25,
+            },
+        ],
+        96,
+    );
+    assert!(events.contains(&TimedEvent::Off(48, 42)), "{events:?}");
+    assert!(events.contains(&TimedEvent::On(48, 42)), "{events:?}");
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, TimedEvent::Off(frame, 42) if (49..80).contains(frame))));
+}
+
+#[test]
+fn project_track_offset_shapes_opted_in_clip_playback() {
+    let events = render_events(
+        GrooveGrid::Sixteenth,
+        SwingAmount::new(0.56),
+        Some(SwingOffset::new(0.04)),
+        1.0,
+        false,
+        0.0,
+        &[midpoint_note(0.25)],
+        96,
+    );
+    assert!(events.contains(&TimedEvent::On(29, 42)), "{events:?}");
+}

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -447,6 +447,23 @@ impl AudioEngine {
                     }
                     self.recalculate_audio_length();
                 }
+                EngineCommand::SetNoteClipGrooveGrid {
+                    track_id,
+                    clip_id,
+                    groove_grid,
+                } => {
+                    if let Some(track) = self.tracks.iter_mut().find(|track| track.id == track_id) {
+                        if let Some(clip) = track
+                            .playback_source
+                            .note_clips
+                            .iter_mut()
+                            .find(|clip| clip.id == clip_id)
+                        {
+                            clip.groove_grid = groove_grid;
+                        }
+                        track.flush_notes();
+                    }
+                }
                 EngineCommand::AddNoteClip {
                     track_id,
                     clip_id,
@@ -455,17 +472,19 @@ impl AudioEngine {
                     loop_enabled,
                     loop_start_beats,
                     loop_end_beats,
+                    groove_grid,
                 } => {
                     if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
-                        track.playback_source.note_clips.push(EngineNoteClip {
-                            id: clip_id,
+                        track.playback_source.note_clips.push(EngineNoteClip::new(
+                            clip_id,
                             position_beats,
                             duration_beats,
-                            notes: Vec::new(),
+                            Vec::new(),
                             loop_enabled,
                             loop_start_beats,
                             loop_end_beats,
-                        });
+                            groove_grid,
+                        ));
                     }
                     self.recalculate_audio_length();
                 }

--- a/crates/vibez-engine/src/engine_note_repeat_tests.rs
+++ b/crates/vibez-engine/src/engine_note_repeat_tests.rs
@@ -1,7 +1,10 @@
 use super::*;
-use vibez_core::id::{ClipId, TrackId};
+use crate::playback_source::{
+    EngineNoteClip, PreparedPlaybackSource, PreparedSectionPlaybackSource,
+};
+use vibez_core::id::{ClipId, SectionId, TrackId};
 use vibez_core::midi::{InstrumentKind, MidiNote};
-use vibez_core::perform::{GrooveProfile, NoteRepeatRate, SwingAmount, SwingOffset};
+use vibez_core::perform::{GrooveGrid, GrooveProfile, NoteRepeatRate, SwingAmount, SwingOffset};
 
 fn repeat_engine() -> (
     AudioEngine,
@@ -321,8 +324,11 @@ fn stopping_repeat_prevents_every_future_generated_note() {
     assert!(repeat_timestamps(&mut events).is_empty());
 }
 
-fn render_clip_with_swing(swing: SwingAmount) -> Vec<f32> {
-    let (mut engine, mut commands, _events) = AudioEngine::new();
+fn clip_engine(
+    swing: SwingAmount,
+    groove_grid: GrooveGrid,
+) -> (AudioEngine, rtrb::Producer<EngineCommand>) {
+    let (engine, mut commands, _events) = AudioEngine::new();
     let track_id = TrackId::new();
     let clip_id = ClipId::new();
     commands.push(EngineCommand::SetSampleRate(8_000)).unwrap();
@@ -348,6 +354,7 @@ fn render_clip_with_swing(swing: SwingAmount) -> Vec<f32> {
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
+            groove_grid,
         })
         .unwrap();
     commands
@@ -357,10 +364,84 @@ fn render_clip_with_swing(swing: SwingAmount) -> Vec<f32> {
             note: MidiNote {
                 pitch: 60,
                 velocity: 100,
-                start_beat: 0.0,
-                duration_beats: 0.5,
+                start_beat: 0.25,
+                duration_beats: 0.25,
             },
         })
+        .unwrap();
+    commands.push(EngineCommand::Play).unwrap();
+    (engine, commands)
+}
+
+fn render_clip_with_swing(swing: SwingAmount, groove_grid: GrooveGrid) -> Vec<f32> {
+    let (mut engine, _commands) = clip_engine(swing, groove_grid);
+    let mut output = vec![0.0; 4_000 * 2];
+    engine.process(&mut output, 2);
+    output
+}
+
+#[test]
+fn swing_does_not_change_clip_playback_when_its_grid_is_off() {
+    assert_eq!(
+        render_clip_with_swing(SwingAmount::STRAIGHT, GrooveGrid::Off),
+        render_clip_with_swing(SwingAmount::new(0.75), GrooveGrid::Off)
+    );
+}
+
+#[test]
+fn swing_changes_opted_in_clip_playback_without_rewriting_notes() {
+    assert_ne!(
+        render_clip_with_swing(SwingAmount::STRAIGHT, GrooveGrid::Sixteenth),
+        render_clip_with_swing(SwingAmount::new(0.75), GrooveGrid::Sixteenth)
+    );
+}
+
+fn render_prepared_section_with_swing(swing: SwingAmount) -> Vec<f32> {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let prepared = PreparedSectionPlaybackSource::new(
+        SectionId::new(),
+        1.0,
+        false,
+        vec![(
+            track_id,
+            PreparedPlaybackSource::new(
+                Vec::new(),
+                vec![EngineNoteClip::new(
+                    ClipId::new(),
+                    0.0,
+                    1.0,
+                    vec![MidiNote {
+                        pitch: 60,
+                        velocity: 100,
+                        start_beat: 0.25,
+                        duration_beats: 0.25,
+                    }],
+                    false,
+                    0.0,
+                    0.0,
+                    GrooveGrid::Sixteenth,
+                )],
+                Vec::new(),
+            ),
+        )],
+    );
+    commands.push(EngineCommand::SetSampleRate(8_000)).unwrap();
+    commands.push(EngineCommand::SetBpm(120.0)).unwrap();
+    commands
+        .push(EngineCommand::AddMidiTrack(track_id, "Section clip".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::SetTrackInstrument(
+            track_id,
+            InstrumentKind::SubtractiveSynth,
+        ))
+        .unwrap();
+    commands
+        .push(EngineCommand::SetProjectSwing(swing))
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(prepared)))
         .unwrap();
     commands.push(EngineCommand::Play).unwrap();
     let mut output = vec![0.0; 4_000 * 2];
@@ -369,11 +450,27 @@ fn render_clip_with_swing(swing: SwingAmount) -> Vec<f32> {
 }
 
 #[test]
-fn swing_does_not_change_existing_clip_playback() {
-    assert_eq!(
-        render_clip_with_swing(SwingAmount::STRAIGHT),
-        render_clip_with_swing(SwingAmount::new(0.75))
+fn prepared_sections_apply_live_swing_at_render_read_time() {
+    assert_ne!(
+        render_prepared_section_with_swing(SwingAmount::STRAIGHT),
+        render_prepared_section_with_swing(SwingAmount::new(0.75))
     );
+}
+
+#[test]
+fn lowering_swing_mid_pair_does_not_move_an_unsounded_clip_note_into_the_past() {
+    let constant = render_clip_with_swing(SwingAmount::new(0.75), GrooveGrid::Sixteenth);
+    let (mut engine, mut commands) = clip_engine(SwingAmount::new(0.75), GrooveGrid::Sixteenth);
+    let mut before_change = vec![0.0; 1_200 * 2];
+    engine.process(&mut before_change, 2);
+    commands
+        .push(EngineCommand::SetProjectSwing(SwingAmount::STRAIGHT))
+        .unwrap();
+    let mut after_change = vec![0.0; 2_800 * 2];
+    engine.process(&mut after_change, 2);
+    before_change.extend(after_change);
+
+    assert_eq!(before_change, constant);
 }
 
 #[test]

--- a/crates/vibez-engine/src/engine_section_playback_tests.rs
+++ b/crates/vibez-engine/src/engine_section_playback_tests.rs
@@ -379,20 +379,21 @@ fn switching_sections_releases_notes_from_the_previous_source() {
                     track_id,
                     PreparedPlaybackSource::new(
                         Vec::new(),
-                        vec![EngineNoteClip {
-                            id: ClipId::new(),
-                            position_beats: 0.0,
-                            duration_beats: 4.0,
-                            notes: vec![MidiNote {
+                        vec![EngineNoteClip::new(
+                            ClipId::new(),
+                            0.0,
+                            4.0,
+                            vec![MidiNote {
                                 pitch: 60,
                                 velocity: 100,
                                 start_beat: 0.0,
                                 duration_beats: 4.0,
                             }],
-                            loop_enabled: false,
-                            loop_start_beats: 0.0,
-                            loop_end_beats: 0.0,
-                        }],
+                            false,
+                            0.0,
+                            0.0,
+                            vibez_core::perform::GrooveGrid::Off,
+                        )],
                         Vec::new(),
                     ),
                 )],

--- a/crates/vibez-engine/src/engine_stuck_note_tests.rs
+++ b/crates/vibez-engine/src/engine_stuck_note_tests.rs
@@ -74,6 +74,7 @@ fn engine_with_held_note() -> (
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
         })
         .unwrap();
     cmd_tx
@@ -147,6 +148,7 @@ fn run_scenario(
             loop_enabled: clip_loop.0,
             loop_start_beats: clip_loop.1,
             loop_end_beats: clip_loop.2,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
         })
         .unwrap();
     cmd_tx
@@ -218,6 +220,7 @@ fn looped_note_ons_per_bar(batch_render: bool) -> Vec<usize> {
             loop_enabled: true,
             loop_start_beats: 0.0,
             loop_end_beats: 4.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
         })
         .unwrap();
     for step in 0..8 {

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -64,6 +64,7 @@ fn midi_clip_commands_keep_project_length_in_sync() {
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
         })
         .unwrap();
     let mut output = [0.0; 2];
@@ -1205,6 +1206,7 @@ fn note_clip_loop_renders() {
             loop_enabled: true,
             loop_start_beats: 0.0,
             loop_end_beats: 2.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
         })
         .unwrap();
     // Add a note at beat 0, 1 beat long

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -15,15 +15,14 @@ use vibez_instruments::Instrument;
 use crate::note_repeat::{NoteRepeatTrigger, TrackNoteRepeats};
 use crate::playback_source::{ArrangementPlaybackSource, PreparedPlaybackSource};
 pub use crate::playback_source::{EngineClip, EngineNoteClip};
+mod groove;
 mod note_repeat;
+mod pan;
 mod render_context;
+use groove::{crossed_beat, mapped_note_end, mapped_note_start};
+pub use pan::{balance_pan, equal_power_pan};
 use render_context::InstrumentRenderBlock;
 pub(crate) use render_context::InstrumentRenderContext;
-
-#[inline]
-fn crossed_beat(previous: f64, current: f64, event: f64) -> bool {
-    previous < event && event <= current
-}
 
 pub struct EffectSlot {
     pub id: EffectId,
@@ -159,6 +158,7 @@ impl EngineTrack {
     /// playhead moves discontinuously; the offs reach the instrument
     /// immediately (built-ins) or on its next render (plugins).
     pub fn flush_notes(&mut self) {
+        self.reset_groove_latches();
         if self.active_notes == 0 {
             return;
         }
@@ -359,26 +359,35 @@ impl EngineTrack {
                 let wrapped = looping
                     && was_in_clip
                     && prev_effective_local > effective_local + beat_step * 0.5;
+                let clip_swing =
+                    clip.swing_for_pair(effective_local, swing, wrapped || !was_in_clip);
 
                 if wrapped {
                     for note in &clip.notes {
                         self.timed_note_offs.push((frame as u32, note.pitch));
                     }
                     for note in &clip.notes {
-                        if note.start_beat >= clip.loop_start_beats
-                            && note.start_beat <= effective_local
+                        let mapped_start = mapped_note_start(clip, note, clip_swing);
+                        if mapped_start >= clip.loop_start_beats && mapped_start <= effective_local
                         {
                             self.timed_note_ons
                                 .push((frame as u32, note.pitch, note.velocity));
                         }
                     }
                 } else {
-                    for note in &clip.notes {
-                        if crossed_beat(prev_effective_local, effective_local, note.start_beat) {
+                    for (note_index, note) in clip.notes.iter().enumerate() {
+                        let mapped_start = mapped_note_start(clip, note, clip_swing);
+                        if mapped_start < clip.duration_beats
+                            && crossed_beat(prev_effective_local, effective_local, mapped_start)
+                        {
                             self.timed_note_ons
                                 .push((frame as u32, note.pitch, note.velocity));
                         }
-                        if crossed_beat(prev_effective_local, effective_local, note.end_beat()) {
+                        if crossed_beat(
+                            prev_effective_local,
+                            effective_local,
+                            mapped_note_end(clip, note_index, clip_swing),
+                        ) {
                             self.timed_note_offs.push((frame as u32, note.pitch));
                         }
                     }
@@ -509,24 +518,33 @@ impl EngineTrack {
                 let wrapped = looping
                     && was_in_clip
                     && prev_effective_local > effective_local + beat_step * 0.5;
+                let clip_swing =
+                    clip.swing_for_pair(effective_local, swing, wrapped || !was_in_clip);
 
                 if wrapped {
                     for note in &clip.notes {
                         note_offs.push(note.pitch);
                     }
                     for note in &clip.notes {
-                        if note.start_beat >= clip.loop_start_beats
-                            && note.start_beat <= effective_local
+                        let mapped_start = mapped_note_start(clip, note, clip_swing);
+                        if mapped_start >= clip.loop_start_beats && mapped_start <= effective_local
                         {
                             note_ons.push((note.pitch, note.velocity));
                         }
                     }
                 } else {
-                    for note in &clip.notes {
-                        if crossed_beat(prev_effective_local, effective_local, note.start_beat) {
+                    for (note_index, note) in clip.notes.iter().enumerate() {
+                        let mapped_start = mapped_note_start(clip, note, clip_swing);
+                        if mapped_start < clip.duration_beats
+                            && crossed_beat(prev_effective_local, effective_local, mapped_start)
+                        {
                             note_ons.push((note.pitch, note.velocity));
                         }
-                        if crossed_beat(prev_effective_local, effective_local, note.end_beat()) {
+                        if crossed_beat(
+                            prev_effective_local,
+                            effective_local,
+                            mapped_note_end(clip, note_index, clip_swing),
+                        ) {
                             note_offs.push(note.pitch);
                         }
                     }
@@ -561,25 +579,6 @@ impl EngineTrack {
 
         rendered
     }
-}
-
-/// Equal-power pan law.
-/// `pan` ranges from 0.0 (hard left) to 1.0 (hard right).
-/// Returns `(left_gain, right_gain)`.
-/// At center (0.5): both channels get ~0.707 (-3dB).
-pub fn equal_power_pan(pan: f32) -> (f32, f32) {
-    let pan = pan.clamp(0.0, 1.0);
-    let angle = pan * std::f32::consts::FRAC_PI_2;
-    (angle.cos(), angle.sin())
-}
-
-/// Stereo balance law for channels that carry already-panned
-/// material (buses): center passes both channels at unity, off-
-/// center attenuates the far side. Equal-power panning here would
-/// tax every centered return 3 dB.
-pub fn balance_pan(pan: f32) -> (f32, f32) {
-    let pan = pan.clamp(0.0, 1.0);
-    (((1.0 - pan) * 2.0).min(1.0), (pan * 2.0).min(1.0))
 }
 
 /// Returns `true` if any track in the slice has solo enabled.

--- a/crates/vibez-engine/src/mixer/groove.rs
+++ b/crates/vibez-engine/src/mixer/groove.rs
@@ -1,0 +1,43 @@
+//! Shared event-read boundary for non-destructive MIDI clip Groove.
+
+use super::*;
+use vibez_core::midi::MidiNote;
+use vibez_core::perform::GrooveGrid;
+
+#[inline]
+pub(super) fn crossed_beat(previous: f64, current: f64, event: f64) -> bool {
+    previous < event && event <= current
+}
+
+#[inline]
+pub(super) fn mapped_note_start(clip: &EngineNoteClip, note: &MidiNote, swing: SwingAmount) -> f64 {
+    clip.groove_grid.map_beat(note.start_beat, swing)
+}
+
+pub(super) fn mapped_note_end(clip: &EngineNoteClip, note_index: usize, swing: SwingAmount) -> f64 {
+    let note = &clip.notes[note_index];
+    let mapped_end = clip.groove_grid.map_beat(note.end_beat(), swing);
+    if clip.groove_grid == GrooveGrid::Off {
+        return mapped_end;
+    }
+    let next_same_pitch = clip
+        .notes
+        .iter()
+        .filter(|candidate| candidate.pitch == note.pitch && candidate.start_beat > note.start_beat)
+        .map(|candidate| mapped_note_start(clip, candidate, swing))
+        .min_by(f64::total_cmp);
+    next_same_pitch.map_or(mapped_end, |next_start| mapped_end.min(next_start))
+}
+
+impl EngineTrack {
+    pub(super) fn reset_groove_latches(&self) {
+        for clip in self
+            .playback_source
+            .note_clips
+            .iter()
+            .chain(self.section_playback_source.note_clips.iter())
+        {
+            clip.reset_groove_latch();
+        }
+    }
+}

--- a/crates/vibez-engine/src/mixer/pan.rs
+++ b/crates/vibez-engine/src/mixer/pan.rs
@@ -1,0 +1,18 @@
+/// Equal-power pan law.
+/// `pan` ranges from 0.0 (hard left) to 1.0 (hard right).
+/// Returns `(left_gain, right_gain)`.
+/// At center (0.5): both channels get ~0.707 (-3dB).
+pub fn equal_power_pan(pan: f32) -> (f32, f32) {
+    let pan = pan.clamp(0.0, 1.0);
+    let angle = pan * std::f32::consts::FRAC_PI_2;
+    (angle.cos(), angle.sin())
+}
+
+/// Stereo balance law for channels that carry already-panned
+/// material (buses): center passes both channels at unity, off-
+/// center attenuates the far side. Equal-power panning here would
+/// tax every centered return 3 dB.
+pub fn balance_pan(pan: f32) -> (f32, f32) {
+    let pan = pan.clamp(0.0, 1.0);
+    (((1.0 - pan) * 2.0).min(1.0), (pan * 2.0).min(1.0))
+}

--- a/crates/vibez-engine/src/playback_source.rs
+++ b/crates/vibez-engine/src/playback_source.rs
@@ -4,12 +4,14 @@
 //! effects, sends, gain/pan, mute/solo, meters, and scratch buffers remain on
 //! [`EngineTrack`](crate::mixer::EngineTrack), the project-owned channel strip.
 
+use std::cell::Cell;
 use std::sync::Arc;
 
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::automation::AutomationLane;
 use vibez_core::id::{ClipId, SectionId, TrackId};
 use vibez_core::midi::MidiNote;
+use vibez_core::perform::GrooveGrid;
 
 /// A resident audio clip on a prepared timeline.
 pub struct EngineClip {
@@ -43,6 +45,59 @@ pub struct EngineNoteClip {
     pub loop_enabled: bool,
     pub loop_start_beats: f64,
     pub loop_end_beats: f64,
+    pub groove_grid: GrooveGrid,
+    groove_latch: Cell<Option<(i64, vibez_core::perform::SwingAmount)>>,
+}
+
+impl EngineNoteClip {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: ClipId,
+        position_beats: f64,
+        duration_beats: f64,
+        notes: Vec<MidiNote>,
+        loop_enabled: bool,
+        loop_start_beats: f64,
+        loop_end_beats: f64,
+        groove_grid: GrooveGrid,
+    ) -> Self {
+        Self {
+            id,
+            position_beats,
+            duration_beats,
+            notes,
+            loop_enabled,
+            loop_start_beats,
+            loop_end_beats,
+            groove_grid,
+            groove_latch: Cell::new(None),
+        }
+    }
+
+    pub fn reset_groove_latch(&self) {
+        self.groove_latch.set(None);
+    }
+
+    pub fn swing_for_pair(
+        &self,
+        local_beat: f64,
+        current: vibez_core::perform::SwingAmount,
+        force_new_pair: bool,
+    ) -> vibez_core::perform::SwingAmount {
+        let Some(pair_beats) = self.groove_grid.pair_beats() else {
+            return current;
+        };
+        let pair_index = (local_beat / pair_beats).floor() as i64;
+        if !force_new_pair {
+            if let Some((latched_pair, latched_swing)) = self.groove_latch.get() {
+                if latched_pair == pair_index {
+                    return latched_swing;
+                }
+            }
+        }
+        self.groove_latch.set(Some((pair_index, current)));
+        current
+    }
 }
 
 /// Map a raw timeline frame through the active Arrange loop.
@@ -310,15 +365,16 @@ mod tests {
         );
         let note_source = PreparedPlaybackSource::new(
             Vec::new(),
-            vec![EngineNoteClip {
-                id: ClipId::new(),
-                position_beats: 2.0,
-                duration_beats: 4.0,
-                notes: Vec::new(),
-                loop_enabled: false,
-                loop_start_beats: 0.0,
-                loop_end_beats: 0.0,
-            }],
+            vec![EngineNoteClip::new(
+                ClipId::new(),
+                2.0,
+                4.0,
+                Vec::new(),
+                false,
+                0.0,
+                0.0,
+                GrooveGrid::Off,
+            )],
             Vec::new(),
         );
         let sources = [audio_source, note_source];

--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -65,6 +65,7 @@ pub struct BounceRequest {
     pub range_samples: (u64, u64),
     pub bpm: f64,
     pub sample_rate: u32,
+    pub swing: vibez_core::perform::SwingAmount,
 }
 
 pub struct BounceResult {
@@ -92,6 +93,7 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
         let mut engine = EngineTrack::new(track_info.id);
         engine.gain = track_info.gain;
         engine.pan = track_info.pan;
+        engine.swing_offset = track_info.swing_offset;
         engine.sends = track_info.sends.clone();
         match req.mode {
             BounceMode::Master => {
@@ -187,15 +189,16 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
             if !clip_included_for_mode(nc.id, req.mode, true) {
                 continue;
             }
-            engine.playback_source.note_clips.push(EngineNoteClip {
-                id: nc.id,
-                position_beats: nc.position_beats,
-                duration_beats: nc.duration_beats,
-                notes: nc.notes.clone(),
-                loop_enabled: nc.loop_enabled,
-                loop_start_beats: nc.loop_start_beats,
-                loop_end_beats: nc.loop_end_beats,
-            });
+            engine.playback_source.note_clips.push(EngineNoteClip::new(
+                nc.id,
+                nc.position_beats,
+                nc.duration_beats,
+                nc.notes.clone(),
+                nc.loop_enabled,
+                nc.loop_start_beats,
+                nc.loop_end_beats,
+                nc.groove_grid,
+            ));
         }
 
         tracks.push(engine);
@@ -297,7 +300,7 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
                         frames: block,
                         channels: CHANNELS,
                         tempo_map: &tempo,
-                        project_swing: vibez_core::perform::SwingAmount::default(),
+                        project_swing: req.swing,
                     },
                     &mut |_| {},
                 )
@@ -452,6 +455,7 @@ mod tests {
             range_samples: (0, 512),
             bpm: 120.0,
             sample_rate: 44_100,
+            swing: vibez_core::perform::SwingAmount::STRAIGHT,
         };
 
         let result = render_offline(&request);
@@ -506,6 +510,7 @@ mod tests {
             range_samples: (0, 200),
             bpm: 120.0,
             sample_rate: 44_100,
+            swing: vibez_core::perform::SwingAmount::STRAIGHT,
         };
         let result = render_offline(&req);
         // Dry + unity send through a flat centered bus doubles the
@@ -568,6 +573,7 @@ mod tests {
             range_samples: (0, 200),
             bpm: 120.0,
             sample_rate: 44_100,
+            swing: vibez_core::perform::SwingAmount::STRAIGHT,
         };
 
         let result = render_offline(&req);
@@ -618,6 +624,7 @@ mod tests {
             range_samples: (0, 100),
             bpm: 120.0,
             sample_rate: 44_100,
+            swing: vibez_core::perform::SwingAmount::STRAIGHT,
         };
         let out = render_offline(&req);
         assert!(out.audio.channels[0].iter().all(|&s| s.abs() < 1e-6));
@@ -661,6 +668,7 @@ mod tests {
             range_samples: (0, 100),
             bpm: 120.0,
             sample_rate: 44_100,
+            swing: vibez_core::perform::SwingAmount::STRAIGHT,
         };
         let out = render_offline(&req);
         assert!(out.audio.channels[0].iter().any(|&s| s.abs() > 1e-4));
@@ -728,6 +736,7 @@ mod tests {
             range_samples: (0, 100),
             bpm: 120.0,
             sample_rate: 44_100,
+            swing: vibez_core::perform::SwingAmount::STRAIGHT,
         };
         let out = render_offline(&req);
         let expected = 0.3 * std::f32::consts::FRAC_1_SQRT_2;
@@ -764,14 +773,15 @@ mod tests {
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Sixteenth,
             notes: vec![MidiNote {
                 pitch: 60,
                 velocity: 100,
-                start_beat: 0.0,
+                start_beat: 0.25,
                 duration_beats: 0.5,
             }],
         };
-        let req = BounceRequest {
+        let mut req = BounceRequest {
             master: None,
             buses: Vec::new(),
             tracks: vec![track],
@@ -784,9 +794,13 @@ mod tests {
             range_samples: (0, 22_050),
             bpm: 120.0,
             sample_rate: 44_100,
+            swing: vibez_core::perform::SwingAmount::STRAIGHT,
         };
-        let out = render_offline(&req);
-        assert!(out.audio.channels[0].iter().any(|&s| s.abs() > 1e-3));
+        let straight = render_offline(&req);
+        assert!(straight.audio.channels[0].iter().any(|&s| s.abs() > 1e-3));
+        req.swing = vibez_core::perform::SwingAmount::new(0.75);
+        let swung = render_offline(&req);
+        assert_ne!(straight.audio.channels, swung.audio.channels);
     }
 
     #[test]
@@ -822,6 +836,7 @@ mod tests {
             range_samples: (0, 4_410),
             bpm: 120.0,
             sample_rate: 44_100,
+            swing: vibez_core::perform::SwingAmount::STRAIGHT,
         };
         let out = render_offline(&req);
         assert!(!out.warnings.is_empty());
@@ -874,6 +889,7 @@ mod tests {
             range_samples: (0, 100),
             bpm: 120.0,
             sample_rate: 44_100,
+            swing: vibez_core::perform::SwingAmount::STRAIGHT,
         };
         let out = render_offline(&req);
         let peak = out.audio.channels[0]

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -542,6 +542,7 @@ mod tests {
                     loop_enabled: false,
                     loop_start_beats: 0.0,
                     loop_end_beats: 0.0,
+                    groove_grid: vibez_core::perform::GrooveGrid::Sixteenth,
                     notes: vec![
                         MidiNote {
                             pitch: 60,
@@ -570,6 +571,10 @@ mod tests {
         assert_eq!(loaded.arrange.note_clips[0].notes.len(), 2);
         assert_eq!(loaded.arrange.note_clips[0].notes[0].pitch, 60);
         assert_eq!(loaded.arrange.note_clips[0].notes[1].pitch, 64);
+        assert_eq!(
+            loaded.arrange.note_clips[0].groove_grid,
+            vibez_core::perform::GrooveGrid::Sixteenth
+        );
     }
 
     #[test]

--- a/crates/vibez-project/src/project_format_v1.rs
+++ b/crates/vibez-project/src/project_format_v1.rs
@@ -980,6 +980,7 @@ pub fn representative_document() -> ProjectDocumentV1 {
                 loop_enabled: true,
                 loop_start_beats: 0.0,
                 loop_end_beats: 4.0,
+                groove_grid: vibez_core::perform::GrooveGrid::Off,
             }],
             ..crate::TimelineInfo::default()
         },

--- a/crates/vibez-ui/examples/make_demo.rs
+++ b/crates/vibez-ui/examples/make_demo.rs
@@ -52,6 +52,7 @@ fn clip(
         loop_enabled: false,
         loop_start_beats: 0.0,
         loop_end_beats: 0.0,
+        groove_grid: vibez_core::perform::GrooveGrid::Off,
     }
 }
 

--- a/crates/vibez-ui/src/app/bounce.rs
+++ b/crates/vibez-ui/src/app/bounce.rs
@@ -109,6 +109,7 @@ impl App {
             range_samples,
             bpm,
             sample_rate,
+            swing: project.swing,
         };
 
         self.state.status_text = format!("Bouncing {clip_name}...");

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -727,6 +727,7 @@ impl App {
                 loop_enabled: note_clip.loop_enabled,
                 loop_start_beats: note_clip.loop_start_beats,
                 loop_end_beats: note_clip.loop_end_beats,
+                groove_grid: note_clip.groove_grid,
             });
             for note in &note_clip.notes {
                 self.send_command(EngineCommand::AddNote {
@@ -749,6 +750,7 @@ impl App {
                         loop_enabled: note_clip.loop_enabled,
                         loop_start_beats: note_clip.loop_start_beats,
                         loop_end_beats: note_clip.loop_end_beats,
+                        groove_grid: note_clip.groove_grid,
                     });
             }
         }
@@ -888,6 +890,7 @@ impl App {
             range_samples: (0, total),
             bpm,
             sample_rate,
+            swing: project.swing,
         };
         self.state.status_text = format!("Exporting to {}...", path.display());
         Task::perform(export_async(request, path), Message::ExportComplete)

--- a/crates/vibez-ui/src/app/project_replay.rs
+++ b/crates/vibez-ui/src/app/project_replay.rs
@@ -269,6 +269,7 @@ impl App {
                 loop_enabled: clip.loop_enabled,
                 loop_start_beats: clip.loop_start_beats,
                 loop_end_beats: clip.loop_end_beats,
+                groove_grid: clip.groove_grid,
             });
             for note in &clip.notes {
                 self.send_command(EngineCommand::AddNote {

--- a/crates/vibez-ui/src/app/project_sections.rs
+++ b/crates/vibez-ui/src/app/project_sections.rs
@@ -49,6 +49,7 @@ pub(super) fn timeline_info_from_ui(timeline: &ArrangementTimeline) -> TimelineI
                         loop_enabled: clip.loop_enabled,
                         loop_start_beats: clip.loop_start_beats,
                         loop_end_beats: clip.loop_end_beats,
+                        groove_grid: clip.groove_grid,
                     }),
             );
         if !content.automation.is_empty() {
@@ -105,6 +106,7 @@ pub(super) fn timeline_without_audio(info: &TimelineInfo) -> ArrangementTimeline
             loop_enabled: clip.loop_enabled,
             loop_start_beats: clip.loop_start_beats,
             loop_end_beats: clip.loop_end_beats,
+            groove_grid: clip.groove_grid,
         });
     }
     timeline
@@ -207,6 +209,7 @@ mod tests {
                 loop_enabled: true,
                 loop_start_beats: 0.0,
                 loop_end_beats: 4.0,
+                groove_grid: vibez_core::perform::GrooveGrid::Sixteenth,
             });
 
         let info = section_info_from_ui(&section);

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -11,6 +11,7 @@ use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::piano_roll::PianoRollMsg;
 use crate::domains::view::ViewMsg;
 use vibez_core::id::{ClipId, TrackId};
+use vibez_core::perform::GrooveGrid;
 
 use crate::icons;
 use crate::message::Message;
@@ -207,7 +208,7 @@ impl App {
         let playhead_beats = self.state.position_beats();
 
         // Extract clip data as owned values (avoids lifetime conflicts with widget construction)
-        let clip_data: Option<(String, f64, f64, bool, TrackId, ClipId)> =
+        let clip_data: Option<(String, f64, f64, bool, GrooveGrid, TrackId, ClipId)> =
             if let Some((tid, cid)) = self.state.active_timeline_editor().selected_note_clip {
                 if tid == track_id {
                     self.state
@@ -219,6 +220,7 @@ impl App {
                                 c.position_beats,
                                 c.duration_beats,
                                 c.loop_enabled,
+                                c.groove_grid,
                                 tid,
                                 cid,
                             )
@@ -232,7 +234,7 @@ impl App {
 
         let piano_widget = if let Some(ref cd) = clip_data {
             if let Some(content) = self.state.active_timeline_content(track_id) {
-                if let Some(clip) = content.note_clips.iter().find(|c| c.id == cd.5) {
+                if let Some(clip) = content.note_clips.iter().find(|c| c.id == cd.6) {
                     let clip_relative_playhead = playhead_beats - clip.position_beats;
                     PianoRollWidget::from_clip(
                         track_id,
@@ -262,7 +264,9 @@ impl App {
         // ── Clip properties bar (shown when a clip is selected) ──
         let mut content_col = column![].spacing(2).padding(4);
 
-        if let Some((ref clip_name_str, clip_pos, clip_dur, clip_loop, tid, cid)) = clip_data {
+        if let Some((ref clip_name_str, clip_pos, clip_dur, clip_loop, groove_grid, tid, cid)) =
+            clip_data
+        {
             let clip_name = text(clip_name_str.clone()).size(11).color(th::text());
             let pos_label = text(format!("Pos: {clip_pos:.1}"))
                 .size(10)
@@ -270,6 +274,48 @@ impl App {
             let dur_label = text(format!("Dur: {clip_dur:.1}"))
                 .size(10)
                 .color(th::text_dim());
+
+            let groove_grid_control = GrooveGrid::ALL.into_iter().fold(
+                row![text("GROOVE GRID").size(8).color(th::text_dim())]
+                    .spacing(1)
+                    .align_y(iced::Alignment::Center),
+                |control, grid| {
+                    let selected = grid == groove_grid;
+                    control.push(
+                        button(text(grid.label()).size(9).color(if selected {
+                            th::accent()
+                        } else {
+                            th::text_dim()
+                        }))
+                        .on_press(Message::PianoRoll(PianoRollMsg::SetNoteClipGrooveGrid(
+                            tid, cid, grid,
+                        )))
+                        .padding([2, 5])
+                        .style(move |_theme: &Theme, _status| button::Style {
+                            background: Some(if selected {
+                                th::accent_dim().into()
+                            } else {
+                                th::bg_elevated().into()
+                            }),
+                            text_color: if selected {
+                                th::accent()
+                            } else {
+                                th::text_dim()
+                            },
+                            border: iced::Border {
+                                color: if selected {
+                                    th::accent_dim()
+                                } else {
+                                    th::border()
+                                },
+                                width: 1.0,
+                                radius: 2.0.into(),
+                            },
+                            ..Default::default()
+                        }),
+                    )
+                },
+            );
 
             // Loop toggle
             let loop_icon_color = if clip_loop {
@@ -348,7 +394,14 @@ impl App {
             .style(op_btn_style);
 
             let props_row = row![
-                clip_name, pos_label, dur_label, loop_btn, dup_btn, double_btn, halve_btn,
+                clip_name,
+                groove_grid_control,
+                pos_label,
+                dur_label,
+                loop_btn,
+                dup_btn,
+                double_btn,
+                halve_btn,
                 crop_btn,
             ]
             .spacing(6)

--- a/crates/vibez-ui/src/domains/arrangement/media_ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/media_ops.rs
@@ -539,6 +539,7 @@ impl TimelineEditorState {
             loop_enabled: joined_loop_enabled,
             loop_start_beats: 0.0,
             loop_end_beats: total_duration,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
         });
         for note in &merged_notes {
             engine.send(EngineCommand::AddNote {
@@ -558,6 +559,7 @@ impl TimelineEditorState {
                 loop_enabled: joined_loop_enabled,
                 loop_start_beats: 0.0,
                 loop_end_beats: total_duration,
+                groove_grid: vibez_core::perform::GrooveGrid::Off,
             });
         }
 
@@ -694,6 +696,7 @@ impl TimelineEditorState {
                     loop_enabled: clip.loop_enabled,
                     loop_start_beats: clip.loop_start_beats,
                     loop_end_beats: clip.loop_end_beats,
+                    groove_grid: clip.groove_grid,
                 });
                 for note in &clip.notes {
                     engine.send(EngineCommand::AddNote {

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -493,6 +493,7 @@ impl TimelineEditorState {
                             loop_enabled: clip.loop_enabled,
                             loop_start_beats: clip.loop_start_beats,
                             loop_end_beats: clip.loop_end_beats,
+                            groove_grid: clip.groove_grid,
                         });
                         for note in &clip.notes {
                             engine.send(EngineCommand::AddNote {
@@ -654,6 +655,7 @@ impl TimelineEditorState {
                                         loop_enabled: duplicate.loop_enabled,
                                         loop_start_beats: duplicate.loop_start_beats,
                                         loop_end_beats: duplicate.loop_end_beats,
+                                        groove_grid: duplicate.groove_grid,
                                     });
                                     for note in &duplicate.notes {
                                         engine.send(EngineCommand::AddNote {
@@ -773,6 +775,7 @@ impl TimelineEditorState {
                                 loop_enabled: clip.loop_enabled,
                                 loop_start_beats: clip.loop_start_beats,
                                 loop_end_beats: clip.loop_end_beats,
+                                groove_grid: clip.groove_grid,
                             },
                             new_pos,
                             clip.duration_beats,
@@ -780,12 +783,21 @@ impl TimelineEditorState {
                             clip.loop_enabled,
                             clip.loop_start_beats,
                             clip.loop_end_beats,
+                            clip.groove_grid,
                         ));
                     }
                 }
 
-                if let Some((new_clip, pos, dur, notes, loop_enabled, loop_start, loop_end)) =
-                    new_clip_data
+                if let Some((
+                    new_clip,
+                    pos,
+                    dur,
+                    notes,
+                    loop_enabled,
+                    loop_start,
+                    loop_end,
+                    groove_grid,
+                )) = new_clip_data
                 {
                     if let Some(track) = self.find_content_mut(track_id) {
                         track.note_clips.push(new_clip);
@@ -798,6 +810,7 @@ impl TimelineEditorState {
                         loop_enabled,
                         loop_start_beats: loop_start,
                         loop_end_beats: loop_end,
+                        groove_grid,
                     });
                     for note in &notes {
                         engine.send(EngineCommand::AddNote {

--- a/crates/vibez-ui/src/domains/arrangement/ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/ops.rs
@@ -216,6 +216,7 @@ impl TimelineEditorState {
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
         });
         engine.send(EngineCommand::AddNoteClip {
             track_id,
@@ -225,6 +226,7 @@ impl TimelineEditorState {
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
         });
         self.selected_note_clip = Some((track_id, clip_id));
         self.selected_clips.clear();
@@ -499,6 +501,7 @@ impl TimelineEditorState {
                         loop_enabled: clip.loop_enabled,
                         loop_start_beats: clip.loop_start_beats,
                         loop_end_beats: clip.loop_end_beats,
+                        groove_grid: clip.groove_grid,
                     });
                     for note in &clip.notes {
                         engine.send(EngineCommand::AddNote {
@@ -695,6 +698,7 @@ impl TimelineEditorState {
                             loop_enabled: clip.loop_enabled,
                             loop_start_beats: clip.loop_start_beats,
                             loop_end_beats: clip.loop_end_beats,
+                            groove_grid: clip.groove_grid,
                         });
                         for note in clip.notes {
                             engine.send(EngineCommand::AddNote {

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -565,6 +565,7 @@ fn partial_time_selection_copies_audio_and_trimmed_midi() {
         loop_enabled: false,
         loop_start_beats: 0.0,
         loop_end_beats: 0.0,
+        groove_grid: vibez_core::perform::GrooveGrid::Off,
     });
     a.time_selection_active = true;
     a.selection_start_beats = 2.0;
@@ -683,6 +684,7 @@ fn duplicate_preserves_audio_and_midi_loop_settings() {
         loop_enabled: true,
         loop_start_beats: 0.0,
         loop_end_beats: 4.0,
+        groove_grid: vibez_core::perform::GrooveGrid::Sixteenth,
     });
     a.selected_clips.insert(ArrangementSelection::AudioClip {
         track_id: audio_tid,
@@ -773,6 +775,7 @@ fn midi_duplicate_keeps_the_source_clip_name_readable() {
         loop_enabled: false,
         loop_start_beats: 0.0,
         loop_end_beats: 0.0,
+        groove_grid: vibez_core::perform::GrooveGrid::Off,
     });
     a.selected_clips
         .insert(ArrangementSelection::NoteClip { track_id, clip_id });
@@ -842,6 +845,7 @@ fn split_looped_midi_materializes_both_looped_halves() {
         loop_enabled: true,
         loop_start_beats: 0.0,
         loop_end_beats: 4.0,
+        groove_grid: vibez_core::perform::GrooveGrid::Sixteenth,
     });
 
     a.update(
@@ -922,6 +926,7 @@ fn join_looped_midi_expands_repetitions_and_remains_looped() {
             loop_enabled: true,
             loop_start_beats: 0.0,
             loop_end_beats: 4.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Sixteenth,
         });
         a.selected_clips
             .insert(ArrangementSelection::NoteClip { track_id, clip_id });

--- a/crates/vibez-ui/src/domains/perform/sections.rs
+++ b/crates/vibez-ui/src/domains/perform/sections.rs
@@ -152,14 +152,17 @@ impl Section {
                 let note_clips = content
                     .into_iter()
                     .flat_map(|content| content.note_clips.iter())
-                    .map(|clip| EngineNoteClip {
-                        id: clip.id,
-                        position_beats: clip.position_beats,
-                        duration_beats: clip.duration_beats,
-                        notes: clip.notes.clone(),
-                        loop_enabled: clip.loop_enabled,
-                        loop_start_beats: clip.loop_start_beats,
-                        loop_end_beats: clip.loop_end_beats,
+                    .map(|clip| {
+                        EngineNoteClip::new(
+                            clip.id,
+                            clip.position_beats,
+                            clip.duration_beats,
+                            clip.notes.clone(),
+                            clip.loop_enabled,
+                            clip.loop_start_beats,
+                            clip.loop_end_beats,
+                            clip.groove_grid,
+                        )
                     })
                     .collect();
                 let automation = content
@@ -273,6 +276,7 @@ mod tests {
                     loop_enabled: false,
                     loop_start_beats: 0.0,
                     loop_end_beats: 0.0,
+                    groove_grid: vibez_core::perform::GrooveGrid::Sixteenth,
                 }],
                 automation: vec![lane],
                 ..TrackTimelineContent::default()
@@ -320,6 +324,7 @@ mod tests {
                 loop_enabled: false,
                 loop_start_beats: 0.0,
                 loop_end_beats: 0.0,
+                groove_grid: vibez_core::perform::GrooveGrid::Off,
             });
 
         assert!(arrange.editor.timeline.get(track_id).is_none());
@@ -347,6 +352,7 @@ mod tests {
                 loop_enabled: false,
                 loop_start_beats: 0.0,
                 loop_end_beats: 0.0,
+                groove_grid: vibez_core::perform::GrooveGrid::Off,
             });
         let section_clip = &section.editor().timeline.get(track_id).unwrap().note_clips[0];
         assert_eq!(section_clip.name, "Section Pattern");
@@ -367,6 +373,7 @@ mod tests {
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
         };
         Arc::make_mut(&mut section.timeline)
             .ensure(track_id)
@@ -406,6 +413,7 @@ mod tests {
                 loop_enabled: false,
                 loop_start_beats: 0.0,
                 loop_end_beats: 0.0,
+                groove_grid: vibez_core::perform::GrooveGrid::Off,
             });
         let tracks = [
             crate::state::ProjectTrack::new(populated_id, "Drums".into(), 0),

--- a/crates/vibez-ui/src/domains/piano_roll.rs
+++ b/crates/vibez-ui/src/domains/piano_roll.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::MidiNote;
+use vibez_core::perform::GrooveGrid;
 use vibez_engine::commands::EngineCommand;
 
 use super::EngineHandle;
@@ -23,6 +24,7 @@ use crate::state::{
 #[derive(Debug, Clone)]
 pub enum PianoRollMsg {
     ToggleNoteClipLoop(TrackId, ClipId),
+    SetNoteClipGrooveGrid(TrackId, ClipId, GrooveGrid),
     SetNoteClipLoopRegion {
         track_id: TrackId,
         clip_id: ClipId,
@@ -228,6 +230,20 @@ impl PianoRollState {
                     });
                 }
             }
+            PianoRollMsg::SetNoteClipGrooveGrid(track_id, clip_id, groove_grid) => {
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if let Some(clip) = track.note_clips.iter_mut().find(|clip| clip.id == clip_id)
+                    {
+                        clip.groove_grid = groove_grid;
+                    }
+                }
+                engine.send(EngineCommand::SetNoteClipGrooveGrid {
+                    track_id,
+                    clip_id,
+                    groove_grid,
+                });
+                action.status = Some(format!("Groove Grid: {}", groove_grid.label()));
+            }
             PianoRollMsg::SetNoteClipLoopRegion {
                 track_id,
                 clip_id,
@@ -265,6 +281,7 @@ impl PianoRollState {
                     loop_enabled: true,
                     loop_start_beats: 0.0,
                     loop_end_beats: duration_beats,
+                    groove_grid: vibez_core::perform::GrooveGrid::Off,
                 });
                 engine.send(EngineCommand::AddNoteClip {
                     track_id,
@@ -274,6 +291,7 @@ impl PianoRollState {
                     loop_enabled: true,
                     loop_start_beats: 0.0,
                     loop_end_beats: duration_beats,
+                    groove_grid: vibez_core::perform::GrooveGrid::Off,
                 });
                 // Auto-select the new note clip for piano roll editing
                 action.select_note_clip = Some((track_id, clip_id));
@@ -554,12 +572,13 @@ impl PianoRollState {
                                 clip.position_beats,
                                 clip.duration_beats,
                                 clip.notes.clone(),
+                                clip.groove_grid,
                             ));
                         }
                     }
                 }
                 // Sync to engine outside the mutable borrow
-                if let Some((pos, dur, notes)) = sync_data {
+                if let Some((pos, dur, notes, groove_grid)) = sync_data {
                     engine.send(EngineCommand::RemoveNoteClip(track_id, clip_id));
                     engine.send(EngineCommand::AddNoteClip {
                         track_id,
@@ -569,6 +588,7 @@ impl PianoRollState {
                         loop_enabled: false,
                         loop_start_beats: 0.0,
                         loop_end_beats: 0.0,
+                        groove_grid,
                     });
                     for note in &notes {
                         engine.send(EngineCommand::AddNote {
@@ -625,12 +645,20 @@ impl PianoRollState {
                             clip.loop_enabled,
                             clip.loop_start_beats,
                             clip.loop_end_beats,
+                            clip.groove_grid,
                         ));
                     }
                 }
                 // Sync to engine via Remove+Add+re-add-notes (loop state included atomically)
-                if let Some((pos, dur, notes, loop_enabled, loop_start_beats, loop_end_beats)) =
-                    sync_data
+                if let Some((
+                    pos,
+                    dur,
+                    notes,
+                    loop_enabled,
+                    loop_start_beats,
+                    loop_end_beats,
+                    groove_grid,
+                )) = sync_data
                 {
                     engine.send(EngineCommand::RemoveNoteClip(track_id, clip_id));
                     engine.send(EngineCommand::AddNoteClip {
@@ -641,6 +669,7 @@ impl PianoRollState {
                         loop_enabled,
                         loop_start_beats,
                         loop_end_beats,
+                        groove_grid,
                     });
                     for note in &notes {
                         engine.send(EngineCommand::AddNote {
@@ -731,6 +760,7 @@ mod tests {
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
+            groove_grid: GrooveGrid::Off,
         });
         (timeline, track_id, clip_id)
     }
@@ -855,6 +885,34 @@ mod tests {
         assert_eq!(clip.loop_start_beats, 0.0);
         assert_eq!(clip.loop_end_beats, 4.0);
         assert!(matches!(engine.0[0], EngineCommand::SetNoteClipLoop { .. }));
+    }
+
+    #[test]
+    fn groove_grid_updates_the_clip_and_live_engine_source() {
+        let (mut tracks, tid, cid) = midi_track_with_clip();
+        let mut piano_roll = PianoRollState::default();
+        let mut engine = RecordingEngine::default();
+
+        let action = piano_roll.update(
+            PianoRollMsg::SetNoteClipGrooveGrid(tid, cid, GrooveGrid::Sixteenth),
+            &mut engine,
+            &mut tracks,
+            PianoRollCtx::default(),
+        );
+
+        assert_eq!(
+            tracks.get(tid).unwrap().note_clips[0].groove_grid,
+            GrooveGrid::Sixteenth
+        );
+        assert!(matches!(
+            engine.0[0],
+            EngineCommand::SetNoteClipGrooveGrid {
+                track_id,
+                clip_id,
+                groove_grid: GrooveGrid::Sixteenth,
+            } if track_id == tid && clip_id == cid
+        ));
+        assert_eq!(action.status.as_deref(), Some("Groove Grid: 1/16"));
     }
 
     #[test]

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -813,6 +813,7 @@ mod tests {
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
         });
         if let Some(t) = Arc::make_mut(&mut state.arrangement.timeline).get_mut(tid) {
             if let Some(c) = t.note_clips.iter_mut().find(|c| c.id == cid) {

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -168,6 +168,7 @@ pub struct UiNoteClip {
     pub loop_enabled: bool,
     pub loop_start_beats: f64,
     pub loop_end_beats: f64,
+    pub groove_grid: vibez_core::perform::GrooveGrid,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -142,6 +142,7 @@ fn clip_resize_does_not_hide_the_preceding_automation_undo_step() {
                     loop_enabled: false,
                     loop_start_beats: 0.0,
                     loop_end_beats: 0.0,
+                    groove_grid: vibez_core::perform::GrooveGrid::Sixteenth,
                 }],
                 ..Default::default()
             },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,10 +167,15 @@ Project Swing, and optional Project Track Swing offsets as canonical project
 data and undo state. Swing uses the profile's native `50..75%` long/short pair
 ratio and the Project Track offset adds percentage points before clamping to
 that range. Generated `1/8` and `1/16` events resolve on the profile's 96 PPQN
-clock; `1/4`, `1/32`, and triplet rates remain exact. Existing clip notes keep
-their persisted absolute beat positions and never enter this transform. The
-engine retains Swing beside its generated-event scheduler so later Section
-Record quantization can share the contract without changing clip playback.
+clock; `1/4`, `1/32`, and triplet rates remain exact. MIDI clips opt into the
+same live transform with a persisted `Off | 1/8 | 1/16` Groove Grid; `Off` is
+the legacy and new-clip default. The render scheduler maps both endpoints
+through a monotonic pair shape whose midpoint is the same 96 PPQN Swing tick,
+so stored beat positions remain canonical and free human timing needs no
+tolerance heuristic. Swing is latched at each clip-local pair boundary, applied
+at the shared Arrange/Section event read, and never baked into prepared Section
+content. Shortened sources drop mapped onsets beyond their boundary, and mapped
+note-offs are clamped to the next same-pitch onset.
 While transport plays, the first repeated hit comes from the active musical
 grid and an Immediate Section transition establishes a new grid origin. Vibez
 deliberately extends MPC Note Repeat to stopped transport: the first pad sounds
@@ -335,7 +340,8 @@ are handled in three stages:
   flattened into the existing `clips`/`note_clips` keys for compatibility;
   legacy track automation is migrated into Arrange Timeline Content on load.
   Project Groove data persists as the versioned `groove_profile`, native
-  `swing` ratio, and optional Project Track `swing_offset` fields.
+  `swing` ratio, optional Project Track `swing_offset` fields, and each MIDI
+  clip's opt-in `groove_grid`.
   Existing project bytes therefore load with an empty Section store and no
   format migration.
 - Save, load, media collection and hydration, unresolved-media preservation,


### PR DESCRIPTION
## Summary

- persist an explicit Off / 1/8 / 1/16 Groove Grid on MIDI clips, defaulting legacy and new clips to Off
- map opted-in Arrange and resident Section playback through the MPC2000XL 96 PPQN pair shape without rewriting stored notes
- latch Swing at clip-local pair boundaries and guard shortened sources, same-pitch retriggers, Track offsets, and offline bounce parity
- place the compact Groove Grid selector in the shared clip detail strip

## Stack

- stacked on #92
- no merge requested

## Verification

- cargo test --workspace -j 4
- cargo clippy --workspace -j 4 -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- off-screen native UI render at 1400x900

Exact fixtures cover 50%, 56%, 66%, and 75% ticks, Grid Off identity, off-grid monotonic mapping, pair-boundary latching, loop-local playback, prepared Sections, shortened boundaries, same-pitch note-off clamping, Track offsets, persistence, and bounce parity.