### PR TITLE
Deepen project transactions for recording

### DIFF
--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -807,15 +807,10 @@ mod perform_action_tests {
             arrange_timeline: Arc::clone(&state.arrangement.timeline),
             sections: Arc::clone(&state.perform.sections),
             bpm: state.transport.bpm,
-            bpm_text: state.transport.bpm_text.clone(),
             project_swing: state.perform.project_swing(),
             loop_enabled: state.transport.loop_enabled,
             loop_start_beats: state.transport.loop_start_beats,
             loop_end_beats: state.transport.loop_end_beats,
-            selected_track: state.arrangement.selected_track,
-            selected_clips: state.arrangement.selected_clips.clone(),
-            selected_note_clip: state.arrangement.selected_note_clip,
-            selected_section: state.perform.selected_section,
         }
     }
 

--- a/crates/vibez-ui/src/app/project_replay.rs
+++ b/crates/vibez-ui/src/app/project_replay.rs
@@ -18,21 +18,78 @@ impl App {
             arrange_timeline: Arc::clone(&self.state.arrangement.timeline),
             sections: Arc::clone(&self.state.perform.sections),
             bpm: self.state.transport.bpm,
-            bpm_text: self.state.transport.bpm_text.clone(),
             project_swing: self.state.perform.project_swing(),
             loop_enabled: self.state.transport.loop_enabled,
             loop_start_beats: self.state.transport.loop_start_beats,
             loop_end_beats: self.state.transport.loop_end_beats,
-            selected_track: self.state.arrangement.selected_track,
-            selected_clips: self.state.arrangement.selected_clips.clone(),
-            selected_note_clip: self.state.arrangement.selected_note_clip,
-            selected_section: self.state.perform.selected_section,
         }
     }
 
     pub(super) fn push_undo_snapshot(&mut self, gesture: Option<crate::state::UndoGestureId>) {
         let snapshot = self.take_snapshot();
         self.state.project.history.push_edit(snapshot, gesture);
+    }
+
+    /// Open one project transaction at the current canonical editable state.
+    /// Returns false when a wider transaction is already active.
+    pub(super) fn begin_project_transaction(&mut self) -> bool {
+        let snapshot = self.take_snapshot();
+        self.state
+            .project
+            .history
+            .begin_transaction(snapshot, self.state.project.dirty)
+    }
+
+    pub(super) fn commit_project_transaction(&mut self) -> bool {
+        self.state.project.history.commit_transaction()
+    }
+
+    /// Project Track deletion is the first multi-store consumer of project
+    /// transactions: Arrange removes the channel and local content, then the
+    /// application action removes that identity from every Section.
+    pub(super) fn begin_project_track_deletion_transaction(
+        &mut self,
+        message: &crate::message::Message,
+    ) -> bool {
+        matches!(
+            message,
+            crate::message::Message::Arrangement(
+                crate::domains::arrangement::ArrangementMsg::ConfirmRemoveTrack(_)
+                    | crate::domains::arrangement::ArrangementMsg::RemoveTrack(_)
+            )
+        ) && self.begin_project_transaction()
+    }
+
+    pub(super) fn apply_arrangement_action_in_transaction(
+        &mut self,
+        action: crate::domains::arrangement::ArrangementAction,
+        owns_transaction: bool,
+    ) -> iced::Task<crate::message::Message> {
+        let removed_project_track = action.remove_track_from_sections.is_some();
+        let task = self.apply_arrangement_action(action);
+        if owns_transaction {
+            if removed_project_track {
+                self.commit_project_transaction();
+            } else {
+                // A stale confirmation or missing id is a no-op, so it must
+                // not create an empty transaction in history.
+                if let Some((_, dirty_before)) = self.state.project.history.abandon_transaction() {
+                    self.state.project.dirty = dirty_before;
+                }
+            }
+        }
+        task
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn abandon_project_transaction(&mut self) -> bool {
+        let Some((snapshot, dirty_before)) = self.state.project.history.abandon_transaction()
+        else {
+            return false;
+        };
+        self.apply_snapshot(snapshot);
+        self.state.project.dirty = dirty_before;
+        true
     }
 
     pub(super) fn apply_snapshot(&mut self, mut snapshot: crate::state::ProjectSnapshot) {
@@ -100,15 +157,11 @@ impl App {
         self.state.arrangement.timeline = snapshot.arrange_timeline;
         self.state.perform.sections = snapshot.sections;
         self.state.transport.bpm = snapshot.bpm;
-        self.state.transport.bpm_text = snapshot.bpm_text;
+        self.state.transport.bpm_text = format!("{:.0}", snapshot.bpm);
         self.state.perform.set_project_swing(snapshot.project_swing);
         self.state.transport.loop_enabled = snapshot.loop_enabled;
         self.state.transport.loop_start_beats = snapshot.loop_start_beats;
         self.state.transport.loop_end_beats = snapshot.loop_end_beats;
-        self.state.arrangement.selected_track = snapshot.selected_track;
-        self.state.arrangement.selected_clips = snapshot.selected_clips;
-        self.state.arrangement.selected_note_clip = snapshot.selected_note_clip;
-        self.state.perform.selected_section = snapshot.selected_section;
         self.state
             .perform
             .sync_selected_section_editor(self.state.arrangement.selected_track);

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -27,6 +27,7 @@ impl App {
         };
         let message =
             apply_project_track_deletion_policy(message, self.state.confirm_project_track_deletion);
+        let owns_project_transaction = self.begin_project_track_deletion_transaction(&message);
         if self.state.view.edit_menu_open {
             let keep_menu = matches!(
                 &message,
@@ -155,7 +156,8 @@ impl App {
                 self.state
                     .perform
                     .sync_project_tracks(&self.state.project_tracks.tracks);
-                return self.apply_arrangement_action(action);
+                return self
+                    .apply_arrangement_action_in_transaction(action, owns_project_transaction);
             }
             Message::PianoRoll(msg) => {
                 let ctx = crate::domains::piano_roll::PianoRollCtx {

--- a/crates/vibez-ui/src/domains/project.rs
+++ b/crates/vibez-ui/src/domains/project.rs
@@ -43,6 +43,11 @@ pub struct ProjectAction {
 impl ProjectState {
     pub fn update(&mut self, msg: ProjectMsg, ctx: ProjectCtx) -> ProjectAction {
         let mut action = ProjectAction::default();
+        if self.history.transaction_active() && matches!(&msg, ProjectMsg::Undo | ProjectMsg::Redo)
+        {
+            action.status = Some("Finish the current project transaction first".to_string());
+            return action;
+        }
         match msg {
             ProjectMsg::ToggleFileMenu => {
                 self.file_menu_open = !self.file_menu_open;
@@ -138,7 +143,6 @@ pub fn collect_plugin_reload_requests(
 mod tests {
     use super::*;
     use crate::state::{ArrangementTimeline, ProjectTrack, ProjectTracksState, UiEffect};
-    use std::collections::HashSet;
     use vibez_core::effect::EffectType;
 
     fn plugin_device(name: &str) -> PluginDeviceInfo {
@@ -177,15 +181,10 @@ mod tests {
             arrange_timeline: std::sync::Arc::new(ArrangementTimeline::default()),
             sections: std::sync::Arc::new(crate::domains::perform::SectionStore::default()),
             bpm: 120.0,
-            bpm_text: "120".to_string(),
             project_swing: vibez_core::perform::SwingAmount::default(),
             loop_enabled: false,
             loop_start_beats: 0.0,
             loop_end_beats: 0.0,
-            selected_track: None,
-            selected_clips: HashSet::new(),
-            selected_note_clip: None,
-            selected_section: None,
         }
     }
 
@@ -247,6 +246,23 @@ mod tests {
         assert!(action.apply_snapshot.is_none());
         assert_eq!(action.status.as_deref(), Some("Nothing to undo"));
         assert_eq!(p.history.redo.len(), 0);
+    }
+
+    #[test]
+    fn undo_waits_for_an_open_project_transaction() {
+        let mut p = ProjectState::default();
+        assert!(p
+            .history
+            .begin_transaction(snapshot_with(Vec::new()), false));
+
+        let action = p.update(ProjectMsg::Undo, ctx());
+
+        assert!(action.apply_snapshot.is_none());
+        assert_eq!(
+            action.status.as_deref(),
+            Some("Finish the current project transaction first")
+        );
+        assert!(p.history.transaction_active());
     }
 
     #[test]

--- a/crates/vibez-ui/src/state/snapshot.rs
+++ b/crates/vibez-ui/src/state/snapshot.rs
@@ -1,13 +1,11 @@
 //! Project snapshots and bounded undo/redo history.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use vibez_core::id::{ClipId, TrackId};
-
-use super::{ArrangementSelection, ArrangementTimeline, ProjectTracksState};
+use super::{ArrangementTimeline, ProjectTracksState};
 
 /// A point-in-time snapshot of the editable project state, used to implement
 /// undo / redo. Project Tracks, Arrange, and the Section store are independently
@@ -18,15 +16,20 @@ pub struct ProjectSnapshot {
     pub arrange_timeline: Arc<ArrangementTimeline>,
     pub sections: Arc<crate::domains::perform::SectionStore>,
     pub bpm: f64,
-    pub bpm_text: String,
     pub project_swing: vibez_core::perform::SwingAmount,
     pub loop_enabled: bool,
     pub loop_start_beats: f64,
     pub loop_end_beats: f64,
-    pub selected_track: Option<TrackId>,
-    pub selected_clips: HashSet<ArrangementSelection>,
-    pub selected_note_clip: Option<(TrackId, ClipId)>,
-    pub selected_section: Option<vibez_core::id::SectionId>,
+}
+
+/// One open project edit that will either become one undo step or be rolled
+/// back. The pre-edit snapshot is independently `Arc`-shared, so opening a
+/// recording-length transaction does not clone project media or device state.
+#[derive(Debug)]
+struct ProjectTransaction {
+    before: ProjectSnapshot,
+    dirty_before: bool,
+    changed: bool,
 }
 
 /// Runtime identity for one continuous pointer gesture. Every incremental
@@ -61,6 +64,7 @@ pub struct UndoHistory {
     pub undo: VecDeque<ProjectSnapshot>,
     pub redo: VecDeque<ProjectSnapshot>,
     last_gesture: Option<UndoGestureId>,
+    transaction: Option<ProjectTransaction>,
 }
 
 impl UndoHistory {
@@ -80,6 +84,11 @@ impl UndoHistory {
     }
 
     pub fn push_edit(&mut self, snapshot: ProjectSnapshot, gesture: Option<UndoGestureId>) {
+        if let Some(transaction) = &mut self.transaction {
+            transaction.changed = true;
+            self.last_gesture = None;
+            return;
+        }
         if gesture.is_some() && self.last_gesture == gesture {
             return;
         }
@@ -114,9 +123,52 @@ impl UndoHistory {
         !self.redo.is_empty()
     }
 
+    /// Open a transaction at the supplied pre-edit project state. Nested
+    /// transactions are deliberately rejected: an inner multi-edit operation
+    /// simply participates in the already-open recording transaction.
+    pub fn begin_transaction(&mut self, before: ProjectSnapshot, dirty_before: bool) -> bool {
+        if self.transaction.is_some() {
+            return false;
+        }
+        self.last_gesture = None;
+        self.transaction = Some(ProjectTransaction {
+            before,
+            dirty_before,
+            changed: false,
+        });
+        true
+    }
+
+    /// Commit every edit since `begin_transaction` as exactly one undo step.
+    /// Returns whether the transaction contained an effective project edit.
+    pub fn commit_transaction(&mut self) -> bool {
+        let Some(transaction) = self.transaction.take() else {
+            return false;
+        };
+        if !transaction.changed {
+            return false;
+        }
+        self.push_snapshot(transaction.before);
+        true
+    }
+
+    /// Abandon the open transaction and return its pre-edit state for the
+    /// application boundary to restore. History itself is left unchanged.
+    pub fn abandon_transaction(&mut self) -> Option<(ProjectSnapshot, bool)> {
+        self.last_gesture = None;
+        self.transaction
+            .take()
+            .map(|transaction| (transaction.before, transaction.dirty_before))
+    }
+
+    pub fn transaction_active(&self) -> bool {
+        self.transaction.is_some()
+    }
+
     pub fn clear(&mut self) {
         self.undo.clear();
         self.redo.clear();
         self.last_gesture = None;
+        self.transaction = None;
     }
 }

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -19,15 +19,10 @@ fn snapshot(state: &AppState) -> ProjectSnapshot {
         arrange_timeline: Arc::clone(&state.arrangement.timeline),
         sections: Arc::clone(&state.perform.sections),
         bpm: state.transport.bpm,
-        bpm_text: state.transport.bpm_text.clone(),
         project_swing: state.perform.project_swing(),
         loop_enabled: state.transport.loop_enabled,
         loop_start_beats: state.transport.loop_start_beats,
         loop_end_beats: state.transport.loop_end_beats,
-        selected_track: state.arrangement.selected_track,
-        selected_clips: state.arrangement.selected_clips.clone(),
-        selected_note_clip: state.arrangement.selected_note_clip,
-        selected_section: state.perform.selected_section,
     }
 }
 
@@ -35,8 +30,12 @@ fn apply_snapshot(state: &mut AppState, snapshot: ProjectSnapshot) {
     state.project_tracks = snapshot.project_tracks;
     state.arrangement.timeline = snapshot.arrange_timeline;
     state.perform.sections = snapshot.sections;
+    state.transport.bpm = snapshot.bpm;
+    state.transport.bpm_text = format!("{:.0}", snapshot.bpm);
     state.perform.set_project_swing(snapshot.project_swing);
-    state.perform.selected_section = snapshot.selected_section;
+    state.transport.loop_enabled = snapshot.loop_enabled;
+    state.transport.loop_start_beats = snapshot.loop_start_beats;
+    state.transport.loop_end_beats = snapshot.loop_end_beats;
 }
 
 fn perform_edit(
@@ -308,6 +307,10 @@ fn project_track_deletion_across_timelines_is_one_undo_step() {
         &mut engine,
         ArrangementCtx::default(),
     );
+    assert!(state
+        .project
+        .history
+        .begin_transaction(snapshot(&state), state.project.dirty));
     state.project.history.push_edit(snapshot(&state), None);
     let action = state.arrangement.update(
         Arc::make_mut(&mut state.project_tracks),
@@ -320,6 +323,7 @@ fn project_track_deletion_across_timelines_is_one_undo_step() {
             .remove_track_from_sections
             .expect("confirmed deletion spans Sections"),
     );
+    assert!(state.project.history.commit_transaction());
 
     assert_eq!(state.project.history.undo.len(), 1);
     assert!(state.project_tracks.find(track_id).is_none());
@@ -331,7 +335,10 @@ fn project_track_deletion_across_timelines_is_one_undo_step() {
         .iter()
         .all(|section| section.timeline.get(track_id).is_none()));
 
-    undo_once(&mut state);
+    let deleted = snapshot(&state);
+    let before_deletion = state.project.history.pop_undo().unwrap();
+    state.project.history.push_redo(deleted);
+    apply_snapshot(&mut state, before_deletion);
     assert!(state.project_tracks.find(track_id).is_some());
     assert!(state.arrangement.timeline.get(track_id).is_some());
     assert!(state
@@ -340,4 +347,120 @@ fn project_track_deletion_across_timelines_is_one_undo_step() {
         .sections
         .iter()
         .all(|section| section.timeline.get(track_id).is_some()));
+
+    let restored = snapshot(&state);
+    let after_deletion = state.project.history.pop_redo().unwrap();
+    state.project.history.push_undo(restored);
+    apply_snapshot(&mut state, after_deletion);
+    assert!(state.project_tracks.find(track_id).is_none());
+    assert!(state.arrangement.timeline.get(track_id).is_none());
+    assert!(state
+        .perform
+        .sections
+        .sections
+        .iter()
+        .all(|section| section.timeline.get(track_id).is_none()));
+}
+
+#[test]
+fn transaction_snapshot_capture_shares_project_storage() {
+    let mut state = AppState::default();
+    let track_id = TrackId::new();
+    Arc::make_mut(&mut state.project_tracks)
+        .tracks
+        .push(ProjectTrack::new(track_id, "Shared".into(), 0));
+    Arc::make_mut(&mut state.arrangement.timeline).ensure(track_id);
+    Arc::make_mut(&mut state.perform.sections).insert(crate::domains::perform::Section::new(0));
+
+    let captured = snapshot(&state);
+
+    assert!(Arc::ptr_eq(&captured.project_tracks, &state.project_tracks));
+    assert!(Arc::ptr_eq(
+        &captured.arrange_timeline,
+        &state.arrangement.timeline
+    ));
+    assert!(Arc::ptr_eq(&captured.sections, &state.perform.sections));
+}
+
+#[test]
+fn abandoning_a_transaction_rolls_back_all_canonical_edits_without_history() {
+    let mut state = AppState::default();
+    let track_id = TrackId::new();
+    Arc::make_mut(&mut state.project_tracks)
+        .tracks
+        .push(ProjectTrack::new(track_id, "Shared".into(), 0));
+    Arc::make_mut(&mut state.arrangement.timeline).ensure(track_id);
+    let mut section = crate::domains::perform::Section::new(0);
+    Arc::make_mut(&mut section.timeline).ensure(track_id);
+    let section_id = section.id;
+    Arc::make_mut(&mut state.perform.sections).insert(section);
+
+    assert!(state
+        .project
+        .history
+        .begin_transaction(snapshot(&state), state.project.dirty));
+    state.project.history.push_edit(snapshot(&state), None);
+    Arc::make_mut(&mut state.arrangement.timeline).remove(track_id);
+    Arc::make_mut(&mut state.perform.sections)
+        .by_id_mut(section_id)
+        .unwrap()
+        .timeline = Arc::new(ArrangementTimeline::default());
+
+    state.project.dirty = true;
+    let (before, dirty_before) = state
+        .project
+        .history
+        .abandon_transaction()
+        .expect("open transaction");
+    apply_snapshot(&mut state, before);
+    state.project.dirty = dirty_before;
+
+    assert!(state.arrangement.timeline.get(track_id).is_some());
+    assert!(state
+        .perform
+        .sections
+        .by_id(section_id)
+        .unwrap()
+        .timeline
+        .get(track_id)
+        .is_some());
+    assert!(state.project.history.undo.is_empty());
+    assert!(state.project.history.redo.is_empty());
+    assert!(!state.project.history.transaction_active());
+    assert!(!state.project.dirty);
+}
+
+#[test]
+fn undo_restores_canonical_state_without_restoring_selection() {
+    let mut state = AppState::default();
+    let first = TrackId::new();
+    let second = TrackId::new();
+    Arc::make_mut(&mut state.project_tracks).tracks.extend([
+        ProjectTrack::new(first, "First".into(), 0),
+        ProjectTrack::new(second, "Second".into(), 1),
+    ]);
+    state.arrangement.selected_track = Some(first);
+
+    state.project.history.push_edit(snapshot(&state), None);
+    Arc::make_mut(&mut state.project_tracks)
+        .find_mut(first)
+        .unwrap()
+        .gain = 0.25;
+    state.arrangement.selected_track = Some(second);
+
+    undo_once(&mut state);
+
+    assert_eq!(state.project_tracks.find(first).unwrap().gain, 1.0);
+    assert_eq!(state.arrangement.selected_track, Some(second));
+}
+
+#[test]
+fn empty_transaction_does_not_create_an_undo_step() {
+    let mut state = AppState::default();
+    assert!(state
+        .project
+        .history
+        .begin_transaction(snapshot(&state), state.project.dirty));
+    assert!(!state.project.history.commit_transaction());
+    assert!(state.project.history.undo.is_empty());
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -270,6 +270,17 @@ being edited. Meters, decoded device media, waveform/runtime caches, and UI
 selection are UI runtime state; they are not fields of persisted timeline
 content.
 
+`UndoHistory` also owns the single open `ProjectTransaction`. Beginning a
+transaction retains those same `Arc`-shared canonical stores, edits continue
+through their existing domain boundaries, and commit adds the pre-edit state as
+exactly one undo step. Abandon returns that state for rollback without changing
+history. Transactions do not nest: a multi-store operation encountered inside
+an existing recording transaction participates in the outer transaction. The
+first consumer is Project Track deletion, which removes the shared identity
+from Project Tracks, Arrange, and every Section before committing one step.
+Editor selections, meters, decoded/runtime caches, and live plugin pointers are
+outside the transaction snapshot and are neither cloned nor restored.
+
 ## The audio engine
 
 The engine lives on the cpal audio callback. Its rules:
@@ -376,6 +387,10 @@ are handled in three stages:
   Arrange store.
   Live plugin state is captured before teardown so undo does not reset
   plugin parameters.
+- Long-lived recording edits use one explicit Project Transaction from start
+  through stop. Commit creates one undo step regardless of the number of
+  canonical stores edited; abandonment rolls every canonical edit back and
+  creates no history entry.
 - Warping detects a clip's BPM, then time-stretches it to the project tempo
   with Signalsmith Stretch (near-unity ratios use a resampler instead).
   Changing the project tempo re-warps every warped clip so the arrangement


### PR DESCRIPTION
## Summary

- add an explicit begin/commit/abandon project transaction around the existing Arc-shared snapshots
- keep selection and other runtime UI state outside canonical undo snapshots
- migrate Project Track deletion across Arrange and every Section onto one transaction
- document the recording transaction boundary in ARCHITECTURE.md

## Verification

- `cargo fmt --all -- --check`
- `cargo test -j 4 --workspace`
- `cargo clippy -j 4 --workspace -- -D warnings`
- focused transaction and project-domain tests
- native Xvfb dogfood: ordinary add/undo/redo and confirmed Project Track delete/undo/redo
- touched Rust line audit: maximum 996 lines

## Scope

Card 15 only. Section Record, Capture, and recording UI remain out of scope.