### PR TITLE
Perform Card 17: capture Sections into Arrange

### DIFF
--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -59,6 +59,10 @@ pub enum EngineCommand {
     },
     /// Stop the current armed or active Section recording session.
     StopSectionRecord,
+    /// Mark the exact engine boundary where Capture into Arrange begins.
+    StartPerformanceCapture,
+    /// Mark the exact engine boundary where Capture into Arrange stops.
+    StopPerformanceCapture,
     /// Load decoded audio into the engine for playback (legacy single-file).
     LoadAudio(Arc<DecodedAudio>),
     /// Remove any loaded audio from the engine (legacy single-file).

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -916,29 +916,6 @@ impl AudioEngine {
             std::mem::forget(item);
         }
     }
-
-    fn recalculate_audio_length(&mut self) {
-        let samples_per_beat = if self.transport.bpm() > 0.0 {
-            self.sample_rate as f64 * 60.0 / self.transport.bpm()
-        } else {
-            0.0
-        };
-        let total = calculate_total_length(
-            self.tracks
-                .iter()
-                .map(|track| track.playback_source.as_ref()),
-            samples_per_beat,
-        );
-        self.arrangement_audio_length = if total > 0 {
-            Some(total)
-        } else {
-            self.audio.as_ref().map(|audio| audio.num_frames() as u64)
-        };
-        if self.active_section.is_none() {
-            self.transport
-                .set_audio_length(self.arrangement_audio_length);
-        }
-    }
 }
 
 /// Stream a block to the UI spectrum analyser as mono samples.

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -341,6 +341,9 @@ impl AudioEngine {
         }
         if section_ended {
             self.stop_section_record();
+            let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
+                effective_at_samples: new_pos,
+            });
             self.transport.stop();
             let _ = self.event_tx.push(EngineEvent::PlaybackStopped);
             self.active_section = None;
@@ -994,3 +997,7 @@ mod section_queue_tests;
 #[cfg(test)]
 #[path = "engine_section_record_tests.rs"]
 mod section_record_tests;
+
+#[cfg(test)]
+#[path = "engine_capture_tests.rs"]
+mod capture_tests;

--- a/crates/vibez-engine/src/engine_capture_tests.rs
+++ b/crates/vibez-engine/src/engine_capture_tests.rs
@@ -75,3 +75,40 @@ fn capture_stop_reports_callback_boundary_without_ui_tick_timing() {
     });
     assert_eq!(stopped, Some(7));
 }
+
+#[test]
+fn transport_stop_ends_capture_and_section_playback_at_one_boundary() {
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let section_id = SectionId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(empty_section(
+            section_id, track_id,
+        )))
+        .unwrap();
+    commands
+        .push(EngineCommand::StartPerformanceCapture)
+        .unwrap();
+    engine.process(&mut [0.0; 7], 1);
+    while events.pop().is_ok() {}
+
+    commands.push(EngineCommand::Stop).unwrap();
+    engine.process(&mut [0.0; 3], 1);
+
+    let terminal: Vec<_> = std::iter::from_fn(|| events.pop().ok())
+        .filter_map(|event| match event {
+            EngineEvent::PerformanceCaptureStopped {
+                effective_at_samples,
+            } => Some(("capture", effective_at_samples)),
+            EngineEvent::PlaybackStopped => Some(("playback", 7)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(terminal, [("capture", 7), ("playback", 7)]);
+    assert!(!engine.transport().is_playing());
+    assert!(engine.active_section.is_none());
+}

--- a/crates/vibez-engine/src/engine_capture_tests.rs
+++ b/crates/vibez-engine/src/engine_capture_tests.rs
@@ -1,0 +1,77 @@
+//! Capture timestamp regressions at the public engine command/event seam.
+
+use super::*;
+
+use vibez_core::id::{SectionId, TrackId};
+
+use crate::playback_source::{PreparedPlaybackSource, PreparedSectionPlaybackSource};
+
+fn empty_section(section_id: SectionId, track_id: TrackId) -> Box<PreparedSectionPlaybackSource> {
+    Box::new(PreparedSectionPlaybackSource::new(
+        section_id,
+        4.0,
+        true,
+        vec![(
+            track_id,
+            PreparedPlaybackSource::new(Vec::new(), Vec::new(), Vec::new()),
+        )],
+    ))
+}
+
+fn capture_started(events: &mut rtrb::Consumer<EngineEvent>) -> Option<(u64, SectionId, u64)> {
+    std::iter::from_fn(|| events.pop().ok()).find_map(|event| match event {
+        EngineEvent::PerformanceCaptureStarted {
+            effective_at_samples,
+            section_id: Some(section_id),
+            section_position_samples: Some(section_position_samples),
+        } => Some((effective_at_samples, section_id, section_position_samples)),
+        _ => None,
+    })
+}
+
+#[test]
+fn capture_start_reports_exact_transport_and_active_section_position() {
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let section_id = SectionId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands.push(EngineCommand::SetBpm(120.0)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(empty_section(
+            section_id, track_id,
+        )))
+        .unwrap();
+    engine.process(&mut [0.0; 3], 1);
+    while events.pop().is_ok() {}
+
+    commands
+        .push(EngineCommand::StartPerformanceCapture)
+        .unwrap();
+    engine.process(&mut [0.0; 5], 1);
+
+    assert_eq!(capture_started(&mut events), Some((3, section_id, 3)));
+}
+
+#[test]
+fn capture_stop_reports_callback_boundary_without_ui_tick_timing() {
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
+    commands.push(EngineCommand::Play).unwrap();
+    engine.process(&mut [0.0; 7], 1);
+    while events.pop().is_ok() {}
+
+    commands
+        .push(EngineCommand::StopPerformanceCapture)
+        .unwrap();
+    engine.process(&mut [0.0; 3], 1);
+
+    let stopped = std::iter::from_fn(|| events.pop().ok()).find_map(|event| match event {
+        EngineEvent::PerformanceCaptureStopped {
+            effective_at_samples,
+        } => Some(effective_at_samples),
+        _ => None,
+    });
+    assert_eq!(stopped, Some(7));
+}

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -18,6 +18,9 @@ impl AudioEngine {
                 }
                 EngineCommand::Stop => {
                     self.stop_section_record();
+                    let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
+                        effective_at_samples: self.transport.position(),
+                    });
                     self.transport.stop();
                     self.performance_position = self.transport.position();
                     self.cancel_section_queue();
@@ -137,6 +140,21 @@ impl AudioEngine {
                     replace_existing,
                 ),
                 EngineCommand::StopSectionRecord => self.stop_section_record(),
+                EngineCommand::StartPerformanceCapture => {
+                    let section_id = self.active_section.map(|section| section.section_id);
+                    let section_position_samples =
+                        self.active_section.map(|section| section.position_samples);
+                    let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStarted {
+                        effective_at_samples: self.transport.position(),
+                        section_id,
+                        section_position_samples,
+                    });
+                }
+                EngineCommand::StopPerformanceCapture => {
+                    let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
+                        effective_at_samples: self.transport.position(),
+                    });
+                }
                 EngineCommand::LoadAudio(audio) => {
                     let len = audio.num_frames() as u64;
                     self.audio = Some(audio);
@@ -147,6 +165,9 @@ impl AudioEngine {
                 }
                 EngineCommand::UnloadAudio => {
                     self.stop_section_record();
+                    let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
+                        effective_at_samples: self.transport.position(),
+                    });
                     self.audio = None;
                     self.arrangement_audio_length = None;
                     self.active_section = None;

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -930,4 +930,27 @@ impl AudioEngine {
             }
         }
     }
+
+    fn recalculate_audio_length(&mut self) {
+        let samples_per_beat = if self.transport.bpm() > 0.0 {
+            self.sample_rate as f64 * 60.0 / self.transport.bpm()
+        } else {
+            0.0
+        };
+        let total = calculate_total_length(
+            self.tracks
+                .iter()
+                .map(|track| track.playback_source.as_ref()),
+            samples_per_beat,
+        );
+        self.arrangement_audio_length = if total > 0 {
+            Some(total)
+        } else {
+            self.audio.as_ref().map(|audio| audio.num_frames() as u64)
+        };
+        if self.active_section.is_none() {
+            self.transport
+                .set_audio_length(self.arrangement_audio_length);
+        }
+    }
 }

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -135,6 +135,17 @@ pub enum EngineEvent {
         retired: Option<Box<PreparedSectionPlaybackSource>>,
     },
 
+    /// Capture into Arrange began on this exact engine boundary. An already
+    /// active Section includes its exact local playhead for a mid-loop start.
+    PerformanceCaptureStarted {
+        effective_at_samples: u64,
+        section_id: Option<SectionId>,
+        section_position_samples: Option<u64>,
+    },
+
+    /// Capture into Arrange stopped on this exact engine boundary.
+    PerformanceCaptureStopped { effective_at_samples: u64 },
+
     /// A resident Section is queued for this exact transport sample.
     /// Re-queueing returns the displaced resident owner for UI-thread drop.
     SectionQueued {
@@ -353,6 +364,26 @@ impl PartialEq for EngineEvent {
                         _ => false,
                     }
             }
+            (
+                Self::PerformanceCaptureStarted {
+                    effective_at_samples: le,
+                    section_id: ls,
+                    section_position_samples: lp,
+                },
+                Self::PerformanceCaptureStarted {
+                    effective_at_samples: re,
+                    section_id: rs,
+                    section_position_samples: rp,
+                },
+            ) => le == re && ls == rs && lp == rp,
+            (
+                Self::PerformanceCaptureStopped {
+                    effective_at_samples: left,
+                },
+                Self::PerformanceCaptureStopped {
+                    effective_at_samples: right,
+                },
+            ) => left == right,
             (
                 Self::SectionQueued {
                     section_id: left_section,

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -5,12 +5,11 @@ use iced::Task;
 use vibez_core::effect::EffectType;
 use vibez_core::id::SectionId;
 use vibez_engine::commands::EngineCommand;
-use vibez_engine::events::EngineEvent;
 use vibez_plugin_host::gui::PluginGuiKey;
 
 use crate::message::Message;
 use crate::plugin_window::PluginWindowEvent;
-use crate::state::{ArrangementSelection, AuditionMode, DetailPanelTab, UiEffect};
+use crate::state::{ArrangementSelection, DetailPanelTab, UiEffect};
 
 use super::*;
 
@@ -99,6 +98,9 @@ impl App {
         }
         if let Some(record_action) = action.section_record {
             tasks.push(self.apply_section_record_action(record_action));
+        }
+        if let Some(capture_action) = action.capture {
+            tasks.push(self.apply_capture_action(capture_action));
         }
         if action.persist_settings {
             self.persist_ui_settings();
@@ -590,222 +592,6 @@ impl App {
                     // CC mapping not wired yet.
                 }
             }
-        }
-    }
-
-    pub(super) fn poll_engine_events(&mut self) {
-        let mut completed_section_recordings = Vec::new();
-        if let Some(ref mut rx) = self.event_rx {
-            while let Ok(event) = rx.pop() {
-                match event {
-                    EngineEvent::DisposeEffect(cell) => {
-                        // Plugin teardown on the UI thread: dlclose,
-                        // COM release, JUCE MessageManager access.
-                        drop(cell.take());
-                    }
-                    EngineEvent::DisposeInstrument(cell) => {
-                        drop(cell.take());
-                    }
-                    EngineEvent::PlaybackPosition(pos) => {
-                        self.state.transport.position_samples = pos;
-                    }
-                    EngineEvent::Metering { peak_l, peak_r, .. } => {
-                        self.state.peak_l = peak_l.max(self.state.peak_l * 0.85);
-                        self.state.peak_r = peak_r.max(self.state.peak_r * 0.85);
-                        // The master strip meters the same summed mix.
-                        let project_tracks = Arc::make_mut(&mut self.state.project_tracks);
-                        project_tracks.master.peak_l = self.state.peak_l;
-                        project_tracks.master.peak_r = self.state.peak_r;
-                    }
-                    EngineEvent::PlaybackStopped => {
-                        self.state.transport.playing = false;
-                        self.state.perform.playing_section = None;
-                        self.state.perform.queued_section = None;
-                        self.state.perform.pending_section_boundary_samples = None;
-                        self.state.perform.section_playhead_samples = 0;
-                    }
-                    EngineEvent::PlaybackStarted => {
-                        self.state.transport.playing = true;
-                    }
-                    EngineEvent::AuditionStopped => {
-                        self.state.browser.stop_audition_state();
-                        if matches!(
-                            self.state.status_text.as_str(),
-                            "RAW Audition playing" | "WARP Audition playing"
-                        ) {
-                            self.state.status_text = "Audition finished".into();
-                        }
-                    }
-                    EngineEvent::AuditionQueued => {
-                        self.state.browser.audition_loading = false;
-                        self.state.browser.audition_playing = false;
-                        self.state.browser.audition_queued = true;
-                    }
-                    EngineEvent::AuditionStarted => {
-                        self.state.browser.audition_loading = false;
-                        self.state.browser.audition_queued = false;
-                        self.state.browser.audition_playing = true;
-                        self.state.status_text = match self.state.browser.audition_mode {
-                            AuditionMode::Raw => "RAW Audition playing".into(),
-                            AuditionMode::Warp => "WARP Audition playing".into(),
-                        };
-                    }
-                    EngineEvent::TrackMeter {
-                        track_id,
-                        peak_l,
-                        peak_r,
-                    } => {
-                        if let Some(track) = self.state.find_track_mut(track_id) {
-                            track.peak_l = peak_l.max(track.peak_l * 0.85);
-                            track.peak_r = peak_r.max(track.peak_r * 0.85);
-                        }
-                    }
-                    EngineEvent::TrackMuteChanged {
-                        track_id,
-                        muted,
-                        effective_at_samples: _,
-                    } => {
-                        if let Some(track) = self.state.find_track_mut(track_id) {
-                            track.mute = muted;
-                        }
-                    }
-                    EngineEvent::NoteRepeated {
-                        track_id,
-                        pitch,
-                        velocity,
-                        rate,
-                        effective_at_samples,
-                        section_id,
-                        canonical_section_position_samples,
-                        ..
-                    } => {
-                        self.state.perform.section_record.repeated_note(
-                            section_id,
-                            track_id,
-                            pitch,
-                            velocity,
-                            rate,
-                            effective_at_samples,
-                            canonical_section_position_samples,
-                        );
-                    }
-                    EngineEvent::InstrumentNoteInput {
-                        track_id,
-                        pitch,
-                        velocity,
-                        on,
-                        effective_at_samples,
-                        section_id,
-                        section_position_samples,
-                    } => {
-                        self.state.perform.section_record.input_note(
-                            crate::domains::perform::section_record::SectionRecordInput {
-                                section_id,
-                                track_id,
-                                pitch,
-                                velocity,
-                                on,
-                                effective_at_samples,
-                                section_position_samples,
-                            },
-                        );
-                    }
-                    EngineEvent::SectionRecordArmed {
-                        section_id,
-                        track_id,
-                        effective_at_samples,
-                        ..
-                    } => {
-                        self.state.perform.section_record.arm(
-                            section_id,
-                            track_id,
-                            effective_at_samples,
-                        );
-                        self.state.status_text =
-                            format!("Section Record pending at sample {effective_at_samples}");
-                    }
-                    EngineEvent::SectionRecordStarted {
-                        section_id,
-                        track_id,
-                        effective_at_samples,
-                        section_position_samples,
-                    } => {
-                        self.state.perform.section_record.start(
-                            section_id,
-                            track_id,
-                            effective_at_samples,
-                            section_position_samples,
-                        );
-                        self.state.status_text = "Section Record running".into();
-                    }
-                    EngineEvent::SectionRecordStopped {
-                        section_id,
-                        track_id,
-                        effective_at_samples,
-                        section_position_samples,
-                        started,
-                        retired,
-                    } => {
-                        let completed = self.state.perform.section_record.finish(
-                            section_id,
-                            track_id,
-                            effective_at_samples,
-                            section_position_samples,
-                            started,
-                        );
-                        drop(retired);
-                        completed_section_recordings.push(completed);
-                    }
-                    EngineEvent::SectionTransitioned {
-                        section_id,
-                        effective_at_samples,
-                        retired,
-                    } => {
-                        self.state.perform.playing_section = Some(section_id);
-                        self.state.perform.queued_section = None;
-                        self.state.perform.pending_section_boundary_samples = None;
-                        self.state.perform.section_playhead_samples = 0;
-                        self.state.status_text =
-                            format!("Section playing at sample {effective_at_samples}");
-                        drop(retired);
-                    }
-                    EngineEvent::SectionQueued {
-                        section_id,
-                        effective_at_samples,
-                        retired,
-                    } => {
-                        self.state.perform.queued_section = Some(section_id);
-                        self.state.perform.pending_section_boundary_samples =
-                            Some(effective_at_samples);
-                        drop(retired);
-                    }
-                    EngineEvent::SectionQueueCancelled { retired } => {
-                        self.state.perform.queued_section = None;
-                        self.state.perform.pending_section_boundary_samples = None;
-                        drop(retired);
-                    }
-                    EngineEvent::SectionPlaybackPosition {
-                        section_id,
-                        position_samples,
-                    } => {
-                        if self.state.perform.playing_section == Some(section_id) {
-                            self.state.perform.section_playhead_samples = position_samples;
-                        }
-                        self.state
-                            .perform
-                            .section_record
-                            .observe_playhead(section_id, position_samples);
-                    }
-                    EngineEvent::SectionSourceRefreshed {
-                        section_id: _,
-                        applied: _,
-                        retired,
-                    } => drop(retired),
-                }
-            }
-        }
-        for completed in completed_section_recordings {
-            self.finish_section_record_session(completed);
         }
     }
 

--- a/crates/vibez-ui/src/app/capture.rs
+++ b/crates/vibez-ui/src/app/capture.rs
@@ -1,0 +1,252 @@
+//! Application boundary for Capture timing, project transaction, and engine sync.
+
+use iced::Task;
+use std::sync::Arc;
+
+use vibez_engine::commands::EngineCommand;
+
+use crate::domains::perform::capture::CompletedCapture;
+use crate::domains::perform::{CaptureAction, MaterializedCapture};
+use crate::message::Message;
+use crate::state::Workspace;
+
+use super::*;
+
+impl App {
+    pub(super) fn apply_capture_action(&mut self, action: CaptureAction) -> Task<Message> {
+        match action {
+            CaptureAction::Start => {
+                if !self.begin_project_transaction() {
+                    self.state.perform.capture.cancel();
+                    self.state.status_text =
+                        "Finish the current project edit before Capture".into();
+                    return Task::none();
+                }
+                self.state.perform.capture.prepare(
+                    self.state.transport.position_samples,
+                    self.state.transport.sample_rate,
+                    self.state.transport.bpm,
+                );
+                self.send_command(EngineCommand::StartPerformanceCapture);
+                self.state.status_text = "Starting Capture into Arrange…".into();
+            }
+            CaptureAction::Stop => {
+                self.send_command(EngineCommand::StopPerformanceCapture);
+                self.state.status_text = "Stopping Capture…".into();
+            }
+        }
+        Task::none()
+    }
+
+    pub(super) fn finish_performance_capture(&mut self, completed: Option<CompletedCapture>) {
+        let Some(completed) = completed else {
+            self.discard_capture_transaction();
+            self.state.status_text = "Capture stopped · no Section content recorded".into();
+            return;
+        };
+        let materialized = completed.materialize();
+        if materialized.is_empty() {
+            self.discard_capture_transaction();
+            self.state.status_text = "Capture stopped · no Section content recorded".into();
+            return;
+        }
+        let perform_track_ids: Vec<_> = self
+            .state
+            .project_tracks
+            .tracks
+            .iter()
+            .map(|track| track.id)
+            .collect();
+        if !materialized
+            .target_interval_is_empty(&self.state.arrangement.timeline, &perform_track_ids)
+        {
+            self.discard_capture_transaction();
+            self.state.status_text =
+                "Capture needs an empty Arrange interval · replacement arrives next".into();
+            return;
+        }
+
+        let clip_count = apply_capture_to_arrangement(
+            &mut self.state.arrangement.timeline,
+            materialized,
+            &mut self.cmd_tx,
+        );
+        self.push_undo_snapshot(None);
+        self.mark_project_dirty();
+        self.commit_project_transaction();
+        self.state.view.workspace = Workspace::Arrange;
+        self.state.status_text = format!("Capture committed · {clip_count} clips · one undo step");
+    }
+
+    fn discard_capture_transaction(&mut self) {
+        if let Some((_, dirty_before)) = self.state.project.history.abandon_transaction() {
+            self.state.project.dirty = dirty_before;
+        }
+    }
+}
+
+fn apply_capture_to_arrangement(
+    arrange: &mut Arc<crate::state::ArrangementTimeline>,
+    captured: MaterializedCapture,
+    engine: &mut Option<rtrb::Producer<EngineCommand>>,
+) -> usize {
+    let mut commands = Vec::new();
+    let mut clip_count = 0;
+    let timeline = Arc::make_mut(arrange);
+    for (track_id, mut incoming) in captured.by_track {
+        clip_count += incoming.clips.len() + incoming.note_clips.len();
+        for clip in &incoming.clips {
+            commands.push(EngineCommand::AddClip {
+                track_id,
+                clip_id: clip.id,
+                audio: Arc::clone(&clip.audio),
+                position: clip.position,
+                source_offset: clip.source_offset,
+                duration: clip.duration,
+                loop_enabled: clip.loop_enabled,
+                loop_start: clip.loop_start,
+                loop_end: clip.loop_end,
+            });
+        }
+        for clip in &incoming.note_clips {
+            commands.push(EngineCommand::AddNoteClip {
+                track_id,
+                clip_id: clip.id,
+                position_beats: clip.position_beats,
+                duration_beats: clip.duration_beats,
+                loop_enabled: clip.loop_enabled,
+                loop_start_beats: clip.loop_start_beats,
+                loop_end_beats: clip.loop_end_beats,
+                groove_grid: clip.groove_grid,
+            });
+            for note in &clip.notes {
+                commands.push(EngineCommand::AddNote {
+                    track_id,
+                    clip_id: clip.id,
+                    note: *note,
+                });
+            }
+        }
+        let destination = timeline.ensure(track_id);
+        destination.clips.append(&mut incoming.clips);
+        destination.note_clips.append(&mut incoming.note_clips);
+    }
+    if let Some(engine) = engine {
+        for command in commands {
+            let _ = engine.push(command);
+        }
+    }
+    clip_count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{AppState, ArrangementTimeline, ProjectSnapshot, UiNoteClip};
+    use std::collections::HashMap;
+    use vibez_core::id::{ClipId, TrackId};
+    use vibez_core::perform::GrooveGrid;
+
+    fn snapshot(state: &AppState) -> ProjectSnapshot {
+        ProjectSnapshot {
+            project_tracks: Arc::clone(&state.project_tracks),
+            arrange_timeline: Arc::clone(&state.arrangement.timeline),
+            sections: Arc::clone(&state.perform.sections),
+            bpm: state.transport.bpm,
+            project_swing: state.perform.project_swing(),
+            loop_enabled: state.transport.loop_enabled,
+            loop_start_beats: state.transport.loop_start_beats,
+            loop_end_beats: state.transport.loop_end_beats,
+        }
+    }
+
+    #[test]
+    fn applying_capture_changes_only_named_tracks_and_preserves_outside_content() {
+        let captured_track = vibez_core::id::TrackId::new();
+        let untouched_track = vibez_core::id::TrackId::new();
+        let mut arrange = Arc::new(ArrangementTimeline::default());
+        Arc::make_mut(&mut arrange)
+            .ensure(untouched_track)
+            .automation
+            .push(vibez_core::automation::AutomationLane::new(
+                vibez_core::automation::AutomationTarget::TrackGain,
+            ));
+        let untouched_before = arrange.get(untouched_track).unwrap().automation.clone();
+        let mut by_track = HashMap::new();
+        by_track.insert(captured_track, Default::default());
+        let captured = MaterializedCapture {
+            arrange_start_samples: 100,
+            arrange_end_samples: 200,
+            by_track,
+            ..MaterializedCapture::default()
+        };
+
+        assert_eq!(
+            apply_capture_to_arrangement(&mut arrange, captured, &mut None),
+            0
+        );
+        assert_eq!(
+            arrange.get(untouched_track).unwrap().automation,
+            untouched_before
+        );
+        assert!(arrange.get(captured_track).is_some());
+    }
+
+    #[test]
+    fn one_capture_transaction_round_trips_through_undo_and_redo() {
+        let mut state = AppState::default();
+        let track_id = TrackId::new();
+        let before = Arc::clone(&state.arrangement.timeline);
+        assert!(state
+            .project
+            .history
+            .begin_transaction(snapshot(&state), state.project.dirty));
+
+        let mut incoming = crate::state::TrackTimelineContent::default();
+        incoming.note_clips.push(UiNoteClip {
+            id: ClipId::new(),
+            name: "Capture · Groove A · Hats".into(),
+            position_beats: 4.0,
+            duration_beats: 4.0,
+            notes: Vec::new(),
+            selected_notes: Default::default(),
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+            groove_grid: GrooveGrid::Off,
+        });
+        let captured = MaterializedCapture {
+            arrange_start_samples: 16,
+            arrange_end_samples: 32,
+            by_track: HashMap::from([(track_id, incoming)]),
+            samples_per_beat: 4.0,
+        };
+        assert_eq!(
+            apply_capture_to_arrangement(&mut state.arrangement.timeline, captured, &mut None,),
+            1
+        );
+        let changed = snapshot(&state);
+        state.project.history.push_edit(changed, None);
+        assert!(state.project.history.commit_transaction());
+        let captured_timeline = Arc::clone(&state.arrangement.timeline);
+        assert_eq!(state.project.history.undo.len(), 1);
+
+        let current = snapshot(&state);
+        let undo = state.project.history.pop_undo().unwrap();
+        state.project.history.push_redo(current);
+        assert!(Arc::ptr_eq(&undo.arrange_timeline, &before));
+        state.arrangement.timeline = undo.arrange_timeline;
+        assert!(state.arrangement.timeline.by_track.is_empty());
+
+        let redo = state.project.history.pop_redo().unwrap();
+        assert!(Arc::ptr_eq(&redo.arrange_timeline, &captured_timeline));
+        assert_eq!(
+            redo.arrange_timeline
+                .get(track_id)
+                .unwrap()
+                .note_clips
+                .len(),
+            1
+        );
+    }
+}

--- a/crates/vibez-ui/src/app/capture.rs
+++ b/crates/vibez-ui/src/app/capture.rs
@@ -16,6 +16,29 @@ impl App {
     pub(super) fn apply_capture_action(&mut self, action: CaptureAction) -> Task<Message> {
         match action {
             CaptureAction::Start => {
+                let perform_track_ids: Vec<_> = self
+                    .state
+                    .project_tracks
+                    .tracks
+                    .iter()
+                    .map(|track| track.id)
+                    .collect();
+                let samples_per_beat = if self.state.transport.bpm > 0.0 {
+                    60.0 * f64::from(self.state.transport.sample_rate) / self.state.transport.bpm
+                } else {
+                    0.0
+                };
+                if !capture_destination_from_playhead_is_empty(
+                    &self.state.arrangement.timeline,
+                    &perform_track_ids,
+                    self.state.transport.position_samples,
+                    samples_per_beat,
+                ) {
+                    self.state.perform.capture.cancel();
+                    self.state.status_text =
+                        "Capture needs empty Arrange content from the playhead".into();
+                    return Task::none();
+                }
                 if !self.begin_project_transaction() {
                     self.state.perform.capture.cancel();
                     self.state.status_text =
@@ -83,6 +106,29 @@ impl App {
             self.state.project.dirty = dirty_before;
         }
     }
+}
+
+fn capture_destination_from_playhead_is_empty(
+    arrange: &crate::state::ArrangementTimeline,
+    perform_track_ids: &[vibez_core::id::TrackId],
+    arrange_start_samples: u64,
+    samples_per_beat: f64,
+) -> bool {
+    perform_track_ids.iter().all(|track_id| {
+        arrange.get(*track_id).is_none_or(|existing| {
+            let audio_clear = existing
+                .clips
+                .iter()
+                .all(|clip| clip.position.saturating_add(clip.duration) <= arrange_start_samples);
+            let note_clear = existing.note_clips.iter().all(|clip| {
+                let end = ((clip.position_beats + clip.duration_beats) * samples_per_beat)
+                    .round()
+                    .max(0.0) as u64;
+                end <= arrange_start_samples
+            });
+            audio_clear && note_clear && existing.automation.is_empty()
+        })
+    })
 }
 
 fn apply_capture_to_arrangement(
@@ -190,6 +236,31 @@ mod tests {
             untouched_before
         );
         assert!(arrange.get(captured_track).is_some());
+    }
+
+    #[test]
+    fn capture_preflight_rejects_future_content_before_the_take_starts() {
+        let track_id = TrackId::new();
+        let mut arrange = ArrangementTimeline::default();
+        arrange.ensure(track_id).note_clips.push(UiNoteClip {
+            id: ClipId::new(),
+            name: "Future clip".into(),
+            position_beats: 8.0,
+            duration_beats: 1.0,
+            notes: Vec::new(),
+            selected_notes: Default::default(),
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+            groove_grid: GrooveGrid::Off,
+        });
+
+        assert!(!capture_destination_from_playhead_is_empty(
+            &arrange,
+            &[track_id],
+            16,
+            4.0,
+        ));
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/capture.rs
+++ b/crates/vibez-ui/src/app/capture.rs
@@ -54,8 +54,10 @@ impl App {
                 self.state.status_text = "Starting Capture into Arrange…".into();
             }
             CaptureAction::Stop => {
-                self.send_command(EngineCommand::StopPerformanceCapture);
-                self.state.status_text = "Stopping Capture…".into();
+                // Transport Stop publishes the Capture boundary first, then
+                // stops Section playback in the same audio callback.
+                self.send_command(capture_stop_command());
+                self.state.status_text = "Stopping Capture and Section playback…".into();
             }
         }
         Task::none()
@@ -106,6 +108,10 @@ impl App {
             self.state.project.dirty = dirty_before;
         }
     }
+}
+
+fn capture_stop_command() -> EngineCommand {
+    EngineCommand::Stop
 }
 
 fn capture_destination_from_playhead_is_empty(
@@ -192,6 +198,11 @@ mod tests {
     use std::collections::HashMap;
     use vibez_core::id::{ClipId, TrackId};
     use vibez_core::perform::GrooveGrid;
+
+    #[test]
+    fn capture_stop_uses_the_atomic_transport_stop_boundary() {
+        assert!(matches!(capture_stop_command(), EngineCommand::Stop));
+    }
 
     fn snapshot(state: &AppState) -> ProjectSnapshot {
         ProjectSnapshot {

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -1,0 +1,270 @@
+//! UI-thread consumption of audio-engine events.
+
+use std::sync::Arc;
+
+use vibez_engine::events::EngineEvent;
+
+use crate::domains::perform::CapturedSectionSource;
+use crate::state::AuditionMode;
+
+use super::*;
+
+impl App {
+    pub(super) fn poll_engine_events(&mut self) {
+        let mut completed_section_recordings = Vec::new();
+        let mut completed_captures = Vec::new();
+        if let Some(ref mut rx) = self.event_rx {
+            while let Ok(event) = rx.pop() {
+                match event {
+                    EngineEvent::DisposeEffect(cell) => {
+                        // Plugin teardown remains on the UI thread.
+                        drop(cell.take());
+                    }
+                    EngineEvent::DisposeInstrument(cell) => drop(cell.take()),
+                    EngineEvent::PlaybackPosition(pos) => {
+                        self.state.transport.position_samples = pos;
+                    }
+                    EngineEvent::Metering { peak_l, peak_r, .. } => {
+                        self.state.peak_l = peak_l.max(self.state.peak_l * 0.85);
+                        self.state.peak_r = peak_r.max(self.state.peak_r * 0.85);
+                        let project_tracks = Arc::make_mut(&mut self.state.project_tracks);
+                        project_tracks.master.peak_l = self.state.peak_l;
+                        project_tracks.master.peak_r = self.state.peak_r;
+                    }
+                    EngineEvent::PlaybackStopped => {
+                        self.state.transport.playing = false;
+                        self.state.perform.playing_section = None;
+                        self.state.perform.queued_section = None;
+                        self.state.perform.pending_section_boundary_samples = None;
+                        self.state.perform.section_playhead_samples = 0;
+                    }
+                    EngineEvent::PlaybackStarted => {
+                        self.state.transport.playing = true;
+                    }
+                    EngineEvent::AuditionStopped => {
+                        self.state.browser.stop_audition_state();
+                        if matches!(
+                            self.state.status_text.as_str(),
+                            "RAW Audition playing" | "WARP Audition playing"
+                        ) {
+                            self.state.status_text = "Audition finished".into();
+                        }
+                    }
+                    EngineEvent::AuditionQueued => {
+                        self.state.browser.audition_loading = false;
+                        self.state.browser.audition_playing = false;
+                        self.state.browser.audition_queued = true;
+                    }
+                    EngineEvent::AuditionStarted => {
+                        self.state.browser.audition_loading = false;
+                        self.state.browser.audition_queued = false;
+                        self.state.browser.audition_playing = true;
+                        self.state.status_text = match self.state.browser.audition_mode {
+                            AuditionMode::Raw => "RAW Audition playing".into(),
+                            AuditionMode::Warp => "WARP Audition playing".into(),
+                        };
+                    }
+                    EngineEvent::TrackMeter {
+                        track_id,
+                        peak_l,
+                        peak_r,
+                    } => {
+                        if let Some(track) = self.state.find_track_mut(track_id) {
+                            track.peak_l = peak_l.max(track.peak_l * 0.85);
+                            track.peak_r = peak_r.max(track.peak_r * 0.85);
+                        }
+                    }
+                    EngineEvent::TrackMuteChanged {
+                        track_id,
+                        muted,
+                        effective_at_samples: _,
+                    } => {
+                        if let Some(track) = self.state.find_track_mut(track_id) {
+                            track.mute = muted;
+                        }
+                    }
+                    EngineEvent::NoteRepeated {
+                        track_id,
+                        pitch,
+                        velocity,
+                        rate,
+                        effective_at_samples,
+                        section_id,
+                        canonical_section_position_samples,
+                        ..
+                    } => {
+                        self.state.perform.section_record.repeated_note(
+                            section_id,
+                            track_id,
+                            pitch,
+                            velocity,
+                            rate,
+                            effective_at_samples,
+                            canonical_section_position_samples,
+                        );
+                    }
+                    EngineEvent::InstrumentNoteInput {
+                        track_id,
+                        pitch,
+                        velocity,
+                        on,
+                        effective_at_samples,
+                        section_id,
+                        section_position_samples,
+                    } => {
+                        self.state.perform.section_record.input_note(
+                            crate::domains::perform::section_record::SectionRecordInput {
+                                section_id,
+                                track_id,
+                                pitch,
+                                velocity,
+                                on,
+                                effective_at_samples,
+                                section_position_samples,
+                            },
+                        );
+                    }
+                    EngineEvent::SectionRecordArmed {
+                        section_id,
+                        track_id,
+                        effective_at_samples,
+                        ..
+                    } => {
+                        self.state.perform.section_record.arm(
+                            section_id,
+                            track_id,
+                            effective_at_samples,
+                        );
+                        self.state.status_text =
+                            format!("Section Record pending at sample {effective_at_samples}");
+                    }
+                    EngineEvent::SectionRecordStarted {
+                        section_id,
+                        track_id,
+                        effective_at_samples,
+                        section_position_samples,
+                    } => {
+                        self.state.perform.section_record.start(
+                            section_id,
+                            track_id,
+                            effective_at_samples,
+                            section_position_samples,
+                        );
+                        self.state.status_text = "Section Record running".into();
+                    }
+                    EngineEvent::SectionRecordStopped {
+                        section_id,
+                        track_id,
+                        effective_at_samples,
+                        section_position_samples,
+                        started,
+                        retired,
+                    } => {
+                        let completed = self.state.perform.section_record.finish(
+                            section_id,
+                            track_id,
+                            effective_at_samples,
+                            section_position_samples,
+                            started,
+                        );
+                        drop(retired);
+                        completed_section_recordings.push(completed);
+                    }
+                    EngineEvent::PerformanceCaptureStarted {
+                        effective_at_samples,
+                        section_id,
+                        section_position_samples,
+                    } => {
+                        let active = section_id.zip(section_position_samples).and_then(
+                            |(section_id, position)| {
+                                self.state
+                                    .perform
+                                    .sections
+                                    .by_id(section_id)
+                                    .map(|section| {
+                                        (CapturedSectionSource::from_section(section), position)
+                                    })
+                            },
+                        );
+                        self.state
+                            .perform
+                            .capture
+                            .start(effective_at_samples, active);
+                        self.state.status_text = "Capture recording into Arrange".into();
+                    }
+                    EngineEvent::PerformanceCaptureStopped {
+                        effective_at_samples,
+                    } => {
+                        if self.state.perform.capture.is_active() {
+                            completed_captures
+                                .push(self.state.perform.capture.finish(effective_at_samples));
+                        }
+                    }
+                    EngineEvent::SectionTransitioned {
+                        section_id,
+                        effective_at_samples,
+                        retired,
+                    } => {
+                        let captured_source = self
+                            .state
+                            .perform
+                            .sections
+                            .by_id(section_id)
+                            .map(CapturedSectionSource::from_section);
+                        if let Some(source) = captured_source {
+                            self.state
+                                .perform
+                                .capture
+                                .transition(source, effective_at_samples);
+                        }
+                        self.state.perform.playing_section = Some(section_id);
+                        self.state.perform.queued_section = None;
+                        self.state.perform.pending_section_boundary_samples = None;
+                        self.state.perform.section_playhead_samples = 0;
+                        self.state.status_text =
+                            format!("Section playing at sample {effective_at_samples}");
+                        drop(retired);
+                    }
+                    EngineEvent::SectionQueued {
+                        section_id,
+                        effective_at_samples,
+                        retired,
+                    } => {
+                        self.state.perform.queued_section = Some(section_id);
+                        self.state.perform.pending_section_boundary_samples =
+                            Some(effective_at_samples);
+                        drop(retired);
+                    }
+                    EngineEvent::SectionQueueCancelled { retired } => {
+                        self.state.perform.queued_section = None;
+                        self.state.perform.pending_section_boundary_samples = None;
+                        drop(retired);
+                    }
+                    EngineEvent::SectionPlaybackPosition {
+                        section_id,
+                        position_samples,
+                    } => {
+                        if self.state.perform.playing_section == Some(section_id) {
+                            self.state.perform.section_playhead_samples = position_samples;
+                        }
+                        self.state
+                            .perform
+                            .section_record
+                            .observe_playhead(section_id, position_samples);
+                    }
+                    EngineEvent::SectionSourceRefreshed {
+                        section_id: _,
+                        applied: _,
+                        retired,
+                    } => drop(retired),
+                }
+            }
+        }
+        for completed in completed_section_recordings {
+            self.finish_section_record_session(completed);
+        }
+        for completed in completed_captures {
+            self.finish_performance_capture(completed);
+        }
+    }
+}

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -4,7 +4,7 @@
 
 use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::browser::BrowserMsg;
-use crate::domains::perform::{PerformMode, PerformMsg, SectionRecordMsg};
+use crate::domains::perform::{CaptureMsg, PerformMode, PerformMsg, SectionRecordMsg};
 use crate::domains::piano_roll::PianoRollMsg;
 use crate::domains::project::ProjectMsg;
 use crate::domains::transport::TransportMsg;
@@ -277,6 +277,9 @@ fn perform_workspace_key_handler(
         iced::keyboard::Key::Named(Named::F4) => Some(Message::Perform(PerformMsg::SectionRecord(
             SectionRecordMsg::Toggle,
         ))),
+        iced::keyboard::Key::Named(Named::F5) => {
+            Some(Message::Perform(PerformMsg::Capture(CaptureMsg::Toggle)))
+        }
         _ => None,
     }
 }
@@ -618,7 +621,7 @@ mod tests {
     }
 
     #[test]
-    fn f4_toggles_section_record_only_without_modifiers_in_perform() {
+    fn f4_and_f5_toggle_recording_controls_only_without_modifiers_in_perform() {
         use iced::keyboard::{key::Named, Key, Modifiers};
 
         assert!(matches!(
@@ -629,6 +632,12 @@ mod tests {
         ));
         assert!(perform_workspace_key_handler(&Key::Named(Named::F4), Modifiers::SHIFT).is_none());
         assert!(global_key_handler(Key::Named(Named::F4), Modifiers::empty()).is_none());
+        assert!(matches!(
+            perform_workspace_key_handler(&Key::Named(Named::F5), Modifiers::empty()),
+            Some(Message::Perform(PerformMsg::Capture(CaptureMsg::Toggle)))
+        ));
+        assert!(perform_workspace_key_handler(&Key::Named(Named::F5), Modifiers::ALT).is_none());
+        assert!(global_key_handler(Key::Named(Named::F5), Modifiers::empty()).is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -130,6 +130,8 @@ mod actions;
 mod async_helpers;
 mod audio_tasks;
 mod bounce;
+mod capture;
+mod engine_events;
 mod keyboard;
 mod local_watcher;
 mod tracked_request;

--- a/crates/vibez-ui/src/app/views_perform_record.rs
+++ b/crates/vibez-ui/src/app/views_perform_record.rs
@@ -1,11 +1,11 @@
-//! Compact Section Record strip shared by every Perform mode.
+//! Compact Section Record and Capture strip shared by every Perform mode.
 
 use iced::widget::{button, container, horizontal_space, pick_list, row, text};
 use iced::{Element, Length, Theme};
 
 use crate::domains::perform::{
-    PerformMsg, SectionRecordCountIn, SectionRecordMode, SectionRecordMsg, SectionRecordPhase,
-    SectionRecordQuantization,
+    CaptureMsg, CapturePhase, PerformMsg, SectionRecordCountIn, SectionRecordMode,
+    SectionRecordMsg, SectionRecordPhase, SectionRecordQuantization,
 };
 use crate::icons;
 use crate::message::Message;
@@ -17,8 +17,11 @@ use super::*;
 impl App {
     pub(super) fn view_section_record_bar(&self) -> Element<'_, Message> {
         let record = &self.state.perform.section_record;
+        let capture = &self.state.perform.capture;
         let active = record.is_active();
         let recording = record.phase == SectionRecordPhase::Recording;
+        let capture_active = capture.is_active();
+        let capturing = capture.phase == CapturePhase::Recording;
         let target = record
             .target()
             .and_then(|(section_id, track_id)| {
@@ -48,6 +51,12 @@ impl App {
                 .unwrap_or_else(|| "ARMED · NEXT BAR".into()),
             SectionRecordPhase::Recording => "RECORDING".into(),
             SectionRecordPhase::Stopping => "STOPPING".into(),
+        };
+        let capture_phase = match capture.phase {
+            CapturePhase::Idle => "ARRANGE · READY",
+            CapturePhase::Starting => "ARRANGE · STARTING",
+            CapturePhase::Recording => "ARRANGE · CAPTURING",
+            CapturePhase::Stopping => "ARRANGE · STOPPING",
         };
 
         let record_button = button(record_button_content(active))
@@ -82,6 +91,49 @@ impl App {
                 }
             });
 
+        let capture_button = button(
+            text(if capture_active {
+                "■ STOP CAPTURE"
+            } else {
+                "● CAPTURE"
+            })
+            .font(PERFORM_TECH_STRONG)
+            .size(10),
+        )
+        .on_press(Message::Perform(PerformMsg::Capture(CaptureMsg::Toggle)))
+        .padding([7, 12])
+        .style(move |_theme: &Theme, status| {
+            let hovered = matches!(status, button::Status::Hovered | button::Status::Pressed);
+            let emphasized = capture_active || hovered;
+            button::Style {
+                background: Some(
+                    if capturing {
+                        th::danger()
+                    } else if emphasized {
+                        th::accent()
+                    } else {
+                        th::perform_inset()
+                    }
+                    .into(),
+                ),
+                text_color: if emphasized {
+                    th::bg_dark()
+                } else {
+                    th::accent()
+                },
+                border: iced::Border {
+                    color: if capturing {
+                        th::danger()
+                    } else {
+                        th::accent_dim()
+                    },
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                ..Default::default()
+            }
+        });
+
         let count_in = record_pick_list(
             &SectionRecordCountIn::ALL,
             record.count_in,
@@ -114,6 +166,7 @@ impl App {
                 count_in,
                 mode,
                 quantization,
+                capture_button,
                 container(horizontal_space()).width(Length::Fill),
                 row![
                     text(target)
@@ -121,6 +174,14 @@ impl App {
                         .size(9)
                         .color(th::text_dim()),
                     text(phase).font(PERFORM_LABEL).size(9).color(state_color),
+                    text(capture_phase)
+                        .font(PERFORM_LABEL)
+                        .size(9)
+                        .color(if capturing {
+                            th::danger()
+                        } else {
+                            th::accent()
+                        }),
                 ]
                 .spacing(12)
                 .align_y(iced::Alignment::Center),

--- a/crates/vibez-ui/src/app/views_perform_record.rs
+++ b/crates/vibez-ui/src/app/views_perform_record.rs
@@ -91,48 +91,42 @@ impl App {
                 }
             });
 
-        let capture_button = button(
-            text(if capture_active {
-                "■ STOP CAPTURE"
-            } else {
-                "● CAPTURE"
-            })
-            .font(PERFORM_TECH_STRONG)
-            .size(10),
-        )
-        .on_press(Message::Perform(PerformMsg::Capture(CaptureMsg::Toggle)))
-        .padding([7, 12])
-        .style(move |_theme: &Theme, status| {
-            let hovered = matches!(status, button::Status::Hovered | button::Status::Pressed);
-            let emphasized = capture_active || hovered;
-            button::Style {
-                background: Some(
-                    if capturing {
-                        th::danger()
-                    } else if emphasized {
+        let capture_button = button(capture_button_content(capture_active))
+            .on_press(Message::Perform(PerformMsg::Capture(CaptureMsg::Toggle)))
+            .padding([7, 12])
+            .style(move |_theme: &Theme, status| {
+                let hovered = matches!(status, button::Status::Hovered | button::Status::Pressed);
+                let emphasized = capture_active || hovered;
+                button::Style {
+                    background: Some(
+                        if capturing {
+                            th::danger()
+                        } else if capture_active {
+                            th::accent()
+                        } else if hovered {
+                            th::blend(th::perform_inset(), th::accent(), 0.14)
+                        } else {
+                            th::perform_inset()
+                        }
+                        .into(),
+                    ),
+                    text_color: if emphasized {
+                        th::bg_dark()
+                    } else {
                         th::accent()
-                    } else {
-                        th::perform_inset()
-                    }
-                    .into(),
-                ),
-                text_color: if emphasized {
-                    th::bg_dark()
-                } else {
-                    th::accent()
-                },
-                border: iced::Border {
-                    color: if capturing {
-                        th::danger()
-                    } else {
-                        th::accent_dim()
                     },
-                    width: 1.0,
-                    radius: 3.0.into(),
-                },
-                ..Default::default()
-            }
-        });
+                    border: iced::Border {
+                        color: if capturing {
+                            th::danger()
+                        } else {
+                            th::accent_dim()
+                        },
+                        width: 1.0,
+                        radius: 3.0.into(),
+                    },
+                    ..Default::default()
+                }
+            });
 
         let count_in = record_pick_list(
             &SectionRecordCountIn::ALL,
@@ -221,17 +215,6 @@ fn count_in_beats_remaining(
 
 fn record_button_content(active: bool) -> Element<'static, Message> {
     let color = if active { th::bg_dark() } else { th::danger() };
-    let shortcut = container(text("F4").font(PERFORM_TECH_STRONG).size(8).color(color))
-        .padding([1, 4])
-        .style(move |_theme: &Theme| container::Style {
-            background: (!active).then(|| th::blend(th::bg_dark(), color, 0.08).into()),
-            border: iced::Border {
-                color: th::blend(th::border_light(), color, 0.3),
-                width: 1.0,
-                radius: 2.0.into(),
-            },
-            ..Default::default()
-        });
     row![
         icons::icon(if active {
             icons::STOP
@@ -248,11 +231,55 @@ fn record_button_content(active: bool) -> Element<'static, Message> {
         .font(PERFORM_TECH_STRONG)
         .size(9)
         .color(color),
-        shortcut,
+        shortcut_keycap("F4", color, active),
     ]
     .spacing(6)
     .align_y(iced::Alignment::Center)
     .into()
+}
+
+fn capture_button_content(active: bool) -> Element<'static, Message> {
+    let color = if active { th::bg_dark() } else { th::accent() };
+    row![
+        icons::icon(if active {
+            icons::STOP
+        } else {
+            icons::LAYOUT_LIST
+        })
+        .size(11)
+        .color(color),
+        text(if active {
+            "STOP CAPTURE"
+        } else {
+            "CAPTURE → ARRANGE"
+        })
+        .font(PERFORM_TECH_STRONG)
+        .size(9)
+        .color(color),
+        shortcut_keycap("F5", color, active),
+    ]
+    .spacing(6)
+    .align_y(iced::Alignment::Center)
+    .into()
+}
+
+fn shortcut_keycap(
+    label: &'static str,
+    color: iced::Color,
+    active: bool,
+) -> Element<'static, Message> {
+    container(text(label).font(PERFORM_TECH_STRONG).size(8).color(color))
+        .padding([1, 4])
+        .style(move |_theme: &Theme| container::Style {
+            background: (!active).then(|| th::blend(th::bg_dark(), color, 0.08).into()),
+            border: iced::Border {
+                color: th::blend(th::border_light(), color, 0.3),
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
 }
 
 fn record_pick_list<'a, T: Copy + Eq + std::fmt::Display + 'static>(

--- a/crates/vibez-ui/src/app/views_perform_record.rs
+++ b/crates/vibez-ui/src/app/views_perform_record.rs
@@ -240,14 +240,13 @@ fn record_button_content(active: bool) -> Element<'static, Message> {
 
 fn capture_button_content(active: bool) -> Element<'static, Message> {
     let color = if active { th::bg_dark() } else { th::accent() };
+    let capture_icon: Element<'static, Message> = if active {
+        icons::icon(icons::STOP).size(11).color(color).into()
+    } else {
+        capture_to_arrange_icon()
+    };
     row![
-        icons::icon(if active {
-            icons::STOP
-        } else {
-            icons::LAYOUT_LIST
-        })
-        .size(11)
-        .color(color),
+        capture_icon,
         text(if active {
             "STOP CAPTURE"
         } else {
@@ -259,6 +258,36 @@ fn capture_button_content(active: bool) -> Element<'static, Message> {
         shortcut_keycap("F5", color, active),
     ]
     .spacing(6)
+    .align_y(iced::Alignment::Center)
+    .into()
+}
+
+/// Purpose-built Capture mark: a record source feeding linear timeline lanes.
+/// It deliberately shares no glyph with the Arrange workspace or timeline
+/// expansion controls.
+fn capture_to_arrange_icon() -> Element<'static, Message> {
+    let lane = || {
+        container(horizontal_space())
+            .width(Length::Fixed(8.0))
+            .height(Length::Fixed(1.0))
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::accent().into()),
+                ..Default::default()
+            })
+    };
+    let lanes = iced::widget::column![lane(), lane(), lane()]
+        .spacing(2)
+        .align_x(iced::Alignment::Start);
+
+    row![
+        icons::icon(icons::CIRCLE_DOT).size(10).color(th::danger()),
+        text("›")
+            .font(PERFORM_TECH_STRONG)
+            .size(10)
+            .color(th::accent()),
+        lanes,
+    ]
+    .spacing(2)
     .align_y(iced::Alignment::Center)
     .into()
 }

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -14,11 +14,16 @@ use vibez_project::SectionLaunchQuantization;
 use super::EngineHandle;
 use crate::state::ProjectTrack;
 
+pub(crate) mod capture;
 mod input_mapping;
 mod instrument;
 mod note_repeat;
 pub(crate) mod section_record;
 mod sections;
+pub use capture::{
+    CaptureAction, CaptureMsg, CapturePhase, CaptureState, CapturedSectionSource,
+    MaterializedCapture,
+};
 pub use input_mapping::{ComputerKey, PerformInputMapping};
 pub use instrument::SixteenLevelsParameter;
 use instrument::{ActiveInstrumentNote, InstrumentPerformanceState};
@@ -179,6 +184,7 @@ pub struct PerformState {
     note_repeat_momentary: bool,
     note_repeat_momentary_key_id: Option<String>,
     note_repeat_latched: bool,
+    pub capture: CaptureState,
     pub section_record: section_record::SectionRecordState,
     pub sections: Arc<SectionStore>,
     pub selected_section: Option<SectionId>,
@@ -199,6 +205,7 @@ pub struct PerformState {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum PerformMsg {
+    Capture(CaptureMsg),
     SectionRecord(SectionRecordMsg),
     SelectMode(PerformMode),
     FocusEditor(PerformEditorFocus),
@@ -315,6 +322,7 @@ pub struct PerformAction {
     pub select_project_track: Option<TrackId>,
     pub section_launch: Option<SectionId>,
     pub section_content_changed: Option<SectionId>,
+    pub capture: Option<CaptureAction>,
     pub section_record: Option<SectionRecordAction>,
     pub section_record_status: Option<&'static str>,
 }
@@ -403,6 +411,7 @@ impl PerformState {
         self.sync_track_mute_slots(ctx.project_tracks);
         self.sync_instrument_target_from_selection(ctx.selected_project_track, ctx.project_tracks);
         match msg {
+            PerformMsg::Capture(msg) => return self.capture.update(msg),
             PerformMsg::SectionRecord(msg) => return self.update_section_record(msg),
             PerformMsg::SelectMode(mode) => {
                 if ctx.workspace_visible {
@@ -826,6 +835,7 @@ impl PerformState {
                     select_project_track: selected_instrument_target,
                     section_launch,
                     section_content_changed: None,
+                    capture: None,
                     section_record: None,
                     section_record_status: None,
                 };

--- a/crates/vibez-ui/src/domains/perform/capture.rs
+++ b/crates/vibez-ui/src/domains/perform/capture.rs
@@ -1,0 +1,651 @@
+//! Runtime Capture log and pure Section-to-Arrange materialization.
+//!
+//! The audio engine owns effective timestamps. This module snapshots the
+//! canonical Section source at those boundaries, then creates independent
+//! linear Arrange clips only after the engine confirms Capture stop.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use vibez_core::id::{ClipId, TrackId};
+use vibez_core::midi::MidiNote;
+
+use crate::state::{ArrangementTimeline, TrackTimelineContent, UiClip, UiNoteClip};
+
+use super::{PerformAction, Section};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CapturePhase {
+    #[default]
+    Idle,
+    Starting,
+    Recording,
+    Stopping,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureMsg {
+    Toggle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureAction {
+    Start,
+    Stop,
+}
+
+#[derive(Debug, Clone)]
+pub struct CapturedSectionSource {
+    pub name: String,
+    pub length_beats: f64,
+    pub looping: bool,
+    pub timeline: Arc<ArrangementTimeline>,
+}
+
+impl CapturedSectionSource {
+    pub fn from_section(section: &Section) -> Self {
+        Self {
+            name: section.name.clone(),
+            length_beats: section.length_beats,
+            looping: section.looping,
+            timeline: Arc::clone(&section.timeline),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CaptureClock {
+    arrange_start_samples: u64,
+    sample_rate: u32,
+    bpm: f64,
+}
+
+#[derive(Debug, Clone)]
+struct ActiveSpan {
+    source: CapturedSectionSource,
+    effective_start_samples: u64,
+    source_start_samples: u64,
+}
+
+#[derive(Debug, Clone)]
+struct CapturedSectionSpan {
+    source: CapturedSectionSource,
+    effective_start_samples: u64,
+    effective_end_samples: u64,
+    source_start_samples: u64,
+}
+
+#[derive(Debug)]
+struct CaptureSession {
+    clock: CaptureClock,
+    engine_start_samples: u64,
+    active: Option<ActiveSpan>,
+    spans: Vec<CapturedSectionSpan>,
+}
+
+#[derive(Debug)]
+pub struct CompletedCapture {
+    clock: CaptureClock,
+    engine_start_samples: u64,
+    engine_end_samples: u64,
+    spans: Vec<CapturedSectionSpan>,
+}
+
+#[derive(Debug, Default)]
+pub struct MaterializedCapture {
+    pub arrange_start_samples: u64,
+    pub arrange_end_samples: u64,
+    pub by_track: HashMap<TrackId, TrackTimelineContent>,
+    pub(crate) samples_per_beat: f64,
+}
+
+impl MaterializedCapture {
+    pub fn is_empty(&self) -> bool {
+        self.by_track.values().all(|content| {
+            content.clips.is_empty()
+                && content.note_clips.is_empty()
+                && content.automation.is_empty()
+        })
+    }
+
+    /// Card 17 is deliberately safe only for an empty destination interval.
+    /// Replacement and lane surgery arrive in Card 18.
+    pub fn target_interval_is_empty(
+        &self,
+        arrange: &ArrangementTimeline,
+        perform_track_ids: &[TrackId],
+    ) -> bool {
+        if self.arrange_end_samples <= self.arrange_start_samples {
+            return true;
+        }
+        perform_track_ids.iter().all(|track_id| {
+            arrange.get(*track_id).is_none_or(|existing| {
+                let audio_clear = existing.clips.iter().all(|clip| {
+                    clip.position.saturating_add(clip.duration) <= self.arrange_start_samples
+                        || clip.position >= self.arrange_end_samples
+                });
+                let note_clear = existing.note_clips.iter().all(|clip| {
+                    let start = (clip.position_beats * self.samples_per_beat)
+                        .round()
+                        .max(0.0) as u64;
+                    let end = ((clip.position_beats + clip.duration_beats) * self.samples_per_beat)
+                        .round()
+                        .max(0.0) as u64;
+                    end <= self.arrange_start_samples || start >= self.arrange_end_samples
+                });
+                audio_clear && note_clear && existing.automation.is_empty()
+            })
+        })
+    }
+}
+
+impl CompletedCapture {
+    pub fn materialize(&self) -> MaterializedCapture {
+        let mut result = MaterializedCapture {
+            arrange_start_samples: self.clock.arrange_start_samples,
+            arrange_end_samples: self.clock.arrange_start_samples.saturating_add(
+                self.engine_end_samples
+                    .saturating_sub(self.engine_start_samples),
+            ),
+            by_track: HashMap::new(),
+            samples_per_beat: samples_per_beat(self.clock.sample_rate, self.clock.bpm),
+        };
+        let samples_per_beat = result.samples_per_beat;
+        if samples_per_beat <= 0.0 {
+            return result;
+        }
+
+        for span in &self.spans {
+            let span_length = span
+                .effective_end_samples
+                .saturating_sub(span.effective_start_samples);
+            let section_length = (span.source.length_beats * samples_per_beat)
+                .round()
+                .max(1.0) as u64;
+            let mut remaining = span_length;
+            let mut source_cursor = span.source_start_samples.min(section_length);
+            let mut destination_cursor = self.clock.arrange_start_samples.saturating_add(
+                span.effective_start_samples
+                    .saturating_sub(self.engine_start_samples),
+            );
+
+            while remaining > 0 && source_cursor < section_length {
+                let segment_length = remaining.min(section_length - source_cursor);
+                append_timeline_window(
+                    &mut result.by_track,
+                    &span.source,
+                    source_cursor,
+                    source_cursor + segment_length,
+                    destination_cursor,
+                    samples_per_beat,
+                );
+                remaining -= segment_length;
+                destination_cursor = destination_cursor.saturating_add(segment_length);
+                if remaining == 0 || !span.source.looping {
+                    break;
+                }
+                source_cursor = 0;
+            }
+        }
+
+        for content in result.by_track.values_mut() {
+            content.clips.sort_by_key(|clip| clip.position);
+            content
+                .note_clips
+                .sort_by(|left, right| left.position_beats.total_cmp(&right.position_beats));
+        }
+        result
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct CaptureState {
+    pub phase: CapturePhase,
+    prepared_clock: Option<CaptureClock>,
+    session: Option<CaptureSession>,
+}
+
+impl CaptureState {
+    pub fn is_active(&self) -> bool {
+        self.phase != CapturePhase::Idle
+    }
+
+    pub fn update(&mut self, msg: CaptureMsg) -> PerformAction {
+        match (msg, self.phase) {
+            (CaptureMsg::Toggle, CapturePhase::Idle) => {
+                self.phase = CapturePhase::Starting;
+                PerformAction {
+                    capture: Some(CaptureAction::Start),
+                    ..PerformAction::default()
+                }
+            }
+            (CaptureMsg::Toggle, CapturePhase::Recording) => {
+                self.phase = CapturePhase::Stopping;
+                PerformAction {
+                    capture: Some(CaptureAction::Stop),
+                    ..PerformAction::default()
+                }
+            }
+            (CaptureMsg::Toggle, CapturePhase::Starting | CapturePhase::Stopping) => {
+                PerformAction::default()
+            }
+        }
+    }
+
+    pub fn prepare(&mut self, arrange_start_samples: u64, sample_rate: u32, bpm: f64) {
+        self.prepared_clock = Some(CaptureClock {
+            arrange_start_samples,
+            sample_rate,
+            bpm,
+        });
+    }
+
+    pub fn start(
+        &mut self,
+        effective_at_samples: u64,
+        active: Option<(CapturedSectionSource, u64)>,
+    ) {
+        if self.phase != CapturePhase::Starting {
+            return;
+        }
+        let Some(clock) = self.prepared_clock.take() else {
+            self.cancel();
+            return;
+        };
+        self.session = Some(CaptureSession {
+            clock,
+            engine_start_samples: effective_at_samples,
+            active: active.map(|(source, source_start_samples)| ActiveSpan {
+                source,
+                effective_start_samples: effective_at_samples,
+                source_start_samples,
+            }),
+            spans: Vec::new(),
+        });
+        self.phase = CapturePhase::Recording;
+    }
+
+    pub fn transition(&mut self, source: CapturedSectionSource, effective_at_samples: u64) {
+        let Some(session) = &mut self.session else {
+            return;
+        };
+        close_active_span(session, effective_at_samples);
+        session.active = Some(ActiveSpan {
+            source,
+            effective_start_samples: effective_at_samples,
+            source_start_samples: 0,
+        });
+    }
+
+    pub fn finish(&mut self, effective_at_samples: u64) -> Option<CompletedCapture> {
+        let Some(mut session) = self.session.take() else {
+            self.cancel();
+            return None;
+        };
+        close_active_span(&mut session, effective_at_samples);
+        self.phase = CapturePhase::Idle;
+        self.prepared_clock = None;
+        Some(CompletedCapture {
+            clock: session.clock,
+            engine_start_samples: session.engine_start_samples,
+            engine_end_samples: effective_at_samples,
+            spans: session.spans,
+        })
+    }
+
+    pub fn cancel(&mut self) {
+        self.phase = CapturePhase::Idle;
+        self.prepared_clock = None;
+        self.session = None;
+    }
+}
+
+fn close_active_span(session: &mut CaptureSession, effective_end_samples: u64) {
+    let Some(active) = session.active.take() else {
+        return;
+    };
+    if effective_end_samples > active.effective_start_samples {
+        session.spans.push(CapturedSectionSpan {
+            source: active.source,
+            effective_start_samples: active.effective_start_samples,
+            effective_end_samples,
+            source_start_samples: active.source_start_samples,
+        });
+    }
+}
+
+fn samples_per_beat(sample_rate: u32, bpm: f64) -> f64 {
+    if bpm > 0.0 {
+        60.0 * sample_rate as f64 / bpm
+    } else {
+        0.0
+    }
+}
+
+fn append_timeline_window(
+    destination: &mut HashMap<TrackId, TrackTimelineContent>,
+    source: &CapturedSectionSource,
+    window_start_samples: u64,
+    window_end_samples: u64,
+    destination_start_samples: u64,
+    samples_per_beat: f64,
+) {
+    let window_start_beats = window_start_samples as f64 / samples_per_beat;
+    let window_end_beats = window_end_samples as f64 / samples_per_beat;
+    let destination_start_beats = destination_start_samples as f64 / samples_per_beat;
+
+    for (track_id, content) in &source.timeline.by_track {
+        for clip in &content.clips {
+            let overlap_start = clip.position.max(window_start_samples);
+            let overlap_end = clip
+                .position
+                .saturating_add(clip.duration)
+                .min(window_end_samples);
+            if overlap_end <= overlap_start {
+                continue;
+            }
+            let delta = overlap_start - clip.position;
+            let mut fragment = UiClip {
+                id: ClipId::new(),
+                name: format!("Capture · {} · {}", source.name, clip.name),
+                audio: Arc::clone(&clip.audio),
+                source: clip.source.clone(),
+                position: destination_start_samples + (overlap_start - window_start_samples),
+                source_offset: mapped_audio_offset(clip, delta),
+                duration: overlap_end - overlap_start,
+                loop_enabled: clip.loop_enabled,
+                loop_start: clip.loop_start,
+                loop_end: clip.loop_end,
+                original_bpm: clip.original_bpm,
+                warped: clip.warped,
+                warped_to_bpm: clip.warped_to_bpm,
+                original_audio: clip.original_audio.as_ref().map(Arc::clone),
+            };
+            if fragment.loop_enabled && fragment.loop_end <= fragment.loop_start {
+                fragment.loop_enabled = false;
+            }
+            destination
+                .entry(*track_id)
+                .or_default()
+                .clips
+                .push(fragment);
+        }
+
+        for clip in &content.note_clips {
+            let clip_end = clip.position_beats + clip.duration_beats;
+            let overlap_start = clip.position_beats.max(window_start_beats);
+            let overlap_end = clip_end.min(window_end_beats);
+            if overlap_end <= overlap_start {
+                continue;
+            }
+            let local_start = overlap_start - clip.position_beats;
+            let local_end = overlap_end - clip.position_beats;
+            let notes = visible_notes(clip, local_start, local_end);
+            let fragment = UiNoteClip {
+                id: ClipId::new(),
+                name: format!("Capture · {} · {}", source.name, clip.name),
+                position_beats: destination_start_beats + (overlap_start - window_start_beats),
+                duration_beats: overlap_end - overlap_start,
+                notes,
+                selected_notes: Default::default(),
+                loop_enabled: false,
+                loop_start_beats: 0.0,
+                loop_end_beats: 0.0,
+                groove_grid: clip.groove_grid,
+            };
+            destination
+                .entry(*track_id)
+                .or_default()
+                .note_clips
+                .push(fragment);
+        }
+    }
+}
+
+fn mapped_audio_offset(clip: &UiClip, timeline_delta: u64) -> u64 {
+    let raw = clip.source_offset.saturating_add(timeline_delta);
+    if clip.loop_enabled && clip.loop_end > clip.loop_start && raw >= clip.loop_end {
+        clip.loop_start + (raw - clip.loop_start) % (clip.loop_end - clip.loop_start)
+    } else {
+        raw
+    }
+}
+
+fn visible_notes(clip: &UiNoteClip, local_start: f64, local_end: f64) -> Vec<MidiNote> {
+    let looping = clip.loop_enabled && clip.loop_end_beats > clip.loop_start_beats;
+    let mut visible = Vec::new();
+    for note in &clip.notes {
+        let mut occurrence = note.start_beat;
+        loop {
+            let note_end = occurrence + note.duration_beats;
+            let kept_start = occurrence.max(local_start);
+            let kept_end = note_end.min(local_end);
+            if kept_end > kept_start {
+                visible.push(MidiNote {
+                    start_beat: kept_start - local_start,
+                    duration_beats: kept_end - kept_start,
+                    ..*note
+                });
+            }
+            if !looping
+                || note.start_beat < clip.loop_start_beats
+                || note.start_beat >= clip.loop_end_beats
+            {
+                break;
+            }
+            occurrence += clip.loop_end_beats - clip.loop_start_beats;
+            if occurrence >= local_end {
+                break;
+            }
+        }
+    }
+    visible.sort_by(|left, right| {
+        left.start_beat
+            .total_cmp(&right.start_beat)
+            .then(left.pitch.cmp(&right.pitch))
+    });
+    visible
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibez_core::audio_buffer::DecodedAudio;
+    use vibez_core::perform::GrooveGrid;
+
+    fn audio_section(name: &str, length_beats: f64, frames: u64) -> Section {
+        let mut section = Section::new(0);
+        section.name = name.into();
+        section.length_beats = length_beats;
+        let track_id = TrackId::new();
+        Arc::make_mut(&mut section.timeline)
+            .ensure(track_id)
+            .clips
+            .push(UiClip {
+                id: ClipId::new(),
+                name: format!("{name} Audio"),
+                audio: Arc::new(DecodedAudio {
+                    channels: vec![vec![0.5; frames as usize]],
+                    sample_rate: 8,
+                }),
+                source: None,
+                position: 0,
+                source_offset: 0,
+                duration: frames,
+                loop_enabled: false,
+                loop_start: 0,
+                loop_end: 0,
+                original_bpm: None,
+                warped: false,
+                warped_to_bpm: None,
+                original_audio: None,
+            });
+        section
+    }
+
+    fn midi_section(name: &str, track_id: TrackId, pitch: u8) -> Section {
+        let mut section = Section::new(0);
+        section.name = name.into();
+        section.length_beats = 4.0;
+        Arc::make_mut(&mut section.timeline)
+            .ensure(track_id)
+            .note_clips
+            .push(UiNoteClip {
+                id: ClipId::new(),
+                name: format!("{name} Notes"),
+                position_beats: 0.0,
+                duration_beats: 4.0,
+                notes: vec![MidiNote {
+                    pitch,
+                    velocity: 100,
+                    start_beat: 0.0,
+                    duration_beats: 0.25,
+                }],
+                selected_notes: Default::default(),
+                loop_enabled: false,
+                loop_start_beats: 0.0,
+                loop_end_beats: 0.0,
+                groove_grid: GrooveGrid::Sixteenth,
+            });
+        section
+    }
+
+    #[test]
+    fn effective_mid_buffer_boundaries_become_exact_arrange_positions() {
+        let first = audio_section("Groove A", 4.0, 16);
+        let second = audio_section("Groove B", 4.0, 16);
+        let track_id = *first.timeline.by_track.keys().next().unwrap();
+        let mut second = second;
+        let second_track_id = *second.timeline.by_track.keys().next().unwrap();
+        let second_content = Arc::make_mut(&mut second.timeline)
+            .by_track
+            .remove(&second_track_id)
+            .unwrap();
+        Arc::make_mut(&mut second.timeline)
+            .by_track
+            .insert(track_id, second_content);
+
+        let mut capture = CaptureState::default();
+        capture.phase = CapturePhase::Starting;
+        capture.prepare(40, 8, 120.0);
+        capture.start(3, Some((CapturedSectionSource::from_section(&first), 0)));
+        capture.transition(CapturedSectionSource::from_section(&second), 10);
+        let completed = capture.finish(15).unwrap();
+        let materialized = completed.materialize();
+        let clips = &materialized.by_track[&track_id].clips;
+
+        assert_eq!(clips.len(), 2);
+        assert_eq!((clips[0].position, clips[0].duration), (40, 7));
+        assert_eq!((clips[1].position, clips[1].duration), (47, 5));
+        assert_eq!(materialized.arrange_end_samples, 52);
+    }
+
+    #[test]
+    fn looping_section_is_flattened_into_independent_linear_passes() {
+        let mut section = audio_section("Groove A", 1.0, 4);
+        section.looping = true;
+        let track_id = *section.timeline.by_track.keys().next().unwrap();
+        let mut capture = CaptureState::default();
+        capture.phase = CapturePhase::Starting;
+        capture.prepare(0, 8, 120.0);
+        capture.start(0, Some((CapturedSectionSource::from_section(&section), 0)));
+        let clips = &capture.finish(10).unwrap().materialize().by_track[&track_id].clips;
+
+        assert_eq!(clips.len(), 3);
+        assert_eq!(
+            clips.iter().map(|clip| clip.position).collect::<Vec<_>>(),
+            [0, 4, 8]
+        );
+        assert_eq!(
+            clips.iter().map(|clip| clip.duration).collect::<Vec<_>>(),
+            [4, 4, 2]
+        );
+        assert!(clips.windows(2).all(|pair| pair[0].id != pair[1].id));
+    }
+
+    #[test]
+    fn midi_sections_keep_effective_transition_alignment_and_groove_identity() {
+        let track_id = TrackId::new();
+        let first = midi_section("Groove A", track_id, 36);
+        let second = midi_section("Groove B", track_id, 38);
+        let source_ids = [
+            first.timeline.get(track_id).unwrap().note_clips[0].id,
+            second.timeline.get(track_id).unwrap().note_clips[0].id,
+        ];
+        let mut capture = CaptureState::default();
+        capture.phase = CapturePhase::Starting;
+        capture.prepare(8, 8, 120.0);
+        capture.start(0, Some((CapturedSectionSource::from_section(&first), 0)));
+        capture.transition(CapturedSectionSource::from_section(&second), 5);
+        let clips = &capture.finish(9).unwrap().materialize().by_track[&track_id].note_clips;
+
+        assert_eq!(clips.len(), 2);
+        assert!((clips[0].position_beats - 2.0).abs() < 1e-9);
+        assert!((clips[0].duration_beats - 1.25).abs() < 1e-9);
+        assert!((clips[1].position_beats - 3.25).abs() < 1e-9);
+        assert_eq!([clips[0].notes[0].pitch, clips[1].notes[0].pitch], [36, 38]);
+        assert!(clips
+            .iter()
+            .all(|clip| clip.groove_grid == GrooveGrid::Sixteenth));
+        assert!(clips.iter().all(|clip| !source_ids.contains(&clip.id)));
+    }
+
+    #[test]
+    fn transition_reported_after_stop_cannot_extend_the_capture() {
+        let first = audio_section("Groove A", 4.0, 16);
+        let second = audio_section("Groove B", 4.0, 16);
+        let track_id = *first.timeline.by_track.keys().next().unwrap();
+        let mut capture = CaptureState::default();
+        capture.phase = CapturePhase::Starting;
+        capture.prepare(0, 8, 120.0);
+        capture.start(0, Some((CapturedSectionSource::from_section(&first), 0)));
+        let completed = capture.finish(4).unwrap();
+        capture.transition(CapturedSectionSource::from_section(&second), 6);
+
+        let clips = &completed.materialize().by_track[&track_id].clips;
+        assert_eq!(clips.len(), 1);
+        assert_eq!((clips[0].position, clips[0].duration), (0, 4));
+        assert_eq!(capture.phase, CapturePhase::Idle);
+    }
+
+    #[test]
+    fn source_edits_after_transition_cannot_rewrite_capture_snapshot() {
+        let mut section = audio_section("Breakdown", 4.0, 16);
+        let track_id = *section.timeline.by_track.keys().next().unwrap();
+        let mut capture = CaptureState::default();
+        capture.phase = CapturePhase::Starting;
+        capture.prepare(20, 8, 120.0);
+        capture.start(
+            100,
+            Some((CapturedSectionSource::from_section(&section), 0)),
+        );
+        Arc::make_mut(&mut section.timeline)
+            .ensure(track_id)
+            .clips
+            .clear();
+
+        let materialized = capture.finish(108).unwrap().materialize();
+        assert_eq!(materialized.by_track[&track_id].clips.len(), 1);
+        assert!(section.timeline.get(track_id).unwrap().clips.is_empty());
+    }
+
+    #[test]
+    fn occupied_target_interval_is_rejected_without_touching_outside_content() {
+        let section = audio_section("Drop", 4.0, 16);
+        let track_id = *section.timeline.by_track.keys().next().unwrap();
+        let mut capture = CaptureState::default();
+        capture.phase = CapturePhase::Starting;
+        capture.prepare(40, 8, 120.0);
+        capture.start(0, Some((CapturedSectionSource::from_section(&section), 0)));
+        let completed = capture.finish(8).unwrap();
+        let mut arrange = ArrangementTimeline::default();
+        let silent_track = TrackId::new();
+        let mut outside = section.timeline.get(track_id).unwrap().clips[0].clone();
+        outside.position = 44;
+        arrange.ensure(silent_track).clips.push(outside);
+
+        let materialized = completed.materialize();
+        assert!(materialized.target_interval_is_empty(&ArrangementTimeline::default(), &[track_id]));
+        assert!(!materialized.target_interval_is_empty(&arrange, &[track_id, silent_track]));
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,6 +177,23 @@ duration and keep Groove Grid Off. `1/8` and `1/16` Note Repeat stores the
 canonical straight position with its matching Groove Grid, so playback applies
 live Swing once and later Swing edits remain effective.
 
+Capture into Arrange is a separate runtime log over the same engine clock.
+`PerformanceCaptureStarted`, `SectionTransitioned`, and
+`PerformanceCaptureStopped` report exact effective samples, including a
+transition that splits an audio callback and a Capture begun partway through an
+already-playing Section. The UI snapshots each canonical Section timeline at
+the boundary where it becomes audible. On stop, it flattens those snapshots
+across Section loop passes into newly identified Arrange audio and MIDI clips,
+offset from the Arrange playhead captured at session start. The copied clips
+share only immutable decoded audio; they retain no Section identity or mutable
+reference, so later Section edits and launches cannot rewrite Arrange.
+
+Card 17 applies that materialization only when the destination interval is
+empty on every affected Project Track. Any overlap aborts the still-open
+project transaction without changing Arrange; interval replacement belongs to
+Card 18. Track Mutes, live notes, and effective automation are likewise later
+Capture log consumers rather than implicit work in this first slice.
+
 The project document persists the immutable `mpc_2000xl_v1` Groove Profile,
 Project Swing, and optional Project Track Swing offsets as canonical project
 data and undo state. Swing uses the profile's native `50..75%` long/short pair
@@ -297,6 +314,11 @@ long-lived consumer: it opens before residency/arming and commits the complete
 Overdub or Replace session on the engine-confirmed stop as one undo step.
 Editor selections, meters, decoded/runtime caches, and live plugin pointers are
 outside the transaction snapshot and are neither cloned nor restored.
+Capture opens the same transaction before requesting its engine start boundary,
+then marks one edit and commits only after the engine-confirmed stop has
+materialized independent Arrange content. Empty or overlapping sessions abandon
+the transaction, while undo/redo replays the complete captured Arrangement as
+one project step.
 
 ## The audio engine
 


### PR DESCRIPTION
## Summary
- add engine-owned start/stop capture boundaries and snapshot canonical Section timelines at sample-accurate transitions
- flatten Section loop passes into newly identified, independent Arrange clips at the current playhead and locked BPM
- reject occupied target intervals safely and commit each capture as one Card 15 project transaction
- add the Perform Capture control, Arrange handoff, regression coverage, and architecture documentation

## Verification
- `nice -n 10 cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/home/alexander/Code/Apps/vibez-targets/card-15 nice -n 10 cargo check --workspace -j 4`
- `CARGO_TARGET_DIR=/home/alexander/Code/Apps/vibez-targets/card-15 nice -n 10 cargo clippy --workspace -j 4 -- -D warnings`
- `CARGO_TARGET_DIR=/home/alexander/Code/Apps/vibez-targets/card-15 nice -n 10 cargo test --workspace -j 4`
- native Xvfb `:96` dogfood: quantized Section transition, 50-clip capture, one-step undo/redo, source deletion independence, and captured MIDI playback through the synth

## Stack
- stacked on Card 16 / PR #97
- keep unmerged until explicit approval