### PR TITLE
fix(perform): decouple performance clock from arrange cursor

### DIFF
--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -22,6 +22,8 @@ use crate::note_repeat::{NoteRepeatClock, NoteRepeatStart};
 use crate::playback_source::{calculate_total_length, PreparedSectionPlaybackSource};
 use crate::transport::Transport;
 
+use self::clock::ClockDomain;
+
 /// Capacity of the UI spectrum-analyser sample ring: roughly a third
 /// of a second of mono audio at 48 kHz, ample for a 60 fps drain.
 const SPECTRUM_RING_CAPACITY: usize = 16_384;
@@ -83,8 +85,12 @@ pub struct AudioEngine {
     /// it while existing playback remains untouched.
     project_swing: SwingAmount,
     /// Continues Note Repeat timing while transport is stopped. While playing,
-    /// this is kept aligned with the absolute transport position.
+    /// this follows the active clock domain.
     performance_position: u64,
+    /// The clock currently authorised to advance. Perform owns an independent
+    /// zero-based engine timeline; its playback must never mutate the
+    /// canonical Arrange cursor held by `transport.position()`.
+    clock_domain: ClockDomain,
     /// Vibez extends MPC Note Repeat to stopped transport. The first held pad
     /// establishes this shared musical downbeat until the last repeat stops.
     stopped_note_repeat_anchor: Option<u64>,
@@ -141,6 +147,7 @@ impl AudioEngine {
             arrangement_audio_length: None,
             project_swing: SwingAmount::default(),
             performance_position: 0,
+            clock_domain: ClockDomain::Arrange,
             stopped_note_repeat_anchor: None,
         };
 
@@ -201,7 +208,7 @@ impl AudioEngine {
         let block_beat = if self.transport.is_playing() {
             let bpm = self.transport.bpm();
             if bpm > 0.0 {
-                Some(self.transport.position() as f64 * bpm / (self.sample_rate as f64 * 60.0))
+                Some(self.effective_position() as f64 * bpm / (self.sample_rate as f64 * 60.0))
             } else {
                 None
             }
@@ -302,17 +309,18 @@ impl AudioEngine {
         // ---- 5. Advance transport and send events -----------------------
         let was_playing = self.transport.is_playing();
         let pos_before = self.transport.position();
-        let section_count_in = self
-            .pending_section_record
-            .as_ref()
-            .is_some_and(|pending| pending.prepared.is_some());
-        let new_pos = if self.active_section.is_some() || section_count_in {
-            self.transport.advance_unbounded(frames as u64)
+        let performing = self.clock_domain == ClockDomain::Perform;
+        let new_pos = if performing {
+            self.transport.position()
         } else {
             self.transport.advance(frames as u64)
         };
         self.performance_position = if was_playing {
-            new_pos
+            if performing {
+                self.performance_position.saturating_add(frames as u64)
+            } else {
+                new_pos
+            }
         } else {
             self.performance_position.saturating_add(frames as u64)
         };
@@ -342,11 +350,12 @@ impl AudioEngine {
         if section_ended {
             self.stop_section_record();
             let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
-                effective_at_samples: new_pos,
+                effective_at_samples: self.performance_position,
             });
             self.transport.stop();
             let _ = self.event_tx.push(EngineEvent::PlaybackStopped);
             self.active_section = None;
+            self.clock_domain = ClockDomain::Arrange;
             self.transport
                 .set_audio_length(self.arrangement_audio_length);
         }
@@ -358,6 +367,7 @@ impl AudioEngine {
         // adjacent positions. When the split ran, notes started
         // after the wrap are legitimately sounding and must survive.
         if was_playing
+            && !performing
             && !self.split_wrap_handled
             && new_pos != pos_before.saturating_add(frames as u64)
         {
@@ -369,6 +379,11 @@ impl AudioEngine {
 
         // Position event.
         let _ = self.event_tx.push(EngineEvent::PlaybackPosition(new_pos));
+        if performing {
+            let _ = self
+                .event_tx
+                .push(EngineEvent::PerformancePosition(self.performance_position));
+        }
 
         // Master metering event.
         let meters = metering::calculate_meters(output, channels);
@@ -936,6 +951,9 @@ fn push_spectrum(tx: &mut Producer<f32>, buffer: &[f32], channels: usize) {
 
 #[path = "engine_drain_commands.rs"]
 mod drain_commands;
+
+#[path = "engine_clock.rs"]
+mod clock;
 
 #[path = "engine_section_queue.rs"]
 mod section_queue;

--- a/crates/vibez-engine/src/engine_capture_tests.rs
+++ b/crates/vibez-engine/src/engine_capture_tests.rs
@@ -30,12 +30,13 @@ fn capture_started(events: &mut rtrb::Consumer<EngineEvent>) -> Option<(u64, Sec
 }
 
 #[test]
-fn capture_start_reports_exact_transport_and_active_section_position() {
+fn section_rehearsal_advances_capture_time_without_moving_arrange_cursor() {
     let (mut engine, mut commands, mut events) = AudioEngine::new();
     let track_id = TrackId::new();
     let section_id = SectionId::new();
     commands.push(EngineCommand::SetSampleRate(8)).unwrap();
     commands.push(EngineCommand::SetBpm(120.0)).unwrap();
+    commands.push(EngineCommand::Seek(40)).unwrap();
     commands
         .push(EngineCommand::AddTrack(track_id, "Audio".into()))
         .unwrap();
@@ -45,6 +46,11 @@ fn capture_start_reports_exact_transport_and_active_section_position() {
         )))
         .unwrap();
     engine.process(&mut [0.0; 3], 1);
+    assert_eq!(
+        engine.transport().position(),
+        40,
+        "Perform must not advance the canonical Arrange cursor"
+    );
     while events.pop().is_ok() {}
 
     commands
@@ -53,6 +59,7 @@ fn capture_start_reports_exact_transport_and_active_section_position() {
     engine.process(&mut [0.0; 5], 1);
 
     assert_eq!(capture_started(&mut events), Some((3, section_id, 3)));
+    assert_eq!(engine.transport().position(), 40);
 }
 
 #[test]
@@ -111,4 +118,55 @@ fn transport_stop_ends_capture_and_section_playback_at_one_boundary() {
     assert_eq!(terminal, [("capture", 7), ("playback", 7)]);
     assert!(!engine.transport().is_playing());
     assert!(engine.active_section.is_none());
+}
+
+#[test]
+fn stopping_perform_returns_to_the_exact_arrange_cursor_without_repair() {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let section_id = SectionId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands.push(EngineCommand::Seek(40)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(empty_section(
+            section_id, track_id,
+        )))
+        .unwrap();
+    engine.process(&mut [0.0; 7], 1);
+    commands.push(EngineCommand::Stop).unwrap();
+    engine.process(&mut [0.0; 3], 1);
+
+    assert_eq!(engine.transport().position(), 40);
+    assert!(!engine.transport().is_playing());
+}
+
+#[test]
+fn moving_the_arrange_cursor_during_perform_does_not_retime_performance_events() {
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let section_id = SectionId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(empty_section(
+            section_id, track_id,
+        )))
+        .unwrap();
+    engine.process(&mut [0.0; 3], 1);
+    commands.push(EngineCommand::Seek(40)).unwrap();
+    engine.process(&mut [0.0; 2], 1);
+    while events.pop().is_ok() {}
+
+    commands
+        .push(EngineCommand::StartPerformanceCapture)
+        .unwrap();
+    engine.process(&mut [0.0], 1);
+
+    assert_eq!(engine.transport().position(), 40);
+    assert_eq!(capture_started(&mut events), Some((5, section_id, 5)));
 }

--- a/crates/vibez-engine/src/engine_clock.rs
+++ b/crates/vibez-engine/src/engine_clock.rs
@@ -1,0 +1,27 @@
+//! Playback clock-domain ownership.
+
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ClockDomain {
+    Arrange,
+    Perform,
+}
+
+impl AudioEngine {
+    pub(super) fn begin_performance_clock(&mut self) {
+        if self.clock_domain == ClockDomain::Perform {
+            return;
+        }
+        self.clock_domain = ClockDomain::Perform;
+        self.performance_position = 0;
+        let _ = self.event_tx.push(EngineEvent::PerformancePosition(0));
+    }
+
+    pub(super) fn effective_position(&self) -> u64 {
+        match self.clock_domain {
+            ClockDomain::Arrange => self.transport.position(),
+            ClockDomain::Perform => self.performance_position,
+        }
+    }
+}

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -9,6 +9,7 @@ impl AudioEngine {
         while let Ok(cmd) = self.cmd_rx.pop() {
             match cmd {
                 EngineCommand::Play => {
+                    self.clock_domain = ClockDomain::Arrange;
                     self.transport.play();
                     self.performance_position = self.transport.position();
                     self.stopped_note_repeat_anchor = None;
@@ -19,9 +20,10 @@ impl AudioEngine {
                 EngineCommand::Stop => {
                     self.stop_section_record();
                     let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
-                        effective_at_samples: self.transport.position(),
+                        effective_at_samples: self.effective_position(),
                     });
                     self.transport.stop();
+                    self.clock_domain = ClockDomain::Arrange;
                     self.performance_position = self.transport.position();
                     self.cancel_section_queue();
                     self.active_section = None;
@@ -40,11 +42,13 @@ impl AudioEngine {
                 }
                 EngineCommand::Seek(pos) => {
                     self.transport.seek(pos);
-                    self.performance_position = pos;
                     for track in &mut self.tracks {
                         track.flush_notes();
                     }
-                    self.reschedule_note_repeats();
+                    if self.clock_domain == ClockDomain::Arrange {
+                        self.performance_position = pos;
+                        self.reschedule_note_repeats();
+                    }
                 }
                 EngineCommand::SetBpm(bpm) => {
                     // V1 Perform holds one project tempo from the first
@@ -71,7 +75,8 @@ impl AudioEngine {
                         continue;
                     }
                     self.cancel_section_queue();
-                    self.activate_section(prepared, self.transport.position());
+                    self.begin_performance_clock();
+                    self.activate_section(prepared, self.performance_position);
                 }
                 EngineCommand::QueueSection {
                     prepared,
@@ -145,14 +150,14 @@ impl AudioEngine {
                     let section_position_samples =
                         self.active_section.map(|section| section.position_samples);
                     let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStarted {
-                        effective_at_samples: self.transport.position(),
+                        effective_at_samples: self.effective_position(),
                         section_id,
                         section_position_samples,
                     });
                 }
                 EngineCommand::StopPerformanceCapture => {
                     let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
-                        effective_at_samples: self.transport.position(),
+                        effective_at_samples: self.effective_position(),
                     });
                 }
                 EngineCommand::LoadAudio(audio) => {
@@ -166,11 +171,12 @@ impl AudioEngine {
                 EngineCommand::UnloadAudio => {
                     self.stop_section_record();
                     let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
-                        effective_at_samples: self.transport.position(),
+                        effective_at_samples: self.effective_position(),
                     });
                     self.audio = None;
                     self.arrangement_audio_length = None;
                     self.active_section = None;
+                    self.clock_domain = ClockDomain::Arrange;
                     self.transport.set_audio_length(None);
                     self.transport.stop();
                     let _ = self.event_tx.push(EngineEvent::PlaybackStopped);
@@ -302,7 +308,7 @@ impl AudioEngine {
                     }
                 }
                 EngineCommand::SetTrackMute(id, mute) => {
-                    let effective_at_samples = self.transport.position();
+                    let effective_at_samples = self.effective_position();
                     let changed = if let Some(track) = self.channel_mut(id) {
                         track.mute = mute;
                         true

--- a/crates/vibez-engine/src/engine_section_playback_tests.rs
+++ b/crates/vibez-engine/src/engine_section_playback_tests.rs
@@ -279,16 +279,18 @@ fn arrangement_loop_does_not_wrap_section_engine_time() {
 
     engine.process(&mut [0.0; 3], 1);
 
-    assert_eq!(engine.transport().position(), 3);
-    assert!(
-        std::iter::from_fn(|| events.pop().ok()).any(|event| matches!(
-            event,
-            EngineEvent::SectionPlaybackPosition {
-                section_id: actual,
-                position_samples: 3,
-            } if actual == section_id
-        ))
-    );
+    assert_eq!(engine.transport().position(), 0);
+    let events: Vec<_> = std::iter::from_fn(|| events.pop().ok()).collect();
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, EngineEvent::PerformancePosition(3))));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        EngineEvent::SectionPlaybackPosition {
+            section_id: actual,
+            position_samples: 3,
+        } if *actual == section_id
+    )));
 }
 
 #[test]

--- a/crates/vibez-engine/src/engine_section_queue.rs
+++ b/crates/vibez-engine/src/engine_section_queue.rs
@@ -9,6 +9,7 @@ impl AudioEngine {
         mut prepared: Box<PreparedSectionPlaybackSource>,
         effective_at_samples: u64,
     ) {
+        self.begin_performance_clock();
         let section_id = prepared.section_id;
         let length_samples = self.section_length_samples(prepared.length_beats);
         let looping = prepared.looping;
@@ -33,7 +34,6 @@ impl AudioEngine {
         self.transport.set_audio_length(None);
         if !self.transport.is_playing() {
             self.transport.play();
-            self.performance_position = self.transport.position();
             let _ = self.event_tx.push(EngineEvent::PlaybackStarted);
         }
         self.stopped_note_repeat_anchor = None;
@@ -62,7 +62,8 @@ impl AudioEngine {
             }
             return;
         }
-        let now = self.transport.position();
+        self.begin_performance_clock();
+        let now = self.performance_position;
         if quantization == SectionLaunchQuantization::Immediate
             || self.active_section.is_none()
             || !self.transport.is_playing()
@@ -127,7 +128,7 @@ impl AudioEngine {
         frames: usize,
         channels: usize,
     ) {
-        let block_start = self.transport.position();
+        let block_start = self.performance_position;
         let block_end = block_start.saturating_add(frames as u64);
         let boundary = self
             .queued_section

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -142,6 +142,57 @@ fn immediate_section_launch_reanchors_held_repeat_to_the_section_downbeat() {
 }
 
 #[test]
+fn first_section_launch_reanchors_stopped_held_repeat_to_the_perform_downbeat() {
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    commands.push(EngineCommand::SetSampleRate(96)).unwrap();
+    commands.push(EngineCommand::SetBpm(60.0)).unwrap();
+    commands
+        .push(EngineCommand::SetProjectSwing(SwingAmount::new(0.62)))
+        .unwrap();
+    commands
+        .push(EngineCommand::AddMidiTrack(track_id, "Hats".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::SetTrackInstrument(
+            track_id,
+            InstrumentKind::SubtractiveSynth,
+        ))
+        .unwrap();
+    engine.process(&mut vec![0.0; 9_600 * 2], 2);
+    commands
+        .push(EngineCommand::StartNoteRepeat {
+            id: 0,
+            track_id,
+            pitch: 42,
+            velocity: 100,
+            rate: NoteRepeatRate::Sixteenth,
+        })
+        .unwrap();
+    engine.process(&mut [0.0; 2], 2);
+    while events.pop().is_ok() {}
+
+    commands
+        .push(EngineCommand::QueueSection {
+            prepared: source(SectionId::new(), track_id, 8.0, 0.0),
+            quantization: SectionLaunchQuantization::Immediate,
+        })
+        .unwrap();
+    engine.process(&mut vec![0.0; 60 * 2], 2);
+
+    let repeated: Vec<u64> = std::iter::from_fn(|| events.pop().ok())
+        .filter_map(|event| match event {
+            EngineEvent::NoteRepeated {
+                effective_at_samples,
+                ..
+            } => Some(effective_at_samples),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(repeated, vec![0, 30, 48]);
+}
+
+#[test]
 fn one_beat_transition_lands_mid_buffer_with_engine_timestamp() {
     let (mut engine, mut commands, mut events, track_id) = playing_engine(0.25, 8.0);
     while events.pop().is_ok() {}

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -138,7 +138,7 @@ fn immediate_section_launch_reanchors_held_repeat_to_the_section_downbeat() {
             _ => None,
         })
         .collect();
-    assert_eq!(repeated, vec![36, 66, 84]);
+    assert_eq!(repeated, vec![0, 30, 48]);
 }
 
 #[test]

--- a/crates/vibez-engine/src/engine_section_record.rs
+++ b/crates/vibez-engine/src/engine_section_record.rs
@@ -56,6 +56,7 @@ impl AudioEngine {
             return;
         }
         self.cancel_section_queue();
+        self.begin_performance_clock();
 
         let now = self.performance_position;
         let count_in_beat_samples = self.section_length_samples(1.0);
@@ -94,7 +95,6 @@ impl AudioEngine {
                     .saturating_mul(u64::from(count_in_bars));
                 if !self.transport.is_playing() {
                     self.transport.play();
-                    self.performance_position = self.transport.position();
                     self.stopped_note_repeat_anchor = None;
                     let _ = self.event_tx.push(EngineEvent::PlaybackStarted);
                 }

--- a/crates/vibez-engine/src/engine_section_record_tests.rs
+++ b/crates/vibez-engine/src/engine_section_record_tests.rs
@@ -102,6 +102,7 @@ fn stopped_count_in_variants_activate_section_at_exact_boundary() {
         let section_id = SectionId::new();
         commands.push(EngineCommand::SetSampleRate(8)).unwrap();
         commands.push(EngineCommand::SetBpm(120.0)).unwrap();
+        commands.push(EngineCommand::Seek(40)).unwrap();
         commands
             .push(EngineCommand::AddTrack(track_id, "Audio".into()))
             .unwrap();
@@ -131,6 +132,11 @@ fn stopped_count_in_variants_activate_section_at_exact_boundary() {
         assert_eq!(
             record_events(&mut events),
             vec![(false, boundary, 0), (true, boundary, 0)]
+        );
+        assert_eq!(
+            engine.transport().position(),
+            40,
+            "count-in and Section Record must not move the Arrange cursor"
         );
     }
 }

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -55,8 +55,12 @@ pub enum EngineEvent {
     /// See [`EngineEvent::DisposeEffect`].
     DisposeInstrument(DisposalCell<dyn vibez_instruments::Instrument>),
 
-    /// The current playback position expressed as an absolute sample offset.
+    /// The canonical Arrange cursor expressed as an absolute sample offset.
+    /// Perform playback deliberately leaves this value unchanged.
     PlaybackPosition(u64),
+
+    /// Monotonic, zero-based time for the current Perform session.
+    PerformancePosition(u64),
 
     /// Peak and RMS meter readings for the most recent audio buffer.
     Metering {
@@ -202,6 +206,7 @@ impl PartialEq for EngineEvent {
             (Self::DisposeEffect(left), Self::DisposeEffect(right)) => left == right,
             (Self::DisposeInstrument(left), Self::DisposeInstrument(right)) => left == right,
             (Self::PlaybackPosition(left), Self::PlaybackPosition(right)) => left == right,
+            (Self::PerformancePosition(left), Self::PerformancePosition(right)) => left == right,
             (
                 Self::Metering {
                     peak_l: left_peak_l,
@@ -471,6 +476,7 @@ mod tests {
     #[test]
     fn event_variants_are_constructible() {
         let _pos = EngineEvent::PlaybackPosition(44_100);
+        let _performance_pos = EngineEvent::PerformancePosition(22_050);
         let _meter = EngineEvent::Metering {
             peak_l: 0.8,
             peak_r: 0.75,
@@ -501,6 +507,9 @@ mod tests {
         producer.push(EngineEvent::PlaybackStarted).unwrap();
         producer.push(EngineEvent::PlaybackPosition(512)).unwrap();
         producer
+            .push(EngineEvent::PerformancePosition(256))
+            .unwrap();
+        producer
             .push(EngineEvent::Metering {
                 peak_l: 0.9,
                 peak_r: 0.85,
@@ -517,6 +526,10 @@ mod tests {
         assert!(matches!(
             consumer.pop().unwrap(),
             EngineEvent::PlaybackPosition(512)
+        ));
+        assert!(matches!(
+            consumer.pop().unwrap(),
+            EngineEvent::PerformancePosition(256)
         ));
 
         match consumer.pop().unwrap() {

--- a/crates/vibez-engine/src/transport.rs
+++ b/crates/vibez-engine/src/transport.rs
@@ -153,16 +153,6 @@ impl Transport {
 
         self.position
     }
-
-    /// Advance engine time without applying Arrangement loop or length
-    /// boundaries. Perform Sections own their local playback boundary while
-    /// active, but effective event timestamps must keep moving forward.
-    pub(crate) fn advance_unbounded(&mut self, frames: u64) -> u64 {
-        if self.playing {
-            self.position = self.position.saturating_add(frames);
-        }
-        self.position
-    }
 }
 
 impl Default for Transport {

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -24,6 +24,9 @@ impl App {
                     EngineEvent::PlaybackPosition(pos) => {
                         self.state.transport.position_samples = pos;
                     }
+                    EngineEvent::PerformancePosition(pos) => {
+                        self.state.perform.performance_position_samples = pos;
+                    }
                     EngineEvent::Metering { peak_l, peak_r, .. } => {
                         self.state.peak_l = peak_l.max(self.state.peak_l * 0.85);
                         self.state.peak_r = peak_r.max(self.state.peak_r * 0.85);

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -104,6 +104,9 @@ impl App {
                 if stops_perform {
                     self.section_residency_request.cancel();
                 }
+                let perform_playback_active = self.state.perform.playing_section.is_some()
+                    || self.state.perform.queued_section.is_some()
+                    || self.state.perform.section_record.is_active();
                 let ctx = crate::domains::transport::TransportCtx {
                     total_duration_samples: self.state.total_duration_samples(),
                     time_selection: if self.state.arrangement.time_selection_active {
@@ -114,9 +117,8 @@ impl App {
                     } else {
                         None
                     },
-                    perform_tempo_locked: self.state.perform.playing_section.is_some()
-                        || self.state.perform.queued_section.is_some()
-                        || self.state.perform.section_record.is_active(),
+                    perform_tempo_locked: perform_playback_active,
+                    perform_playback_active,
                 };
                 let action = {
                     let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);

--- a/crates/vibez-ui/src/app/views_perform_record.rs
+++ b/crates/vibez-ui/src/app/views_perform_record.rs
@@ -40,7 +40,7 @@ impl App {
                         .then(|| {
                             count_in_beats_remaining(
                                 boundary,
-                                self.state.transport.position_samples,
+                                self.state.perform.performance_position_samples,
                                 self.state.transport.bpm,
                                 self.state.transport.sample_rate,
                             )
@@ -52,12 +52,14 @@ impl App {
             SectionRecordPhase::Recording => "RECORDING".into(),
             SectionRecordPhase::Stopping => "STOPPING".into(),
         };
-        let capture_phase = match capture.phase {
-            CapturePhase::Idle => "ARRANGE · READY",
-            CapturePhase::Starting => "ARRANGE · STARTING",
-            CapturePhase::Recording => "ARRANGE · CAPTURING",
-            CapturePhase::Stopping => "ARRANGE · STOPPING",
-        };
+        let arrange_destination = capture
+            .arrange_start_samples()
+            .unwrap_or(self.state.transport.position_samples);
+        let capture_phase = capture_destination_label(
+            arrange_destination,
+            self.state.transport.sample_rate,
+            capture.phase,
+        );
 
         let record_button = button(record_button_content(active))
             .on_press(Message::Perform(PerformMsg::SectionRecord(
@@ -213,6 +215,28 @@ fn count_in_beats_remaining(
     Some(remaining.saturating_add(beat_samples - 1) / beat_samples)
 }
 
+fn capture_destination_label(
+    arrange_samples: u64,
+    sample_rate: u32,
+    phase: CapturePhase,
+) -> String {
+    let seconds = if sample_rate == 0 {
+        0.0
+    } else {
+        arrange_samples as f64 / f64::from(sample_rate)
+    };
+    let phase = match phase {
+        CapturePhase::Idle => "READY",
+        CapturePhase::Starting => "STARTING",
+        CapturePhase::Recording => "CAPTURING",
+        CapturePhase::Stopping => "STOPPING",
+    };
+    format!(
+        "ARRANGE @ {} · {phase}",
+        crate::state::AppState::format_time(seconds)
+    )
+}
+
 fn record_button_content(active: bool) -> Element<'static, Message> {
     let color = if active { th::bg_dark() } else { th::danger() };
     row![
@@ -328,7 +352,8 @@ fn record_pick_list<'a, T: Copy + Eq + std::fmt::Display + 'static>(
 
 #[cfg(test)]
 mod tests {
-    use super::count_in_beats_remaining;
+    use super::{capture_destination_label, count_in_beats_remaining};
+    use crate::domains::perform::CapturePhase;
 
     #[test]
     fn count_in_label_counts_whole_beats_down_to_one() {
@@ -348,6 +373,14 @@ mod tests {
         assert_eq!(
             count_in_beats_remaining(88_200, 88_200, 120.0, 44_100),
             None
+        );
+    }
+
+    #[test]
+    fn capture_label_keeps_the_fixed_arrange_destination_visible() {
+        assert_eq!(
+            capture_destination_label(240_000, 48_000, CapturePhase::Recording),
+            "ARRANGE @ 00:05.00 · CAPTURING"
         );
     }
 }

--- a/crates/vibez-ui/src/app/views_transport.rs
+++ b/crates/vibez-ui/src/app/views_transport.rs
@@ -12,7 +12,7 @@ use crate::domains::view::ViewMsg;
 
 use crate::icons;
 use crate::message::Message;
-use crate::state::AppState;
+use crate::state::{AppState, Workspace};
 use crate::theme as th;
 use crate::widgets::swing_knob::{parse_swing_percent, SwingKnobWidget};
 use crate::widgets::vu_meter::VuMeterWidget;
@@ -101,13 +101,9 @@ impl App {
         let transport_buttons = row![skip_back_btn, play_pause_btn, loop_btn].spacing(4);
 
         // Time display
-        let time_text = text(format!(
-            "{} / {}",
-            AppState::format_time(self.state.position_seconds()),
-            AppState::format_time(self.state.duration_seconds()),
-        ))
-        .size(14)
-        .color(th::text());
+        let time_text = text(transport_time_label(&self.state))
+            .size(14)
+            .color(th::text());
 
         // BPM
         let bpm_input = text_input("BPM", &self.state.transport.bpm_text)
@@ -327,5 +323,49 @@ impl App {
                 ..Default::default()
             })
             .into()
+    }
+}
+
+fn transport_time_label(state: &AppState) -> String {
+    if state.view.workspace == Workspace::Perform {
+        let seconds = if state.transport.sample_rate == 0 {
+            0.0
+        } else {
+            state.perform.performance_position_samples as f64
+                / f64::from(state.transport.sample_rate)
+        };
+        format!("PERFORMANCE TIME · {}", AppState::format_time(seconds))
+    } else {
+        format!(
+            "{} / {}",
+            AppState::format_time(state.position_seconds()),
+            AppState::format_time(state.duration_seconds()),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transport_time_label;
+    use crate::state::{AppState, Workspace};
+
+    #[test]
+    fn perform_labels_its_independent_zero_based_clock() {
+        let mut state = AppState::default();
+        state.view.workspace = Workspace::Perform;
+        state.transport.sample_rate = 48_000;
+        state.transport.position_samples = 480_000;
+        state.perform.performance_position_samples = 72_000;
+
+        assert_eq!(transport_time_label(&state), "PERFORMANCE TIME · 00:01.50");
+    }
+
+    #[test]
+    fn arrange_keeps_the_canonical_cursor_and_duration_readout() {
+        let mut state = AppState::default();
+        state.transport.sample_rate = 48_000;
+        state.transport.position_samples = 72_000;
+
+        assert_eq!(transport_time_label(&state), "00:01.50 / 00:00.00");
     }
 }

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -198,6 +198,9 @@ pub struct PerformState {
     pub queued_section: Option<SectionId>,
     pub pending_section_boundary_samples: Option<u64>,
     pub section_playhead_samples: u64,
+    /// Engine-owned, zero-based clock for the current Perform session.
+    /// This is deliberately independent of the Arrange cursor.
+    pub performance_position_samples: u64,
     active_computer_keys:
         HashMap<String, (PadPosition, PadGestureSource, Option<ActiveInstrumentNote>)>,
     track_mute_slots: Vec<Option<TrackId>>,

--- a/crates/vibez-ui/src/domains/perform/capture.rs
+++ b/crates/vibez-ui/src/domains/perform/capture.rs
@@ -210,6 +210,13 @@ impl CaptureState {
         self.phase != CapturePhase::Idle
     }
 
+    pub fn arrange_start_samples(&self) -> Option<u64> {
+        self.session
+            .as_ref()
+            .map(|session| session.clock.arrange_start_samples)
+            .or_else(|| self.prepared_clock.map(|clock| clock.arrange_start_samples))
+    }
+
     pub fn update(&mut self, msg: CaptureMsg) -> PerformAction {
         match (msg, self.phase) {
             (CaptureMsg::Toggle, CapturePhase::Idle) => {
@@ -529,8 +536,10 @@ mod tests {
         capture.phase = CapturePhase::Starting;
         capture.prepare(40, 8, 120.0);
         capture.start(3, Some((CapturedSectionSource::from_section(&first), 0)));
+        assert_eq!(capture.arrange_start_samples(), Some(40));
         capture.transition(CapturedSectionSource::from_section(&second), 10);
         let completed = capture.finish(15).unwrap();
+        assert_eq!(capture.arrange_start_samples(), None);
         let materialized = completed.materialize();
         let clips = &materialized.by_track[&track_id].clips;
 

--- a/crates/vibez-ui/src/domains/transport.rs
+++ b/crates/vibez-ui/src/domains/transport.rs
@@ -47,6 +47,9 @@ pub struct TransportCtx {
     pub time_selection: Option<(f64, f64)>,
     /// Perform holds one project BPM until its Section transport stops.
     pub perform_tempo_locked: bool,
+    /// Perform owns the running playback source, so Stop must not seek the
+    /// independent Arrange cursor back to zero.
+    pub perform_playback_active: bool,
 }
 
 /// Cross-domain effects the transport cannot perform itself. The
@@ -88,9 +91,11 @@ impl TransportState {
             }
             TransportMsg::Stop => {
                 self.playing = false;
-                self.position_samples = 0;
                 engine.send(EngineCommand::Stop);
-                engine.send(EngineCommand::Seek(0));
+                if !ctx.perform_playback_active {
+                    self.position_samples = 0;
+                    engine.send(EngineCommand::Seek(0));
+                }
                 TransportAction::None
             }
             TransportMsg::TogglePlayback => {
@@ -235,6 +240,26 @@ mod tests {
         assert!(!t.playing);
         assert_eq!(t.position_samples, 0);
         assert!(matches!(engine.0[1], EngineCommand::Seek(0)));
+    }
+
+    #[test]
+    fn perform_stop_preserves_the_arrange_cursor_and_does_not_seek() {
+        let mut t = transport();
+        t.playing = true;
+        t.position_samples = 12_345;
+        let mut engine = RecordingEngine::default();
+        t.update(
+            TransportMsg::Stop,
+            &mut engine,
+            TransportCtx {
+                perform_playback_active: true,
+                ..TransportCtx::default()
+            },
+        );
+
+        assert!(!t.playing);
+        assert_eq!(t.position_samples, 12_345);
+        assert!(matches!(engine.0.as_slice(), [EngineCommand::Stop]));
     }
 
     #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,14 +177,22 @@ duration and keep Groove Grid Off. `1/8` and `1/16` Note Repeat stores the
 canonical straight position with its matching Groove Grid, so playback applies
 live Swing once and later Swing edits remain effective.
 
-Capture into Arrange is a separate runtime log over the same engine clock.
+Capture into Arrange is a separate runtime log over the Perform clock. The
+engine owns two explicit clock domains: the canonical Arrange cursor advances
+only while Arrange renders, while a zero-based monotonic Perform clock advances
+during Section playback and stopped-start count-in. Section queue, Record,
+Note Repeat, monitored input, Track Mute, and Capture events use the latter.
+`PlaybackPosition` therefore always means Arrange cursor;
+`PerformancePosition` is the independent value shown as Performance time.
 `PerformanceCaptureStarted`, `SectionTransitioned`, and
 `PerformanceCaptureStopped` report exact effective samples, including a
 transition that splits an audio callback and a Capture begun partway through an
 already-playing Section. The UI snapshots each canonical Section timeline at
 the boundary where it becomes audible. On stop, it flattens those snapshots
 across Section loop passes into newly identified Arrange audio and MIDI clips,
-offset from the Arrange playhead captured at session start. The copied clips
+offset from the fixed Arrange cursor captured at session start. Elapsed Perform
+time is mapped onto that destination, so rehearsal and Section loops cannot
+move it. The copied clips
 share only immutable decoded audio; they retain no Section identity or mutable
 reference, so later Section edits and launches cannot rewrite Arrange.
 
@@ -360,7 +368,8 @@ clip `Arc`s and exposes no loader or I/O API.
 `EngineCommand::LaunchSection` retains the immediate Card 10 path.
 `EngineCommand::QueueSection` transfers a prepared owner plus its Immediate,
 beat, bar, or end-of-Section policy. The engine computes and owns the pending
-absolute sample boundary, returns displaced queued owners to the UI thread, and
+absolute Perform-sample boundary, returns displaced queued owners to the UI
+thread, and
 splits rendering when that boundary falls partway through a callback. Only then
 does it swap the resident pointers, reset the local Section playhead, and emit a
 sample-timestamped `SectionTransitioned` event. `SectionQueued` is likewise the
@@ -374,9 +383,10 @@ hold one Project BPM until Perform playback stops.
 
 `EngineCommand::ArmSectionRecord` adds a separate engine-clock state machine.
 An already-playing Section computes the next bar from its local playhead. A
-stopped-start count-in advances on an unbounded clock and, if its boundary falls
-inside a callback, renders the prefix before activating the resident Section at
-local sample zero for the suffix. Recording does not route notes through a
+stopped-start count-in advances the monotonic Perform clock without touching
+the Arrange cursor and, if its boundary falls inside a callback, renders the
+prefix before activating the resident Section at local sample zero for the
+suffix. Recording does not route notes through a
 second renderer: monitored input stays on the existing instrument path while
 `InstrumentNoteInput` and enriched `NoteRepeated` events report the exact
 effective/local positions. `StopSectionRecord` returns a cancelled resident


### PR DESCRIPTION
## Summary
- give Perform a zero-based monotonic engine clock without advancing the Arrange cursor
- keep Capture mapped to a fixed Arrange destination and show both clock truths explicitly
- preserve the Arrange cursor on Perform stop, including Section Record count-in and Capture

## Verification
- `cargo test --workspace -j 4` (195 engine, 360 UI, all workspace crates green)
- `cargo clippy --workspace -j 4 -- -D warnings`
- `cargo fmt --all -- --check`
- Xvfb native dogfood at non-zero Arrange cursors across Section loops and a real Capture; three clips committed at the unchanged 38.95s destination with no crash

## Stack
- base: Card 34 / PR #100
- no merge requested