### PR TITLE
UI: make menu dismissal explicit

### DIFF
--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -173,9 +173,6 @@ impl App {
         &mut self,
         action: crate::domains::arrangement::ArrangementAction,
     ) -> Task<Message> {
-        if action.close_context_menu {
-            self.state.view.context_menu = None;
-        }
         if action.focus_clip_tab {
             self.state.view.detail_panel_tab = DetailPanelTab::Clip;
         }
@@ -183,7 +180,6 @@ impl App {
             self.auto_scroll_to_beat(beat);
         }
         if let Some((start, end)) = action.loop_from_selection {
-            self.state.view.context_menu = None;
             let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
             let _ = self.state.transport.update(
                 crate::domains::transport::TransportMsg::SetArrangementLoopRegion {
@@ -320,9 +316,6 @@ impl App {
         &mut self,
         action: crate::domains::piano_roll::PianoRollAction,
     ) {
-        if action.close_context_menu {
-            self.state.view.context_menu = None;
-        }
         if let Some(sel) = action.select_note_clip {
             if self.state.view.workspace == crate::state::Workspace::Perform
                 && self.state.perform.selected_section.is_some()

--- a/crates/vibez-ui/src/app/bounce.rs
+++ b/crates/vibez-ui/src/app/bounce.rs
@@ -191,7 +191,6 @@ impl App {
         clip_id: ClipId,
         is_note_clip: bool,
     ) -> Task<Message> {
-        self.state.view.context_menu = None;
         let (range, insert_pos, name) = if is_note_clip {
             let spb = self.state.transport.sample_rate as f64 * 60.0 / self.state.transport.bpm;
             let nc = self

--- a/crates/vibez-ui/src/app/menu_lifecycle.rs
+++ b/crates/vibez-ui/src/app/menu_lifecycle.rs
@@ -1,0 +1,160 @@
+//! Explicit lifecycle for application and Arrange context-menu overlays.
+//!
+//! Background messages never pass through this module. Only a menu item,
+//! backdrop press, or Escape is allowed to dismiss one of these overlays.
+
+use crate::message::MenuOverlay;
+use crate::state::AppState;
+
+pub(super) fn dismiss(state: &mut AppState, overlay: MenuOverlay) -> bool {
+    let was_open = match overlay {
+        MenuOverlay::ArrangementContext => state.view.context_menu.is_some(),
+        MenuOverlay::File => state.project.file_menu_open,
+        MenuOverlay::Edit => state.view.edit_menu_open,
+    };
+
+    match overlay {
+        MenuOverlay::ArrangementContext => state.view.context_menu = None,
+        MenuOverlay::File => state.project.file_menu_open = false,
+        MenuOverlay::Edit => state.view.edit_menu_open = false,
+    }
+
+    was_open
+}
+
+/// Return the topmost menu Escape should dismiss, matching shell overlay order.
+pub(super) fn visible(state: &AppState) -> Option<MenuOverlay> {
+    if state.project.file_menu_open {
+        Some(MenuOverlay::File)
+    } else if state.view.edit_menu_open {
+        Some(MenuOverlay::Edit)
+    } else if state.view.context_menu.is_some() {
+        Some(MenuOverlay::ArrangementContext)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::view::ViewMsg;
+    use crate::message::Message;
+    use crate::state::{ContextMenu, ContextMenuTarget};
+
+    fn test_app() -> super::super::App {
+        let (plugin_effect_tx, plugin_effect_rx) = std::sync::mpsc::channel();
+        let (plugin_instrument_tx, plugin_instrument_rx) = std::sync::mpsc::channel();
+
+        super::super::App {
+            state: AppState::default(),
+            edge_shortcuts: Default::default(),
+            cmd_tx: None,
+            event_rx: None,
+            spectrum_rx: None,
+            spectrum_tap: None,
+            _stream: None,
+            plugin_effect_rx,
+            plugin_effect_tx,
+            plugin_instrument_rx,
+            plugin_instrument_tx,
+            plugin_window_manager: None,
+            plugin_gui_raw_ptrs: Default::default(),
+            plugin_state_ptrs: Default::default(),
+            dropbox_settings: Default::default(),
+            dropbox_cache: Default::default(),
+            dropbox_client: None,
+            remote_materialization_request: Default::default(),
+            remote_import_request: Default::default(),
+            remote_audition_cache_lease: None,
+            pending_remote_audition: None,
+            browser_import_request: Default::default(),
+            remote_catalog_request: Default::default(),
+            section_residency_request: Default::default(),
+            remote_catalog_pending: Vec::new(),
+            midi_input: None,
+            midi_input_ports: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn backdrop_or_escape_dismisses_an_open_menu_exactly_once() {
+        let mut state = AppState::default();
+        state.view.context_menu = Some(ContextMenu {
+            x: 24.0,
+            y: 48.0,
+            target: ContextMenuTarget::ArrangementEmpty,
+        });
+
+        assert!(dismiss(&mut state, MenuOverlay::ArrangementContext));
+        assert!(!dismiss(&mut state, MenuOverlay::ArrangementContext));
+    }
+
+    #[test]
+    fn escape_targets_the_topmost_visible_application_menu() {
+        let mut state = AppState::default();
+        state.view.context_menu = Some(ContextMenu {
+            x: 24.0,
+            y: 48.0,
+            target: ContextMenuTarget::ArrangementEmpty,
+        });
+        state.view.edit_menu_open = true;
+        state.project.file_menu_open = true;
+
+        assert_eq!(visible(&state), Some(MenuOverlay::File));
+        dismiss(&mut state, MenuOverlay::File);
+        assert_eq!(visible(&state), Some(MenuOverlay::Edit));
+        dismiss(&mut state, MenuOverlay::Edit);
+        assert_eq!(visible(&state), Some(MenuOverlay::ArrangementContext));
+    }
+
+    #[test]
+    fn unrelated_application_messages_leave_context_and_file_menus_open() {
+        let mut app = test_app();
+        app.state.view.context_menu = Some(ContextMenu {
+            x: 24.0,
+            y: 48.0,
+            target: ContextMenuTarget::ArrangementEmpty,
+        });
+        app.state.project.file_menu_open = true;
+
+        let _ = app.update(Message::View(ViewMsg::CursorMoved(50.0, 75.0)));
+        let _ = app.update(Message::EngineMetering {
+            peak_l: 0.25,
+            peak_r: 0.5,
+        });
+
+        assert!(app.state.view.context_menu.is_some());
+        assert!(app.state.project.file_menu_open);
+    }
+
+    #[test]
+    fn selecting_an_item_dispatches_its_action_then_dismisses_its_menu() {
+        let mut app = test_app();
+        app.state.project.file_menu_open = true;
+
+        let _ = app.update(Message::menu_item(MenuOverlay::File, Message::OpenSettings));
+
+        assert!(app.state.settings_open);
+        assert!(!app.state.project.file_menu_open);
+    }
+
+    #[test]
+    fn escape_dismisses_the_menu_before_unrelated_cancellation_paths() {
+        let mut app = test_app();
+        app.state.project.file_menu_open = true;
+        app.state.browser.pending_drag = Some(crate::state::PendingMediaDrag {
+            source: vibez_core::track::MediaSourceRef::LocalFile {
+                path: "/music/kick.wav".into(),
+            },
+            label: "kick.wav".into(),
+            origin_x: 10.0,
+            origin_y: 10.0,
+        });
+
+        let _ = app.update(Message::EscapePressed);
+
+        assert!(!app.state.project.file_menu_open);
+        assert!(app.state.browser.pending_drag.is_some());
+    }
+}

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -134,6 +134,7 @@ mod capture;
 mod engine_events;
 mod keyboard;
 mod local_watcher;
+mod menu_lifecycle;
 mod tracked_request;
 
 use async_helpers::*;

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -6,7 +6,6 @@ use iced::Task;
 use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::browser::BrowserMsg;
 use crate::domains::transport::TransportMsg;
-use crate::domains::view::ViewMsg;
 use vibez_engine::commands::EngineCommand;
 use vibez_plugin_host::gui::PluginGuiKey;
 
@@ -14,7 +13,7 @@ use crate::services::plugin_loader::{load_plugin_effect_bg, load_plugin_instrume
 
 use crate::message::Message;
 
-use super::update_policy::{apply_project_track_deletion_policy, context_menu_message_keeps_open};
+use super::update_policy::apply_project_track_deletion_policy;
 use super::*;
 
 impl App {
@@ -26,28 +25,6 @@ impl App {
         let message =
             apply_project_track_deletion_policy(message, self.state.confirm_project_track_deletion);
         let owns_project_transaction = self.begin_project_track_deletion_transaction(&message);
-        if self.state.view.edit_menu_open {
-            let keep_menu = matches!(
-                &message,
-                Message::Tick
-                    | Message::Transport(TransportMsg::EnginePosition(_))
-                    | Message::EngineMetering { .. }
-                    | Message::Transport(TransportMsg::EngineStopped)
-                    | Message::Arrangement(ArrangementMsg::EngineTrackMeter { .. })
-                    | Message::View(ViewMsg::ToggleEditMenu)
-                    | Message::View(ViewMsg::CursorMoved(_, _))
-                    | Message::View(ViewMsg::WindowResized(_, _))
-                    | Message::View(ViewMsg::MouseReleased)
-            );
-            if !keep_menu {
-                self.state.view.edit_menu_open = false;
-            }
-        }
-        // Auto-dismiss context menu on any action except tick/engine/menu events
-        if self.state.view.context_menu.is_some() && !context_menu_message_keeps_open(&message) {
-            self.state.view.context_menu = None;
-        }
-
         let should_mark_dirty = matches!(
             &message,
             Message::Transport(TransportMsg::BpmSubmit)
@@ -83,6 +60,14 @@ impl App {
         }
 
         match message {
+            Message::MenuItemSelected(overlay, action) => {
+                let task = self.update(*action);
+                menu_lifecycle::dismiss(&mut self.state, overlay);
+                return task;
+            }
+            Message::DismissMenu(overlay) => {
+                menu_lifecycle::dismiss(&mut self.state, overlay);
+            }
             Message::UndoGesture { .. } => {
                 unreachable!("undo gesture wrappers are removed before routing")
             }
@@ -251,7 +236,6 @@ impl App {
             // -- Settings --
             Message::OpenSettings => {
                 self.state.settings_open = true;
-                self.state.project.file_menu_open = false;
             }
             Message::CloseSettings => {
                 self.state.settings_open = false;
@@ -411,7 +395,6 @@ impl App {
 
             // -- Bounce / resample --
             Message::BounceSelectionToAudio => {
-                self.state.view.context_menu = None;
                 if !self.state.arrangement.time_selection_active
                     || self.state.arrangement.selection_end_beats
                         <= self.state.arrangement.selection_start_beats
@@ -452,7 +435,6 @@ impl App {
 
             // -- Quantize --
             Message::QuantizeAudioClip { track_id, clip_id } => {
-                self.state.view.context_menu = None;
                 let grid = self
                     .state
                     .view
@@ -536,7 +518,6 @@ impl App {
 
             // -- Export --
             Message::ExportProject => {
-                self.state.project.file_menu_open = false;
                 let default_name = self
                     .state
                     .project

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -410,6 +410,11 @@ impl App {
     }
 
     pub(super) fn on_escape_pressed(&mut self) -> Task<Message> {
+        if let Some(overlay) = menu_lifecycle::visible(&self.state) {
+            menu_lifecycle::dismiss(&mut self.state, overlay);
+            return Task::none();
+        }
+
         // Escape abandons any pending browser import at whatever stage it is
         // in; the shared tracker aborts attached work and rejects late output.
         self.browser_import_request.cancel();

--- a/crates/vibez-ui/src/app/update_policy.rs
+++ b/crates/vibez-ui/src/app/update_policy.rs
@@ -2,9 +2,6 @@
 //! dispatch so policy growth cannot turn `update.rs` back into a megafile.
 
 use crate::domains::arrangement::ArrangementMsg;
-use crate::domains::project::ProjectMsg;
-use crate::domains::transport::TransportMsg;
-use crate::domains::view::ViewMsg;
 use crate::message::Message;
 
 pub(super) fn apply_project_track_deletion_policy(message: Message, confirm: bool) -> Message {
@@ -16,64 +13,9 @@ pub(super) fn apply_project_track_deletion_policy(message: Message, confirm: boo
     }
 }
 
-pub(super) fn context_menu_message_keeps_open(message: &Message) -> bool {
-    if let Message::Browser(message) = message {
-        return message.keeps_context_menu();
-    }
-
-    matches!(
-        message,
-        Message::Tick
-            | Message::Transport(TransportMsg::EnginePosition(_))
-            | Message::EngineMetering { .. }
-            | Message::Transport(TransportMsg::EngineStopped)
-            | Message::Arrangement(ArrangementMsg::EngineTrackMeter { .. })
-            | Message::View(ViewMsg::ShowContextMenu { .. })
-            | Message::View(ViewMsg::DismissContextMenu)
-            | Message::Arrangement(ArrangementMsg::DeleteClipsInRegion { .. })
-            | Message::Arrangement(ArrangementMsg::SetSelectionAsLoop)
-            | Message::Arrangement(ArrangementMsg::DeleteSelectedClip)
-            | Message::Arrangement(ArrangementMsg::DuplicateSelectedClip)
-            | Message::Arrangement(ArrangementMsg::SplitSelectedAtPlayhead)
-            | Message::Arrangement(ArrangementMsg::JoinSelectedClips)
-            | Message::Arrangement(ArrangementMsg::SplitAudioClip { .. })
-            | Message::Arrangement(ArrangementMsg::SplitNoteClip { .. })
-            | Message::Arrangement(ArrangementMsg::SplitClipsAtRegion { .. })
-            | Message::Arrangement(ArrangementMsg::CreateNoteClipFromSelection(_))
-            | Message::View(ViewMsg::EditNameText(_))
-            | Message::View(ViewMsg::CursorMoved(_, _))
-            | Message::View(ViewMsg::WindowResized(_, _))
-            | Message::View(ViewMsg::MouseReleased)
-            | Message::KeyboardInput {
-                event: iced::keyboard::Event::ModifiersChanged(_),
-                ..
-            }
-            | Message::RemoteCatalogPageFetched { .. }
-            | Message::RemoteCatalogSaved { .. }
-            | Message::NewProject
-            | Message::OpenProject
-            | Message::SaveProject
-            | Message::SaveProjectAs
-            | Message::Project(ProjectMsg::ToggleFileMenu)
-            | Message::Project(ProjectMsg::DismissFileMenu)
-            | Message::ProjectOpenPathSelected(_)
-            | Message::ProjectSavePathSelected(_)
-            | Message::ProjectLoaded(_)
-            | Message::ProjectSaved(_)
-            | Message::OpenSettings
-            | Message::CloseSettings
-            | Message::SelectSettingsTab(_)
-            | Message::SetBufferSize(_)
-            | Message::ScanPlugins
-            | Message::ScanPluginsComplete(_)
-            | Message::PluginLoadError(_)
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domains::browser::BrowserMsg;
     use vibez_core::id::TrackId;
 
     #[test]
@@ -96,42 +38,5 @@ mod tests {
             confirmed,
             Message::Arrangement(ArrangementMsg::RequestRemoveTrack(id)) if id == track_id
         ));
-    }
-
-    #[test]
-    fn passive_arrangement_drag_hover_does_not_dismiss_context_menu() {
-        assert!(context_menu_message_keeps_open(&Message::Browser(
-            BrowserMsg::DragHoverTrack {
-                track_id: TrackId::new(),
-                beat: 4.0,
-                compatible: true,
-            },
-        )));
-    }
-
-    #[test]
-    fn deliberate_browser_actions_dismiss_context_menu() {
-        assert!(!context_menu_message_keeps_open(&Message::Browser(
-            BrowserMsg::ToggleSampleBrowser,
-        )));
-    }
-
-    #[test]
-    fn remote_catalog_progress_does_not_dismiss_context_menu() {
-        assert!(context_menu_message_keeps_open(
-            &Message::RemoteCatalogSaved {
-                generation: 1,
-                next_checkpoint: None,
-                result: Ok(()),
-            },
-        ));
-    }
-
-    #[test]
-    fn modifier_state_sync_after_right_click_does_not_dismiss_context_menu() {
-        assert!(context_menu_message_keeps_open(&Message::KeyboardInput {
-            event: iced::keyboard::Event::ModifiersChanged(iced::keyboard::Modifiers::empty()),
-            occurred_at: std::time::Instant::now(),
-        }));
     }
 }

--- a/crates/vibez-ui/src/app/update_project.rs
+++ b/crates/vibez-ui/src/app/update_project.rs
@@ -23,13 +23,11 @@ impl App {
     }
 
     pub(super) fn route_new_project(&mut self) -> Task<Message> {
-        self.state.project.file_menu_open = false;
         self.reset_to_new_project();
         Task::none()
     }
 
     pub(super) fn route_open_project(&mut self) -> Task<Message> {
-        self.state.project.file_menu_open = false;
         Task::perform(
             async {
                 let handle = rfd::AsyncFileDialog::new()
@@ -44,7 +42,6 @@ impl App {
     }
 
     pub(super) fn route_save_project(&mut self) -> Task<Message> {
-        self.state.project.file_menu_open = false;
         let project = self.project_for_save();
         if let Some(path) = self.state.project.current_path.clone() {
             return Task::perform(
@@ -56,7 +53,6 @@ impl App {
     }
 
     pub(super) fn route_save_project_as(&mut self) -> Task<Message> {
-        self.state.project.file_menu_open = false;
         Task::perform(
             async {
                 let handle = rfd::AsyncFileDialog::new()

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -10,14 +10,13 @@ use iced::{Element, Length, Theme};
 
 use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::piano_roll::PianoRollMsg;
-use crate::domains::project::ProjectMsg;
 use crate::domains::view::ViewMsg;
 use vibez_core::effect::EffectType;
 use vibez_core::midi::InstrumentKind;
 use vibez_plugin_host::{PluginCategory, PluginFormat};
 
 use crate::icons;
-use crate::message::Message;
+use crate::message::{MenuOverlay, Message};
 use crate::state::ContextMenuTarget;
 use crate::theme as th;
 
@@ -166,7 +165,7 @@ impl App {
                 .spacing(8)
                 .align_y(iced::Alignment::Center),
             )
-            .on_press(message)
+            .on_press(Message::menu_item(MenuOverlay::Edit, message))
             .padding([7, 12])
             .width(Length::Fill)
             .style(|_theme: &Theme, status| button::Style {
@@ -248,7 +247,7 @@ impl App {
                 .width(Length::Fill)
                 .height(Length::Fill),
         )
-        .on_press(Message::View(ViewMsg::DismissEditMenu))
+        .on_press(Message::dismiss_menu(MenuOverlay::Edit))
         .into()
     }
 
@@ -554,7 +553,7 @@ impl App {
                 .spacing(6)
                 .align_y(iced::Alignment::Center),
             )
-            .on_press(msg)
+            .on_press(Message::menu_item(MenuOverlay::File, msg))
             .padding([8, 16])
             .width(Length::Fill)
             .style(|_theme: &Theme, status| {
@@ -598,7 +597,7 @@ impl App {
             .spacing(6)
             .align_y(iced::Alignment::Center),
         )
-        .on_press(Message::OpenSettings)
+        .on_press(Message::menu_item(MenuOverlay::File, Message::OpenSettings))
         .padding([8, 16])
         .width(Length::Fill)
         .style(|_theme: &Theme, status| {
@@ -641,7 +640,7 @@ impl App {
         ];
 
         mouse_area(container(padded).width(Length::Fill).height(Length::Fill))
-            .on_press(Message::Project(ProjectMsg::DismissFileMenu))
+            .on_press(Message::dismiss_menu(MenuOverlay::File))
             .into()
     }
 
@@ -692,7 +691,7 @@ impl App {
                     .spacing(8)
                     .align_y(iced::Alignment::Center),
                 )
-                .on_press(msg)
+                .on_press(Message::menu_item(MenuOverlay::ArrangementContext, msg))
                 .padding([6, 12])
                 .width(Length::Fill)
                 .style(|_theme: &Theme, status| {
@@ -880,7 +879,7 @@ impl App {
                 .width(Length::Fill)
                 .height(Length::Fill),
         )
-        .on_press(Message::View(ViewMsg::DismissContextMenu))
+        .on_press(Message::dismiss_menu(MenuOverlay::ArrangementContext))
         .into()
     }
 }

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -210,8 +210,6 @@ pub struct ArrangementAction {
     pub loop_from_selection: Option<(f64, f64)>,
     /// A drag moved a clip near the view edge; auto-scroll to it.
     pub scroll_to_beat: Option<f64>,
-    /// Dismiss the arrangement context menu.
-    pub close_context_menu: bool,
     /// The project content changed outside the undo-snapshot path.
     pub mark_dirty: bool,
 }

--- a/crates/vibez-ui/src/domains/arrangement/ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/ops.rs
@@ -22,10 +22,7 @@ impl TimelineEditorState {
         end_beats: f64,
         track_id: Option<TrackId>,
     ) -> ArrangementAction {
-        let mut action = ArrangementAction {
-            close_context_menu: true,
-            ..Default::default()
-        };
+        let mut action = ArrangementAction::default();
         let target_track = track_id;
         let spb = ctx.samples_per_beat;
         // Preserve material outside the range. Splitting first turns
@@ -84,10 +81,7 @@ impl TimelineEditorState {
         end_beats: f64,
         track_id: Option<TrackId>,
     ) -> ArrangementAction {
-        let mut action = ArrangementAction {
-            close_context_menu: true,
-            ..Default::default()
-        };
+        let mut action = ArrangementAction::default();
         let target_track = track_id;
         let spb = ctx.samples_per_beat;
         let mut split_count = 0u32;
@@ -188,10 +182,7 @@ impl TimelineEditorState {
         _ctx: ArrangementCtx,
         track_id: TrackId,
     ) -> ArrangementAction {
-        let mut action = ArrangementAction {
-            close_context_menu: true,
-            ..Default::default()
-        };
+        let mut action = ArrangementAction::default();
         if !self.time_selection_active || self.selection_end_beats <= self.selection_start_beats {
             action.status = Some("No time selection active".to_string());
             return action;

--- a/crates/vibez-ui/src/domains/browser.rs
+++ b/crates/vibez-ui/src/domains/browser.rs
@@ -75,47 +75,6 @@ pub enum BrowserMsg {
     SetDropboxAppKey(String),
 }
 
-impl BrowserMsg {
-    /// Whether this message is passive Browser traffic that must not dismiss
-    /// an unrelated context menu. Keep this match exhaustive so every new
-    /// Browser interaction declares its menu behavior deliberately.
-    pub(crate) fn keeps_context_menu(&self) -> bool {
-        match self {
-            Self::PendingDragMoved { .. }
-            | Self::DragHoverTrack { .. }
-            | Self::DragHoverEmptyArrangement { .. }
-            | Self::DragHoverSampler { .. }
-            | Self::DragHoverDrumRackPad { .. }
-            | Self::ClearDragTarget
-            | Self::LocalRootWatchEvent(_)
-            | Self::ReconcileLocalRoot { .. }
-            | Self::LocalRootCatalogReconciled { .. } => true,
-            Self::ToggleSampleBrowser
-            | Self::BeginDockResize
-            | Self::ResizeDock(_)
-            | Self::EndDockResize
-            | Self::NudgeDockWidth(_)
-            | Self::SampleBrowserSearchChanged(_)
-            | Self::SelectLocalFolder(_)
-            | Self::ToggleLocalFolder(_)
-            | Self::CycleSearchScope
-            | Self::ShowMoreLocalResults
-            | Self::SelectSampleBrowserEntry(_)
-            | Self::SetSampleBrowserMode(_)
-            | Self::BeginPendingDrag { .. }
-            | Self::CancelDrag(_)
-            | Self::EndDragSample
-            | Self::RemoveSampleLibraryRoot(_)
-            | Self::ToggleRemotePlace
-            | Self::ToggleRemoteConnection
-            | Self::SelectRemoteFolder(_)
-            | Self::ToggleRemoteFolder(_)
-            | Self::SelectRemoteEntry(_)
-            | Self::SetDropboxAppKey(_) => false,
-        }
-    }
-}
-
 /// Cross-domain effects requested by a browser update.
 #[derive(Debug, Default, PartialEq)]
 pub struct BrowserAction {

--- a/crates/vibez-ui/src/domains/piano_roll.rs
+++ b/crates/vibez-ui/src/domains/piano_roll.rs
@@ -116,8 +116,6 @@ pub struct PianoRollAction {
     pub scroll_to_beat: Option<f64>,
     /// A resize drag is in flight (suppresses click-through selection).
     pub drag_resize_active: bool,
-    /// Dismiss the arrangement context menu.
-    pub close_context_menu: bool,
 }
 
 fn find_track(timeline: &TimelineContent, track_id: TrackId) -> Option<&TrackTimelineContent> {
@@ -714,7 +712,6 @@ impl PianoRollState {
                 action.status = Some(format!("Piano roll: {mode_name} mode"));
             }
             PianoRollMsg::QuantizeNoteClip { track_id, clip_id } => {
-                action.close_context_menu = true;
                 quantize_note_clip(
                     tracks,
                     track_id,
@@ -847,7 +844,6 @@ mod tests {
         let clip = &tracks.get(tid).unwrap().note_clips[0];
         assert_eq!(clip.notes[0].start_beat, 0.0);
         assert_eq!(clip.notes[1].start_beat, 2.0);
-        assert!(action.close_context_menu);
         assert_eq!(action.status.as_deref(), Some("Quantized 2 note(s) to 1/4"));
     }
 

--- a/crates/vibez-ui/src/domains/project.rs
+++ b/crates/vibez-ui/src/domains/project.rs
@@ -17,7 +17,6 @@ use crate::state::{ProjectSnapshot, ProjectState};
 #[derive(Debug, Clone)]
 pub enum ProjectMsg {
     ToggleFileMenu,
-    DismissFileMenu,
     Undo,
     Redo,
 }
@@ -51,9 +50,6 @@ impl ProjectState {
         match msg {
             ProjectMsg::ToggleFileMenu => {
                 self.file_menu_open = !self.file_menu_open;
-            }
-            ProjectMsg::DismissFileMenu => {
-                self.file_menu_open = false;
             }
             ProjectMsg::Undo => {
                 let Some(snapshot) = self.history.pop_undo() else {

--- a/crates/vibez-ui/src/domains/view.rs
+++ b/crates/vibez-ui/src/domains/view.rs
@@ -40,9 +40,7 @@ pub enum ViewMsg {
         y: f32,
         target: ContextMenuTarget,
     },
-    DismissContextMenu,
     ToggleEditMenu,
-    DismissEditMenu,
     StartEditingTrackName {
         track_id: TrackId,
         name: String,
@@ -203,14 +201,8 @@ impl ViewState {
                 }
                 self.context_menu = Some(crate::state::ContextMenu { x, y, target });
             }
-            ViewMsg::DismissContextMenu => {
-                self.context_menu = None;
-            }
             ViewMsg::ToggleEditMenu => {
                 self.edit_menu_open = !self.edit_menu_open;
-            }
-            ViewMsg::DismissEditMenu => {
-                self.edit_menu_open = false;
             }
             ViewMsg::StartEditingTrackName { track_id, name } => {
                 self.edit_name_text = name;
@@ -218,7 +210,6 @@ impl ViewState {
                 self.editing_clip_name = None;
             }
             ViewMsg::StartEditingClipName(track_id, clip_id) => {
-                self.context_menu = None;
                 let name = timeline.get(track_id).and_then(|t| {
                     t.clips
                         .iter()
@@ -367,6 +358,30 @@ mod tests {
 
         let menu = view.context_menu.expect("context menu");
         assert_eq!((menu.x, menu.y), (240.0, 180.0));
+    }
+
+    #[test]
+    fn passive_view_updates_do_not_dismiss_an_arrange_context_menu() {
+        let mut view = ViewState::default();
+        let timeline = TimelineEditorState::default();
+        view.update(
+            ViewMsg::ShowContextMenu {
+                x: 240.0,
+                y: 180.0,
+                target: ContextMenuTarget::ArrangementEmpty,
+            },
+            &timeline,
+            ViewCtx::default(),
+        );
+
+        for message in [
+            ViewMsg::CursorMoved(10.0, 20.0),
+            ViewMsg::WindowResized(1400.0, 900.0),
+            ViewMsg::MouseReleased,
+        ] {
+            view.update(message, &timeline, ViewCtx::default());
+            assert!(view.context_menu.is_some());
+        }
     }
 
     #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -56,6 +56,15 @@ pub enum DrumPadParam {
     FineTune,
 }
 
+/// Menus whose lifecycle is owned by their overlay rather than inferred from
+/// unrelated application messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MenuOverlay {
+    ArrangementContext,
+    File,
+    Edit,
+}
+
 #[derive(Debug, Clone)]
 pub struct LoadedClipData {
     pub info: ClipInfo,
@@ -254,6 +263,12 @@ pub struct ProjectSaveResult {
 
 #[derive(Debug, Clone)]
 pub enum Message {
+    /// A menu item was chosen. The router dispatches the action, then closes
+    /// only the overlay that produced it.
+    MenuItemSelected(MenuOverlay, Box<Message>),
+    /// Explicit dismissal from an overlay backdrop or another first-class
+    /// lifecycle input such as Escape.
+    DismissMenu(MenuOverlay),
     /// One incremental update within a continuous pointer edit. Messages from
     /// the same gesture share one pre-edit undo snapshot.
     UndoGesture {
@@ -658,6 +673,14 @@ impl Message {
 }
 
 impl Message {
+    pub fn menu_item(overlay: MenuOverlay, action: Self) -> Self {
+        Self::MenuItemSelected(overlay, Box::new(action))
+    }
+
+    pub fn dismiss_menu(overlay: MenuOverlay) -> Self {
+        Self::DismissMenu(overlay)
+    }
+
     pub fn select_track(t: TrackId) -> Self {
         Self::Arrangement(crate::domains::arrangement::ArrangementMsg::SelectTrack(t))
     }

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -825,6 +825,61 @@ mod tests {
         )
     }
 
+    fn right_click(
+        canvas: &TrackClipCanvas,
+        position: Point,
+    ) -> (canvas::event::Status, Option<Message>) {
+        <TrackClipCanvas as canvas::Program<Message>>::update(
+            canvas,
+            &mut ClipInteractionState::default(),
+            canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(
+                iced::mouse::Button::Right,
+            )),
+            Rectangle::new(Point::ORIGIN, Size::new(800.0, 80.0)),
+            mouse::Cursor::Available(position),
+        )
+    }
+
+    #[test]
+    fn physical_right_click_opens_clip_and_empty_arrange_context_menus() {
+        let mut canvas = empty_track_canvas();
+        let (status, message) = right_click(&canvas, Point::new(300.0, 20.0));
+        assert_eq!(status, canvas::event::Status::Captured);
+        assert!(matches!(
+            message,
+            Some(Message::View(ViewMsg::ShowContextMenu {
+                target: ContextMenuTarget::ArrangementEmpty,
+                ..
+            }))
+        ));
+
+        let clip_id = ClipId::new();
+        canvas.clips.push(TimelineClip {
+            clip_id,
+            position: 0,
+            duration: 44_100,
+            name: "Clip".into(),
+            peaks: Arc::new(Vec::new()),
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+            warp_stale: false,
+        });
+        let (status, message) = right_click(&canvas, Point::new(10.0, 10.0));
+        assert_eq!(status, canvas::event::Status::Captured);
+        assert!(matches!(
+            message,
+            Some(Message::View(ViewMsg::ShowContextMenu {
+                target: ContextMenuTarget::Clip {
+                    clip_id: id,
+                    is_note_clip: false,
+                    ..
+                },
+                ..
+            })) if id == clip_id
+        ));
+    }
+
     #[test]
     fn per_track_canvas_ignores_global_track_creation_shortcuts() {
         let canvas = empty_track_canvas();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,6 +107,15 @@ Browser import preparation, Remote catalog refresh, and Section residency keep
 separate tracker instances but do not duplicate request IDs, generations, or
 abort handles.
 
+Application menus and the Arrange context menu also use explicit router
+events. Their overlay backdrops emit dismissal, Escape targets the topmost
+visible menu, and a menu-item event dispatches its command before closing its
+origin overlay. Ordinary application messages never participate in menu
+lifecycle, so engine ticks, metering, catalog work, and future message variants
+cannot dismiss a menu accidentally. Buttons remain native iced controls for
+focus and keyboard activation; device and plug-in menus retain their separate
+domain-owned lifecycles.
+
 Perform follows the same boundary. `PerformState` owns runtime-only mode, bank,
 selection, and editor-focus state alongside an `Arc<SectionStore>` that enters
 project persistence and undo. Each Section owns its properties and an


### PR DESCRIPTION
## Summary
- replace message-type keep-open inference with explicit menu item, backdrop, and Escape lifecycle messages
- preserve Arrange, File, and Edit menus across unrelated engine/browser/UI traffic
- add state-machine and physical right-click coverage plus native menu dogfood evidence

## Validation
- 363 `vibez-ui` tests
- production `vibez-ui` clippy clean
- full workspace tests
- isolated Xvfb dogfood for Arrange/File item, backdrop, Escape, outside-click, and keyboard focus paths
