### PR TITLE
Audio: surface output stream health

### DIFF
--- a/crates/vibez-audio-io/src/audio_stream.rs
+++ b/crates/vibez-audio-io/src/audio_stream.rs
@@ -6,6 +6,7 @@
 
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -38,6 +39,33 @@ impl StreamHealth {
         } else {
             CallbackAction::Process
         }
+    }
+}
+
+/// A presentation-facing transition in the output stream lifecycle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AudioStreamEvent {
+    /// The stream started successfully.
+    Running,
+    /// The stream failed. The description is suitable for producer-facing UI.
+    Error(String),
+    /// The existing stream is being replaced.
+    Rebuilding,
+    /// A replacement stream was built successfully.
+    Recovered,
+}
+
+#[derive(Clone)]
+struct StreamEventReporter(SyncSender<AudioStreamEvent>);
+
+impl StreamEventReporter {
+    fn channel() -> (Self, Receiver<AudioStreamEvent>) {
+        let (tx, rx) = mpsc::sync_channel(16);
+        (Self(tx), rx)
+    }
+
+    fn report(&self, event: AudioStreamEvent) {
+        let _ = self.0.try_send(event);
     }
 }
 
@@ -151,6 +179,8 @@ pub struct AudioOutputStream {
     /// Shared engine slot.  The audio callback `try_lock`s this each
     /// invocation and calls `engine.process()` if the lock is obtained.
     engine_slot: Arc<Mutex<Option<AudioEngine>>>,
+    event_reporter: StreamEventReporter,
+    event_rx: Receiver<AudioStreamEvent>,
 }
 
 impl AudioOutputStream {
@@ -179,7 +209,20 @@ impl AudioOutputStream {
         buffer_size: Option<u32>,
     ) -> Result<Self, AudioStreamError> {
         let engine_slot = Arc::new(Mutex::new(Some(engine)));
-        Self::build_stream(engine_slot, device, buffer_size)
+        let (event_reporter, event_rx) = StreamEventReporter::channel();
+        let (stream, params) = Self::build_stream(
+            Arc::clone(&engine_slot),
+            device,
+            buffer_size,
+            event_reporter.clone(),
+        )?;
+        Ok(Self {
+            stream,
+            params,
+            engine_slot,
+            event_reporter,
+            event_rx,
+        })
     }
 
     /// Reconfigure the stream with a new buffer size, preserving the engine
@@ -189,25 +232,45 @@ impl AudioOutputStream {
     /// brief moment the engine is being moved between streams, the old
     /// callback outputs silence (one buffer, inaudible).
     pub fn reconfigure(&mut self, buffer_size: Option<u32>) -> Result<(), AudioStreamError> {
-        let host = cpal::default_host();
-        let device = host
-            .default_output_device()
-            .ok_or(AudioStreamError::NoOutputDevice)?;
+        self.event_reporter.report(AudioStreamEvent::Rebuilding);
+        let result: Result<(), AudioStreamError> = (|| {
+            let host = cpal::default_host();
+            let device = host
+                .default_output_device()
+                .ok_or(AudioStreamError::NoOutputDevice)?;
 
-        // Pause the old stream so the callback stops firing.
-        let _ = self.stream.pause();
+            // Pause the old stream so the callback stops firing.
+            let _ = self.stream.pause();
 
-        // Take the engine out of the shared slot.  The old callback will
-        // output silence if it fires between pause and drop.
-        let engine_slot = Arc::clone(&self.engine_slot);
+            // Take the engine out of the shared slot.  The old callback will
+            // output silence if it fires between pause and drop.
+            let engine_slot = Arc::clone(&self.engine_slot);
 
-        // Build a new stream that reuses the same engine slot.
-        let new = Self::build_stream(engine_slot, &device, buffer_size)?;
+            // Build a new stream that reuses the same engine slot.
+            let (stream, params) = Self::build_stream(
+                engine_slot,
+                &device,
+                buffer_size,
+                self.event_reporter.clone(),
+            )?;
 
-        self.stream = new.stream;
-        self.params = new.params;
-        // engine_slot is already the same Arc
-        Ok(())
+            self.stream = stream;
+            self.params = params;
+            self.stream.play()?;
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => {
+                self.event_reporter.report(AudioStreamEvent::Recovered);
+                Ok(())
+            }
+            Err(error) => {
+                self.event_reporter
+                    .report(AudioStreamEvent::Error(error.to_string()));
+                Err(error)
+            }
+        }
     }
 
     /// Internal: build a cpal stream around an existing engine slot.
@@ -215,7 +278,8 @@ impl AudioOutputStream {
         engine_slot: Arc<Mutex<Option<AudioEngine>>>,
         device: &cpal::Device,
         buffer_size: Option<u32>,
-    ) -> Result<Self, AudioStreamError> {
+        event_reporter: StreamEventReporter,
+    ) -> Result<(cpal::Stream, StreamParams), AudioStreamError> {
         let supported_config = device.default_output_config()?;
 
         // Prefer our default sample rate if the device supports it, otherwise
@@ -262,6 +326,7 @@ impl AudioOutputStream {
         let slot = Arc::clone(&engine_slot);
         let health = StreamHealth::default();
         let callback_health = health.clone();
+        let error_reporter = event_reporter;
 
         let stream = device.build_output_stream(
             &config,
@@ -312,22 +377,28 @@ impl AudioOutputStream {
             },
             move |err| {
                 health.mark_failed();
+                error_reporter.report(AudioStreamEvent::Error(err.to_string()));
                 eprintln!("vibez: audio stream error: {err}");
             },
             None,
         )?;
 
-        Ok(Self {
-            stream,
-            params,
-            engine_slot,
-        })
+        Ok((stream, params))
     }
 
     /// Start (or resume) audio playback.
     pub fn play(&self) -> Result<(), AudioStreamError> {
-        self.stream.play()?;
-        Ok(())
+        match self.stream.play().map_err(AudioStreamError::from) {
+            Ok(()) => {
+                self.event_reporter.report(AudioStreamEvent::Running);
+                Ok(())
+            }
+            Err(error) => {
+                self.event_reporter
+                    .report(AudioStreamEvent::Error(error.to_string()));
+                Err(error)
+            }
+        }
     }
 
     /// Pause audio playback.
@@ -352,6 +423,11 @@ impl AudioOutputStream {
     /// Return the channel count negotiated with the device.
     pub fn channels(&self) -> usize {
         self.params.channels
+    }
+
+    /// Return the next lifecycle event without blocking the UI thread.
+    pub fn try_next_event(&self) -> Option<AudioStreamEvent> {
+        self.event_rx.try_recv().ok()
     }
 }
 
@@ -409,6 +485,29 @@ mod tests {
 
         assert_eq!(health.callback_action(), CallbackAction::SilenceAndYield);
         assert_eq!(health.callback_action(), CallbackAction::SilenceAndYield);
+    }
+
+    #[test]
+    fn stream_lifecycle_reports_error_rebuild_and_recovery_in_order() {
+        let (reporter, events) = StreamEventReporter::channel();
+
+        reporter.report(AudioStreamEvent::Running);
+        reporter.report(AudioStreamEvent::Error(
+            "device disconnected mid-session".into(),
+        ));
+        reporter.report(AudioStreamEvent::Rebuilding);
+        reporter.report(AudioStreamEvent::Recovered);
+
+        assert_eq!(events.try_recv(), Ok(AudioStreamEvent::Running));
+        assert_eq!(
+            events.try_recv(),
+            Ok(AudioStreamEvent::Error(
+                "device disconnected mid-session".into()
+            ))
+        );
+        assert_eq!(events.try_recv(), Ok(AudioStreamEvent::Rebuilding));
+        assert_eq!(events.try_recv(), Ok(AudioStreamEvent::Recovered));
+        assert!(events.try_recv().is_err());
     }
 
     /// Verify `BufferSize::Default` is used for `None`.

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -632,9 +632,22 @@ impl App {
             .analyse(self.state.transport.sample_rate as f32);
     }
 
+    pub(super) fn poll_audio_stream_events(&mut self) {
+        let mut events = Vec::new();
+        if let Some(stream) = self._stream.as_ref() {
+            while let Some(event) = stream.try_next_event() {
+                events.push(event);
+            }
+        }
+        for event in events {
+            self.state.apply_audio_stream_event(event);
+        }
+    }
+
     /// One frame of the 60fps subscription: drain engine events and
     /// pump every background service.
     pub(super) fn handle_tick(&mut self) -> Task<Message> {
+        self.poll_audio_stream_events();
         self.poll_engine_events();
         self.poll_spectrum();
         self.poll_plugin_loads();

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -28,7 +28,7 @@ use crate::message::{
     ProjectSaveResult, SampleLibraryScanResult,
 };
 use crate::plugin_window::{PluginRawPtr, PluginWindowManager};
-use crate::state::AppState;
+use crate::state::{AppState, AudioStreamHealth};
 use crate::theme as th;
 use crate::ui_settings::UiSettings;
 
@@ -186,19 +186,25 @@ impl App {
         let spectrum_rx = engine.take_spectrum_consumer();
         let ui_settings = UiSettings::load();
 
-        let (stream, sample_rate) = match AudioOutputStream::open(engine, Some(512)) {
-            Ok(s) => {
-                let sr = s.sample_rate();
-                if let Err(e) = s.play() {
-                    eprintln!("vibez: failed to start audio stream: {e}");
+        let (stream, sample_rate, audio_stream_health) =
+            match AudioOutputStream::open(engine, Some(512)) {
+                Ok(s) => {
+                    let sr = s.sample_rate();
+                    let health = match s.play() {
+                        Ok(()) => AudioStreamHealth::Running,
+                        Err(e) => {
+                            eprintln!("vibez: failed to start audio stream: {e}");
+                            AudioStreamHealth::Error(e.to_string())
+                        }
+                    };
+                    (Some(s), sr, health)
                 }
-                (Some(s), sr)
-            }
-            Err(e) => {
-                eprintln!("vibez: failed to open audio stream: {e}");
-                (None, 44_100)
-            }
-        };
+                Err(e) => {
+                    eprintln!("vibez: failed to open audio stream: {e}");
+                    let cause = e.to_string();
+                    (None, 44_100, AudioStreamHealth::Error(cause))
+                }
+            };
 
         let dropbox_settings = DropboxSettings::load();
         let dropbox_cache = DropboxCache::with_policy(vibez_dropbox::MediaCachePolicy {
@@ -252,6 +258,7 @@ impl App {
                 sample_rate,
                 ..Default::default()
             },
+            audio_stream_health,
             auto_warp_on_import: ui_settings.auto_warp_on_import,
             warp_confidence_threshold: ui_settings.warp_confidence_threshold,
             confirm_project_track_deletion: ui_settings.confirm_project_track_deletion,
@@ -275,6 +282,9 @@ impl App {
             },
             ..Default::default()
         };
+        if let AudioStreamHealth::Error(cause) = &state.audio_stream_health {
+            state.status_text = format!("Audio stream error: {cause}");
+        }
         state.perform.input_mapping = ui_settings.perform_input_mapping.clone();
         state
             .perform

--- a/crates/vibez-ui/src/app/views_transport.rs
+++ b/crates/vibez-ui/src/app/views_transport.rs
@@ -2,7 +2,7 @@
 //! Split from views_shell.rs; inherent methods on [`super::App`].
 
 use iced::widget::{
-    button, canvas, column, container, horizontal_space, pick_list, row, text, text_input,
+    button, canvas, column, container, horizontal_space, pick_list, row, text, text_input, tooltip,
 };
 use iced::{Element, Length, Theme};
 
@@ -12,12 +12,53 @@ use crate::domains::view::ViewMsg;
 
 use crate::icons;
 use crate::message::Message;
-use crate::state::{AppState, Workspace};
+use crate::state::{AppState, AudioStreamHealth, Workspace};
 use crate::theme as th;
 use crate::widgets::swing_knob::{parse_swing_percent, SwingKnobWidget};
 use crate::widgets::vu_meter::VuMeterWidget;
 
 use super::*;
+
+fn audio_stream_indicator(health: &AudioStreamHealth) -> Element<'_, Message> {
+    let (color, description) = match health {
+        AudioStreamHealth::Running => (th::success(), health.description().to_string()),
+        AudioStreamHealth::Rebuilding => (th::meter_yellow(), health.description().to_string()),
+        AudioStreamHealth::Error(cause) => (th::danger(), format!("Audio stream error: {cause}")),
+    };
+    let control = container(
+        row![
+            icons::icon(icons::CIRCLE_DOT).size(10).color(color),
+            text("AUDIO").size(9).color(color),
+        ]
+        .spacing(4)
+        .align_y(iced::Alignment::Center),
+    )
+    .padding([4, 6])
+    .style(move |_theme: &Theme| container::Style {
+        background: Some(th::bg_elevated().into()),
+        border: iced::Border {
+            color,
+            width: 1.0,
+            radius: 3.0.into(),
+        },
+        ..Default::default()
+    });
+    let hint = container(text(description).size(10).color(th::text()))
+        .padding([5, 7])
+        .style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_elevated().into()),
+            border: iced::Border {
+                color: th::border_light(),
+                width: 1.0,
+                radius: 3.0.into(),
+            },
+            ..Default::default()
+        });
+    tooltip(control, hint, tooltip::Position::Bottom)
+        .gap(6)
+        .padding(0)
+        .into()
+}
 
 impl App {
     pub(super) fn view_transport(&self) -> Element<'_, Message> {
@@ -292,12 +333,14 @@ impl App {
             .into();
 
         let volume_icon = icons::icon(icons::VOLUME_2).size(14).color(th::text_dim());
+        let stream_health = audio_stream_indicator(&self.state.audio_stream_health);
 
         let transport = row![
             transport_buttons,
             horizontal_space(),
             time_text,
             horizontal_space(),
+            stream_health,
             volume_icon,
             master_meter_canvas,
             row![bpm_input, bpm_spinner]

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -410,6 +410,24 @@ pub struct ResolvedTimelineMut<'a> {
     pub editor: &'a mut TimelineEditorState,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum AudioStreamHealth {
+    #[default]
+    Running,
+    Rebuilding,
+    Error(String),
+}
+
+impl AudioStreamHealth {
+    pub fn description(&self) -> &str {
+        match self {
+            Self::Running => "Audio stream running",
+            Self::Rebuilding => "Rebuilding audio stream",
+            Self::Error(cause) => cause,
+        }
+    }
+}
+
 pub struct AppState {
     // Transport domain slice (playback, tempo, arrangement loop).
     pub transport: TransportState,
@@ -422,6 +440,7 @@ pub struct AppState {
     pub spectrum: crate::spectrum::SpectrumState,
 
     pub status_text: String,
+    pub audio_stream_health: AudioStreamHealth,
     pub view: ViewState,
 
     pub piano_roll: PianoRollState,
@@ -480,6 +499,7 @@ impl Default for AppState {
             peak_r: 0.0,
             spectrum: crate::spectrum::SpectrumState::default(),
             status_text: "Ready — Add a track to get started".to_string(),
+            audio_stream_health: AudioStreamHealth::default(),
             view: ViewState::default(),
             piano_roll: PianoRollState::default(),
             perform: crate::domains::perform::PerformState::default(),
@@ -513,6 +533,31 @@ pub fn default_drum_rack_pads() -> Vec<UiDrumPad> {
 }
 
 impl AppState {
+    pub fn apply_audio_stream_event(
+        &mut self,
+        event: vibez_audio_io::audio_stream::AudioStreamEvent,
+    ) {
+        use vibez_audio_io::audio_stream::AudioStreamEvent;
+
+        match event {
+            AudioStreamEvent::Running => {
+                self.audio_stream_health = AudioStreamHealth::Running;
+            }
+            AudioStreamEvent::Error(cause) => {
+                self.status_text = format!("Audio stream error: {cause}");
+                self.audio_stream_health = AudioStreamHealth::Error(cause);
+            }
+            AudioStreamEvent::Rebuilding => {
+                self.status_text = "Rebuilding audio stream…".into();
+                self.audio_stream_health = AudioStreamHealth::Rebuilding;
+            }
+            AudioStreamEvent::Recovered => {
+                self.status_text = "Audio stream recovered".into();
+                self.audio_stream_health = AudioStreamHealth::Running;
+            }
+        }
+    }
+
     pub fn position_seconds(&self) -> f64 {
         self.transport.position_samples as f64 / self.transport.sample_rate as f64
     }
@@ -692,6 +737,41 @@ impl AppState {
         };
 
         audio_max.max(note_max)
+    }
+}
+
+#[cfg(test)]
+mod audio_stream_health_tests {
+    use super::{AppState, AudioStreamHealth};
+    use vibez_audio_io::audio_stream::AudioStreamEvent;
+
+    #[test]
+    fn stream_error_and_recovery_update_persistent_health_and_status() {
+        let mut state = AppState::default();
+
+        state.apply_audio_stream_event(AudioStreamEvent::Error(
+            "device disconnected mid-session".into(),
+        ));
+        assert_eq!(
+            state.audio_stream_health,
+            AudioStreamHealth::Error("device disconnected mid-session".into())
+        );
+        assert_eq!(
+            state.status_text,
+            "Audio stream error: device disconnected mid-session"
+        );
+
+        state.apply_audio_stream_event(AudioStreamEvent::Rebuilding);
+        assert_eq!(state.audio_stream_health, AudioStreamHealth::Rebuilding);
+        assert_eq!(state.status_text, "Rebuilding audio stream…");
+
+        state.apply_audio_stream_event(AudioStreamEvent::Recovered);
+        assert_eq!(state.audio_stream_health, AudioStreamHealth::Running);
+        assert_eq!(state.status_text, "Audio stream recovered");
+
+        state.apply_audio_stream_event(AudioStreamEvent::Running);
+        assert_eq!(state.audio_stream_health, AudioStreamHealth::Running);
+        assert_eq!(state.status_text, "Audio stream recovered");
     }
 }
 


### PR DESCRIPTION
## Summary
- bridge output-stream Running/Error/Rebuilding/Recovered transitions to the UI through a bounded non-blocking channel
- show persistent global AUDIO health with truthful status and error tooltips
- keep callback and engine render paths unchanged; recovery is reported only after the replacement stream resumes

## Validation
- `vibez-audio-io`: 32 unit + 3 format-matrix tests
- targeted UI health reducer test
- strict production clippy for `vibez-audio-io` and `vibez-ui`
- full workspace tests and isolated Xvfb healthy/error dogfood
- callback and engine-tree hashes unchanged
