### PR TITLE
Perform: replace captured intervals and capture Track Mutes

### DIFF
--- a/crates/vibez-core/src/automation.rs
+++ b/crates/vibez-core/src/automation.rs
@@ -1,10 +1,9 @@
 //! Automation lanes: parameter values drawn over time.
 //!
 //! A lane targets one parameter and holds points sorted by beat.
-//! Evaluation is linear interpolation between points, holding the
-//! first value before the first point and the last value after the
-//! last point. Block-rate evaluation (once per render segment) is
-//! the v1 contract; no sample-accurate ramps yet.
+//! Continuous lanes interpolate between points and hold their edge
+//! values. Stepped lanes hold the preceding point and impose no
+//! value before their first point.
 
 use serde::{Deserialize, Serialize};
 
@@ -38,10 +37,14 @@ pub fn shape(t: f32, curve: f32) -> f32 {
 }
 
 /// What a lane drives.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum AutomationTarget {
     TrackGain,
     TrackPan,
+    /// Channel mute. Values below 0.5 are unmuted; values at or above
+    /// 0.5 are muted. Unlike continuous targets this lane is stepped.
+    #[serde(rename = "track_mute")]
+    TrackMute,
     /// Project-relative Track Swing offset, normalized from -25..+25 points.
     #[serde(rename = "track_swing_offset")]
     TrackSwingOffset,
@@ -88,6 +91,9 @@ impl AutomationLane {
         if points.is_empty() {
             return None;
         }
+        if self.target.is_stepped() && beat < points[0].beat {
+            return None;
+        }
         if beat <= points[0].beat {
             return Some(points[0].value);
         }
@@ -99,6 +105,9 @@ impl AutomationLane {
         let idx = points.partition_point(|p| p.beat <= beat);
         let a = points[idx - 1];
         let b = points[idx];
+        if self.target.is_stepped() {
+            return Some(a.value);
+        }
         let span = b.beat - a.beat;
         if span <= f64::EPSILON {
             return Some(b.value);
@@ -125,6 +134,14 @@ impl AutomationLane {
     }
 }
 
+impl AutomationTarget {
+    /// Whether points describe instantaneous state changes rather than
+    /// interpolated segments.
+    pub const fn is_stepped(self) -> bool {
+        matches!(self, Self::TrackMute)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -136,6 +153,16 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<AutomationTarget>(&json).unwrap(),
             AutomationTarget::TrackSwingOffset
+        );
+    }
+
+    #[test]
+    fn track_mute_has_a_stable_persisted_identity() {
+        let json = serde_json::to_string(&AutomationTarget::TrackMute).unwrap();
+        assert_eq!(json, "\"track_mute\"");
+        assert_eq!(
+            serde_json::from_str::<AutomationTarget>(&json).unwrap(),
+            AutomationTarget::TrackMute
         );
     }
 
@@ -168,6 +195,26 @@ mod tests {
         let l = lane(&[(0.0, 0.0), (8.0, 1.0)]);
         assert_eq!(l.value_at(4.0), Some(0.5));
         assert_eq!(l.value_at(2.0), Some(0.25));
+    }
+
+    #[test]
+    fn stepped_lane_imposes_nothing_before_first_point_and_holds_steps() {
+        let mut l = AutomationLane::new(AutomationTarget::TrackMute);
+        l.insert_point(AutomationPoint {
+            beat: 4.0,
+            value: 1.0,
+            curve: 0.75,
+        });
+        l.insert_point(AutomationPoint {
+            beat: 8.0,
+            value: 0.0,
+            curve: -0.75,
+        });
+
+        assert_eq!(l.value_at(3.999), None);
+        assert_eq!(l.value_at(4.0), Some(1.0));
+        assert_eq!(l.value_at(7.999), Some(1.0));
+        assert_eq!(l.value_at(8.0), Some(0.0));
     }
 
     #[test]

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -126,6 +126,12 @@ pub enum EngineCommand {
     SetTrackPan(TrackId, f32),
     /// Set the mute state for a track.
     SetTrackMute(TrackId, bool),
+    /// Enable or clear a manual override for one automated parameter.
+    SetAutomationOverride {
+        track_id: TrackId,
+        target: vibez_core::automation::AutomationTarget,
+        overridden: bool,
+    },
     /// Set the solo state for a track.
     SetTrackSolo(TrackId, bool),
     /// Set the optional Project Track Swing adjustment used by generated

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -538,6 +538,9 @@ mod tests;
 mod stuck_note_tests;
 
 #[cfg(test)]
+#[path = "engine_mute_automation_tests.rs"]
+mod mute_automation_tests;
+#[cfg(test)]
 #[path = "engine_mute_event_tests.rs"]
 mod mute_event_tests;
 

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -309,17 +309,47 @@ impl AudioEngine {
                 }
                 EngineCommand::SetTrackMute(id, mute) => {
                     let effective_at_samples = self.effective_position();
-                    let changed = if let Some(track) = self.channel_mut(id) {
-                        track.mute = mute;
-                        true
+                    let playing = self.transport.is_playing();
+                    let (changed, override_changed) = if let Some(track) = self.channel_mut(id) {
+                        let override_changed = track.has_automation_target(
+                            vibez_core::automation::AutomationTarget::TrackMute,
+                        ) && track.set_automation_override(
+                            vibez_core::automation::AutomationTarget::TrackMute,
+                            true,
+                        );
+                        track.set_manual_mute(mute, !playing);
+                        (true, override_changed)
                     } else {
-                        false
+                        (false, false)
                     };
                     if changed {
                         let _ = self.event_tx.push(EngineEvent::TrackMuteChanged {
                             track_id: id,
                             muted: mute,
                             effective_at_samples,
+                        });
+                    }
+                    if override_changed {
+                        let _ = self.event_tx.push(EngineEvent::AutomationOverrideChanged {
+                            track_id: id,
+                            target: vibez_core::automation::AutomationTarget::TrackMute,
+                            overridden: true,
+                        });
+                    }
+                }
+                EngineCommand::SetAutomationOverride {
+                    track_id,
+                    target,
+                    overridden,
+                } => {
+                    let changed = self
+                        .channel_mut(track_id)
+                        .is_some_and(|track| track.set_automation_override(target, overridden));
+                    if changed {
+                        let _ = self.event_tx.push(EngineEvent::AutomationOverrideChanged {
+                            track_id,
+                            target,
+                            overridden,
                         });
                     }
                 }

--- a/crates/vibez-engine/src/engine_mute_automation_tests.rs
+++ b/crates/vibez-engine/src/engine_mute_automation_tests.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use vibez_core::audio_buffer::DecodedAudio;
+use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+use vibez_core::id::{ClipId, TrackId};
+
+use super::*;
+
+fn constant_audio(frames: usize) -> Arc<DecodedAudio> {
+    Arc::new(DecodedAudio {
+        channels: vec![vec![0.8; frames]],
+        sample_rate: 100,
+    })
+}
+
+fn add_constant_track(commands: &mut rtrb::Producer<EngineCommand>, track_id: TrackId) {
+    commands.push(EngineCommand::SetSampleRate(100)).unwrap();
+    commands.push(EngineCommand::SetBpm(60.0)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Mute automation".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::AddClip {
+            track_id,
+            clip_id: ClipId::new(),
+            audio: constant_audio(256),
+            position: 0,
+            source_offset: 0,
+            duration: 256,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+}
+
+#[test]
+fn mute_step_inside_buffer_starts_the_shared_ramp_at_its_exact_sample() {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    add_constant_track(&mut commands, track_id);
+    let mut lane = AutomationLane::new(AutomationTarget::TrackMute);
+    lane.insert_point(AutomationPoint {
+        beat: 0.04,
+        value: 1.0,
+        curve: 0.0,
+    });
+    commands
+        .push(EngineCommand::SetAutomationLane { track_id, lane })
+        .unwrap();
+    commands.push(EngineCommand::Play).unwrap();
+
+    let mut output = vec![0.0; 80 * 2];
+    engine.process(&mut output, 2);
+
+    let frame = |index: usize| output[index * 2].abs();
+    assert!(frame(3) > 0.5, "signal must remain open before the step");
+    assert!(
+        frame(4) < frame(3),
+        "the anti-click ramp must begin on the point's exact sample"
+    );
+    assert_eq!(frame(67), 0.0, "the 64-frame ramp must reach silence");
+    assert_eq!(frame(79), 0.0);
+}
+
+#[test]
+fn manual_mute_override_holds_until_automation_is_reenabled() {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    add_constant_track(&mut commands, track_id);
+    let mut lane = AutomationLane::new(AutomationTarget::TrackMute);
+    lane.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 1.0,
+        curve: 0.0,
+    });
+    commands
+        .push(EngineCommand::SetAutomationLane { track_id, lane })
+        .unwrap();
+    commands.push(EngineCommand::Play).unwrap();
+    let mut output = vec![0.0; 80 * 2];
+    engine.process(&mut output, 2);
+    assert!(output.iter().all(|sample| *sample == 0.0));
+
+    commands
+        .push(EngineCommand::SetTrackMute(track_id, false))
+        .unwrap();
+    output.fill(0.0);
+    engine.process(&mut output, 2);
+    assert!(
+        output[79 * 2].abs() > 0.5,
+        "manual unmute must override the mute lane"
+    );
+
+    commands
+        .push(EngineCommand::SetAutomationOverride {
+            track_id,
+            target: AutomationTarget::TrackMute,
+            overridden: false,
+        })
+        .unwrap();
+    output.fill(0.0);
+    engine.process(&mut output, 2);
+    assert_eq!(
+        output[79 * 2],
+        0.0,
+        "re-enable must return control to the lane"
+    );
+}

--- a/crates/vibez-engine/src/engine_render.rs
+++ b/crates/vibez-engine/src/engine_render.rs
@@ -93,19 +93,15 @@ impl AudioEngine {
     ) {
         let has_track_solo = any_solo(&self.tracks);
         let has_bus_solo = any_solo(&self.buses);
+        let bpm = self.transport.bpm();
+        let samples_per_beat = if bpm > 0.0 {
+            self.sample_rate as f64 * 60.0 / bpm
+        } else {
+            0.0
+        };
 
         for track_idx in 0..self.tracks.len() {
             let track = &mut self.tracks[track_idx];
-
-            // Skip muted tracks always
-            if track.mute {
-                let _ = self.event_tx.push(EngineEvent::TrackMeter {
-                    track_id: track.id,
-                    peak_l: 0.0,
-                    peak_r: 0.0,
-                });
-                continue;
-            }
 
             // A soloed return still needs every source to render its
             // sends. Without a return solo, preserve normal track
@@ -124,7 +120,6 @@ impl AudioEngine {
             // place; gain/pan come back as overrides for the sum
             // stage below.
             let beat = {
-                let bpm = self.transport.bpm();
                 if bpm > 0.0 {
                     pos as f64 * bpm / (self.sample_rate as f64 * 60.0)
                 } else {
@@ -185,6 +180,7 @@ impl AudioEngine {
             // Always run the shared device chain. A silent new Section stops
             // source material while already-produced effect tails continue.
             track.process_effects(frames, channels);
+            track.apply_mute_envelope(pos, frames, channels, samples_per_beat);
             let rendered = rendered
                 || track.mix_buffer[..frames * channels]
                     .iter()
@@ -329,7 +325,7 @@ impl AudioEngine {
         let has_track_solo = any_solo(&self.tracks);
         let has_bus_solo = any_solo(&self.buses);
         for track in &mut self.tracks {
-            if track.mute || (has_track_solo && !track.solo && !has_bus_solo) {
+            if has_track_solo && !track.solo && !has_bus_solo {
                 continue;
             }
             // Instruments render so auditioned notes sound; every
@@ -344,6 +340,9 @@ impl AudioEngine {
                 0.0
             };
             track.apply_automation(beat);
+            if track.effective_muted() {
+                continue;
+            }
             let has_signal = if track.instrument.is_some() {
                 let tempo_map = TempoMap::new(self.transport.bpm(), self.sample_rate);
                 let track_id = track.id;

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -331,10 +331,17 @@ fn perform_bpm_is_locked_and_live_mute_survives_transition() {
         })
         .unwrap();
 
-    let mut output = [1.0; 6];
+    let mut output = [1.0; 70];
     engine.process(&mut output, 1);
 
     assert_eq!(engine.transport().bpm(), 120.0);
     assert!(engine.tracks()[0].mute);
-    assert_eq!(output, [0.0; 6]);
+    assert!(
+        output[0] > 0.0 && output[0] < 0.4,
+        "live mute must enter the shared anti-click ramp immediately"
+    );
+    assert!(
+        output[64..].iter().all(|sample| *sample == 0.0),
+        "mute must remain closed after the queued Section transition"
+    );
 }

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -85,6 +85,13 @@ pub enum EngineEvent {
         muted: bool,
         effective_at_samples: u64,
     },
+    /// A manual control took precedence over automation, or automation
+    /// was explicitly re-enabled.
+    AutomationOverrideChanged {
+        track_id: TrackId,
+        target: vibez_core::automation::AutomationTarget,
+        overridden: bool,
+    },
 
     /// A generated Note Repeat retrigger became effective at this exact
     /// engine sample. Later recording cards consume the same audible truth.
@@ -257,6 +264,22 @@ impl PartialEq for EngineEvent {
                 left_track == right_track
                     && left_muted == right_muted
                     && left_effective == right_effective
+            }
+            (
+                Self::AutomationOverrideChanged {
+                    track_id: left_track,
+                    target: left_target,
+                    overridden: left_overridden,
+                },
+                Self::AutomationOverrideChanged {
+                    track_id: right_track,
+                    target: right_target,
+                    overridden: right_overridden,
+                },
+            ) => {
+                left_track == right_track
+                    && left_target == right_target
+                    && left_overridden == right_overridden
             }
             (
                 Self::NoteRepeated {
@@ -492,6 +515,11 @@ mod tests {
             track_id: TrackId::new(),
             muted: true,
             effective_at_samples: 44_100,
+        };
+        let _automation_override = EngineEvent::AutomationOverrideChanged {
+            track_id: TrackId::new(),
+            target: vibez_core::automation::AutomationTarget::TrackMute,
+            overridden: true,
         };
         let _started = EngineEvent::PlaybackStarted;
         let _stopped = EngineEvent::PlaybackStopped;

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -18,6 +18,74 @@ pub use pan::{any_solo, balance_pan, equal_power_pan};
 use render_context::InstrumentRenderBlock;
 pub(crate) use render_context::InstrumentRenderContext;
 
+const MUTE_RAMP_FRAMES: u32 = 64;
+
+#[derive(Debug, Clone, Copy)]
+struct MuteRamp {
+    gain: f32,
+    target: f32,
+    remaining: u32,
+}
+
+impl Default for MuteRamp {
+    fn default() -> Self {
+        Self {
+            gain: 1.0,
+            target: 1.0,
+            remaining: 0,
+        }
+    }
+}
+
+impl MuteRamp {
+    fn set_muted(&mut self, muted: bool, immediate: bool) {
+        let target = if muted { 0.0 } else { 1.0 };
+        if immediate {
+            self.gain = target;
+            self.target = target;
+            self.remaining = 0;
+        } else if self.target != target {
+            self.target = target;
+            self.remaining = MUTE_RAMP_FRAMES;
+        }
+    }
+
+    fn next_gain(&mut self) -> f32 {
+        if self.remaining == 0 {
+            return self.gain;
+        }
+        self.gain += (self.target - self.gain) / self.remaining as f32;
+        self.remaining -= 1;
+        if self.remaining == 0 {
+            self.gain = self.target;
+        }
+        self.gain
+    }
+}
+
+/// Runtime manual-overrides for automated parameters. Mute is the first
+/// consumer; later parameters extend this value without changing ownership.
+#[derive(Debug, Default)]
+struct AutomationOverrides {
+    track_mute: bool,
+}
+
+impl AutomationOverrides {
+    fn contains(&self, target: vibez_core::automation::AutomationTarget) -> bool {
+        matches!(target, vibez_core::automation::AutomationTarget::TrackMute) && self.track_mute
+    }
+
+    fn set(&mut self, target: vibez_core::automation::AutomationTarget, overridden: bool) -> bool {
+        let slot = match target {
+            vibez_core::automation::AutomationTarget::TrackMute => &mut self.track_mute,
+            _ => return false,
+        };
+        let changed = *slot != overridden;
+        *slot = overridden;
+        changed
+    }
+}
+
 /// A track as it exists at runtime in the engine.
 pub struct EngineTrack {
     pub id: TrackId,
@@ -31,6 +99,9 @@ pub struct EngineTrack {
     pub gain: f32,
     pub pan: f32,
     pub mute: bool,
+    automation_mute: Option<bool>,
+    automation_overrides: AutomationOverrides,
+    mute_ramp: MuteRamp,
     pub solo: bool,
     pub swing_offset: Option<SwingOffset>,
     /// Block-evaluated automation override; manual FOLLOW/offset remains intact.

--- a/crates/vibez-engine/src/mixer/channel_strip.rs
+++ b/crates/vibez-engine/src/mixer/channel_strip.rs
@@ -18,6 +18,9 @@ impl EngineTrack {
             gain: DEFAULT_TRACK_GAIN,
             pan: DEFAULT_TRACK_PAN,
             mute: false,
+            automation_mute: None,
+            automation_overrides: AutomationOverrides::default(),
+            mute_ramp: MuteRamp::default(),
             solo: false,
             swing_offset: None,
             automation_swing_offset: None,
@@ -39,8 +42,13 @@ impl EngineTrack {
         let mut gain = None;
         let mut pan = None;
         let mut swing_offset = None;
+        let mut mute = None;
+        let mut has_mute_lane = false;
         for lane_idx in 0..self.playback_source.automation.len() {
             let lane = &self.playback_source.automation[lane_idx];
+            if lane.target == AutomationTarget::TrackMute {
+                has_mute_lane = true;
+            }
             let Some(value) = lane.value_at(beat) else {
                 continue;
             };
@@ -48,6 +56,9 @@ impl EngineTrack {
                 // Gain's native range is 0..2; pan is already 0..1.
                 AutomationTarget::TrackGain => gain = Some(value * 2.0),
                 AutomationTarget::TrackPan => pan = Some(value),
+                AutomationTarget::TrackMute => {
+                    mute = Some(value >= 0.5);
+                }
                 AutomationTarget::TrackSwingOffset => {
                     swing_offset = Some(SwingOffset::from_normalized(value));
                 }
@@ -85,7 +96,121 @@ impl EngineTrack {
             }
         }
         self.automation_swing_offset = swing_offset;
+        if has_mute_lane {
+            self.set_automation_mute(mute, true);
+        } else {
+            self.set_automation_mute(None, true);
+        }
         (gain, pan)
+    }
+
+    pub(crate) fn has_automation_target(
+        &self,
+        target: vibez_core::automation::AutomationTarget,
+    ) -> bool {
+        self.playback_source
+            .automation
+            .iter()
+            .any(|lane| lane.target == target)
+    }
+
+    pub(crate) fn set_manual_mute(&mut self, muted: bool, immediate: bool) {
+        self.mute = muted;
+        let effective_muted = self.effective_muted();
+        self.mute_ramp.set_muted(effective_muted, immediate);
+    }
+
+    pub(crate) fn set_automation_override(
+        &mut self,
+        target: vibez_core::automation::AutomationTarget,
+        overridden: bool,
+    ) -> bool {
+        let changed = self.automation_overrides.set(target, overridden);
+        if changed && target == vibez_core::automation::AutomationTarget::TrackMute {
+            let effective_muted = self.effective_muted();
+            self.mute_ramp.set_muted(effective_muted, false);
+        }
+        changed
+    }
+
+    pub(crate) fn effective_muted(&self) -> bool {
+        if self
+            .automation_overrides
+            .contains(vibez_core::automation::AutomationTarget::TrackMute)
+        {
+            self.mute
+        } else {
+            self.automation_mute.unwrap_or(self.mute)
+        }
+    }
+
+    fn set_automation_mute(&mut self, muted: Option<bool>, immediate_first_value: bool) {
+        if self.automation_mute == muted {
+            return;
+        }
+        let first_value = self.automation_mute.is_none() && muted.is_some();
+        self.automation_mute = muted;
+        if !self
+            .automation_overrides
+            .contains(vibez_core::automation::AutomationTarget::TrackMute)
+        {
+            let effective_muted = self.effective_muted();
+            self.mute_ramp
+                .set_muted(effective_muted, immediate_first_value && first_value);
+        }
+    }
+
+    /// Apply the shared live/automation mute ramp after effects and before
+    /// the dry/sends split. TrackMute points inside this block take effect at
+    /// their exact sample rather than waiting for the next callback.
+    pub(crate) fn apply_mute_envelope(
+        &mut self,
+        position_samples: u64,
+        frames: usize,
+        channels: usize,
+        samples_per_beat: f64,
+    ) {
+        let mute_lane_index =
+            self.playback_source.automation.iter().position(|lane| {
+                lane.target == vibez_core::automation::AutomationTarget::TrackMute
+            });
+        let mut next_point = mute_lane_index.map_or(0, |index| {
+            let start_beat = if samples_per_beat > 0.0 {
+                position_samples as f64 / samples_per_beat
+            } else {
+                0.0
+            };
+            self.playback_source.automation[index]
+                .points
+                .partition_point(|point| point.beat <= start_beat)
+        });
+
+        for frame in 0..frames {
+            if let Some(index) = mute_lane_index {
+                loop {
+                    let next = self.playback_source.automation[index]
+                        .points
+                        .get(next_point)
+                        .copied();
+                    let Some(point) = next else {
+                        break;
+                    };
+                    let point_sample = (point.beat * samples_per_beat).round().max(0.0) as u64;
+                    if point_sample > position_samples.saturating_add(frame as u64) {
+                        break;
+                    }
+                    self.set_automation_mute(Some(point.value >= 0.5), false);
+                    next_point += 1;
+                }
+            }
+
+            let gain = self.mute_ramp.next_gain();
+            let start = frame * channels;
+            let end = (start + channels).min(self.mix_buffer.len());
+            for sample in &mut self.mix_buffer[start..end] {
+                *sample *= gain;
+            }
+        }
     }
 
     /// Zero the mix buffer: an idle block for a track with no source

--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -97,11 +97,11 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
         engine.sends = track_info.sends.clone();
         match req.mode {
             BounceMode::Master => {
-                engine.mute = track_info.mute;
+                engine.set_manual_mute(track_info.mute, true);
                 engine.solo = track_info.solo;
             }
             _ => {
-                engine.mute = false;
+                engine.set_manual_mute(false, true);
                 engine.solo = false;
             }
         }
@@ -283,13 +283,12 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
         }
 
         for track in tracks.iter_mut() {
-            if matches!(req.mode, BounceMode::Master) {
-                if track.mute {
-                    continue;
-                }
-                if has_track_solo && !track.solo && !has_bus_solo {
-                    continue;
-                }
+            if matches!(req.mode, BounceMode::Master)
+                && has_track_solo
+                && !track.solo
+                && !has_bus_solo
+            {
+                continue;
             }
 
             let beat = pos as f64 / tempo.samples_per_beat();
@@ -316,6 +315,9 @@ pub fn render_offline(req: &BounceRequest) -> BounceResult {
                 continue;
             }
             track.process_effects(block, CHANNELS);
+            if matches!(req.mode, BounceMode::Master) {
+                track.apply_mute_envelope(pos, block, CHANNELS, tempo.samples_per_beat());
+            }
 
             let (pan_l, pan_r) = equal_power_pan(auto_pan.unwrap_or(track.pan));
             let gain = auto_gain.unwrap_or(track.gain);

--- a/crates/vibez-ui/src/app/capture.rs
+++ b/crates/vibez-ui/src/app/capture.rs
@@ -16,29 +16,6 @@ impl App {
     pub(super) fn apply_capture_action(&mut self, action: CaptureAction) -> Task<Message> {
         match action {
             CaptureAction::Start => {
-                let perform_track_ids: Vec<_> = self
-                    .state
-                    .project_tracks
-                    .tracks
-                    .iter()
-                    .map(|track| track.id)
-                    .collect();
-                let samples_per_beat = if self.state.transport.bpm > 0.0 {
-                    60.0 * f64::from(self.state.transport.sample_rate) / self.state.transport.bpm
-                } else {
-                    0.0
-                };
-                if !capture_destination_from_playhead_is_empty(
-                    &self.state.arrangement.timeline,
-                    &perform_track_ids,
-                    self.state.transport.position_samples,
-                    samples_per_beat,
-                ) {
-                    self.state.perform.capture.cancel();
-                    self.state.status_text =
-                        "Capture needs empty Arrange content from the playhead".into();
-                    return Task::none();
-                }
                 if !self.begin_project_transaction() {
                     self.state.perform.capture.cancel();
                     self.state.status_text =
@@ -49,6 +26,13 @@ impl App {
                     self.state.transport.position_samples,
                     self.state.transport.sample_rate,
                     self.state.transport.bpm,
+                );
+                self.state.perform.capture.prepare_controlled_tracks(
+                    self.state
+                        .project_tracks
+                        .tracks
+                        .iter()
+                        .map(|track| (track.id, track.mute)),
                 );
                 self.send_command(EngineCommand::StartPerformanceCapture);
                 self.state.status_text = "Starting Capture into Arrange…".into();
@@ -70,27 +54,33 @@ impl App {
             return;
         };
         let materialized = completed.materialize();
-        if materialized.is_empty() {
+        if materialized.is_empty()
+            && !capture_replaces_existing_content(&self.state.arrangement.timeline, &materialized)
+        {
             self.discard_capture_transaction();
             self.state.status_text = "Capture stopped · no Section content recorded".into();
             return;
         }
-        let perform_track_ids: Vec<_> = self
-            .state
-            .project_tracks
-            .tracks
-            .iter()
-            .map(|track| track.id)
-            .collect();
-        if !materialized
-            .target_interval_is_empty(&self.state.arrangement.timeline, &perform_track_ids)
-        {
-            self.discard_capture_transaction();
-            self.state.status_text =
-                "Capture needs an empty Arrange interval · replacement arrives next".into();
-            return;
+        for (track_id, muted) in &materialized.pre_capture_mutes {
+            let captured_mute = materialized.by_track.get(track_id).is_some_and(|content| {
+                content
+                    .automation
+                    .iter()
+                    .any(|lane| lane.target == vibez_core::automation::AutomationTarget::TrackMute)
+            });
+            if captured_mute {
+                if let Some(track) =
+                    Arc::make_mut(&mut self.state.project_tracks).find_mut(*track_id)
+                {
+                    track.mute = *muted;
+                }
+                self.state.automation_ui.set_override(
+                    *track_id,
+                    vibez_core::automation::AutomationTarget::TrackMute,
+                    false,
+                );
+            }
         }
-
         let clip_count = apply_capture_to_arrangement(
             &mut self.state.arrangement.timeline,
             materialized,
@@ -114,25 +104,24 @@ fn capture_stop_command() -> EngineCommand {
     EngineCommand::Stop
 }
 
-fn capture_destination_from_playhead_is_empty(
+fn capture_replaces_existing_content(
     arrange: &crate::state::ArrangementTimeline,
-    perform_track_ids: &[vibez_core::id::TrackId],
-    arrange_start_samples: u64,
-    samples_per_beat: f64,
+    captured: &MaterializedCapture,
 ) -> bool {
-    perform_track_ids.iter().all(|track_id| {
-        arrange.get(*track_id).is_none_or(|existing| {
-            let audio_clear = existing
-                .clips
-                .iter()
-                .all(|clip| clip.position.saturating_add(clip.duration) <= arrange_start_samples);
-            let note_clear = existing.note_clips.iter().all(|clip| {
-                let end = ((clip.position_beats + clip.duration_beats) * samples_per_beat)
+    captured.controlled_track_ids.iter().any(|track_id| {
+        arrange.get(*track_id).is_some_and(|existing| {
+            existing.clips.iter().any(|clip| {
+                clip.position < captured.arrange_end_samples
+                    && clip.position.saturating_add(clip.duration) > captured.arrange_start_samples
+            }) || existing.note_clips.iter().any(|clip| {
+                let start = (clip.position_beats * captured.samples_per_beat)
                     .round()
                     .max(0.0) as u64;
-                end <= arrange_start_samples
-            });
-            audio_clear && note_clear && existing.automation.is_empty()
+                let end = ((clip.position_beats + clip.duration_beats) * captured.samples_per_beat)
+                    .round()
+                    .max(0.0) as u64;
+                start < captured.arrange_end_samples && end > captured.arrange_start_samples
+            }) || !existing.automation.is_empty()
         })
     })
 }
@@ -142,46 +131,88 @@ fn apply_capture_to_arrangement(
     captured: MaterializedCapture,
     engine: &mut Option<rtrb::Producer<EngineCommand>>,
 ) -> usize {
+    let MaterializedCapture {
+        arrange_start_samples,
+        arrange_end_samples,
+        mut by_track,
+        mut controlled_track_ids,
+        pre_capture_mutes,
+        samples_per_beat,
+    } = captured;
     let mut commands = Vec::new();
     let mut clip_count = 0;
     let timeline = Arc::make_mut(arrange);
-    for (track_id, mut incoming) in captured.by_track {
+    for track_id in by_track.keys().copied() {
+        if !controlled_track_ids.contains(&track_id) {
+            controlled_track_ids.push(track_id);
+        }
+    }
+    let start_beat = arrange_start_samples as f64 / samples_per_beat;
+    let end_beat = arrange_end_samples as f64 / samples_per_beat;
+
+    for track_id in controlled_track_ids {
+        let mut incoming = by_track.remove(&track_id).unwrap_or_default();
+        let captured_mute = incoming
+            .automation
+            .iter()
+            .any(|lane| lane.target == vibez_core::automation::AutomationTarget::TrackMute);
         clip_count += incoming.clips.len() + incoming.note_clips.len();
-        for clip in &incoming.clips {
-            commands.push(EngineCommand::AddClip {
+
+        let destination = timeline.ensure(track_id);
+        for clip in &destination.clips {
+            commands.push(EngineCommand::RemoveClip(track_id, clip.id));
+        }
+        for clip in &destination.note_clips {
+            commands.push(EngineCommand::RemoveNoteClip(track_id, clip.id));
+        }
+
+        destination.clips = destination
+            .clips
+            .iter()
+            .flat_map(|clip| {
+                preserve_audio_outside_interval(clip, arrange_start_samples, arrange_end_samples)
+            })
+            .collect();
+        destination.note_clips = destination
+            .note_clips
+            .iter()
+            .flat_map(|clip| preserve_notes_outside_interval(clip, start_beat, end_beat))
+            .collect();
+        replace_automation_interval(
+            &mut destination.automation,
+            incoming.automation,
+            start_beat,
+            end_beat,
+        );
+        destination.clips.append(&mut incoming.clips);
+        destination.note_clips.append(&mut incoming.note_clips);
+        destination.clips.sort_by_key(|clip| clip.position);
+        destination
+            .note_clips
+            .sort_by(|left, right| left.position_beats.total_cmp(&right.position_beats));
+
+        for clip in &destination.clips {
+            commands.push(add_audio_clip_command(track_id, clip));
+        }
+        for clip in &destination.note_clips {
+            commands.extend(add_note_clip_commands(track_id, clip));
+        }
+        for lane in &destination.automation {
+            commands.push(EngineCommand::SetAutomationLane {
                 track_id,
-                clip_id: clip.id,
-                audio: Arc::clone(&clip.audio),
-                position: clip.position,
-                source_offset: clip.source_offset,
-                duration: clip.duration,
-                loop_enabled: clip.loop_enabled,
-                loop_start: clip.loop_start,
-                loop_end: clip.loop_end,
+                lane: lane.clone(),
             });
         }
-        for clip in &incoming.note_clips {
-            commands.push(EngineCommand::AddNoteClip {
-                track_id,
-                clip_id: clip.id,
-                position_beats: clip.position_beats,
-                duration_beats: clip.duration_beats,
-                loop_enabled: clip.loop_enabled,
-                loop_start_beats: clip.loop_start_beats,
-                loop_end_beats: clip.loop_end_beats,
-                groove_grid: clip.groove_grid,
-            });
-            for note in &clip.notes {
-                commands.push(EngineCommand::AddNote {
+        if let Some(muted) = pre_capture_mutes.get(&track_id) {
+            if captured_mute {
+                commands.push(EngineCommand::SetTrackMute(track_id, *muted));
+                commands.push(EngineCommand::SetAutomationOverride {
                     track_id,
-                    clip_id: clip.id,
-                    note: *note,
+                    target: vibez_core::automation::AutomationTarget::TrackMute,
+                    overridden: false,
                 });
             }
         }
-        let destination = timeline.ensure(track_id);
-        destination.clips.append(&mut incoming.clips);
-        destination.note_clips.append(&mut incoming.note_clips);
     }
     if let Some(engine) = engine {
         for command in commands {
@@ -191,11 +222,172 @@ fn apply_capture_to_arrangement(
     clip_count
 }
 
+fn preserve_audio_outside_interval(
+    clip: &crate::state::UiClip,
+    start: u64,
+    end: u64,
+) -> Vec<crate::state::UiClip> {
+    let clip_end = clip.position.saturating_add(clip.duration);
+    if clip_end <= start || clip.position >= end {
+        return vec![clip.clone()];
+    }
+    let mut fragments = Vec::with_capacity(2);
+    if clip.position < start {
+        let mut before = clip.clone();
+        before.duration = start - clip.position;
+        fragments.push(before);
+    }
+    if clip_end > end {
+        let mut after = clip.clone();
+        if !fragments.is_empty() {
+            after.id = vibez_core::id::ClipId::new();
+        }
+        let delta = end.saturating_sub(clip.position);
+        after.position = end;
+        after.source_offset = crate::domains::perform::capture::captured_audio_offset(clip, delta);
+        after.duration = clip_end - end;
+        fragments.push(after);
+    }
+    fragments
+}
+
+fn preserve_notes_outside_interval(
+    clip: &crate::state::UiNoteClip,
+    start: f64,
+    end: f64,
+) -> Vec<crate::state::UiNoteClip> {
+    let clip_end = clip.position_beats + clip.duration_beats;
+    if clip_end <= start || clip.position_beats >= end {
+        return vec![clip.clone()];
+    }
+    let mut fragments = Vec::with_capacity(2);
+    if clip.position_beats < start {
+        fragments.push(note_clip_window(clip, clip.position_beats, start, clip.id));
+    }
+    if clip_end > end {
+        let id = if fragments.is_empty() {
+            clip.id
+        } else {
+            vibez_core::id::ClipId::new()
+        };
+        fragments.push(note_clip_window(clip, end, clip_end, id));
+    }
+    fragments
+}
+
+fn note_clip_window(
+    clip: &crate::state::UiNoteClip,
+    window_start: f64,
+    window_end: f64,
+    id: vibez_core::id::ClipId,
+) -> crate::state::UiNoteClip {
+    let local_start = window_start - clip.position_beats;
+    let local_end = window_end - clip.position_beats;
+    crate::state::UiNoteClip {
+        id,
+        name: clip.name.clone(),
+        position_beats: window_start,
+        duration_beats: window_end - window_start,
+        notes: crate::domains::perform::capture::captured_visible_notes(
+            clip,
+            local_start,
+            local_end,
+        ),
+        selected_notes: Default::default(),
+        loop_enabled: false,
+        loop_start_beats: 0.0,
+        loop_end_beats: 0.0,
+        groove_grid: clip.groove_grid,
+    }
+}
+
+fn replace_automation_interval(
+    existing: &mut Vec<vibez_core::automation::AutomationLane>,
+    incoming: Vec<vibez_core::automation::AutomationLane>,
+    start_beat: f64,
+    end_beat: f64,
+) {
+    for lane in existing.iter_mut() {
+        let start_value = lane.value_at(start_beat);
+        let end_value = lane.value_at(end_beat);
+        lane.points
+            .retain(|point| point.beat < start_beat || point.beat > end_beat);
+        if let Some(value) = start_value {
+            lane.insert_point(vibez_core::automation::AutomationPoint {
+                beat: start_beat,
+                value,
+                curve: 0.0,
+            });
+        }
+        if let Some(value) = end_value {
+            lane.insert_point(vibez_core::automation::AutomationPoint {
+                beat: end_beat,
+                value,
+                curve: 0.0,
+            });
+        }
+    }
+    for incoming_lane in incoming {
+        match existing
+            .iter_mut()
+            .find(|lane| lane.target == incoming_lane.target)
+        {
+            Some(lane) => {
+                for point in incoming_lane.points {
+                    lane.insert_point(point);
+                }
+            }
+            None => existing.push(incoming_lane),
+        }
+    }
+}
+
+fn add_audio_clip_command(
+    track_id: vibez_core::id::TrackId,
+    clip: &crate::state::UiClip,
+) -> EngineCommand {
+    EngineCommand::AddClip {
+        track_id,
+        clip_id: clip.id,
+        audio: Arc::clone(&clip.audio),
+        position: clip.position,
+        source_offset: clip.source_offset,
+        duration: clip.duration,
+        loop_enabled: clip.loop_enabled,
+        loop_start: clip.loop_start,
+        loop_end: clip.loop_end,
+    }
+}
+
+fn add_note_clip_commands(
+    track_id: vibez_core::id::TrackId,
+    clip: &crate::state::UiNoteClip,
+) -> Vec<EngineCommand> {
+    let mut commands = vec![EngineCommand::AddNoteClip {
+        track_id,
+        clip_id: clip.id,
+        position_beats: clip.position_beats,
+        duration_beats: clip.duration_beats,
+        loop_enabled: clip.loop_enabled,
+        loop_start_beats: clip.loop_start_beats,
+        loop_end_beats: clip.loop_end_beats,
+        groove_grid: clip.groove_grid,
+    }];
+    commands.extend(clip.notes.iter().map(|note| EngineCommand::AddNote {
+        track_id,
+        clip_id: clip.id,
+        note: *note,
+    }));
+    commands
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::state::{AppState, ArrangementTimeline, ProjectSnapshot, UiNoteClip};
     use std::collections::HashMap;
+    use vibez_core::audio_buffer::DecodedAudio;
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
     use vibez_core::id::{ClipId, TrackId};
     use vibez_core::perform::GrooveGrid;
 
@@ -217,6 +409,28 @@ mod tests {
         }
     }
 
+    fn audio_clip(position: u64, duration: u64) -> crate::state::UiClip {
+        crate::state::UiClip {
+            id: ClipId::new(),
+            name: "Existing audio".into(),
+            audio: Arc::new(DecodedAudio {
+                channels: vec![vec![0.5; 32]],
+                sample_rate: 8,
+            }),
+            source: None,
+            position,
+            source_offset: 0,
+            duration,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+            original_bpm: None,
+            warped: false,
+            warped_to_bpm: None,
+            original_audio: None,
+        }
+    }
+
     #[test]
     fn applying_capture_changes_only_named_tracks_and_preserves_outside_content() {
         let captured_track = vibez_core::id::TrackId::new();
@@ -235,7 +449,9 @@ mod tests {
             arrange_start_samples: 100,
             arrange_end_samples: 200,
             by_track,
-            ..MaterializedCapture::default()
+            controlled_track_ids: vec![captured_track],
+            pre_capture_mutes: HashMap::new(),
+            samples_per_beat: 4.0,
         };
 
         assert_eq!(
@@ -250,14 +466,14 @@ mod tests {
     }
 
     #[test]
-    fn capture_preflight_rejects_future_content_before_the_take_starts() {
+    fn silent_capture_detects_material_that_it_will_replace() {
         let track_id = TrackId::new();
         let mut arrange = ArrangementTimeline::default();
         arrange.ensure(track_id).note_clips.push(UiNoteClip {
             id: ClipId::new(),
-            name: "Future clip".into(),
-            position_beats: 8.0,
-            duration_beats: 1.0,
+            name: "Occupied interval".into(),
+            position_beats: 4.0,
+            duration_beats: 2.0,
             notes: Vec::new(),
             selected_notes: Default::default(),
             loop_enabled: false,
@@ -266,12 +482,106 @@ mod tests {
             groove_grid: GrooveGrid::Off,
         });
 
-        assert!(!capture_destination_from_playhead_is_empty(
-            &arrange,
-            &[track_id],
-            16,
-            4.0,
-        ));
+        let captured = MaterializedCapture {
+            arrange_start_samples: 16,
+            arrange_end_samples: 24,
+            controlled_track_ids: vec![track_id],
+            pre_capture_mutes: HashMap::new(),
+            samples_per_beat: 4.0,
+            ..MaterializedCapture::default()
+        };
+        assert!(capture_replaces_existing_content(&arrange, &captured));
+    }
+
+    #[test]
+    fn replacement_splits_straddling_content_and_pins_lane_edges() {
+        let track_id = TrackId::new();
+        let mut arrange = Arc::new(ArrangementTimeline::default());
+        let content = Arc::make_mut(&mut arrange).ensure(track_id);
+        let straddling_audio = audio_clip(2, 8);
+        let original_audio_id = straddling_audio.id;
+        content.clips.push(straddling_audio);
+        content.note_clips.push(UiNoteClip {
+            id: ClipId::new(),
+            name: "Existing notes".into(),
+            position_beats: 2.0,
+            duration_beats: 8.0,
+            notes: vec![
+                vibez_core::midi::MidiNote {
+                    pitch: 60,
+                    velocity: 100,
+                    start_beat: 1.0,
+                    duration_beats: 3.0,
+                },
+                vibez_core::midi::MidiNote {
+                    pitch: 64,
+                    velocity: 100,
+                    start_beat: 5.0,
+                    duration_beats: 2.0,
+                },
+            ],
+            selected_notes: Default::default(),
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+            groove_grid: GrooveGrid::Off,
+        });
+        let mut gain = AutomationLane::new(AutomationTarget::TrackGain);
+        for (beat, value) in [(0.0, 0.0), (5.0, 1.0), (10.0, 0.0)] {
+            gain.insert_point(AutomationPoint {
+                beat,
+                value,
+                curve: 0.0,
+            });
+        }
+        content.automation.push(gain);
+
+        let captured = MaterializedCapture {
+            arrange_start_samples: 4,
+            arrange_end_samples: 6,
+            by_track: HashMap::new(),
+            controlled_track_ids: vec![track_id],
+            pre_capture_mutes: HashMap::new(),
+            samples_per_beat: 1.0,
+        };
+        assert_eq!(
+            apply_capture_to_arrangement(&mut arrange, captured, &mut None),
+            0
+        );
+        let content = arrange.get(track_id).unwrap();
+
+        assert_eq!(content.clips.len(), 2);
+        assert_eq!(
+            content
+                .clips
+                .iter()
+                .map(|clip| (clip.position, clip.duration, clip.source_offset))
+                .collect::<Vec<_>>(),
+            [(2, 2, 0), (6, 4, 4)]
+        );
+        assert_eq!(content.clips[0].id, original_audio_id);
+        assert_ne!(content.clips[1].id, original_audio_id);
+        assert_eq!(
+            content
+                .note_clips
+                .iter()
+                .map(|clip| (clip.position_beats, clip.duration_beats))
+                .collect::<Vec<_>>(),
+            [(2.0, 2.0), (6.0, 4.0)]
+        );
+        assert_eq!(content.note_clips[0].notes[0].duration_beats, 1.0);
+        assert_eq!(content.note_clips[1].notes[0].start_beat, 1.0);
+
+        let lane = &content.automation[0];
+        assert_eq!(
+            lane.points
+                .iter()
+                .map(|point| point.beat)
+                .collect::<Vec<_>>(),
+            [0.0, 4.0, 6.0, 10.0]
+        );
+        assert!((lane.value_at(2.0).unwrap() - 0.4).abs() < 1e-6);
+        assert!((lane.value_at(8.0).unwrap() - 0.4).abs() < 1e-6);
     }
 
     #[test]
@@ -301,6 +611,8 @@ mod tests {
             arrange_start_samples: 16,
             arrange_end_samples: 32,
             by_track: HashMap::from([(track_id, incoming)]),
+            controlled_track_ids: vec![track_id],
+            pre_capture_mutes: HashMap::new(),
             samples_per_beat: 4.0,
         };
         assert_eq!(

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -80,11 +80,25 @@ impl App {
                     EngineEvent::TrackMuteChanged {
                         track_id,
                         muted,
-                        effective_at_samples: _,
+                        effective_at_samples,
                     } => {
+                        self.state.perform.capture.track_mute_changed(
+                            track_id,
+                            muted,
+                            effective_at_samples,
+                        );
                         if let Some(track) = self.state.find_track_mut(track_id) {
                             track.mute = muted;
                         }
+                    }
+                    EngineEvent::AutomationOverrideChanged {
+                        track_id,
+                        target,
+                        overridden,
+                    } => {
+                        self.state
+                            .automation_ui
+                            .set_override(track_id, target, overridden);
                     }
                     EngineEvent::NoteRepeated {
                         track_id,

--- a/crates/vibez-ui/src/app/views_automation.rs
+++ b/crates/vibez-ui/src/app/views_automation.rs
@@ -61,28 +61,41 @@ impl App {
                     border: iced::Border::default(),
                     ..Default::default()
                 });
-            let header = container(
-                row![
-                    text(label).size(11).color(th::text_dim()),
-                    horizontal_space(),
-                    remove
-                ]
-                .spacing(4)
-                .align_y(iced::Alignment::Center),
-            )
-            .padding([0, 10])
-            .width(Length::Fixed(layout.header_width))
-            .height(Length::Fixed(LANE_HEIGHT))
-            .align_y(iced::alignment::Vertical::Center)
-            .style(|_theme: &Theme| container::Style {
-                background: Some(th::bg_surface().into()),
-                border: iced::Border {
-                    color: th::divider(),
-                    width: 1.0,
-                    radius: 0.0.into(),
-                },
-                ..Default::default()
-            });
+            let overridden = self
+                .state
+                .automation_ui
+                .is_overridden(track.id, lane.target);
+            let mut header_row = row![text(label).size(11).color(if overridden {
+                th::accent()
+            } else {
+                th::text_dim()
+            })]
+            .spacing(4)
+            .align_y(iced::Alignment::Center);
+            if overridden {
+                header_row = header_row.push(
+                    button(text("RE-ENABLE").size(8).color(th::accent()))
+                        .on_press(Message::Automation(AutomationMsg::ReenableAutomation {
+                            track_id: track.id,
+                            target: lane.target,
+                        }))
+                        .padding([2, 4]),
+                );
+            }
+            let header = container(header_row.push(horizontal_space()).push(remove))
+                .padding([0, 10])
+                .width(Length::Fixed(layout.header_width))
+                .height(Length::Fixed(LANE_HEIGHT))
+                .align_y(iced::alignment::Vertical::Center)
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(th::bg_surface().into()),
+                    border: iced::Border {
+                        color: th::divider(),
+                        width: 1.0,
+                        radius: 0.0.into(),
+                    },
+                    ..Default::default()
+                });
 
             let selected = match self.state.automation_ui.selected {
                 Some((t, l, i)) if t == track.id && l == lane.id => Some(i),
@@ -102,6 +115,7 @@ impl App {
                 min_label,
                 max_label,
                 ref_label,
+                stepped: lane.target.is_stepped(),
             })
             .width(body_width())
             .height(Length::Fixed(LANE_HEIGHT));
@@ -312,6 +326,10 @@ impl App {
                 label: "Pan".into(),
                 target: vibez_core::automation::AutomationTarget::TrackPan,
             },
+            LaneChoice {
+                label: "Track Mute".into(),
+                target: vibez_core::automation::AutomationTarget::TrackMute,
+            },
         ];
         if track.kind.is_midi() {
             choices.push(LaneChoice {
@@ -434,6 +452,12 @@ fn lane_scale(
             };
             (reference, "L".into(), "R".into(), label)
         }
+        AutomationTarget::TrackMute => (
+            reference,
+            "Off".into(),
+            "On".into(),
+            if track.mute { "On" } else { "Off" }.into(),
+        ),
         _ => match target_descriptor(target, track) {
             Some(descriptor) => {
                 let label = reference

--- a/crates/vibez-ui/src/domains/automation.rs
+++ b/crates/vibez-ui/src/domains/automation.rs
@@ -75,6 +75,11 @@ pub enum AutomationMsg {
     OpenLanePicker(TrackId),
     LanePickerQuery(String),
     CloseLanePicker,
+    /// Return an overridden parameter to lane control (view/runtime only).
+    ReenableAutomation {
+        track_id: TrackId,
+        target: AutomationTarget,
+    },
 }
 
 impl AutomationMsg {
@@ -87,6 +92,7 @@ impl AutomationMsg {
                 | AutomationMsg::OpenLanePicker(_)
                 | AutomationMsg::LanePickerQuery(_)
                 | AutomationMsg::CloseLanePicker
+                | AutomationMsg::ReenableAutomation { .. }
         )
     }
 }
@@ -107,6 +113,8 @@ pub struct AutomationState {
     pub selected: Option<(TrackId, LaneId, usize)>,
     /// The open add-lane picker, with its search query.
     pub picker: Option<(TrackId, String)>,
+    /// Runtime parameters whose manual control currently wins over a lane.
+    pub overridden: HashSet<(TrackId, AutomationTarget)>,
 }
 
 fn sync_lane(engine: &mut impl EngineHandle, track_id: TrackId, lane: &AutomationLane) {
@@ -123,6 +131,7 @@ pub fn normalized_target_value(target: &AutomationTarget, track: &ProjectTrack) 
     match target {
         AutomationTarget::TrackGain => Some((track.gain / 2.0).clamp(0.0, 1.0)),
         AutomationTarget::TrackPan => Some(track.pan.clamp(0.0, 1.0)),
+        AutomationTarget::TrackMute => Some(if track.mute { 1.0 } else { 0.0 }),
         AutomationTarget::TrackSwingOffset => Some(
             track
                 .swing_offset
@@ -226,6 +235,7 @@ pub fn target_label(target: &AutomationTarget, track: &ProjectTrack) -> String {
     match target {
         AutomationTarget::TrackGain => "Volume".to_string(),
         AutomationTarget::TrackPan => "Pan".to_string(),
+        AutomationTarget::TrackMute => "Track Mute".to_string(),
         AutomationTarget::TrackSwingOffset => "Track Swing".to_string(),
         AutomationTarget::EffectParam {
             effect_id,
@@ -343,10 +353,26 @@ impl AutomationState {
                 action.status = Some(format!("Added automation lane: {label}"));
             }
             AutomationMsg::RemoveLane { track_id, lane_id } => {
+                let removed_target = timeline.get(track_id).and_then(|content| {
+                    content
+                        .automation
+                        .iter()
+                        .find(|lane| lane.id == lane_id)
+                        .map(|lane| lane.target)
+                });
                 if let Some(content) = timeline.get_mut(track_id) {
                     content.automation.retain(|l| l.id != lane_id);
                 }
                 engine.send(EngineCommand::RemoveAutomationLane { track_id, lane_id });
+                if let Some(target) = removed_target {
+                    if self.overridden.remove(&(track_id, target)) {
+                        engine.send(EngineCommand::SetAutomationOverride {
+                            track_id,
+                            target,
+                            overridden: false,
+                        });
+                    }
+                }
                 if matches!(self.selected, Some((t, l, _)) if t == track_id && l == lane_id) {
                     self.selected = None;
                 }
@@ -366,7 +392,15 @@ impl AutomationState {
                 };
                 let point = AutomationPoint {
                     beat: beat.max(0.0),
-                    value: value.clamp(0.0, 1.0),
+                    value: if lane.target.is_stepped() {
+                        if value >= 0.5 {
+                            1.0
+                        } else {
+                            0.0
+                        }
+                    } else {
+                        value.clamp(0.0, 1.0)
+                    },
                     curve: 0.0,
                 };
                 lane.insert_point(point);
@@ -395,11 +429,24 @@ impl AutomationState {
                 if index >= lane.points.len() {
                     return action;
                 }
-                let curve = lane.points[index].curve;
+                let stepped = lane.target.is_stepped();
+                let curve = if stepped {
+                    0.0
+                } else {
+                    lane.points[index].curve
+                };
                 lane.points.remove(index);
                 let point = AutomationPoint {
                     beat: beat.max(0.0),
-                    value: value.clamp(0.0, 1.0),
+                    value: if stepped {
+                        if value >= 0.5 {
+                            1.0
+                        } else {
+                            0.0
+                        }
+                    } else {
+                        value.clamp(0.0, 1.0)
+                    },
                     curve,
                 };
                 lane.insert_point(point);
@@ -456,6 +503,9 @@ impl AutomationState {
                 if index >= lane.points.len() {
                     return action;
                 }
+                if lane.target.is_stepped() {
+                    return action;
+                }
                 lane.points[index].curve = curve.clamp(-1.0, 1.0);
                 let lane = lane.clone();
                 sync_lane(engine, track_id, &lane);
@@ -499,6 +549,21 @@ impl AutomationState {
             AutomationMsg::CloseLanePicker => {
                 self.picker = None;
             }
+            AutomationMsg::ReenableAutomation { track_id, target } => {
+                self.overridden.remove(&(track_id, target));
+                engine.send(EngineCommand::SetAutomationOverride {
+                    track_id,
+                    target,
+                    overridden: false,
+                });
+                action.status = Some(format!(
+                    "{} automation re-enabled",
+                    project_tracks
+                        .find(track_id)
+                        .map(|track| target_label(&target, track))
+                        .unwrap_or_else(|| "Parameter".to_string())
+                ));
+            }
             AutomationMsg::DeleteSelectedPoint => {
                 if let Some((track_id, lane_id, index)) = self.selected.take() {
                     let Some(lane) = timeline.get_mut(track_id).and_then(|content| {
@@ -518,6 +583,18 @@ impl AutomationState {
             }
         }
         action
+    }
+
+    pub fn set_override(&mut self, track_id: TrackId, target: AutomationTarget, overridden: bool) {
+        if overridden {
+            self.overridden.insert((track_id, target));
+        } else {
+            self.overridden.remove(&(track_id, target));
+        }
+    }
+
+    pub fn is_overridden(&self, track_id: TrackId, target: AutomationTarget) -> bool {
+        self.overridden.contains(&(track_id, target))
     }
 }
 
@@ -647,6 +724,78 @@ mod tests {
         );
         assert_eq!(timeline.get(tid).unwrap().automation[0].points.len(), 1);
         assert_eq!(a.selected, None);
+    }
+
+    #[test]
+    fn track_mute_points_are_binary_and_curve_edits_are_ignored() {
+        let mut automation = AutomationState::default();
+        let mut engine = RecordingEngine::default();
+        let (mut tracks, mut timeline, track_id) = track();
+        automation.update(
+            AutomationMsg::AddLane {
+                track_id,
+                target: AutomationTarget::TrackMute,
+            },
+            &mut engine,
+            &mut tracks,
+            &mut timeline,
+        );
+        let lane_id = timeline.get(track_id).unwrap().automation[0].id;
+        automation.update(
+            AutomationMsg::AddPoint {
+                track_id,
+                lane_id,
+                beat: 4.0,
+                value: 0.7,
+            },
+            &mut engine,
+            &mut tracks,
+            &mut timeline,
+        );
+        automation.update(
+            AutomationMsg::SetCurve {
+                track_id,
+                lane_id,
+                index: 0,
+                curve: 1.0,
+            },
+            &mut engine,
+            &mut tracks,
+            &mut timeline,
+        );
+
+        let lane = &timeline.get(track_id).unwrap().automation[0];
+        assert_eq!(lane.value_at(4.0), Some(1.0));
+        assert!(lane.points.iter().all(|point| point.curve == 0.0));
+    }
+
+    #[test]
+    fn reenable_clears_visible_override_and_notifies_the_engine() {
+        let mut automation = AutomationState::default();
+        let mut engine = RecordingEngine::default();
+        let (mut tracks, mut timeline, track_id) = track();
+        automation.set_override(track_id, AutomationTarget::TrackMute, true);
+        assert!(automation.is_overridden(track_id, AutomationTarget::TrackMute));
+
+        automation.update(
+            AutomationMsg::ReenableAutomation {
+                track_id,
+                target: AutomationTarget::TrackMute,
+            },
+            &mut engine,
+            &mut tracks,
+            &mut timeline,
+        );
+
+        assert!(!automation.is_overridden(track_id, AutomationTarget::TrackMute));
+        assert!(matches!(
+            engine.0.last(),
+            Some(EngineCommand::SetAutomationOverride {
+                track_id: event_track,
+                target: AutomationTarget::TrackMute,
+                overridden: false,
+            }) if *event_track == track_id
+        ));
     }
 
     #[test]

--- a/crates/vibez-ui/src/domains/perform/capture.rs
+++ b/crates/vibez-ui/src/domains/perform/capture.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::MidiNote;
 
@@ -81,6 +82,8 @@ struct CaptureSession {
     engine_start_samples: u64,
     active: Option<ActiveSpan>,
     spans: Vec<CapturedSectionSpan>,
+    controlled_tracks: Vec<(TrackId, bool)>,
+    mute_changes: Vec<CapturedMuteChange>,
 }
 
 #[derive(Debug)]
@@ -89,6 +92,15 @@ pub struct CompletedCapture {
     engine_start_samples: u64,
     engine_end_samples: u64,
     spans: Vec<CapturedSectionSpan>,
+    controlled_tracks: Vec<(TrackId, bool)>,
+    mute_changes: Vec<CapturedMuteChange>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CapturedMuteChange {
+    track_id: TrackId,
+    muted: bool,
+    effective_at_samples: u64,
 }
 
 #[derive(Debug, Default)]
@@ -96,6 +108,12 @@ pub struct MaterializedCapture {
     pub arrange_start_samples: u64,
     pub arrange_end_samples: u64,
     pub by_track: HashMap<TrackId, TrackTimelineContent>,
+    /// Every Project Track controlled by Perform, including tracks whose
+    /// recorded performance was silence.
+    pub controlled_track_ids: Vec<TrackId>,
+    /// Manual mute state heard at Capture start, used to close mute lanes and
+    /// return the mixer to its pre-take state after commit.
+    pub pre_capture_mutes: HashMap<TrackId, bool>,
     pub(crate) samples_per_beat: f64,
 }
 
@@ -105,36 +123,6 @@ impl MaterializedCapture {
             content.clips.is_empty()
                 && content.note_clips.is_empty()
                 && content.automation.is_empty()
-        })
-    }
-
-    /// Card 17 is deliberately safe only for an empty destination interval.
-    /// Replacement and lane surgery arrive in Card 18.
-    pub fn target_interval_is_empty(
-        &self,
-        arrange: &ArrangementTimeline,
-        perform_track_ids: &[TrackId],
-    ) -> bool {
-        if self.arrange_end_samples <= self.arrange_start_samples {
-            return true;
-        }
-        perform_track_ids.iter().all(|track_id| {
-            arrange.get(*track_id).is_none_or(|existing| {
-                let audio_clear = existing.clips.iter().all(|clip| {
-                    clip.position.saturating_add(clip.duration) <= self.arrange_start_samples
-                        || clip.position >= self.arrange_end_samples
-                });
-                let note_clear = existing.note_clips.iter().all(|clip| {
-                    let start = (clip.position_beats * self.samples_per_beat)
-                        .round()
-                        .max(0.0) as u64;
-                    let end = ((clip.position_beats + clip.duration_beats) * self.samples_per_beat)
-                        .round()
-                        .max(0.0) as u64;
-                    end <= self.arrange_start_samples || start >= self.arrange_end_samples
-                });
-                audio_clear && note_clear && existing.automation.is_empty()
-            })
         })
     }
 }
@@ -148,6 +136,8 @@ impl CompletedCapture {
                     .saturating_sub(self.engine_start_samples),
             ),
             by_track: HashMap::new(),
+            controlled_track_ids: Vec::new(),
+            pre_capture_mutes: HashMap::new(),
             samples_per_beat: samples_per_beat(self.clock.sample_rate, self.clock.bpm),
         };
         let samples_per_beat = result.samples_per_beat;
@@ -188,12 +178,64 @@ impl CompletedCapture {
             }
         }
 
+        for (track_id, pre_capture_muted) in &self.controlled_tracks {
+            let changes: Vec<_> = self
+                .mute_changes
+                .iter()
+                .filter(|change| change.track_id == *track_id)
+                .collect();
+            if changes.is_empty() {
+                continue;
+            }
+            let mut lane = AutomationLane::new(AutomationTarget::TrackMute);
+            let start_beat = result.arrange_start_samples as f64 / samples_per_beat;
+            lane.insert_point(AutomationPoint {
+                beat: start_beat,
+                value: if *pre_capture_muted { 1.0 } else { 0.0 },
+                curve: 0.0,
+            });
+            for change in changes {
+                if change.effective_at_samples < self.engine_start_samples
+                    || change.effective_at_samples > self.engine_end_samples
+                {
+                    continue;
+                }
+                let arrange_samples = self.clock.arrange_start_samples.saturating_add(
+                    change
+                        .effective_at_samples
+                        .saturating_sub(self.engine_start_samples),
+                );
+                lane.insert_point(AutomationPoint {
+                    beat: arrange_samples as f64 / samples_per_beat,
+                    value: if change.muted { 1.0 } else { 0.0 },
+                    curve: 0.0,
+                });
+            }
+            lane.insert_point(AutomationPoint {
+                beat: result.arrange_end_samples as f64 / samples_per_beat,
+                value: if *pre_capture_muted { 1.0 } else { 0.0 },
+                curve: 0.0,
+            });
+            result
+                .by_track
+                .entry(*track_id)
+                .or_default()
+                .automation
+                .push(lane);
+        }
+
         for content in result.by_track.values_mut() {
             content.clips.sort_by_key(|clip| clip.position);
             content
                 .note_clips
                 .sort_by(|left, right| left.position_beats.total_cmp(&right.position_beats));
         }
+        result.controlled_track_ids = self
+            .controlled_tracks
+            .iter()
+            .map(|(track_id, _)| *track_id)
+            .collect();
+        result.pre_capture_mutes = self.controlled_tracks.iter().copied().collect();
         result
     }
 }
@@ -203,6 +245,7 @@ pub struct CaptureState {
     pub phase: CapturePhase,
     prepared_clock: Option<CaptureClock>,
     session: Option<CaptureSession>,
+    prepared_controlled_tracks: Vec<(TrackId, bool)>,
 }
 
 impl CaptureState {
@@ -247,6 +290,10 @@ impl CaptureState {
         });
     }
 
+    pub fn prepare_controlled_tracks(&mut self, tracks: impl IntoIterator<Item = (TrackId, bool)>) {
+        self.prepared_controlled_tracks = tracks.into_iter().collect();
+    }
+
     pub fn start(
         &mut self,
         effective_at_samples: u64,
@@ -268,8 +315,35 @@ impl CaptureState {
                 source_start_samples,
             }),
             spans: Vec::new(),
+            controlled_tracks: std::mem::take(&mut self.prepared_controlled_tracks),
+            mute_changes: Vec::new(),
         });
         self.phase = CapturePhase::Recording;
+    }
+
+    pub fn track_mute_changed(
+        &mut self,
+        track_id: TrackId,
+        muted: bool,
+        effective_at_samples: u64,
+    ) {
+        let Some(session) = &mut self.session else {
+            return;
+        };
+        if self.phase != CapturePhase::Recording
+            || effective_at_samples < session.engine_start_samples
+            || !session
+                .controlled_tracks
+                .iter()
+                .any(|(controlled_id, _)| *controlled_id == track_id)
+        {
+            return;
+        }
+        session.mute_changes.push(CapturedMuteChange {
+            track_id,
+            muted,
+            effective_at_samples,
+        });
     }
 
     pub fn transition(&mut self, source: CapturedSectionSource, effective_at_samples: u64) {
@@ -297,6 +371,8 @@ impl CaptureState {
             engine_start_samples: session.engine_start_samples,
             engine_end_samples: effective_at_samples,
             spans: session.spans,
+            controlled_tracks: session.controlled_tracks,
+            mute_changes: session.mute_changes,
         })
     }
 
@@ -304,6 +380,7 @@ impl CaptureState {
         self.phase = CapturePhase::Idle;
         self.prepared_clock = None;
         self.session = None;
+        self.prepared_controlled_tracks.clear();
     }
 }
 
@@ -358,7 +435,7 @@ fn append_timeline_window(
                 audio: Arc::clone(&clip.audio),
                 source: clip.source.clone(),
                 position: destination_start_samples + (overlap_start - window_start_samples),
-                source_offset: mapped_audio_offset(clip, delta),
+                source_offset: captured_audio_offset(clip, delta),
                 duration: overlap_end - overlap_start,
                 loop_enabled: clip.loop_enabled,
                 loop_start: clip.loop_start,
@@ -387,7 +464,7 @@ fn append_timeline_window(
             }
             let local_start = overlap_start - clip.position_beats;
             let local_end = overlap_end - clip.position_beats;
-            let notes = visible_notes(clip, local_start, local_end);
+            let notes = captured_visible_notes(clip, local_start, local_end);
             let fragment = UiNoteClip {
                 id: ClipId::new(),
                 name: format!("Capture · {} · {}", source.name, clip.name),
@@ -409,7 +486,7 @@ fn append_timeline_window(
     }
 }
 
-fn mapped_audio_offset(clip: &UiClip, timeline_delta: u64) -> u64 {
+pub(crate) fn captured_audio_offset(clip: &UiClip, timeline_delta: u64) -> u64 {
     let raw = clip.source_offset.saturating_add(timeline_delta);
     if clip.loop_enabled && clip.loop_end > clip.loop_start && raw >= clip.loop_end {
         clip.loop_start + (raw - clip.loop_start) % (clip.loop_end - clip.loop_start)
@@ -418,7 +495,11 @@ fn mapped_audio_offset(clip: &UiClip, timeline_delta: u64) -> u64 {
     }
 }
 
-fn visible_notes(clip: &UiNoteClip, local_start: f64, local_end: f64) -> Vec<MidiNote> {
+pub(crate) fn captured_visible_notes(
+    clip: &UiNoteClip,
+    local_start: f64,
+    local_end: f64,
+) -> Vec<MidiNote> {
     let looping = clip.loop_enabled && clip.loop_end_beats > clip.loop_start_beats;
     let mut visible = Vec::new();
     for note in &clip.notes {
@@ -517,6 +598,13 @@ mod tests {
         section
     }
 
+    fn starting_capture() -> CaptureState {
+        CaptureState {
+            phase: CapturePhase::Starting,
+            ..CaptureState::default()
+        }
+    }
+
     #[test]
     fn effective_mid_buffer_boundaries_become_exact_arrange_positions() {
         let first = audio_section("Groove A", 4.0, 16);
@@ -532,8 +620,7 @@ mod tests {
             .by_track
             .insert(track_id, second_content);
 
-        let mut capture = CaptureState::default();
-        capture.phase = CapturePhase::Starting;
+        let mut capture = starting_capture();
         capture.prepare(40, 8, 120.0);
         capture.start(3, Some((CapturedSectionSource::from_section(&first), 0)));
         assert_eq!(capture.arrange_start_samples(), Some(40));
@@ -554,8 +641,7 @@ mod tests {
         let mut section = audio_section("Groove A", 1.0, 4);
         section.looping = true;
         let track_id = *section.timeline.by_track.keys().next().unwrap();
-        let mut capture = CaptureState::default();
-        capture.phase = CapturePhase::Starting;
+        let mut capture = starting_capture();
         capture.prepare(0, 8, 120.0);
         capture.start(0, Some((CapturedSectionSource::from_section(&section), 0)));
         let clips = &capture.finish(10).unwrap().materialize().by_track[&track_id].clips;
@@ -581,8 +667,7 @@ mod tests {
             first.timeline.get(track_id).unwrap().note_clips[0].id,
             second.timeline.get(track_id).unwrap().note_clips[0].id,
         ];
-        let mut capture = CaptureState::default();
-        capture.phase = CapturePhase::Starting;
+        let mut capture = starting_capture();
         capture.prepare(8, 8, 120.0);
         capture.start(0, Some((CapturedSectionSource::from_section(&first), 0)));
         capture.transition(CapturedSectionSource::from_section(&second), 5);
@@ -604,8 +689,7 @@ mod tests {
         let first = audio_section("Groove A", 4.0, 16);
         let second = audio_section("Groove B", 4.0, 16);
         let track_id = *first.timeline.by_track.keys().next().unwrap();
-        let mut capture = CaptureState::default();
-        capture.phase = CapturePhase::Starting;
+        let mut capture = starting_capture();
         capture.prepare(0, 8, 120.0);
         capture.start(0, Some((CapturedSectionSource::from_section(&first), 0)));
         let completed = capture.finish(4).unwrap();
@@ -621,8 +705,7 @@ mod tests {
     fn source_edits_after_transition_cannot_rewrite_capture_snapshot() {
         let mut section = audio_section("Breakdown", 4.0, 16);
         let track_id = *section.timeline.by_track.keys().next().unwrap();
-        let mut capture = CaptureState::default();
-        capture.phase = CapturePhase::Starting;
+        let mut capture = starting_capture();
         capture.prepare(20, 8, 120.0);
         capture.start(
             100,
@@ -639,22 +722,35 @@ mod tests {
     }
 
     #[test]
-    fn occupied_target_interval_is_rejected_without_touching_outside_content() {
-        let section = audio_section("Drop", 4.0, 16);
-        let track_id = *section.timeline.by_track.keys().next().unwrap();
-        let mut capture = CaptureState::default();
-        capture.phase = CapturePhase::Starting;
+    fn effective_mute_event_materializes_as_steps_with_start_and_closing_state() {
+        let track_id = TrackId::new();
+        let section = midi_section("Groove A", track_id, 36);
+        let mut capture = starting_capture();
         capture.prepare(40, 8, 120.0);
-        capture.start(0, Some((CapturedSectionSource::from_section(&section), 0)));
-        let completed = capture.finish(8).unwrap();
-        let mut arrange = ArrangementTimeline::default();
-        let silent_track = TrackId::new();
-        let mut outside = section.timeline.get(track_id).unwrap().clips[0].clone();
-        outside.position = 44;
-        arrange.ensure(silent_track).clips.push(outside);
+        capture.prepare_controlled_tracks([(track_id, false)]);
+        capture.start(
+            100,
+            Some((CapturedSectionSource::from_section(&section), 0)),
+        );
+        capture.track_mute_changed(track_id, true, 103);
+        // A Section transition while held must not synthesize another gesture.
+        capture.transition(CapturedSectionSource::from_section(&section), 105);
+        let materialized = capture.finish(110).unwrap().materialize();
+        let lane = materialized.by_track[&track_id]
+            .automation
+            .iter()
+            .find(|lane| lane.target == AutomationTarget::TrackMute)
+            .unwrap();
 
-        let materialized = completed.materialize();
-        assert!(materialized.target_interval_is_empty(&ArrangementTimeline::default(), &[track_id]));
-        assert!(!materialized.target_interval_is_empty(&arrange, &[track_id, silent_track]));
+        assert_eq!(
+            lane.points
+                .iter()
+                .map(|point| (point.beat, point.value))
+                .collect::<Vec<_>>(),
+            [(10.0, 0.0), (10.75, 1.0), (12.5, 0.0)]
+        );
+        assert_eq!(lane.value_at(10.5), Some(0.0));
+        assert_eq!(lane.value_at(11.0), Some(1.0));
+        assert_eq!(lane.value_at(12.5), Some(0.0));
     }
 }

--- a/crates/vibez-ui/src/widgets/automation_lane.rs
+++ b/crates/vibez-ui/src/widgets/automation_lane.rs
@@ -52,6 +52,8 @@ pub struct AutomationLaneWidget {
     pub min_label: String,
     pub max_label: String,
     pub ref_label: String,
+    /// Draw and edit instantaneous state steps; curve handles are disabled.
+    pub stepped: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -126,7 +128,11 @@ impl AutomationLaneWidget {
                 continue;
             }
             let t = (pos.x - x0) / (x1 - x0);
-            let value = a.value + (b.value - a.value) * shape(t, a.curve);
+            let value = if self.stepped {
+                a.value
+            } else {
+                a.value + (b.value - a.value) * shape(t, a.curve)
+            };
             let y = self.value_to_y(value, height);
             if (y - pos.y).abs() <= SEGMENT_HIT {
                 return Some(i);
@@ -241,14 +247,21 @@ impl canvas::Program<Message> for AutomationLaneWidget {
         if !pts.is_empty() {
             let mut path = canvas::path::Builder::new();
             let first_y = self.value_to_y(pts[0].value, h);
-            path.move_to(Point::new(0.0, first_y));
-            path.line_to(Point::new(self.beat_to_x(pts[0].beat), first_y));
+            if self.stepped {
+                path.move_to(Point::new(self.beat_to_x(pts[0].beat), first_y));
+            } else {
+                path.move_to(Point::new(0.0, first_y));
+                path.line_to(Point::new(self.beat_to_x(pts[0].beat), first_y));
+            }
             for i in 0..pts.len() - 1 {
                 let a = pts[i];
                 let b = pts[i + 1];
                 let x0 = self.beat_to_x(a.beat);
                 let x1 = self.beat_to_x(b.beat);
-                if a.curve == 0.0 {
+                if self.stepped {
+                    path.line_to(Point::new(x1, self.value_to_y(a.value, h)));
+                    path.line_to(Point::new(x1, self.value_to_y(b.value, h)));
+                } else if a.curve == 0.0 {
                     path.line_to(Point::new(x1, self.value_to_y(b.value, h)));
                 } else {
                     const STEPS: usize = 24;
@@ -387,7 +400,7 @@ impl canvas::Program<Message> for AutomationLaneWidget {
                     return (canvas::event::Status::Captured, None);
                 }
                 // Alt: bend a segment (alt-double-click resets it).
-                if state.alt {
+                if state.alt && !self.stepped {
                     if let Some(index) = self.hit_segment(pos, h) {
                         if state.double_click.press(
                             Instant::now(),
@@ -515,7 +528,7 @@ impl canvas::Program<Message> for AutomationLaneWidget {
             if state.ctrl {
                 return mouse::Interaction::Crosshair;
             }
-            if state.alt {
+            if state.alt && !self.stepped {
                 if self.hit_segment(pos, bounds.height).is_some() {
                     return mouse::Interaction::ResizingVertically;
                 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,11 +196,14 @@ move it. The copied clips
 share only immutable decoded audio; they retain no Section identity or mutable
 reference, so later Section edits and launches cannot rewrite Arrange.
 
-Card 17 applies that materialization only when the destination interval is
-empty on every affected Project Track. Any overlap aborts the still-open
-project transaction without changing Arrange; interval replacement belongs to
-Card 18. Track Mutes, live notes, and effective automation are likewise later
-Capture log consumers rather than implicit work in this first slice.
+Capture treats every Project Track controlled by Perform as punch-replace,
+including tracks that produced silence. At the confirmed stop boundary it
+removes the recorded interval, preserves and splits material on either side,
+and pins existing automation values at both edges before inserting captured
+content. The still-open transaction therefore covers the whole replacement as
+one undo step. Track Mute events join the Capture log at their engine-effective
+samples and materialize as `track_mute` step points with a closing point that
+restores the pre-take manual state.
 
 The project document persists the immutable `mpc_2000xl_v1` Groove Profile,
 Project Swing, and optional Project Track Swing offsets as canonical project
@@ -247,8 +250,18 @@ Track control remains available but clip application is withheld.
 Track mute commands become authoritative when the audio callback drains them.
 The engine emits `EngineEvent::TrackMuteChanged` with the effective state and
 absolute transport sample; the UI mirrors that result into the shared Project
-Track. This keeps pad, mixer, persisted, and audible state aligned while giving
-later Capture work an engine-timestamped event source.
+Track and an active Capture log. `track_mute` automation is stepped: it imposes
+nothing before its first point and changes state at exact in-buffer sample
+boundaries. Both manual and automated mute feed one post-effects, pre-send
+anti-click ramp, so playback gates tails exactly like the performed mute.
+
+Automation overrides live beside evaluation in the shared `EngineTrack`
+channel strip. A manual mixer or Perform-pad mute on a track with a mute lane
+sets the Track Mute override; the manual value remains authoritative until the
+producer uses the visible `RE-ENABLE` affordance. The command/event protocol is
+parameter-shaped rather than mute-specific so gain and pan can adopt the same
+ownership later without introducing a second override model. Override state is
+runtime UI/engine state and is not persisted.
 
 ## Project Tracks and timeline content
 
@@ -324,7 +337,8 @@ Editor selections, meters, decoded/runtime caches, and live plugin pointers are
 outside the transaction snapshot and are neither cloned nor restored.
 Capture opens the same transaction before requesting its engine start boundary,
 then marks one edit and commits only after the engine-confirmed stop has
-materialized independent Arrange content. Empty or overlapping sessions abandon
+materialized independent Arrange content and replaced the controlled interval.
+A session that has neither captured content nor anything to replace abandons
 the transaction, while undo/redo replays the complete captured Arrangement as
 one project step.
 


### PR DESCRIPTION
## Summary
- replace the captured Arrange interval across every Perform-controlled track, preserving and splitting content on either side
- capture engine-effective Track Mute changes as stepped automation with start/closing baselines
- add engine-owned automation overrides with a visible re-enable control and a shared 64-frame post-effects mute ramp

## Validation
- `cargo fmt --all -- --check`
- strict production clippy for touched `vibez-core`, `vibez-engine`, and `vibez-ui`
- full workspace tests (70 core, 198 engine, 363 UI plus remaining workspace suites)
- native Xvfb dogfood: silence replacement, mute capture, stepped lane, manual override/re-enable
- atomic capture undo/redo regression
