### PR TITLE
Perform: capture live notes and automation

### DIFF
--- a/crates/vibez-core/src/perform.rs
+++ b/crates/vibez-core/src/perform.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// `Off` deliberately remains the default: Vibez never guesses the rhythmic
 /// intent of freely recorded notes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GrooveGrid {
     #[default]

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -132,6 +132,19 @@ pub enum EngineCommand {
         target: vibez_core::automation::AutomationTarget,
         overridden: bool,
     },
+    /// Mark the first or a subsequent effective value in one live pointer
+    /// gesture. The ordinary parameter command follows in the same drain.
+    UpdateAutomationGesture {
+        track_id: TrackId,
+        target: vibez_core::automation::AutomationTarget,
+        normalized_value: f32,
+        begin: bool,
+    },
+    /// Yield a live pointer gesture back to its active automation lane.
+    EndAutomationGesture {
+        track_id: TrackId,
+        target: vibez_core::automation::AutomationTarget,
+    },
     /// Set the solo state for a track.
     SetTrackSolo(TrackId, bool),
     /// Set the optional Project Track Swing adjustment used by generated

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -517,6 +517,9 @@ fn push_spectrum(tx: &mut Producer<f32>, buffer: &[f32], channels: usize) {
 #[path = "engine_drain_commands.rs"]
 mod drain_commands;
 
+#[path = "engine_automation_commands.rs"]
+mod automation_commands;
+
 #[path = "engine_render.rs"]
 mod render_paths;
 

--- a/crates/vibez-engine/src/engine_automation_commands.rs
+++ b/crates/vibez-engine/src/engine_automation_commands.rs
@@ -1,0 +1,153 @@
+//! Audio-thread handlers for manual automation ownership and live gestures.
+
+use vibez_core::automation::AutomationTarget;
+use vibez_core::id::{EffectId, TrackId};
+use vibez_core::perform::SwingOffset;
+
+use crate::events::{AutomationGesturePhase, EngineEvent};
+
+use super::AudioEngine;
+
+impl AudioEngine {
+    pub(super) fn set_track_gain(&mut self, id: TrackId, gain: f32) {
+        if let Some(track) = self.channel_mut(id) {
+            track.gain = gain;
+        }
+    }
+
+    pub(super) fn set_track_pan(&mut self, id: TrackId, pan: f32) {
+        if let Some(track) = self.channel_mut(id) {
+            track.pan = pan.clamp(0.0, 1.0);
+        }
+    }
+
+    pub(super) fn set_track_swing_offset(&mut self, id: TrackId, offset: Option<SwingOffset>) {
+        if let Some(track) = self.tracks.iter_mut().find(|track| track.id == id) {
+            track.swing_offset = offset;
+        }
+    }
+
+    pub(super) fn set_effect_param(
+        &mut self,
+        track_id: TrackId,
+        effect_id: EffectId,
+        param_index: usize,
+        value: f32,
+    ) {
+        if let Some(track) = self.channel_mut(track_id) {
+            if let Some(slot) = track.effects.iter_mut().find(|slot| slot.id == effect_id) {
+                slot.effect.set_param(param_index, value);
+            }
+        }
+    }
+
+    pub(super) fn set_track_mute(&mut self, id: TrackId, muted: bool) {
+        let effective_at_samples = self.effective_position();
+        let playing = self.transport.is_playing();
+        let (changed, override_changed) = if let Some(track) = self.channel_mut(id) {
+            let target = AutomationTarget::TrackMute;
+            let override_changed =
+                track.has_automation_target(target) && track.set_automation_override(target, true);
+            track.set_manual_mute(muted, !playing);
+            (true, override_changed)
+        } else {
+            (false, false)
+        };
+        if changed {
+            let _ = self.event_tx.push(EngineEvent::TrackMuteChanged {
+                track_id: id,
+                muted,
+                effective_at_samples,
+            });
+        }
+        if override_changed {
+            let _ = self.event_tx.push(EngineEvent::AutomationOverrideChanged {
+                track_id: id,
+                target: AutomationTarget::TrackMute,
+                overridden: true,
+            });
+        }
+    }
+
+    pub(super) fn set_automation_override(
+        &mut self,
+        track_id: TrackId,
+        target: AutomationTarget,
+        overridden: bool,
+    ) {
+        let changed = self
+            .channel_mut(track_id)
+            .is_some_and(|track| track.set_automation_override(target, overridden));
+        if changed {
+            let _ = self.event_tx.push(EngineEvent::AutomationOverrideChanged {
+                track_id,
+                target,
+                overridden,
+            });
+        }
+    }
+
+    pub(super) fn update_automation_gesture(
+        &mut self,
+        track_id: TrackId,
+        target: AutomationTarget,
+        normalized_value: f32,
+        begin: bool,
+    ) {
+        self.set_automation_override(track_id, target, true);
+        let _ = self.event_tx.push(EngineEvent::AutomationGestureChanged {
+            track_id,
+            target,
+            normalized_value: normalized_value.clamp(0.0, 1.0),
+            phase: if begin {
+                AutomationGesturePhase::Begin
+            } else {
+                AutomationGesturePhase::Update
+            },
+            effective_at_samples: self.effective_position(),
+        });
+    }
+
+    pub(super) fn end_automation_gesture(&mut self, track_id: TrackId, target: AutomationTarget) {
+        let section_active = self.active_section.is_some();
+        let beat = if let Some(active) = self.active_section {
+            self.samples_to_automation_beat(active.position_samples)
+        } else {
+            self.samples_to_automation_beat(self.effective_position())
+        };
+        let normalized_value = self
+            .tracks
+            .iter()
+            .find(|track| track.id == track_id)
+            .map(|track| track.normalized_target_value(target, beat, section_active))
+            .or_else(|| {
+                if self.master.id == track_id {
+                    Some(self.master.normalized_target_value(target, beat, false))
+                } else {
+                    self.buses
+                        .iter()
+                        .find(|track| track.id == track_id)
+                        .map(|track| track.normalized_target_value(target, beat, false))
+                }
+            });
+        self.set_automation_override(track_id, target, false);
+        if let Some(normalized_value) = normalized_value {
+            let _ = self.event_tx.push(EngineEvent::AutomationGestureChanged {
+                track_id,
+                target,
+                normalized_value,
+                phase: AutomationGesturePhase::End,
+                effective_at_samples: self.effective_position(),
+            });
+        }
+    }
+
+    fn samples_to_automation_beat(&self, samples: u64) -> f64 {
+        let bpm = self.transport.bpm();
+        if bpm > 0.0 {
+            samples as f64 * bpm / (self.sample_rate as f64 * 60.0)
+        } else {
+            0.0
+        }
+    }
+}

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -125,6 +125,12 @@ impl AudioEngine {
                     let event = EngineEvent::SectionSourceRefreshed {
                         section_id,
                         applied,
+                        effective_at_samples: self.effective_position(),
+                        section_position_samples: applied.then(|| {
+                            self.active_section
+                                .map(|active| active.position_samples)
+                                .unwrap_or(0)
+                        }),
                         retired: prepared,
                     };
                     if let Err(rtrb::PushError::Full(event)) = self.event_tx.push(event) {
@@ -280,9 +286,7 @@ impl AudioEngine {
                     self.recalculate_audio_length();
                 }
                 EngineCommand::SetTrackGain(id, gain) => {
-                    if let Some(track) = self.channel_mut(id) {
-                        track.gain = gain;
-                    }
+                    self.set_track_gain(id, gain);
                 }
                 EngineCommand::SetAutomationLane { track_id, lane } => {
                     if let Some(track) = self.channel_mut(track_id) {
@@ -303,55 +307,28 @@ impl AudioEngine {
                     }
                 }
                 EngineCommand::SetTrackPan(id, pan) => {
-                    if let Some(track) = self.channel_mut(id) {
-                        track.pan = pan.clamp(0.0, 1.0);
-                    }
+                    self.set_track_pan(id, pan);
                 }
                 EngineCommand::SetTrackMute(id, mute) => {
-                    let effective_at_samples = self.effective_position();
-                    let playing = self.transport.is_playing();
-                    let (changed, override_changed) = if let Some(track) = self.channel_mut(id) {
-                        let override_changed = track.has_automation_target(
-                            vibez_core::automation::AutomationTarget::TrackMute,
-                        ) && track.set_automation_override(
-                            vibez_core::automation::AutomationTarget::TrackMute,
-                            true,
-                        );
-                        track.set_manual_mute(mute, !playing);
-                        (true, override_changed)
-                    } else {
-                        (false, false)
-                    };
-                    if changed {
-                        let _ = self.event_tx.push(EngineEvent::TrackMuteChanged {
-                            track_id: id,
-                            muted: mute,
-                            effective_at_samples,
-                        });
-                    }
-                    if override_changed {
-                        let _ = self.event_tx.push(EngineEvent::AutomationOverrideChanged {
-                            track_id: id,
-                            target: vibez_core::automation::AutomationTarget::TrackMute,
-                            overridden: true,
-                        });
-                    }
+                    self.set_track_mute(id, mute);
                 }
                 EngineCommand::SetAutomationOverride {
                     track_id,
                     target,
                     overridden,
                 } => {
-                    let changed = self
-                        .channel_mut(track_id)
-                        .is_some_and(|track| track.set_automation_override(target, overridden));
-                    if changed {
-                        let _ = self.event_tx.push(EngineEvent::AutomationOverrideChanged {
-                            track_id,
-                            target,
-                            overridden,
-                        });
-                    }
+                    self.set_automation_override(track_id, target, overridden);
+                }
+                EngineCommand::UpdateAutomationGesture {
+                    track_id,
+                    target,
+                    normalized_value,
+                    begin,
+                } => {
+                    self.update_automation_gesture(track_id, target, normalized_value, begin);
+                }
+                EngineCommand::EndAutomationGesture { track_id, target } => {
+                    self.end_automation_gesture(track_id, target);
                 }
 
                 // -- Busses --
@@ -392,9 +369,7 @@ impl AudioEngine {
                     }
                 }
                 EngineCommand::SetTrackSwingOffset(id, offset) => {
-                    if let Some(track) = self.tracks.iter_mut().find(|track| track.id == id) {
-                        track.swing_offset = offset;
-                    }
+                    self.set_track_swing_offset(id, offset);
                 }
 
                 // -- Infrastructure --
@@ -447,11 +422,7 @@ impl AudioEngine {
                     param_index,
                     value,
                 } => {
-                    if let Some(track) = self.channel_mut(track_id) {
-                        if let Some(slot) = track.effects.iter_mut().find(|e| e.id == effect_id) {
-                            slot.effect.set_param(param_index, value);
-                        }
-                    }
+                    self.set_effect_param(track_id, effect_id, param_index, value);
                 }
                 EngineCommand::SetEffectBypass {
                     track_id,

--- a/crates/vibez-engine/src/engine_mute_automation_tests.rs
+++ b/crates/vibez-engine/src/engine_mute_automation_tests.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
-use vibez_core::id::{ClipId, TrackId};
+use vibez_core::id::{ClipId, SectionId, TrackId};
 
 use super::*;
+use crate::playback_source::{EngineClip, PreparedPlaybackSource, PreparedSectionPlaybackSource};
 
 fn constant_audio(frames: usize) -> Arc<DecodedAudio> {
     Arc::new(DecodedAudio {
@@ -106,4 +107,139 @@ fn manual_mute_override_holds_until_automation_is_reenabled() {
         0.0,
         "re-enable must return control to the lane"
     );
+}
+
+#[test]
+fn live_pan_gesture_overrides_arrange_baseline_then_yields_back() {
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    add_constant_track(&mut commands, track_id);
+    let mut lane = AutomationLane::new(AutomationTarget::TrackPan);
+    lane.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 0.0,
+        curve: 0.0,
+    });
+    commands
+        .push(EngineCommand::SetAutomationLane { track_id, lane })
+        .unwrap();
+    commands.push(EngineCommand::Play).unwrap();
+    let mut output = vec![0.0; 16 * 2];
+    engine.process(&mut output, 2);
+    assert!(output[0].abs() > output[1].abs());
+
+    commands
+        .push(EngineCommand::UpdateAutomationGesture {
+            track_id,
+            target: AutomationTarget::TrackPan,
+            normalized_value: 1.0,
+            begin: true,
+        })
+        .unwrap();
+    commands
+        .push(EngineCommand::SetTrackPan(track_id, 1.0))
+        .unwrap();
+    output.fill(0.0);
+    engine.process(&mut output, 2);
+    assert!(output[1].abs() > output[0].abs());
+
+    commands
+        .push(EngineCommand::EndAutomationGesture {
+            track_id,
+            target: AutomationTarget::TrackPan,
+        })
+        .unwrap();
+    output.fill(0.0);
+    engine.process(&mut output, 2);
+    assert!(output[0].abs() > output[1].abs());
+
+    let gestures: Vec<_> = std::iter::from_fn(|| events.pop().ok())
+        .filter_map(|event| match event {
+            EngineEvent::AutomationGestureChanged {
+                phase,
+                normalized_value,
+                ..
+            } => Some((phase, normalized_value)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        gestures,
+        [
+            (crate::events::AutomationGesturePhase::Begin, 1.0),
+            (crate::events::AutomationGesturePhase::End, 0.0),
+        ]
+    );
+}
+
+#[test]
+fn perform_gesture_uses_the_active_section_lane_not_arrange_automation() {
+    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    commands.push(EngineCommand::SetSampleRate(100)).unwrap();
+    commands.push(EngineCommand::SetBpm(60.0)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Section pan".into()))
+        .unwrap();
+    let mut section_pan = AutomationLane::new(AutomationTarget::TrackPan);
+    section_pan.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 0.0,
+        curve: 0.0,
+    });
+    commands
+        .push(EngineCommand::LaunchSection(Box::new(
+            PreparedSectionPlaybackSource::new(
+                SectionId::new(),
+                4.0,
+                true,
+                vec![(
+                    track_id,
+                    PreparedPlaybackSource::new(
+                        vec![EngineClip {
+                            id: ClipId::new(),
+                            audio: constant_audio(512),
+                            position: 0,
+                            source_offset: 0,
+                            duration: 512,
+                            loop_enabled: false,
+                            loop_start: 0,
+                            loop_end: 0,
+                        }],
+                        Vec::new(),
+                        vec![section_pan],
+                    ),
+                )],
+            ),
+        )))
+        .unwrap();
+
+    let mut output = vec![0.0; 16 * 2];
+    engine.process(&mut output, 2);
+    assert!(output[0].abs() > output[1].abs());
+
+    commands
+        .push(EngineCommand::UpdateAutomationGesture {
+            track_id,
+            target: AutomationTarget::TrackPan,
+            normalized_value: 1.0,
+            begin: true,
+        })
+        .unwrap();
+    commands
+        .push(EngineCommand::SetTrackPan(track_id, 1.0))
+        .unwrap();
+    output.fill(0.0);
+    engine.process(&mut output, 2);
+    assert!(output[1].abs() > output[0].abs());
+
+    commands
+        .push(EngineCommand::EndAutomationGesture {
+            track_id,
+            target: AutomationTarget::TrackPan,
+        })
+        .unwrap();
+    output.fill(0.0);
+    engine.process(&mut output, 2);
+    assert!(output[0].abs() > output[1].abs());
 }

--- a/crates/vibez-engine/src/engine_section_playback_tests.rs
+++ b/crates/vibez-engine/src/engine_section_playback_tests.rs
@@ -148,7 +148,7 @@ fn resident_section_switches_immediately_and_returns_the_displaced_source() {
 
 #[test]
 fn refreshing_the_active_section_changes_content_without_restarting_its_playhead() {
-    let (mut engine, mut commands, _events) = AudioEngine::new();
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
     let track_id = TrackId::new();
     let section_id = SectionId::new();
     commands.push(EngineCommand::SetSampleRate(8)).unwrap();
@@ -200,6 +200,16 @@ fn refreshing_the_active_section_changes_content_without_restarting_its_playhead
         .expect("Section remains active")
         .position_samples;
     assert_eq!(position, 8, "refresh preserves the four elapsed samples");
+    let refresh = std::iter::from_fn(|| events.pop().ok()).find_map(|event| match event {
+        EngineEvent::SectionSourceRefreshed {
+            applied,
+            effective_at_samples,
+            section_position_samples,
+            ..
+        } => Some((applied, effective_at_samples, section_position_samples)),
+        _ => None,
+    });
+    assert_eq!(refresh, Some((true, 4, Some(4))));
 }
 
 #[test]

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -3,6 +3,13 @@ use vibez_core::perform::NoteRepeatRate;
 
 use crate::playback_source::PreparedSectionPlaybackSource;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutomationGesturePhase {
+    Begin,
+    Update,
+    End,
+}
+
 /// Events sent from the audio engine back to the UI thread (via rtrb).
 ///
 /// These are pushed by the engine inside the real-time audio callback and
@@ -91,6 +98,15 @@ pub enum EngineEvent {
         track_id: TrackId,
         target: vibez_core::automation::AutomationTarget,
         overridden: bool,
+    },
+    /// One engine-effective point in a live automation gesture. `End` carries
+    /// the baseline value that became audible again at the release boundary.
+    AutomationGestureChanged {
+        track_id: TrackId,
+        target: vibez_core::automation::AutomationTarget,
+        normalized_value: f32,
+        phase: AutomationGesturePhase,
+        effective_at_samples: u64,
     },
 
     /// A generated Note Repeat retrigger became effective at this exact
@@ -184,6 +200,8 @@ pub enum EngineEvent {
     SectionSourceRefreshed {
         section_id: SectionId,
         applied: bool,
+        effective_at_samples: u64,
+        section_position_samples: Option<u64>,
         retired: Box<PreparedSectionPlaybackSource>,
     },
 
@@ -280,6 +298,28 @@ impl PartialEq for EngineEvent {
                 left_track == right_track
                     && left_target == right_target
                     && left_overridden == right_overridden
+            }
+            (
+                Self::AutomationGestureChanged {
+                    track_id: left_track,
+                    target: left_target,
+                    normalized_value: left_value,
+                    phase: left_phase,
+                    effective_at_samples: left_effective,
+                },
+                Self::AutomationGestureChanged {
+                    track_id: right_track,
+                    target: right_target,
+                    normalized_value: right_value,
+                    phase: right_phase,
+                    effective_at_samples: right_effective,
+                },
+            ) => {
+                left_track == right_track
+                    && left_target == right_target
+                    && left_value == right_value
+                    && left_phase == right_phase
+                    && left_effective == right_effective
             }
             (
                 Self::NoteRepeated {
@@ -470,16 +510,22 @@ impl PartialEq for EngineEvent {
                 Self::SectionSourceRefreshed {
                     section_id: left_section,
                     applied: left_applied,
+                    effective_at_samples: left_effective,
+                    section_position_samples: left_position,
                     retired: left_retired,
                 },
                 Self::SectionSourceRefreshed {
                     section_id: right_section,
                     applied: right_applied,
+                    effective_at_samples: right_effective,
+                    section_position_samples: right_position,
                     retired: right_retired,
                 },
             ) => {
                 left_section == right_section
                     && left_applied == right_applied
+                    && left_effective == right_effective
+                    && left_position == right_position
                     && std::ptr::eq(left_retired.as_ref(), right_retired.as_ref())
             }
             (Self::PlaybackStarted, Self::PlaybackStarted)
@@ -520,6 +566,13 @@ mod tests {
             track_id: TrackId::new(),
             target: vibez_core::automation::AutomationTarget::TrackMute,
             overridden: true,
+        };
+        let _automation_gesture = EngineEvent::AutomationGestureChanged {
+            track_id: TrackId::new(),
+            target: vibez_core::automation::AutomationTarget::TrackPan,
+            normalized_value: 0.75,
+            phase: AutomationGesturePhase::Begin,
+            effective_at_samples: 44_100,
         };
         let _started = EngineEvent::PlaybackStarted;
         let _stopped = EngineEvent::PlaybackStopped;

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -63,26 +63,34 @@ impl MuteRamp {
     }
 }
 
-/// Runtime manual-overrides for automated parameters. Mute is the first
-/// consumer; later parameters extend this value without changing ownership.
+/// Runtime manual-overrides for automated parameters. The fixed-capacity
+/// storage keeps gesture changes allocation-free on the audio thread.
 #[derive(Debug, Default)]
 struct AutomationOverrides {
-    track_mute: bool,
+    targets: [Option<vibez_core::automation::AutomationTarget>; 16],
 }
 
 impl AutomationOverrides {
     fn contains(&self, target: vibez_core::automation::AutomationTarget) -> bool {
-        matches!(target, vibez_core::automation::AutomationTarget::TrackMute) && self.track_mute
+        self.targets.contains(&Some(target))
     }
 
     fn set(&mut self, target: vibez_core::automation::AutomationTarget, overridden: bool) -> bool {
-        let slot = match target {
-            vibez_core::automation::AutomationTarget::TrackMute => &mut self.track_mute,
-            _ => return false,
-        };
-        let changed = *slot != overridden;
-        *slot = overridden;
-        changed
+        let existing = self.targets.iter().position(|entry| *entry == Some(target));
+        match (existing, overridden) {
+            (Some(_), true) | (None, false) => false,
+            (Some(index), false) => {
+                self.targets[index] = None;
+                true
+            }
+            (None, true) => {
+                let Some(slot) = self.targets.iter_mut().find(|entry| entry.is_none()) else {
+                    return false;
+                };
+                *slot = Some(target);
+                true
+            }
+        }
     }
 }
 

--- a/crates/vibez-engine/src/mixer/channel_strip.rs
+++ b/crates/vibez-engine/src/mixer/channel_strip.rs
@@ -52,20 +52,21 @@ impl EngineTrack {
             let Some(value) = lane.value_at(beat) else {
                 continue;
             };
+            let overridden = self.automation_overrides.contains(lane.target);
             match lane.target {
                 // Gain's native range is 0..2; pan is already 0..1.
-                AutomationTarget::TrackGain => gain = Some(value * 2.0),
-                AutomationTarget::TrackPan => pan = Some(value),
+                AutomationTarget::TrackGain if !overridden => gain = Some(value * 2.0),
+                AutomationTarget::TrackPan if !overridden => pan = Some(value),
                 AutomationTarget::TrackMute => {
                     mute = Some(value >= 0.5);
                 }
-                AutomationTarget::TrackSwingOffset => {
+                AutomationTarget::TrackSwingOffset if !overridden => {
                     swing_offset = Some(SwingOffset::from_normalized(value));
                 }
                 AutomationTarget::EffectParam {
                     effect_id,
                     param_index,
-                } => {
+                } if !overridden => {
                     if let Some(slot) = self.effects.iter_mut().find(|e| e.id == effect_id) {
                         // Lanes are normalized 0..1; parameters live in
                         // their native descriptor range.
@@ -93,6 +94,10 @@ impl EngineTrack {
                         None => self.sends.push((bus_id, value)),
                     }
                 }
+                AutomationTarget::TrackGain
+                | AutomationTarget::TrackPan
+                | AutomationTarget::TrackSwingOffset
+                | AutomationTarget::EffectParam { .. } => {}
             }
         }
         self.automation_swing_offset = swing_offset;
@@ -131,6 +136,61 @@ impl EngineTrack {
             self.mute_ramp.set_muted(effective_muted, false);
         }
         changed
+    }
+
+    pub(crate) fn normalized_target_value(
+        &self,
+        target: vibez_core::automation::AutomationTarget,
+        beat: f64,
+        section_active: bool,
+    ) -> f32 {
+        let source = if section_active {
+            self.section_playback_source.as_ref()
+        } else {
+            self.playback_source.as_ref()
+        };
+        if let Some(value) = source
+            .automation
+            .iter()
+            .find(|lane| lane.target == target)
+            .and_then(|lane| lane.value_at(beat))
+        {
+            return value.clamp(0.0, 1.0);
+        }
+        match target {
+            vibez_core::automation::AutomationTarget::TrackGain => {
+                (self.gain / 2.0).clamp(0.0, 1.0)
+            }
+            vibez_core::automation::AutomationTarget::TrackPan => self.pan.clamp(0.0, 1.0),
+            vibez_core::automation::AutomationTarget::TrackMute => {
+                if self.effective_muted() {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
+            vibez_core::automation::AutomationTarget::TrackSwingOffset => self
+                .swing_offset
+                .unwrap_or_default()
+                .normalized()
+                .clamp(0.0, 1.0),
+            vibez_core::automation::AutomationTarget::EffectParam {
+                effect_id,
+                param_index,
+            } => self
+                .effects
+                .iter()
+                .find(|slot| slot.id == effect_id)
+                .and_then(|slot| {
+                    let descriptor = slot.effect.param_descriptors().get(param_index)?;
+                    let span = descriptor.max - descriptor.min;
+                    (span.abs() > f32::EPSILON)
+                        .then(|| (slot.effect.get_param(param_index) - descriptor.min) / span)
+                })
+                .unwrap_or(0.0)
+                .clamp(0.0, 1.0),
+            _ => 0.0,
+        }
     }
 
     pub(crate) fn effective_muted(&self) -> bool {

--- a/crates/vibez-ui/src/app/capture.rs
+++ b/crates/vibez-ui/src/app/capture.rs
@@ -3,12 +3,18 @@
 use iced::Task;
 use std::sync::Arc;
 
+use vibez_core::automation::AutomationTarget;
+use vibez_core::id::TrackId;
+use vibez_core::perform::SwingOffset;
 use vibez_engine::commands::EngineCommand;
 
+use crate::domains::arrangement::ArrangementMsg;
+use crate::domains::devices::DevicesMsg;
 use crate::domains::perform::capture::CompletedCapture;
-use crate::domains::perform::{CaptureAction, MaterializedCapture};
+use crate::domains::perform::{CaptureAction, MaterializedCapture, PerformMsg};
+use crate::domains::view::ViewMsg;
 use crate::message::Message;
-use crate::state::Workspace;
+use crate::state::{UndoGestureId, Workspace};
 
 use super::*;
 
@@ -38,6 +44,7 @@ impl App {
                 self.state.status_text = "Starting Capture into Arrange…".into();
             }
             CaptureAction::Stop => {
+                self.end_capture_automation_gesture();
                 // Transport Stop publishes the Capture boundary first, then
                 // stops Section playback in the same audio callback.
                 self.send_command(capture_stop_command());
@@ -45,6 +52,140 @@ impl App {
             }
         }
         Task::none()
+    }
+
+    pub(super) fn prepare_capture_message(
+        &mut self,
+        undo_gesture: Option<UndoGestureId>,
+        message: &Message,
+    ) -> bool {
+        if self.state.perform.capture.is_active()
+            && matches!(message, Message::Perform(PerformMsg::SetProjectSwing(_)))
+        {
+            self.state.status_text = "Project Swing is locked while Capture records".to_string();
+            return true;
+        }
+        if matches!(message, Message::View(ViewMsg::MouseReleased)) {
+            self.end_capture_automation_gesture();
+        }
+        let Some(gesture) = undo_gesture else {
+            return false;
+        };
+        let values = self.capture_automation_values(message);
+        if values.is_empty() {
+            return false;
+        }
+        let ended = self
+            .state
+            .perform
+            .capture
+            .begin_ui_automation_gesture(gesture);
+        for (track_id, target) in ended {
+            self.send_command(EngineCommand::EndAutomationGesture { track_id, target });
+        }
+        for value in values {
+            if !self
+                .state
+                .perform
+                .capture
+                .is_controlled_track(value.track_id)
+            {
+                continue;
+            }
+            let begin = self
+                .state
+                .perform
+                .capture
+                .register_ui_automation_target(value.track_id, value.target);
+            self.send_command(EngineCommand::UpdateAutomationGesture {
+                track_id: value.track_id,
+                target: value.target,
+                normalized_value: value.normalized,
+                begin,
+            });
+        }
+        false
+    }
+
+    pub(super) fn end_capture_automation_gesture(&mut self) {
+        let targets = self.state.perform.capture.end_ui_automation_gesture();
+        for (track_id, target) in targets {
+            self.send_command(EngineCommand::EndAutomationGesture { track_id, target });
+        }
+    }
+
+    fn capture_automation_values(&self, message: &Message) -> Vec<CaptureAutomationValue> {
+        match message {
+            Message::Arrangement(ArrangementMsg::SetTrackGain(track_id, gain)) => {
+                vec![CaptureAutomationValue {
+                    track_id: *track_id,
+                    target: AutomationTarget::TrackGain,
+                    normalized: (*gain / 2.0).clamp(0.0, 1.0),
+                }]
+            }
+            Message::Arrangement(ArrangementMsg::SetTrackPan(track_id, pan)) => {
+                vec![CaptureAutomationValue {
+                    track_id: *track_id,
+                    target: AutomationTarget::TrackPan,
+                    normalized: (*pan).clamp(0.0, 1.0),
+                }]
+            }
+            Message::Devices(DevicesMsg::SetEffectParam(
+                track_id,
+                effect_id,
+                param_index,
+                value,
+            )) => self
+                .normalize_effect_value(*track_id, *effect_id, *param_index, *value)
+                .into_iter()
+                .collect(),
+            Message::Devices(DevicesMsg::SetEffectParams(track_id, effect_id, updates)) => updates
+                .iter()
+                .filter_map(|(param_index, value)| {
+                    self.normalize_effect_value(*track_id, *effect_id, *param_index, *value)
+                })
+                .collect(),
+            Message::Perform(PerformMsg::SetTrackSwingOffset { track_id, value }) => {
+                vec![CaptureAutomationValue {
+                    track_id: *track_id,
+                    target: AutomationTarget::TrackSwingOffset,
+                    normalized: value.map(SwingOffset::new).unwrap_or_default().normalized(),
+                }]
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn normalize_effect_value(
+        &self,
+        track_id: TrackId,
+        effect_id: vibez_core::id::EffectId,
+        param_index: usize,
+        value: f32,
+    ) -> Option<CaptureAutomationValue> {
+        let effect = self
+            .state
+            .project_tracks
+            .tracks
+            .iter()
+            .find(|track| track.id == track_id)?
+            .effects
+            .iter()
+            .find(|effect| effect.id == effect_id)?;
+        let descriptor = effect.descriptors.get(param_index)?;
+        let span = descriptor.max - descriptor.min;
+        Some(CaptureAutomationValue {
+            track_id,
+            target: AutomationTarget::EffectParam {
+                effect_id,
+                param_index,
+            },
+            normalized: if span.abs() > f32::EPSILON {
+                ((value - descriptor.min) / span).clamp(0.0, 1.0)
+            } else {
+                0.0
+            },
+        })
     }
 
     pub(super) fn finish_performance_capture(&mut self, completed: Option<CompletedCapture>) {
@@ -98,6 +239,13 @@ impl App {
             self.state.project.dirty = dirty_before;
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CaptureAutomationValue {
+    track_id: TrackId,
+    target: AutomationTarget,
+    normalized: f32,
 }
 
 fn capture_stop_command() -> EngineCommand {

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -100,16 +100,40 @@ impl App {
                             .automation_ui
                             .set_override(track_id, target, overridden);
                     }
+                    EngineEvent::AutomationGestureChanged {
+                        track_id,
+                        target,
+                        normalized_value,
+                        phase,
+                        effective_at_samples,
+                    } => {
+                        self.state.perform.capture.automation_changed(
+                            track_id,
+                            target,
+                            normalized_value,
+                            phase,
+                            effective_at_samples,
+                        );
+                    }
                     EngineEvent::NoteRepeated {
                         track_id,
                         pitch,
                         velocity,
                         rate,
                         effective_at_samples,
+                        canonical_at_samples,
                         section_id,
                         canonical_section_position_samples,
                         ..
                     } => {
+                        self.state.perform.capture.repeated_note(
+                            track_id,
+                            pitch,
+                            velocity,
+                            rate,
+                            effective_at_samples,
+                            canonical_at_samples,
+                        );
                         self.state.perform.section_record.repeated_note(
                             section_id,
                             track_id,
@@ -129,6 +153,13 @@ impl App {
                         section_id,
                         section_position_samples,
                     } => {
+                        self.state.perform.capture.input_note(
+                            track_id,
+                            pitch,
+                            velocity,
+                            on,
+                            effective_at_samples,
+                        );
                         self.state.perform.section_record.input_note(
                             crate::domains::perform::section_record::SectionRecordInput {
                                 section_id,
@@ -270,10 +301,29 @@ impl App {
                             .observe_playhead(section_id, position_samples);
                     }
                     EngineEvent::SectionSourceRefreshed {
-                        section_id: _,
-                        applied: _,
+                        section_id,
+                        applied,
+                        effective_at_samples,
+                        section_position_samples,
                         retired,
-                    } => drop(retired),
+                    } => {
+                        if applied {
+                            if let Some(source) = self
+                                .state
+                                .perform
+                                .sections
+                                .by_id(section_id)
+                                .map(CapturedSectionSource::from_section)
+                            {
+                                self.state.perform.capture.refresh(
+                                    source,
+                                    effective_at_samples,
+                                    section_position_samples.unwrap_or(0),
+                                );
+                            }
+                        }
+                        drop(retired);
+                    }
                 }
             }
         }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -24,6 +24,9 @@ impl App {
         };
         let message =
             apply_project_track_deletion_policy(message, self.state.confirm_project_track_deletion);
+        if self.prepare_capture_message(undo_gesture, &message) {
+            return Task::none();
+        }
         let owns_project_transaction = self.begin_project_track_deletion_transaction(&message);
         let deferred_clipboard_project_edit = matches!(
             &message,
@@ -89,6 +92,7 @@ impl App {
                             if self.state.transport.playing
                     );
                 if stops_perform {
+                    self.end_capture_automation_gesture();
                     self.section_residency_request.cancel();
                 }
                 let perform_playback_active = self.state.perform.playing_section.is_some()

--- a/crates/vibez-ui/src/app/views_transport.rs
+++ b/crates/vibez-ui/src/app/views_transport.rs
@@ -184,6 +184,7 @@ impl App {
         let bpm_label = text("BPM").size(12).color(th::text_dim());
 
         let project_swing = self.state.perform.project_swing();
+        let project_swing_locked = self.state.perform.capture.is_active();
         let project_swing_submit = parse_swing_percent(self.state.perform.project_swing_input())
             .map(|swing| Message::Perform(PerformMsg::SetProjectSwing(swing.get())))
             .unwrap_or_else(|| {
@@ -193,20 +194,34 @@ impl App {
                 )))
             });
         let swing_input = text_input("%", self.state.perform.project_swing_input())
-            .on_input(|value| Message::Perform(PerformMsg::ProjectSwingInput(value)))
-            .on_submit(project_swing_submit)
             .width(Length::Fixed(42.0))
             .padding([2, 4])
             .size(11);
-        let swing_knob: Element<'_, Message> = canvas(SwingKnobWidget::project(project_swing))
-            .width(Length::Fixed(30.0))
-            .height(Length::Fixed(30.0))
-            .into();
+        let swing_input = if project_swing_locked {
+            swing_input
+        } else {
+            swing_input
+                .on_input(|value| Message::Perform(PerformMsg::ProjectSwingInput(value)))
+                .on_submit(project_swing_submit)
+        };
+        let swing_knob: Element<'_, Message> = canvas(SwingKnobWidget::project_locked(
+            project_swing,
+            project_swing_locked,
+        ))
+        .width(Length::Fixed(30.0))
+        .height(Length::Fixed(30.0))
+        .into();
         let swing_control = container(
             row![
                 swing_knob,
                 column![
-                    text("PROJECT SWING").size(8).color(th::text_muted()),
+                    text(if project_swing_locked {
+                        "PROJECT SWING · CAPTURE LOCK"
+                    } else {
+                        "PROJECT SWING"
+                    })
+                    .size(8)
+                    .color(th::text_muted()),
                     swing_input,
                 ]
                 .spacing(1),

--- a/crates/vibez-ui/src/domains/perform/capture.rs
+++ b/crates/vibez-ui/src/domains/perform/capture.rs
@@ -11,9 +11,12 @@ use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::MidiNote;
 
-use crate::state::{ArrangementTimeline, TrackTimelineContent, UiClip, UiNoteClip};
+use crate::state::{ArrangementTimeline, TrackTimelineContent, UiClip, UiNoteClip, UndoGestureId};
 
 use super::{PerformAction, Section};
+
+mod performance_log;
+use performance_log::{CompletedPerformanceLog, PerformanceLog};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CapturePhase {
@@ -84,6 +87,7 @@ struct CaptureSession {
     spans: Vec<CapturedSectionSpan>,
     controlled_tracks: Vec<(TrackId, bool)>,
     mute_changes: Vec<CapturedMuteChange>,
+    performance: PerformanceLog,
 }
 
 #[derive(Debug)]
@@ -94,6 +98,7 @@ pub struct CompletedCapture {
     spans: Vec<CapturedSectionSpan>,
     controlled_tracks: Vec<(TrackId, bool)>,
     mute_changes: Vec<CapturedMuteChange>,
+    performance: CompletedPerformanceLog,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -224,6 +229,12 @@ impl CompletedCapture {
                 .push(lane);
         }
 
+        self.performance.materialize(
+            &mut result,
+            self.clock,
+            self.engine_start_samples,
+            self.engine_end_samples,
+        );
         for content in result.by_track.values_mut() {
             content.clips.sort_by_key(|clip| clip.position);
             content
@@ -246,6 +257,8 @@ pub struct CaptureState {
     prepared_clock: Option<CaptureClock>,
     session: Option<CaptureSession>,
     prepared_controlled_tracks: Vec<(TrackId, bool)>,
+    active_automation_gesture: Option<UndoGestureId>,
+    active_automation_targets: Vec<(TrackId, AutomationTarget)>,
 }
 
 impl CaptureState {
@@ -258,6 +271,46 @@ impl CaptureState {
             .as_ref()
             .map(|session| session.clock.arrange_start_samples)
             .or_else(|| self.prepared_clock.map(|clock| clock.arrange_start_samples))
+    }
+
+    pub fn is_controlled_track(&self, track_id: TrackId) -> bool {
+        self.session.as_ref().is_some_and(|session| {
+            session
+                .controlled_tracks
+                .iter()
+                .any(|(controlled_id, _)| *controlled_id == track_id)
+        })
+    }
+
+    pub fn begin_ui_automation_gesture(
+        &mut self,
+        gesture: UndoGestureId,
+    ) -> Vec<(TrackId, AutomationTarget)> {
+        if self.active_automation_gesture == Some(gesture) {
+            return Vec::new();
+        }
+        let ended = self.end_ui_automation_gesture();
+        self.active_automation_gesture = Some(gesture);
+        ended
+    }
+
+    pub fn register_ui_automation_target(
+        &mut self,
+        track_id: TrackId,
+        target: AutomationTarget,
+    ) -> bool {
+        let target = (track_id, target);
+        if self.active_automation_targets.contains(&target) {
+            false
+        } else {
+            self.active_automation_targets.push(target);
+            true
+        }
+    }
+
+    pub fn end_ui_automation_gesture(&mut self) -> Vec<(TrackId, AutomationTarget)> {
+        self.active_automation_gesture = None;
+        std::mem::take(&mut self.active_automation_targets)
     }
 
     pub fn update(&mut self, msg: CaptureMsg) -> PerformAction {
@@ -317,6 +370,7 @@ impl CaptureState {
             spans: Vec::new(),
             controlled_tracks: std::mem::take(&mut self.prepared_controlled_tracks),
             mute_changes: Vec::new(),
+            performance: PerformanceLog::default(),
         });
         self.phase = CapturePhase::Recording;
     }
@@ -330,7 +384,7 @@ impl CaptureState {
         let Some(session) = &mut self.session else {
             return;
         };
-        if self.phase != CapturePhase::Recording
+        if !matches!(self.phase, CapturePhase::Recording | CapturePhase::Stopping)
             || effective_at_samples < session.engine_start_samples
             || !session
                 .controlled_tracks
@@ -346,7 +400,107 @@ impl CaptureState {
         });
     }
 
+    pub fn input_note(
+        &mut self,
+        track_id: TrackId,
+        pitch: u8,
+        velocity: u8,
+        on: bool,
+        effective_at_samples: u64,
+    ) {
+        let Some(session) = &mut self.session else {
+            return;
+        };
+        if !matches!(self.phase, CapturePhase::Recording | CapturePhase::Stopping)
+            || !session
+                .controlled_tracks
+                .iter()
+                .any(|(controlled_id, _)| *controlled_id == track_id)
+        {
+            return;
+        }
+        session.performance.input_note(
+            track_id,
+            pitch,
+            velocity,
+            on,
+            effective_at_samples,
+            session.engine_start_samples,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn repeated_note(
+        &mut self,
+        track_id: TrackId,
+        pitch: u8,
+        velocity: u8,
+        rate: vibez_core::perform::NoteRepeatRate,
+        effective_at_samples: u64,
+        canonical_at_samples: u64,
+    ) {
+        let Some(session) = &mut self.session else {
+            return;
+        };
+        if !matches!(self.phase, CapturePhase::Recording | CapturePhase::Stopping)
+            || !session
+                .controlled_tracks
+                .iter()
+                .any(|(controlled_id, _)| *controlled_id == track_id)
+        {
+            return;
+        }
+        session.performance.repeated_note(
+            track_id,
+            pitch,
+            velocity,
+            rate,
+            effective_at_samples,
+            canonical_at_samples,
+            session.engine_start_samples,
+            session.clock,
+        );
+    }
+
+    pub fn automation_changed(
+        &mut self,
+        track_id: TrackId,
+        target: AutomationTarget,
+        value: f32,
+        phase: vibez_engine::events::AutomationGesturePhase,
+        effective_at_samples: u64,
+    ) {
+        let Some(session) = &mut self.session else {
+            return;
+        };
+        if !matches!(self.phase, CapturePhase::Recording | CapturePhase::Stopping)
+            || !session
+                .controlled_tracks
+                .iter()
+                .any(|(controlled_id, _)| *controlled_id == track_id)
+        {
+            return;
+        }
+        session.performance.automation_changed(
+            track_id,
+            target,
+            value,
+            phase,
+            effective_at_samples,
+            session.engine_start_samples,
+        );
+    }
+
     pub fn transition(&mut self, source: CapturedSectionSource, effective_at_samples: u64) {
+        self.refresh(source, effective_at_samples, 0);
+    }
+
+    pub fn refresh(
+        &mut self,
+        source: CapturedSectionSource,
+        effective_at_samples: u64,
+        source_start_samples: u64,
+    ) {
         let Some(session) = &mut self.session else {
             return;
         };
@@ -354,7 +508,7 @@ impl CaptureState {
         session.active = Some(ActiveSpan {
             source,
             effective_start_samples: effective_at_samples,
-            source_start_samples: 0,
+            source_start_samples,
         });
     }
 
@@ -364,8 +518,11 @@ impl CaptureState {
             return None;
         };
         close_active_span(&mut session, effective_at_samples);
+        let performance = session.performance.finish(effective_at_samples);
         self.phase = CapturePhase::Idle;
         self.prepared_clock = None;
+        self.active_automation_gesture = None;
+        self.active_automation_targets.clear();
         Some(CompletedCapture {
             clock: session.clock,
             engine_start_samples: session.engine_start_samples,
@@ -373,6 +530,7 @@ impl CaptureState {
             spans: session.spans,
             controlled_tracks: session.controlled_tracks,
             mute_changes: session.mute_changes,
+            performance,
         })
     }
 
@@ -381,6 +539,8 @@ impl CaptureState {
         self.prepared_clock = None;
         self.session = None;
         self.prepared_controlled_tracks.clear();
+        self.active_automation_gesture = None;
+        self.active_automation_targets.clear();
     }
 }
 
@@ -483,6 +643,13 @@ fn append_timeline_window(
                 .note_clips
                 .push(fragment);
         }
+        performance_log::append_automation_window(
+            destination.entry(*track_id).or_default(),
+            content,
+            window_start_beats,
+            window_end_beats,
+            destination_start_beats,
+        );
     }
 }
 
@@ -637,6 +804,40 @@ mod tests {
     }
 
     #[test]
+    fn source_refresh_resnapshots_at_the_exact_local_playhead() {
+        let first = audio_section("Before edit", 4.0, 16);
+        let track_id = *first.timeline.by_track.keys().next().unwrap();
+        let mut refreshed = audio_section("After edit", 4.0, 16);
+        let refreshed_track = *refreshed.timeline.by_track.keys().next().unwrap();
+        let content = Arc::make_mut(&mut refreshed.timeline)
+            .by_track
+            .remove(&refreshed_track)
+            .unwrap();
+        Arc::make_mut(&mut refreshed.timeline)
+            .by_track
+            .insert(track_id, content);
+
+        let mut capture = starting_capture();
+        capture.prepare(0, 8, 120.0);
+        capture.start(0, Some((CapturedSectionSource::from_section(&first), 0)));
+        capture.refresh(CapturedSectionSource::from_section(&refreshed), 4, 4);
+        let materialized = capture.finish(8).unwrap().materialize();
+        let clips = &materialized.by_track[&track_id].clips;
+
+        assert_eq!(clips.len(), 2);
+        assert_eq!(
+            (clips[0].position, clips[0].source_offset, clips[0].duration),
+            (0, 0, 4)
+        );
+        assert_eq!(
+            (clips[1].position, clips[1].source_offset, clips[1].duration),
+            (4, 4, 4)
+        );
+        assert!(clips[0].name.contains("Before edit"));
+        assert!(clips[1].name.contains("After edit"));
+    }
+
+    #[test]
     fn looping_section_is_flattened_into_independent_linear_passes() {
         let mut section = audio_section("Groove A", 1.0, 4);
         section.looping = true;
@@ -682,6 +883,35 @@ mod tests {
             .iter()
             .all(|clip| clip.groove_grid == GrooveGrid::Sixteenth));
         assert!(clips.iter().all(|clip| !source_ids.contains(&clip.id)));
+    }
+
+    #[test]
+    fn coincident_live_and_section_notes_are_both_preserved_without_source_mutation() {
+        let track_id = TrackId::new();
+        let section = midi_section("Layer", track_id, 36);
+        let source_id = section.timeline.get(track_id).unwrap().note_clips[0].id;
+        let mut capture = starting_capture();
+        capture.prepare(0, 8, 120.0);
+        capture.prepare_controlled_tracks([(track_id, false)]);
+        capture.start(0, Some((CapturedSectionSource::from_section(&section), 0)));
+        capture.input_note(track_id, 36, 127, true, 0);
+        capture.input_note(track_id, 36, 0, false, 1);
+
+        let materialized = capture.finish(4).unwrap().materialize();
+        let clips = &materialized.by_track[&track_id].note_clips;
+        assert_eq!(
+            clips
+                .iter()
+                .flat_map(|clip| &clip.notes)
+                .filter(|note| note.pitch == 36)
+                .count(),
+            2
+        );
+        assert_eq!(
+            section.timeline.get(track_id).unwrap().note_clips[0].id,
+            source_id
+        );
+        assert!(clips.iter().all(|clip| clip.id != source_id));
     }
 
     #[test]

--- a/crates/vibez-ui/src/domains/perform/capture/performance_log.rs
+++ b/crates/vibez-ui/src/domains/perform/capture/performance_log.rs
@@ -1,0 +1,620 @@
+//! Live-note and pointer-automation facts captured from engine-effective events.
+
+use std::collections::HashMap;
+
+use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+use vibez_core::id::TrackId;
+use vibez_core::midi::MidiNote;
+use vibez_core::perform::{GrooveGrid, NoteRepeatRate};
+use vibez_engine::events::AutomationGesturePhase;
+
+use crate::state::{TrackTimelineContent, UiNoteClip};
+
+use super::{samples_per_beat, CaptureClock, MaterializedCapture};
+
+const AUTOMATION_THIN_TOLERANCE: f32 = 0.002;
+
+pub(super) fn append_automation_window(
+    destination: &mut TrackTimelineContent,
+    source: &TrackTimelineContent,
+    window_start_beats: f64,
+    window_end_beats: f64,
+    destination_start_beats: f64,
+) {
+    for source_lane in &source.automation {
+        let mut mapped = Vec::new();
+        if let Some(value) = source_lane.value_at(window_start_beats) {
+            mapped.push(AutomationPoint {
+                beat: destination_start_beats,
+                value,
+                curve: 0.0,
+            });
+        }
+        mapped.extend(
+            source_lane
+                .points
+                .iter()
+                .filter(|point| point.beat > window_start_beats && point.beat < window_end_beats)
+                .map(|point| AutomationPoint {
+                    beat: destination_start_beats + point.beat - window_start_beats,
+                    ..*point
+                }),
+        );
+        if let Some(value) = source_lane.value_at(window_end_beats) {
+            mapped.push(AutomationPoint {
+                beat: destination_start_beats + window_end_beats - window_start_beats,
+                value,
+                curve: 0.0,
+            });
+        }
+        if mapped.is_empty() {
+            continue;
+        }
+        let lane_index = destination
+            .automation
+            .iter()
+            .position(|lane| lane.target == source_lane.target)
+            .unwrap_or_else(|| {
+                destination
+                    .automation
+                    .push(AutomationLane::new(source_lane.target));
+                destination.automation.len() - 1
+            });
+        let lane = &mut destination.automation[lane_index];
+        for point in mapped {
+            lane.insert_point(point);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OpenNote {
+    track_id: TrackId,
+    pitch: u8,
+    velocity: u8,
+    effective_at_samples: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CapturedLiveNote {
+    track_id: TrackId,
+    pitch: u8,
+    velocity: u8,
+    start_samples: u64,
+    end_samples: u64,
+    heard_at_samples: u64,
+    groove_grid: GrooveGrid,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CapturedAutomationEvent {
+    track_id: TrackId,
+    target: AutomationTarget,
+    value: f32,
+    phase: AutomationGesturePhase,
+    effective_at_samples: u64,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct PerformanceLog {
+    open_notes: Vec<OpenNote>,
+    notes: Vec<CapturedLiveNote>,
+    automation: Vec<CapturedAutomationEvent>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct CompletedPerformanceLog {
+    notes: Vec<CapturedLiveNote>,
+    automation: Vec<CapturedAutomationEvent>,
+}
+
+impl PerformanceLog {
+    pub(super) fn input_note(
+        &mut self,
+        track_id: TrackId,
+        pitch: u8,
+        velocity: u8,
+        on: bool,
+        effective_at_samples: u64,
+        capture_start_samples: u64,
+    ) {
+        if effective_at_samples < capture_start_samples {
+            return;
+        }
+        if on {
+            self.open_notes.push(OpenNote {
+                track_id,
+                pitch,
+                velocity,
+                effective_at_samples,
+            });
+        } else if let Some(index) = self
+            .open_notes
+            .iter()
+            .rposition(|note| note.track_id == track_id && note.pitch == pitch)
+        {
+            let note = self.open_notes.remove(index);
+            self.notes.push(CapturedLiveNote {
+                track_id,
+                pitch,
+                velocity: note.velocity,
+                start_samples: note.effective_at_samples,
+                end_samples: effective_at_samples.max(note.effective_at_samples + 1),
+                heard_at_samples: note.effective_at_samples,
+                groove_grid: GrooveGrid::Off,
+            });
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn repeated_note(
+        &mut self,
+        track_id: TrackId,
+        pitch: u8,
+        velocity: u8,
+        rate: NoteRepeatRate,
+        effective_at_samples: u64,
+        canonical_at_samples: u64,
+        capture_start_samples: u64,
+        clock: CaptureClock,
+    ) {
+        if effective_at_samples < capture_start_samples {
+            return;
+        }
+        let duration = (rate.interval_beats() * samples_per_beat(clock.sample_rate, clock.bpm))
+            .round()
+            .max(1.0) as u64;
+        self.notes.push(CapturedLiveNote {
+            track_id,
+            pitch,
+            velocity,
+            start_samples: canonical_at_samples,
+            end_samples: canonical_at_samples.saturating_add(duration),
+            heard_at_samples: effective_at_samples,
+            groove_grid: match rate {
+                NoteRepeatRate::Eighth => GrooveGrid::Eighth,
+                NoteRepeatRate::Sixteenth => GrooveGrid::Sixteenth,
+                _ => GrooveGrid::Off,
+            },
+        });
+    }
+
+    pub(super) fn automation_changed(
+        &mut self,
+        track_id: TrackId,
+        target: AutomationTarget,
+        value: f32,
+        phase: AutomationGesturePhase,
+        effective_at_samples: u64,
+        capture_start_samples: u64,
+    ) {
+        if effective_at_samples < capture_start_samples || target == AutomationTarget::TrackMute {
+            return;
+        }
+        self.automation.push(CapturedAutomationEvent {
+            track_id,
+            target,
+            value: value.clamp(0.0, 1.0),
+            phase,
+            effective_at_samples,
+        });
+    }
+
+    pub(super) fn finish(mut self, effective_at_samples: u64) -> CompletedPerformanceLog {
+        for note in self.open_notes.drain(..) {
+            if note.effective_at_samples < effective_at_samples {
+                self.notes.push(CapturedLiveNote {
+                    track_id: note.track_id,
+                    pitch: note.pitch,
+                    velocity: note.velocity,
+                    start_samples: note.effective_at_samples,
+                    end_samples: effective_at_samples,
+                    heard_at_samples: note.effective_at_samples,
+                    groove_grid: GrooveGrid::Off,
+                });
+            }
+        }
+        CompletedPerformanceLog {
+            notes: self.notes,
+            automation: self.automation,
+        }
+    }
+}
+
+impl CompletedPerformanceLog {
+    pub(super) fn materialize(
+        &self,
+        result: &mut MaterializedCapture,
+        clock: CaptureClock,
+        engine_start_samples: u64,
+        engine_end_samples: u64,
+    ) {
+        self.materialize_notes(result, clock, engine_start_samples, engine_end_samples);
+        self.materialize_automation(result, clock, engine_start_samples, engine_end_samples);
+    }
+
+    fn materialize_notes(
+        &self,
+        result: &mut MaterializedCapture,
+        clock: CaptureClock,
+        engine_start_samples: u64,
+        engine_end_samples: u64,
+    ) {
+        let spb = result.samples_per_beat;
+        let clip_position_beats = result.arrange_start_samples as f64 / spb;
+        let clip_duration_beats = result
+            .arrange_end_samples
+            .saturating_sub(result.arrange_start_samples) as f64
+            / spb;
+        let mut grouped: HashMap<(TrackId, GrooveGrid), Vec<MidiNote>> = HashMap::new();
+        for note in &self.notes {
+            if note.heard_at_samples < engine_start_samples
+                || note.heard_at_samples >= engine_end_samples
+            {
+                continue;
+            }
+            let start = note.start_samples.max(engine_start_samples);
+            let end = note.end_samples.min(engine_end_samples);
+            if end <= start {
+                continue;
+            }
+            grouped
+                .entry((note.track_id, note.groove_grid))
+                .or_default()
+                .push(MidiNote {
+                    pitch: note.pitch,
+                    velocity: note.velocity,
+                    start_beat: start.saturating_sub(engine_start_samples) as f64 / spb,
+                    duration_beats: (end - start) as f64 / spb,
+                });
+        }
+        for ((track_id, groove_grid), mut notes) in grouped {
+            notes.sort_by(|left, right| {
+                left.start_beat
+                    .total_cmp(&right.start_beat)
+                    .then(left.pitch.cmp(&right.pitch))
+            });
+            result
+                .by_track
+                .entry(track_id)
+                .or_default()
+                .note_clips
+                .push(UiNoteClip {
+                    id: vibez_core::id::ClipId::new(),
+                    name: match groove_grid {
+                        GrooveGrid::Off => "Capture · Live notes",
+                        GrooveGrid::Eighth => "Capture · Note Repeat · 1/8",
+                        GrooveGrid::Sixteenth => "Capture · Note Repeat · 1/16",
+                    }
+                    .into(),
+                    position_beats: clip_position_beats,
+                    duration_beats: clip_duration_beats,
+                    notes,
+                    selected_notes: Default::default(),
+                    loop_enabled: false,
+                    loop_start_beats: 0.0,
+                    loop_end_beats: 0.0,
+                    groove_grid,
+                });
+        }
+        let _ = clock;
+    }
+
+    fn materialize_automation(
+        &self,
+        result: &mut MaterializedCapture,
+        _clock: CaptureClock,
+        engine_start_samples: u64,
+        engine_end_samples: u64,
+    ) {
+        let mut grouped: HashMap<(TrackId, AutomationTarget), Vec<CapturedAutomationEvent>> =
+            HashMap::new();
+        for event in &self.automation {
+            if event.effective_at_samples >= engine_start_samples
+                && event.effective_at_samples <= engine_end_samples
+            {
+                grouped
+                    .entry((event.track_id, event.target))
+                    .or_default()
+                    .push(*event);
+            }
+        }
+        for ((track_id, target), mut events) in grouped {
+            events.sort_by_key(|event| event.effective_at_samples);
+            let content = result.by_track.entry(track_id).or_default();
+            let lane_index = content
+                .automation
+                .iter()
+                .position(|lane| lane.target == target)
+                .unwrap_or_else(|| {
+                    content.automation.push(AutomationLane::new(target));
+                    content.automation.len() - 1
+                });
+            apply_gestures_to_lane(
+                &mut content.automation[lane_index],
+                &events,
+                result.arrange_start_samples,
+                result.arrange_end_samples,
+                engine_start_samples,
+                engine_end_samples,
+                result.samples_per_beat,
+            );
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_gestures_to_lane(
+    lane: &mut AutomationLane,
+    events: &[CapturedAutomationEvent],
+    arrange_start_samples: u64,
+    arrange_end_samples: u64,
+    engine_start_samples: u64,
+    engine_end_samples: u64,
+    samples_per_beat: f64,
+) {
+    let to_beat = |effective: u64| {
+        arrange_start_samples.saturating_add(effective.saturating_sub(engine_start_samples)) as f64
+            / samples_per_beat
+    };
+    let capture_start_beat = arrange_start_samples as f64 / samples_per_beat;
+    let capture_end_beat = arrange_end_samples as f64 / samples_per_beat;
+    let epsilon = 1.0 / samples_per_beat;
+    let mut index = 0;
+    while index < events.len() {
+        while index < events.len() && events[index].phase != AutomationGesturePhase::Begin {
+            index += 1;
+        }
+        if index == events.len() {
+            break;
+        }
+        let start_index = index;
+        index += 1;
+        while index < events.len()
+            && events[index].phase != AutomationGesturePhase::End
+            && events[index].phase != AutomationGesturePhase::Begin
+        {
+            index += 1;
+        }
+        let end_event = (index < events.len()
+            && events[index].phase == AutomationGesturePhase::End)
+            .then_some(events[index]);
+        let end_index = end_event.map_or(index, |_| index + 1);
+        let start_beat = to_beat(events[start_index].effective_at_samples);
+        let end_beat = end_event
+            .map(|event| to_beat(event.effective_at_samples))
+            .unwrap_or(capture_end_beat);
+        let baseline_before = lane
+            .value_at((start_beat - epsilon).max(capture_start_beat))
+            .unwrap_or(events[start_index].value);
+        let baseline_after = end_event
+            .map(|event| event.value)
+            .or_else(|| lane.value_at(end_beat))
+            .unwrap_or(events[end_index.saturating_sub(1)].value);
+        lane.points
+            .retain(|point| point.beat < start_beat || point.beat >= end_beat);
+        lane.insert_point(AutomationPoint {
+            beat: (start_beat - epsilon).max(capture_start_beat),
+            value: baseline_before,
+            curve: 0.0,
+        });
+        let gesture_end = end_event.map_or(index, |_| index);
+        let raw: Vec<_> = events[start_index..gesture_end]
+            .iter()
+            .map(|event| (to_beat(event.effective_at_samples), event.value))
+            .collect();
+        for (beat, value) in thin_points(&raw, AUTOMATION_THIN_TOLERANCE) {
+            lane.insert_point(AutomationPoint {
+                beat,
+                value,
+                curve: 0.0,
+            });
+        }
+        if let Some(last) = raw.last() {
+            lane.insert_point(AutomationPoint {
+                beat: (end_beat - epsilon).max(start_beat),
+                value: last.1,
+                curve: 0.0,
+            });
+        }
+        lane.insert_point(AutomationPoint {
+            beat: end_beat.min(capture_end_beat),
+            value: baseline_after,
+            curve: 0.0,
+        });
+        index = end_index;
+        if end_beat >= to_beat(engine_end_samples) {
+            break;
+        }
+    }
+}
+
+fn thin_points(points: &[(f64, f32)], tolerance: f32) -> Vec<(f64, f32)> {
+    if points.len() <= 2 {
+        return points.to_vec();
+    }
+    let mut keep = vec![false; points.len()];
+    keep[0] = true;
+    keep[points.len() - 1] = true;
+    thin_range(points, tolerance, 0, points.len() - 1, &mut keep);
+    points
+        .iter()
+        .copied()
+        .zip(keep)
+        .filter_map(|(point, keep)| keep.then_some(point))
+        .collect()
+}
+
+fn thin_range(points: &[(f64, f32)], tolerance: f32, start: usize, end: usize, keep: &mut [bool]) {
+    if end <= start + 1 {
+        return;
+    }
+    let (start_x, start_y) = points[start];
+    let (end_x, end_y) = points[end];
+    let span = (end_x - start_x).max(f64::EPSILON);
+    let mut worst = (0.0f32, start);
+    for (offset, (x, y)) in points[start + 1..end].iter().copied().enumerate() {
+        let t = ((x - start_x) / span) as f32;
+        let error = (y - (start_y + (end_y - start_y) * t)).abs();
+        if error > worst.0 {
+            worst = (error, start + 1 + offset);
+        }
+    }
+    if worst.0 > tolerance {
+        keep[worst.1] = true;
+        thin_range(points, tolerance, start, worst.1, keep);
+        thin_range(points, tolerance, worst.1, end, keep);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn materialized() -> MaterializedCapture {
+        MaterializedCapture {
+            arrange_start_samples: 200,
+            arrange_end_samples: 600,
+            samples_per_beat: 100.0,
+            ..MaterializedCapture::default()
+        }
+    }
+
+    #[test]
+    fn free_repeat_and_stop_truncated_notes_keep_their_audible_facts() {
+        let track_id = TrackId::new();
+        let clock = CaptureClock {
+            arrange_start_samples: 200,
+            sample_rate: 100,
+            bpm: 60.0,
+        };
+        let mut log = PerformanceLog::default();
+        // This onset preceded Capture, so its later release must not create a note.
+        log.input_note(track_id, 30, 90, true, 999, 1_000);
+        log.input_note(track_id, 30, 0, false, 1_050, 1_000);
+        log.input_note(track_id, 36, 101, true, 1_050, 1_000);
+        log.input_note(track_id, 36, 0, false, 1_150, 1_000);
+        log.repeated_note(
+            track_id,
+            36,
+            88,
+            NoteRepeatRate::Sixteenth,
+            1_200,
+            1_180,
+            1_000,
+            clock,
+        );
+        log.input_note(track_id, 40, 77, true, 1_300, 1_000);
+
+        let completed = log.finish(1_400);
+        let mut result = materialized();
+        completed.materialize(&mut result, clock, 1_000, 1_400);
+
+        let clips = &result.by_track[&track_id].note_clips;
+        assert_eq!(clips.len(), 2);
+        let free = clips
+            .iter()
+            .find(|clip| clip.groove_grid == GrooveGrid::Off)
+            .unwrap();
+        assert_eq!(free.notes.len(), 2);
+        assert_eq!(
+            (
+                free.notes[0].pitch,
+                free.notes[0].velocity,
+                free.notes[0].start_beat,
+                free.notes[0].duration_beats,
+            ),
+            (36, 101, 0.5, 1.0)
+        );
+        assert_eq!(
+            (
+                free.notes[1].pitch,
+                free.notes[1].start_beat,
+                free.notes[1].duration_beats,
+            ),
+            (40, 3.0, 1.0)
+        );
+        let repeated = clips
+            .iter()
+            .find(|clip| clip.groove_grid == GrooveGrid::Sixteenth)
+            .unwrap();
+        assert_eq!(repeated.notes[0].pitch, 36);
+        assert_eq!(repeated.notes[0].velocity, 88);
+        assert!((repeated.notes[0].start_beat - 1.8).abs() < 1e-6);
+        assert!((repeated.notes[0].duration_beats - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn copied_baseline_keeps_edges_and_internal_shape() {
+        let mut source = TrackTimelineContent::default();
+        let mut lane = AutomationLane::new(AutomationTarget::TrackGain);
+        for (beat, value) in [(0.0, 0.1), (2.0, 0.5), (4.0, 0.9)] {
+            lane.insert_point(AutomationPoint {
+                beat,
+                value,
+                curve: 0.0,
+            });
+        }
+        source.automation.push(lane);
+        let mut destination = TrackTimelineContent::default();
+
+        append_automation_window(&mut destination, &source, 1.0, 3.0, 8.0);
+
+        let lane = &destination.automation[0];
+        assert!((lane.value_at(8.0).unwrap() - 0.3).abs() < 1e-6);
+        assert!((lane.value_at(9.0).unwrap() - 0.5).abs() < 1e-6);
+        assert!((lane.value_at(10.0).unwrap() - 0.7).abs() < 1e-6);
+    }
+
+    #[test]
+    fn linear_fit_thinning_keeps_shape_changes_and_drops_redundant_points() {
+        let thinned = thin_points(&[(0.0, 0.0), (1.0, 0.25), (2.0, 0.5), (3.0, 0.9)], 0.01);
+        assert_eq!(thinned, [(0.0, 0.0), (2.0, 0.5), (3.0, 0.9)]);
+    }
+
+    #[test]
+    fn gesture_splice_pins_baseline_and_yields_back() {
+        let track_id = TrackId::new();
+        let events = [
+            CapturedAutomationEvent {
+                track_id,
+                target: AutomationTarget::TrackPan,
+                value: 0.8,
+                phase: AutomationGesturePhase::Begin,
+                effective_at_samples: 200,
+            },
+            CapturedAutomationEvent {
+                track_id,
+                target: AutomationTarget::TrackPan,
+                value: 0.9,
+                phase: AutomationGesturePhase::Update,
+                effective_at_samples: 250,
+            },
+            CapturedAutomationEvent {
+                track_id,
+                target: AutomationTarget::TrackPan,
+                value: 0.25,
+                phase: AutomationGesturePhase::End,
+                effective_at_samples: 300,
+            },
+        ];
+        let mut lane = AutomationLane::new(AutomationTarget::TrackPan);
+        lane.insert_point(AutomationPoint {
+            beat: 0.0,
+            value: 0.25,
+            curve: 0.0,
+        });
+        lane.insert_point(AutomationPoint {
+            beat: 10.0,
+            value: 0.25,
+            curve: 0.0,
+        });
+
+        apply_gestures_to_lane(&mut lane, &events, 0, 1_000, 0, 1_000, 100.0);
+
+        assert!((lane.value_at(1.99).unwrap() - 0.25).abs() < 1e-6);
+        assert!((lane.value_at(2.0).unwrap() - 0.8).abs() < 1e-6);
+        assert!((lane.value_at(2.5).unwrap() - 0.9).abs() < 1e-6);
+        assert!((lane.value_at(3.0).unwrap() - 0.25).abs() < 1e-6);
+    }
+}

--- a/crates/vibez-ui/src/widgets/swing_knob.rs
+++ b/crates/vibez-ui/src/widgets/swing_knob.rs
@@ -55,10 +55,14 @@ pub struct SwingKnobWidget {
 
 impl SwingKnobWidget {
     pub fn project(value: SwingAmount) -> Self {
+        Self::project_locked(value, false)
+    }
+
+    pub fn project_locked(value: SwingAmount, locked: bool) -> Self {
         Self {
             target: SwingTarget::Project,
             effective_value: value.get(),
-            automated: false,
+            automated: locked,
         }
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,6 +214,28 @@ one undo step. Track Mute events join the Capture log at their engine-effective
 samples and materialize as `track_mute` step points with a closing point that
 restores the pre-take manual state.
 
+Live Instrument input and pointer automation join that same engine-timestamped
+Capture log. Free notes retain their audible onset, velocity, and duration with
+Groove Grid Off; Note Repeat retains the canonical straight-clock onset and
+matching Groove Grid so Track Swing is applied exactly once. Notes already held
+at the Capture boundary are excluded, open notes truncate at stop, and live
+notes remain independent from coincident Section notes and Section Record's
+quantized copy. A resident Section source refresh reports both its exact
+Perform timestamp and local Section playhead so Capture can close the old span
+and re-snapshot the newly audible source without rewriting earlier passes.
+
+On Perform-controlled Project Tracks, the resident Section automation is the
+baseline while a pointer gesture temporarily owns its target. The audio thread
+stores active target ownership in fixed-capacity channel-strip state, so
+automation evaluation cannot overwrite gain, pan, Track Swing, or device
+parameters during the gesture. Gesture events carry effective values and
+sample timestamps back to Capture; materialization thins each curve, pins the
+copied baseline around the gesture, and writes an immediate yield-back step on
+release. Transport Stop ends active ownership before closing Capture. Arrange
+automation remains suspended for those resident tracks and stays active on
+tracks outside Perform. Project Swing is locked for the whole Capture session
+because Capture has no master Project Swing lane.
+
 The project document persists the immutable `mpc_2000xl_v1` Groove Profile,
 Project Swing, and optional Project Track Swing offsets as canonical project
 data and undo state. Swing uses the profile's native `50..75%` long/short pair


### PR DESCRIPTION
## Summary
- capture free notes and Note Repeat into independent Arrange clips using engine-effective and canonical timing
- splice thinned gain, pan, Track Swing, and effect gestures into copied Section automation with explicit live ownership and yield-back
- timestamp resident Section refreshes, lock Project Swing during Capture, and preserve the one-step punch-replace transaction

## Verification
- cargo fmt --all -- --check
- cargo clippy -p vibez-core -p vibez-engine -p vibez-ui --lib -j 4 -- -D warnings
- cargo test --workspace -j 4 (866 tests green)
- isolated native dogfood on Xvfb :96: free notes, 1/16 Note Repeat, HMF gain gesture, Arrange and automation audit
- touched Rust files below 1,000 lines

## Evidence
/home/alexander/Code/Apps/vibez-demo-artifacts/card-19-live-notes-automation/EVIDENCE.md