### PR TITLE
Fix Arrange context menu dismissal race

### DIFF
--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -146,6 +146,7 @@ mod project_replay;
 mod project_sections;
 mod update;
 mod update_media;
+mod update_policy;
 mod update_remote;
 mod update_timeline;
 mod views_arrangement;

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -51,6 +51,10 @@ fn context_menu_message_keeps_open(message: &Message) -> bool {
             | Message::View(ViewMsg::CursorMoved(_, _))
             | Message::View(ViewMsg::WindowResized(_, _))
             | Message::View(ViewMsg::MouseReleased)
+            | Message::KeyboardInput {
+                event: iced::keyboard::Event::ModifiersChanged(_),
+                ..
+            }
             | Message::Browser(_)
             | Message::RemoteCatalogPageFetched { .. }
             | Message::RemoteCatalogSaved { .. }
@@ -1095,5 +1099,13 @@ mod tests {
                 result: Ok(()),
             },
         ));
+    }
+
+    #[test]
+    fn modifier_state_sync_after_right_click_does_not_dismiss_context_menu() {
+        assert!(context_menu_message_keeps_open(&Message::KeyboardInput {
+            event: iced::keyboard::Event::ModifiersChanged(iced::keyboard::Modifiers::empty(),),
+            occurred_at: std::time::Instant::now(),
+        }));
     }
 }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -27,6 +27,53 @@ fn apply_project_track_deletion_policy(message: Message, confirm: bool) -> Messa
     }
 }
 
+fn context_menu_message_keeps_open(message: &Message) -> bool {
+    matches!(
+        message,
+        Message::Tick
+            | Message::Transport(TransportMsg::EnginePosition(_))
+            | Message::EngineMetering { .. }
+            | Message::Transport(TransportMsg::EngineStopped)
+            | Message::Arrangement(ArrangementMsg::EngineTrackMeter { .. })
+            | Message::View(ViewMsg::ShowContextMenu { .. })
+            | Message::View(ViewMsg::DismissContextMenu)
+            | Message::Arrangement(ArrangementMsg::DeleteClipsInRegion { .. })
+            | Message::Arrangement(ArrangementMsg::SetSelectionAsLoop)
+            | Message::Arrangement(ArrangementMsg::DeleteSelectedClip)
+            | Message::Arrangement(ArrangementMsg::DuplicateSelectedClip)
+            | Message::Arrangement(ArrangementMsg::SplitSelectedAtPlayhead)
+            | Message::Arrangement(ArrangementMsg::JoinSelectedClips)
+            | Message::Arrangement(ArrangementMsg::SplitAudioClip { .. })
+            | Message::Arrangement(ArrangementMsg::SplitNoteClip { .. })
+            | Message::Arrangement(ArrangementMsg::SplitClipsAtRegion { .. })
+            | Message::Arrangement(ArrangementMsg::CreateNoteClipFromSelection(_))
+            | Message::View(ViewMsg::EditNameText(_))
+            | Message::View(ViewMsg::CursorMoved(_, _))
+            | Message::View(ViewMsg::WindowResized(_, _))
+            | Message::View(ViewMsg::MouseReleased)
+            | Message::Browser(_)
+            | Message::RemoteCatalogPageFetched { .. }
+            | Message::RemoteCatalogSaved { .. }
+            | Message::NewProject
+            | Message::OpenProject
+            | Message::SaveProject
+            | Message::SaveProjectAs
+            | Message::Project(ProjectMsg::ToggleFileMenu)
+            | Message::Project(ProjectMsg::DismissFileMenu)
+            | Message::ProjectOpenPathSelected(_)
+            | Message::ProjectSavePathSelected(_)
+            | Message::ProjectLoaded(_)
+            | Message::ProjectSaved(_)
+            | Message::OpenSettings
+            | Message::CloseSettings
+            | Message::SelectSettingsTab(_)
+            | Message::SetBufferSize(_)
+            | Message::ScanPlugins
+            | Message::ScanPluginsComplete(_)
+            | Message::PluginLoadError(_)
+    )
+}
+
 impl App {
     pub(super) fn update(&mut self, message: Message) -> Task<Message> {
         let (message, undo_gesture) = match message {
@@ -53,51 +100,8 @@ impl App {
             }
         }
         // Auto-dismiss context menu on any action except tick/engine/menu events
-        if self.state.view.context_menu.is_some() {
-            let keep_menu = matches!(
-                message,
-                Message::Tick
-                    | Message::Transport(TransportMsg::EnginePosition(_))
-                    | Message::EngineMetering { .. }
-                    | Message::Transport(TransportMsg::EngineStopped)
-                    | Message::Arrangement(ArrangementMsg::EngineTrackMeter { .. })
-                    | Message::View(ViewMsg::ShowContextMenu { .. })
-                    | Message::View(ViewMsg::DismissContextMenu)
-                    | Message::Arrangement(ArrangementMsg::DeleteClipsInRegion { .. })
-                    | Message::Arrangement(ArrangementMsg::SetSelectionAsLoop)
-                    | Message::Arrangement(ArrangementMsg::DeleteSelectedClip)
-                    | Message::Arrangement(ArrangementMsg::DuplicateSelectedClip)
-                    | Message::Arrangement(ArrangementMsg::SplitSelectedAtPlayhead)
-                    | Message::Arrangement(ArrangementMsg::JoinSelectedClips)
-                    | Message::Arrangement(ArrangementMsg::SplitAudioClip { .. })
-                    | Message::Arrangement(ArrangementMsg::SplitNoteClip { .. })
-                    | Message::Arrangement(ArrangementMsg::SplitClipsAtRegion { .. })
-                    | Message::Arrangement(ArrangementMsg::CreateNoteClipFromSelection(_))
-                    | Message::View(ViewMsg::EditNameText(_))
-                    | Message::View(ViewMsg::CursorMoved(_, _))
-                    | Message::View(ViewMsg::WindowResized(_, _))
-                    | Message::View(ViewMsg::MouseReleased)
-                    | Message::NewProject
-                    | Message::OpenProject
-                    | Message::SaveProject
-                    | Message::SaveProjectAs
-                    | Message::Project(ProjectMsg::ToggleFileMenu)
-                    | Message::Project(ProjectMsg::DismissFileMenu)
-                    | Message::ProjectOpenPathSelected(_)
-                    | Message::ProjectSavePathSelected(_)
-                    | Message::ProjectLoaded(_)
-                    | Message::ProjectSaved(_)
-                    | Message::OpenSettings
-                    | Message::CloseSettings
-                    | Message::SelectSettingsTab(_)
-                    | Message::SetBufferSize(_)
-                    | Message::ScanPlugins
-                    | Message::ScanPluginsComplete(_)
-                    | Message::PluginLoadError(_)
-            );
-            if !keep_menu {
-                self.state.view.context_menu = None;
-            }
+        if self.state.view.context_menu.is_some() && !context_menu_message_keeps_open(&message) {
+            self.state.view.context_menu = None;
         }
 
         let should_mark_dirty = matches!(
@@ -1068,6 +1072,28 @@ mod tests {
         assert!(matches!(
             confirmed,
             Message::Arrangement(ArrangementMsg::RequestRemoveTrack(id)) if id == track_id
+        ));
+    }
+
+    #[test]
+    fn arrangement_drag_hover_does_not_dismiss_an_open_context_menu() {
+        assert!(context_menu_message_keeps_open(&Message::Browser(
+            BrowserMsg::DragHoverTrack {
+                track_id: TrackId::new(),
+                beat: 4.0,
+                compatible: true,
+            },
+        )));
+    }
+
+    #[test]
+    fn remote_catalog_progress_does_not_dismiss_an_open_context_menu() {
+        assert!(context_menu_message_keeps_open(
+            &Message::RemoteCatalogSaved {
+                generation: 1,
+                next_checkpoint: None,
+                result: Ok(()),
+            },
         ));
     }
 }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -16,67 +16,8 @@ use crate::services::plugin_loader::{load_plugin_effect_bg, load_plugin_instrume
 
 use crate::message::Message;
 
+use super::update_policy::{apply_project_track_deletion_policy, context_menu_message_keeps_open};
 use super::*;
-
-fn apply_project_track_deletion_policy(message: Message, confirm: bool) -> Message {
-    match message {
-        Message::Arrangement(ArrangementMsg::RequestRemoveTrack(track_id)) if !confirm => {
-            Message::Arrangement(ArrangementMsg::RemoveTrack(track_id))
-        }
-        message => message,
-    }
-}
-
-fn context_menu_message_keeps_open(message: &Message) -> bool {
-    matches!(
-        message,
-        Message::Tick
-            | Message::Transport(TransportMsg::EnginePosition(_))
-            | Message::EngineMetering { .. }
-            | Message::Transport(TransportMsg::EngineStopped)
-            | Message::Arrangement(ArrangementMsg::EngineTrackMeter { .. })
-            | Message::View(ViewMsg::ShowContextMenu { .. })
-            | Message::View(ViewMsg::DismissContextMenu)
-            | Message::Arrangement(ArrangementMsg::DeleteClipsInRegion { .. })
-            | Message::Arrangement(ArrangementMsg::SetSelectionAsLoop)
-            | Message::Arrangement(ArrangementMsg::DeleteSelectedClip)
-            | Message::Arrangement(ArrangementMsg::DuplicateSelectedClip)
-            | Message::Arrangement(ArrangementMsg::SplitSelectedAtPlayhead)
-            | Message::Arrangement(ArrangementMsg::JoinSelectedClips)
-            | Message::Arrangement(ArrangementMsg::SplitAudioClip { .. })
-            | Message::Arrangement(ArrangementMsg::SplitNoteClip { .. })
-            | Message::Arrangement(ArrangementMsg::SplitClipsAtRegion { .. })
-            | Message::Arrangement(ArrangementMsg::CreateNoteClipFromSelection(_))
-            | Message::View(ViewMsg::EditNameText(_))
-            | Message::View(ViewMsg::CursorMoved(_, _))
-            | Message::View(ViewMsg::WindowResized(_, _))
-            | Message::View(ViewMsg::MouseReleased)
-            | Message::KeyboardInput {
-                event: iced::keyboard::Event::ModifiersChanged(_),
-                ..
-            }
-            | Message::Browser(_)
-            | Message::RemoteCatalogPageFetched { .. }
-            | Message::RemoteCatalogSaved { .. }
-            | Message::NewProject
-            | Message::OpenProject
-            | Message::SaveProject
-            | Message::SaveProjectAs
-            | Message::Project(ProjectMsg::ToggleFileMenu)
-            | Message::Project(ProjectMsg::DismissFileMenu)
-            | Message::ProjectOpenPathSelected(_)
-            | Message::ProjectSavePathSelected(_)
-            | Message::ProjectLoaded(_)
-            | Message::ProjectSaved(_)
-            | Message::OpenSettings
-            | Message::CloseSettings
-            | Message::SelectSettingsTab(_)
-            | Message::SetBufferSize(_)
-            | Message::ScanPlugins
-            | Message::ScanPluginsComplete(_)
-            | Message::PluginLoadError(_)
-    )
-}
 
 impl App {
     pub(super) fn update(&mut self, message: Message) -> Task<Message> {
@@ -1049,63 +990,5 @@ impl App {
             }
         }
         Task::none()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use vibez_core::id::TrackId;
-
-    #[test]
-    fn project_track_deletion_policy_defaults_to_the_direct_undoable_command() {
-        let track_id = TrackId::new();
-        let direct = apply_project_track_deletion_policy(
-            Message::Arrangement(ArrangementMsg::RequestRemoveTrack(track_id)),
-            false,
-        );
-        assert!(matches!(
-            direct,
-            Message::Arrangement(ArrangementMsg::RemoveTrack(id)) if id == track_id
-        ));
-
-        let confirmed = apply_project_track_deletion_policy(
-            Message::Arrangement(ArrangementMsg::RequestRemoveTrack(track_id)),
-            true,
-        );
-        assert!(matches!(
-            confirmed,
-            Message::Arrangement(ArrangementMsg::RequestRemoveTrack(id)) if id == track_id
-        ));
-    }
-
-    #[test]
-    fn arrangement_drag_hover_does_not_dismiss_an_open_context_menu() {
-        assert!(context_menu_message_keeps_open(&Message::Browser(
-            BrowserMsg::DragHoverTrack {
-                track_id: TrackId::new(),
-                beat: 4.0,
-                compatible: true,
-            },
-        )));
-    }
-
-    #[test]
-    fn remote_catalog_progress_does_not_dismiss_an_open_context_menu() {
-        assert!(context_menu_message_keeps_open(
-            &Message::RemoteCatalogSaved {
-                generation: 1,
-                next_checkpoint: None,
-                result: Ok(()),
-            },
-        ));
-    }
-
-    #[test]
-    fn modifier_state_sync_after_right_click_does_not_dismiss_context_menu() {
-        assert!(context_menu_message_keeps_open(&Message::KeyboardInput {
-            event: iced::keyboard::Event::ModifiersChanged(iced::keyboard::Modifiers::empty(),),
-            occurred_at: std::time::Instant::now(),
-        }));
     }
 }

--- a/crates/vibez-ui/src/app/update_policy.rs
+++ b/crates/vibez-ui/src/app/update_policy.rs
@@ -1,0 +1,137 @@
+//! Router-level message policies kept separate from the exhaustive update
+//! dispatch so policy growth cannot turn `update.rs` back into a megafile.
+
+use crate::domains::arrangement::ArrangementMsg;
+use crate::domains::project::ProjectMsg;
+use crate::domains::transport::TransportMsg;
+use crate::domains::view::ViewMsg;
+use crate::message::Message;
+
+pub(super) fn apply_project_track_deletion_policy(message: Message, confirm: bool) -> Message {
+    match message {
+        Message::Arrangement(ArrangementMsg::RequestRemoveTrack(track_id)) if !confirm => {
+            Message::Arrangement(ArrangementMsg::RemoveTrack(track_id))
+        }
+        message => message,
+    }
+}
+
+pub(super) fn context_menu_message_keeps_open(message: &Message) -> bool {
+    if let Message::Browser(message) = message {
+        return message.keeps_context_menu();
+    }
+
+    matches!(
+        message,
+        Message::Tick
+            | Message::Transport(TransportMsg::EnginePosition(_))
+            | Message::EngineMetering { .. }
+            | Message::Transport(TransportMsg::EngineStopped)
+            | Message::Arrangement(ArrangementMsg::EngineTrackMeter { .. })
+            | Message::View(ViewMsg::ShowContextMenu { .. })
+            | Message::View(ViewMsg::DismissContextMenu)
+            | Message::Arrangement(ArrangementMsg::DeleteClipsInRegion { .. })
+            | Message::Arrangement(ArrangementMsg::SetSelectionAsLoop)
+            | Message::Arrangement(ArrangementMsg::DeleteSelectedClip)
+            | Message::Arrangement(ArrangementMsg::DuplicateSelectedClip)
+            | Message::Arrangement(ArrangementMsg::SplitSelectedAtPlayhead)
+            | Message::Arrangement(ArrangementMsg::JoinSelectedClips)
+            | Message::Arrangement(ArrangementMsg::SplitAudioClip { .. })
+            | Message::Arrangement(ArrangementMsg::SplitNoteClip { .. })
+            | Message::Arrangement(ArrangementMsg::SplitClipsAtRegion { .. })
+            | Message::Arrangement(ArrangementMsg::CreateNoteClipFromSelection(_))
+            | Message::View(ViewMsg::EditNameText(_))
+            | Message::View(ViewMsg::CursorMoved(_, _))
+            | Message::View(ViewMsg::WindowResized(_, _))
+            | Message::View(ViewMsg::MouseReleased)
+            | Message::KeyboardInput {
+                event: iced::keyboard::Event::ModifiersChanged(_),
+                ..
+            }
+            | Message::RemoteCatalogPageFetched { .. }
+            | Message::RemoteCatalogSaved { .. }
+            | Message::NewProject
+            | Message::OpenProject
+            | Message::SaveProject
+            | Message::SaveProjectAs
+            | Message::Project(ProjectMsg::ToggleFileMenu)
+            | Message::Project(ProjectMsg::DismissFileMenu)
+            | Message::ProjectOpenPathSelected(_)
+            | Message::ProjectSavePathSelected(_)
+            | Message::ProjectLoaded(_)
+            | Message::ProjectSaved(_)
+            | Message::OpenSettings
+            | Message::CloseSettings
+            | Message::SelectSettingsTab(_)
+            | Message::SetBufferSize(_)
+            | Message::ScanPlugins
+            | Message::ScanPluginsComplete(_)
+            | Message::PluginLoadError(_)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::browser::BrowserMsg;
+    use vibez_core::id::TrackId;
+
+    #[test]
+    fn project_track_deletion_policy_defaults_to_the_direct_undoable_command() {
+        let track_id = TrackId::new();
+        let direct = apply_project_track_deletion_policy(
+            Message::Arrangement(ArrangementMsg::RequestRemoveTrack(track_id)),
+            false,
+        );
+        assert!(matches!(
+            direct,
+            Message::Arrangement(ArrangementMsg::RemoveTrack(id)) if id == track_id
+        ));
+
+        let confirmed = apply_project_track_deletion_policy(
+            Message::Arrangement(ArrangementMsg::RequestRemoveTrack(track_id)),
+            true,
+        );
+        assert!(matches!(
+            confirmed,
+            Message::Arrangement(ArrangementMsg::RequestRemoveTrack(id)) if id == track_id
+        ));
+    }
+
+    #[test]
+    fn passive_arrangement_drag_hover_does_not_dismiss_context_menu() {
+        assert!(context_menu_message_keeps_open(&Message::Browser(
+            BrowserMsg::DragHoverTrack {
+                track_id: TrackId::new(),
+                beat: 4.0,
+                compatible: true,
+            },
+        )));
+    }
+
+    #[test]
+    fn deliberate_browser_actions_dismiss_context_menu() {
+        assert!(!context_menu_message_keeps_open(&Message::Browser(
+            BrowserMsg::ToggleSampleBrowser,
+        )));
+    }
+
+    #[test]
+    fn remote_catalog_progress_does_not_dismiss_context_menu() {
+        assert!(context_menu_message_keeps_open(
+            &Message::RemoteCatalogSaved {
+                generation: 1,
+                next_checkpoint: None,
+                result: Ok(()),
+            },
+        ));
+    }
+
+    #[test]
+    fn modifier_state_sync_after_right_click_does_not_dismiss_context_menu() {
+        assert!(context_menu_message_keeps_open(&Message::KeyboardInput {
+            event: iced::keyboard::Event::ModifiersChanged(iced::keyboard::Modifiers::empty()),
+            occurred_at: std::time::Instant::now(),
+        }));
+    }
+}

--- a/crates/vibez-ui/src/app/views_arrangement.rs
+++ b/crates/vibez-ui/src/app/views_arrangement.rs
@@ -213,6 +213,7 @@ impl App {
         // Track rows: header widgets + clip canvas
         let mut track_rows = column![].spacing(0);
         let empty_content = TrackTimelineContent::default();
+        let browser_drag_active = self.state.browser.drag_source.is_some();
 
         for (track_index, track) in self.state.project_tracks.tracks.iter().enumerate() {
             let content = timeline.timeline.get(track.id).unwrap_or(&empty_content);
@@ -275,7 +276,7 @@ impl App {
                 timeline.selection_start_beats,
                 timeline.selection_end_beats,
                 timeline.time_selection_track,
-                self.state.browser.drag_source.is_some(),
+                browser_drag_active,
                 browser_drag_duration,
                 browser_drag_detail.clone(),
             );
@@ -283,24 +284,27 @@ impl App {
             let compatible = !track.kind.is_midi();
             let grid = self.state.view.grid_config();
             let track_geometry = geometry;
-            let clip_canvas: Element<'_, Message> = mouse_area(
+            let mut clip_canvas_area = mouse_area(
                 canvas(clip_canvas_widget)
                     .width(Length::Fill)
                     .height(Length::Fixed(70.0)),
-            )
-            .on_move(move |point| {
-                let beat = grid.snap_beat(
-                    track_geometry.x_to_beat(point.x),
-                    track_geometry.pixels_per_beat(),
-                );
-                Message::Browser(BrowserMsg::DragHoverTrack {
-                    track_id,
-                    beat: beat.max(0.0),
-                    compatible,
-                })
-            })
-            .on_exit(Message::Browser(BrowserMsg::ClearDragTarget))
-            .into();
+            );
+            if browser_drag_active {
+                clip_canvas_area = clip_canvas_area
+                    .on_move(move |point| {
+                        let beat = grid.snap_beat(
+                            track_geometry.x_to_beat(point.x),
+                            track_geometry.pixels_per_beat(),
+                        );
+                        Message::Browser(BrowserMsg::DragHoverTrack {
+                            track_id,
+                            beat: beat.max(0.0),
+                            compatible,
+                        })
+                    })
+                    .on_exit(Message::Browser(BrowserMsg::ClearDragTarget));
+            }
+            let clip_canvas: Element<'_, Message> = clip_canvas_area.into();
 
             let track_row = row![header, clip_canvas].height(Length::Fixed(70.0));
 

--- a/crates/vibez-ui/src/app/views_arrangement.rs
+++ b/crates/vibez-ui/src/app/views_arrangement.rs
@@ -58,8 +58,8 @@ impl App {
                     }),
             )
             .on_right_press(Message::View(ViewMsg::ShowContextMenu {
-                x: 400.0,
-                y: 300.0,
+                x: self.state.view.cursor_x,
+                y: self.state.view.cursor_y,
                 target: ContextMenuTarget::ArrangementEmpty,
             }));
             if browser_drag_active {
@@ -501,9 +501,8 @@ impl App {
         ));
 
         // mouse_area only provides on_right_press (no cursor position),
-        // so the right-click context menu from the scrollable background
-        // opens at a default position. Track canvas right-clicks still
-        // use the precise cursor location.
+        // so use the globally tracked cursor for the scrollable background.
+        // Track canvas right-clicks still supply their precise event position.
         mouse_area(
             container(scrollable_content)
                 .width(Length::Fill)
@@ -514,8 +513,8 @@ impl App {
                 }),
         )
         .on_right_press(Message::View(ViewMsg::ShowContextMenu {
-            x: 400.0,
-            y: 300.0,
+            x: self.state.view.cursor_x,
+            y: self.state.view.cursor_y,
             target: ContextMenuTarget::ArrangementEmpty,
         }))
         .into()

--- a/crates/vibez-ui/src/app/views_mixer.rs
+++ b/crates/vibez-ui/src/app/views_mixer.rs
@@ -156,8 +156,8 @@ impl App {
                 }),
         )
         .on_right_press(Message::View(ViewMsg::ShowContextMenu {
-            x: 400.0,
-            y: 300.0,
+            x: self.state.view.cursor_x,
+            y: self.state.view.cursor_y,
             target: ContextMenuTarget::ArrangementEmpty,
         }))
         .into()

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -75,6 +75,47 @@ pub enum BrowserMsg {
     SetDropboxAppKey(String),
 }
 
+impl BrowserMsg {
+    /// Whether this message is passive Browser traffic that must not dismiss
+    /// an unrelated context menu. Keep this match exhaustive so every new
+    /// Browser interaction declares its menu behavior deliberately.
+    pub(crate) fn keeps_context_menu(&self) -> bool {
+        match self {
+            Self::PendingDragMoved { .. }
+            | Self::DragHoverTrack { .. }
+            | Self::DragHoverEmptyArrangement { .. }
+            | Self::DragHoverSampler { .. }
+            | Self::DragHoverDrumRackPad { .. }
+            | Self::ClearDragTarget
+            | Self::LocalRootWatchEvent(_)
+            | Self::ReconcileLocalRoot { .. }
+            | Self::LocalRootCatalogReconciled { .. } => true,
+            Self::ToggleSampleBrowser
+            | Self::BeginDockResize
+            | Self::ResizeDock(_)
+            | Self::EndDockResize
+            | Self::NudgeDockWidth(_)
+            | Self::SampleBrowserSearchChanged(_)
+            | Self::SelectLocalFolder(_)
+            | Self::ToggleLocalFolder(_)
+            | Self::CycleSearchScope
+            | Self::ShowMoreLocalResults
+            | Self::SelectSampleBrowserEntry(_)
+            | Self::SetSampleBrowserMode(_)
+            | Self::BeginPendingDrag { .. }
+            | Self::CancelDrag(_)
+            | Self::EndDragSample
+            | Self::RemoveSampleLibraryRoot(_)
+            | Self::ToggleRemotePlace
+            | Self::ToggleRemoteConnection
+            | Self::SelectRemoteFolder(_)
+            | Self::ToggleRemoteFolder(_)
+            | Self::SelectRemoteEntry(_)
+            | Self::SetDropboxAppKey(_) => false,
+        }
+    }
+}
+
 /// Cross-domain effects requested by a browser update.
 #[derive(Debug, Default, PartialEq)]
 pub struct BrowserAction {

--- a/crates/vibez-ui/src/domains/view.rs
+++ b/crates/vibez-ui/src/domains/view.rs
@@ -191,13 +191,6 @@ impl ViewState {
                 action.end_drag_resize = true;
             }
             ViewMsg::ShowContextMenu { x, y, target } => {
-                // For ArrangementEmpty from mouse_area (no cursor coords),
-                // use the globally tracked cursor position instead.
-                let (menu_x, menu_y) = if matches!(target, ContextMenuTarget::ArrangementEmpty) {
-                    (self.cursor_x, self.cursor_y)
-                } else {
-                    (x, y)
-                };
                 // Also select the clip if targeting one; the router
                 // applies this to the arrangement slice.
                 if let ContextMenuTarget::Clip {
@@ -208,11 +201,7 @@ impl ViewState {
                 {
                     action.select_clip = Some((*track_id, *clip_id, *is_note_clip));
                 }
-                self.context_menu = Some(crate::state::ContextMenu {
-                    x: menu_x,
-                    y: menu_y,
-                    target,
-                });
+                self.context_menu = Some(crate::state::ContextMenu { x, y, target });
             }
             ViewMsg::DismissContextMenu => {
                 self.context_menu = None;
@@ -357,6 +346,27 @@ mod tests {
         );
         assert!(v.context_menu.is_some());
         assert_eq!(action.select_clip, Some((tid, cid, false)));
+    }
+
+    #[test]
+    fn arrangement_empty_context_menu_uses_the_click_position() {
+        let mut view = ViewState {
+            cursor_x: 900.0,
+            cursor_y: 700.0,
+            ..ViewState::default()
+        };
+        view.update(
+            ViewMsg::ShowContextMenu {
+                x: 240.0,
+                y: 180.0,
+                target: ContextMenuTarget::ArrangementEmpty,
+            },
+            &TimelineEditorState::default(),
+            ViewCtx::default(),
+        );
+
+        let menu = view.context_menu.expect("context menu");
+        assert_eq!((menu.x, menu.y), (240.0, 180.0));
     }
 
     #[test]


### PR DESCRIPTION
## What changed
- only install Arrange browser drag-hover handlers while a sample drag is active
- keep context menus open through passive Browser-domain and Dropbox catalog progress updates
- add regression coverage for both dismissal races

## Why
Right-clicking a clip rebuilt the Arrange view, which emitted a passive `DragHoverTrack` message. The global context-menu policy treated it—and an in-flight Dropbox catalog save—as unrelated actions and immediately cleared the menu.

## Verification
- `cargo test --workspace -j 4`
- `cargo clippy -p vibez-ui --lib -j 4 -- -D warnings`
- `cargo fmt --all --check`
- offscreen X11 interaction: right-click menu remains open after release and through catalog refresh

Stacked on #94 so the demo contains both requested fixes. No merge performed.