### PR TITLE
Perform Card 39: quantize Track Mute pad gestures

### DIFF
--- a/crates/vibez-core/src/perform.rs
+++ b/crates/vibez-core/src/perform.rs
@@ -325,6 +325,43 @@ mod groove_tests {
     }
 }
 
+/// Reusable musical grid boundary for deferred Perform actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MusicalBoundary {
+    #[default]
+    Immediate,
+    OneBeat,
+    OneBar,
+}
+
+impl MusicalBoundary {
+    pub const ALL: [Self; 3] = [Self::Immediate, Self::OneBeat, Self::OneBar];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Immediate => "Immediate",
+            Self::OneBeat => "1 Beat",
+            Self::OneBar => "1 Bar",
+        }
+    }
+
+    /// Grid size for deferred boundaries. Immediate has no future grid.
+    pub const fn beats(self) -> Option<f64> {
+        match self {
+            Self::Immediate => None,
+            Self::OneBeat => Some(1.0),
+            Self::OneBar => Some(4.0),
+        }
+    }
+}
+
+impl std::fmt::Display for MusicalBoundary {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.label())
+    }
+}
+
 /// Musical boundary at which a resident Section launch becomes effective.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -345,11 +382,19 @@ impl SectionLaunchQuantization {
     ];
 
     pub const fn label(self) -> &'static str {
+        if let Some(boundary) = self.musical_boundary() {
+            boundary.label()
+        } else {
+            "End of Section"
+        }
+    }
+
+    pub const fn musical_boundary(self) -> Option<MusicalBoundary> {
         match self {
-            Self::Immediate => "Immediate",
-            Self::OneBeat => "1 Beat",
-            Self::OneBar => "1 Bar",
-            Self::EndOfSection => "End of Section",
+            Self::Immediate => Some(MusicalBoundary::Immediate),
+            Self::OneBeat => Some(MusicalBoundary::OneBeat),
+            Self::OneBar => Some(MusicalBoundary::OneBar),
+            Self::EndOfSection => None,
         }
     }
 }
@@ -360,37 +405,23 @@ impl std::fmt::Display for SectionLaunchQuantization {
     }
 }
 
-/// Musical boundary at which a live Track Mute Pad Gesture becomes effective.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TrackMuteQuantization {
-    #[default]
-    Immediate,
-    OneBeat,
-    OneBar,
-}
-
-impl TrackMuteQuantization {
-    pub const ALL: [Self; 3] = [Self::Immediate, Self::OneBeat, Self::OneBar];
-
-    pub const fn label(self) -> &'static str {
-        match self {
-            Self::Immediate => "Immediate",
-            Self::OneBeat => "1 Beat",
-            Self::OneBar => "1 Bar",
-        }
-    }
-}
-
-impl std::fmt::Display for TrackMuteQuantization {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(self.label())
-    }
-}
+/// Track Mutes accept every reusable grid boundary and no Section-only policy.
+pub type TrackMuteQuantization = MusicalBoundary;
 
 #[cfg(test)]
 mod track_mute_quantization_tests {
     use super::*;
+
+    #[test]
+    fn section_launch_and_track_mute_share_one_musical_boundary_descriptor() {
+        assert_eq!(MusicalBoundary::Immediate.beats(), None);
+        assert_eq!(MusicalBoundary::OneBeat.beats(), Some(1.0));
+        assert_eq!(MusicalBoundary::OneBar.beats(), Some(4.0));
+        assert_eq!(
+            SectionLaunchQuantization::OneBar.musical_boundary(),
+            Some(MusicalBoundary::OneBar)
+        );
+    }
 
     #[test]
     fn immediate_is_the_stable_compatibility_default() {

--- a/crates/vibez-core/src/perform.rs
+++ b/crates/vibez-core/src/perform.rs
@@ -359,3 +359,52 @@ impl std::fmt::Display for SectionLaunchQuantization {
         formatter.write_str(self.label())
     }
 }
+
+/// Musical boundary at which a live Track Mute Pad Gesture becomes effective.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackMuteQuantization {
+    #[default]
+    Immediate,
+    OneBeat,
+    OneBar,
+}
+
+impl TrackMuteQuantization {
+    pub const ALL: [Self; 3] = [Self::Immediate, Self::OneBeat, Self::OneBar];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Immediate => "Immediate",
+            Self::OneBeat => "1 Beat",
+            Self::OneBar => "1 Bar",
+        }
+    }
+}
+
+impl std::fmt::Display for TrackMuteQuantization {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.label())
+    }
+}
+
+#[cfg(test)]
+mod track_mute_quantization_tests {
+    use super::*;
+
+    #[test]
+    fn immediate_is_the_stable_compatibility_default() {
+        assert_eq!(
+            TrackMuteQuantization::default(),
+            TrackMuteQuantization::Immediate
+        );
+        assert_eq!(
+            TrackMuteQuantization::ALL.map(TrackMuteQuantization::label),
+            ["Immediate", "1 Beat", "1 Bar"]
+        );
+        assert_eq!(
+            serde_json::to_string(&TrackMuteQuantization::OneBar).unwrap(),
+            "\"one_bar\""
+        );
+    }
+}

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -4,7 +4,9 @@ use vibez_core::effect::EffectType;
 use vibez_core::id::{ClipId, EffectId, TrackId};
 use vibez_core::midi::{InstrumentKind, MidiNote};
 use vibez_core::perform::SectionLaunchQuantization;
-use vibez_core::perform::{GrooveGrid, NoteRepeatRate, SwingAmount, SwingOffset};
+use vibez_core::perform::{
+    GrooveGrid, NoteRepeatRate, SwingAmount, SwingOffset, TrackMuteQuantization,
+};
 use vibez_core::track::DrumPadState;
 use vibez_dsp::effect::AudioEffect;
 use vibez_instruments::Instrument;
@@ -126,6 +128,12 @@ pub enum EngineCommand {
     SetTrackPan(TrackId, f32),
     /// Set the mute state for a track.
     SetTrackMute(TrackId, bool),
+    /// Queue a live Track Mute for an engine-owned musical boundary.
+    QueueTrackMute {
+        track_id: TrackId,
+        muted: bool,
+        quantization: TrackMuteQuantization,
+    },
     /// Enable or clear a manual override for one automated parameter.
     SetAutomationOverride {
         track_id: TrackId,

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -349,6 +349,7 @@ impl AudioEngine {
         }
         if section_ended {
             self.stop_section_record();
+            self.cancel_queued_track_mutes();
             let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
                 effective_at_samples: self.performance_position,
             });

--- a/crates/vibez-engine/src/engine_automation_commands.rs
+++ b/crates/vibez-engine/src/engine_automation_commands.rs
@@ -106,11 +106,9 @@ impl AudioEngine {
             return;
         }
 
-        let beats = match quantization {
-            TrackMuteQuantization::Immediate => 0.0,
-            TrackMuteQuantization::OneBeat => 1.0,
-            TrackMuteQuantization::OneBar => 4.0,
-        };
+        let beats = quantization
+            .beats()
+            .expect("Immediate Track Mutes return before boundary resolution");
         let effective_at_samples = self.next_grid_boundary(now, beats);
         if effective_at_samples <= now {
             let _ = self.event_tx.push(EngineEvent::TrackMuteQueued {

--- a/crates/vibez-engine/src/engine_automation_commands.rs
+++ b/crates/vibez-engine/src/engine_automation_commands.rs
@@ -3,8 +3,10 @@
 use vibez_core::automation::AutomationTarget;
 use vibez_core::id::{EffectId, TrackId};
 use vibez_core::perform::SwingOffset;
+use vibez_core::perform::TrackMuteQuantization;
 
 use crate::events::{AutomationGesturePhase, EngineEvent};
+use crate::mixer::QueuedTrackMute;
 
 use super::AudioEngine;
 
@@ -43,8 +45,21 @@ impl AudioEngine {
 
     pub(super) fn set_track_mute(&mut self, id: TrackId, muted: bool) {
         let effective_at_samples = self.effective_position();
+        let cancelled = self
+            .channel_mut(id)
+            .is_some_and(|track| track.queued_mute.take().is_some());
+        if cancelled {
+            let _ = self
+                .event_tx
+                .push(EngineEvent::TrackMuteQueueCancelled { track_id: id });
+        }
+        self.apply_track_mute_at(id, muted, effective_at_samples);
+    }
+
+    fn apply_track_mute_at(&mut self, id: TrackId, muted: bool, effective_at_samples: u64) {
         let playing = self.transport.is_playing();
         let (changed, override_changed) = if let Some(track) = self.channel_mut(id) {
+            track.queued_mute = None;
             let target = AutomationTarget::TrackMute;
             let override_changed =
                 track.has_automation_target(target) && track.set_automation_override(target, true);
@@ -66,6 +81,85 @@ impl AudioEngine {
                 target: AutomationTarget::TrackMute,
                 overridden: true,
             });
+        }
+    }
+
+    pub(super) fn queue_track_mute(
+        &mut self,
+        track_id: TrackId,
+        muted: bool,
+        quantization: TrackMuteQuantization,
+    ) {
+        let now = self.effective_position();
+        if quantization == TrackMuteQuantization::Immediate || !self.transport.is_playing() {
+            self.apply_track_mute_at(track_id, muted, now);
+            return;
+        }
+
+        let Some(track) = self.channel_mut(track_id) else {
+            return;
+        };
+        if track.queued_mute.take().is_some() {
+            let _ = self
+                .event_tx
+                .push(EngineEvent::TrackMuteQueueCancelled { track_id });
+            return;
+        }
+
+        let beats = match quantization {
+            TrackMuteQuantization::Immediate => 0.0,
+            TrackMuteQuantization::OneBeat => 1.0,
+            TrackMuteQuantization::OneBar => 4.0,
+        };
+        let effective_at_samples = self.next_grid_boundary(now, beats);
+        if effective_at_samples <= now {
+            let _ = self.event_tx.push(EngineEvent::TrackMuteQueued {
+                track_id,
+                muted,
+                effective_at_samples: now,
+            });
+            self.apply_track_mute_at(track_id, muted, now);
+            return;
+        }
+        let Some(track) = self.channel_mut(track_id) else {
+            return;
+        };
+        track.queued_mute = Some(QueuedTrackMute {
+            muted,
+            effective_at_samples,
+        });
+        let _ = self.event_tx.push(EngineEvent::TrackMuteQueued {
+            track_id,
+            muted,
+            effective_at_samples,
+        });
+    }
+
+    pub(super) fn next_track_mute_boundary(&self) -> Option<u64> {
+        self.tracks
+            .iter()
+            .filter_map(|track| track.queued_mute.map(|queued| queued.effective_at_samples))
+            .min()
+    }
+
+    pub(super) fn apply_track_mutes_due(&mut self, at_samples: u64) {
+        while let Some((track_id, queued)) = self.tracks.iter().find_map(|track| {
+            track
+                .queued_mute
+                .filter(|queued| queued.effective_at_samples <= at_samples)
+                .map(|queued| (track.id, queued))
+        }) {
+            self.apply_track_mute_at(track_id, queued.muted, queued.effective_at_samples);
+        }
+    }
+
+    pub(super) fn cancel_queued_track_mutes(&mut self) {
+        for track in &mut self.tracks {
+            if track.queued_mute.take().is_some() {
+                let _ = self
+                    .event_tx
+                    .push(EngineEvent::TrackMuteQueueCancelled { track_id: track.id });
+            }
         }
     }
 

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -26,6 +26,7 @@ impl AudioEngine {
                     self.clock_domain = ClockDomain::Arrange;
                     self.performance_position = self.transport.position();
                     self.cancel_section_queue();
+                    self.cancel_queued_track_mutes();
                     self.active_section = None;
                     self.transport
                         .set_audio_length(self.arrangement_audio_length);
@@ -311,6 +312,13 @@ impl AudioEngine {
                 }
                 EngineCommand::SetTrackMute(id, mute) => {
                     self.set_track_mute(id, mute);
+                }
+                EngineCommand::QueueTrackMute {
+                    track_id,
+                    muted,
+                    quantization,
+                } => {
+                    self.queue_track_mute(track_id, muted, quantization);
                 }
                 EngineCommand::SetAutomationOverride {
                     track_id,

--- a/crates/vibez-engine/src/engine_mute_event_tests.rs
+++ b/crates/vibez-engine/src/engine_mute_event_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use vibez_core::id::TrackId;
+use vibez_core::perform::TrackMuteQuantization;
 
 #[test]
 fn mute_change_reports_engine_effective_state_and_sample_time() {
@@ -28,5 +29,278 @@ fn mute_change_reports_engine_effective_state_and_sample_time() {
             muted: true,
             effective_at_samples: 4,
         }) if event_track == track_id
+    ));
+}
+
+#[test]
+fn one_beat_mute_becomes_effective_at_the_exact_engine_boundary() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    cmd_tx.push(EngineCommand::SetSampleRate(8)).unwrap();
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx
+        .push(EngineCommand::AddTrack(track_id, "Track 1".into()))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    engine.process(&mut [0.0], 1);
+    while event_rx.pop().is_ok() {}
+
+    cmd_tx
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::OneBeat,
+        })
+        .unwrap();
+    engine.process(&mut [0.0; 7], 1);
+
+    let effective = std::iter::from_fn(|| event_rx.pop().ok()).find_map(|event| match event {
+        EngineEvent::TrackMuteChanged {
+            track_id: event_track,
+            muted,
+            effective_at_samples,
+        } if event_track == track_id => Some((muted, effective_at_samples)),
+        _ => None,
+    });
+    assert_eq!(effective, Some((true, 4)));
+    assert!(engine.tracks()[0].mute);
+}
+
+#[test]
+fn second_quantized_gesture_cancels_without_changing_effective_mute() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    cmd_tx.push(EngineCommand::SetSampleRate(8)).unwrap();
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx
+        .push(EngineCommand::AddTrack(track_id, "Track 1".into()))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    engine.process(&mut [0.0], 1);
+    while event_rx.pop().is_ok() {}
+
+    for _ in 0..2 {
+        cmd_tx
+            .push(EngineCommand::QueueTrackMute {
+                track_id,
+                muted: true,
+                quantization: TrackMuteQuantization::OneBeat,
+            })
+            .unwrap();
+    }
+    engine.process(&mut [0.0; 7], 1);
+
+    let events: Vec<_> = std::iter::from_fn(|| event_rx.pop().ok()).collect();
+    assert!(events.iter().any(|event| matches!(
+        event,
+        EngineEvent::TrackMuteQueueCancelled {
+            track_id: event_track
+        } if *event_track == track_id
+    )));
+    assert!(!events.iter().any(|event| matches!(
+        event,
+        EngineEvent::TrackMuteChanged {
+            track_id: event_track,
+            ..
+        } if *event_track == track_id
+    )));
+    assert!(!engine.tracks()[0].mute);
+}
+
+#[test]
+fn quantized_choice_applies_immediately_while_stopped() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(track_id, "Track 1".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::OneBar,
+        })
+        .unwrap();
+
+    engine.process(&mut [0.0], 1);
+
+    let events: Vec<_> = std::iter::from_fn(|| event_rx.pop().ok()).collect();
+    assert!(events.iter().any(|event| matches!(
+        event,
+        EngineEvent::TrackMuteChanged {
+            track_id: event_track,
+            muted: true,
+            effective_at_samples: 0,
+        } if *event_track == track_id
+    )));
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, EngineEvent::TrackMuteQueued { .. })));
+    assert!(engine.tracks()[0].mute);
+}
+
+#[test]
+fn one_bar_mute_uses_the_next_bar_boundary() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    cmd_tx.push(EngineCommand::SetSampleRate(8)).unwrap();
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx
+        .push(EngineCommand::AddTrack(track_id, "Track 1".into()))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    engine.process(&mut [0.0], 1);
+    while event_rx.pop().is_ok() {}
+
+    cmd_tx
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::OneBar,
+        })
+        .unwrap();
+    engine.process(&mut [0.0; 20], 1);
+
+    assert!(
+        std::iter::from_fn(|| event_rx.pop().ok()).any(|event| matches!(
+            event,
+            EngineEvent::TrackMuteChanged {
+                track_id: event_track,
+                muted: true,
+                effective_at_samples: 16,
+            } if event_track == track_id
+        ))
+    );
+}
+
+#[test]
+fn stopping_cancels_a_pending_quantized_mute() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    cmd_tx.push(EngineCommand::SetSampleRate(8)).unwrap();
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx
+        .push(EngineCommand::AddTrack(track_id, "Track 1".into()))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    engine.process(&mut [0.0], 1);
+    while event_rx.pop().is_ok() {}
+
+    cmd_tx
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::OneBar,
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Stop).unwrap();
+    engine.process(&mut [0.0], 1);
+
+    let events: Vec<_> = std::iter::from_fn(|| event_rx.pop().ok()).collect();
+    assert!(events.iter().any(|event| matches!(
+        event,
+        EngineEvent::TrackMuteQueueCancelled {
+            track_id: event_track
+        } if *event_track == track_id
+    )));
+    assert!(!engine.tracks()[0].mute);
+}
+
+#[test]
+fn quantized_mute_on_a_boundary_still_reports_deferred_ownership_before_effective_state() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    cmd_tx.push(EngineCommand::SetSampleRate(8)).unwrap();
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx
+        .push(EngineCommand::AddTrack(track_id, "Track 1".into()))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    engine.process(&mut [0.0; 4], 1);
+    while event_rx.pop().is_ok() {}
+
+    cmd_tx
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::OneBeat,
+        })
+        .unwrap();
+    engine.process(&mut [0.0], 1);
+
+    let mute_events: Vec<_> = std::iter::from_fn(|| event_rx.pop().ok())
+        .filter(|event| {
+            matches!(
+                event,
+                EngineEvent::TrackMuteQueued { .. } | EngineEvent::TrackMuteChanged { .. }
+            )
+        })
+        .collect();
+    assert!(matches!(
+        mute_events.as_slice(),
+        [
+            EngineEvent::TrackMuteQueued {
+                track_id: queued_track,
+                muted: true,
+                effective_at_samples: 4,
+            },
+            EngineEvent::TrackMuteChanged {
+                track_id: changed_track,
+                muted: true,
+                effective_at_samples: 4,
+            }
+        ] if *queued_track == track_id && *changed_track == track_id
+    ));
+}
+
+#[test]
+fn immediate_mixer_mute_cancels_a_pending_pad_change_before_applying() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    cmd_tx.push(EngineCommand::SetSampleRate(8)).unwrap();
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx
+        .push(EngineCommand::AddTrack(track_id, "Track 1".into()))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    engine.process(&mut [0.0], 1);
+    while event_rx.pop().is_ok() {}
+
+    cmd_tx
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::OneBar,
+        })
+        .unwrap();
+    engine.process(&mut [0.0], 1);
+    while event_rx.pop().is_ok() {}
+
+    cmd_tx
+        .push(EngineCommand::SetTrackMute(track_id, true))
+        .unwrap();
+    engine.process(&mut [0.0], 1);
+
+    let mute_events: Vec<_> = std::iter::from_fn(|| event_rx.pop().ok())
+        .filter(|event| {
+            matches!(
+                event,
+                EngineEvent::TrackMuteQueueCancelled { .. } | EngineEvent::TrackMuteChanged { .. }
+            )
+        })
+        .collect();
+    assert!(matches!(
+        mute_events.as_slice(),
+        [
+            EngineEvent::TrackMuteQueueCancelled {
+                track_id: cancelled_track,
+            },
+            EngineEvent::TrackMuteChanged {
+                track_id: changed_track,
+                muted: true,
+                ..
+            }
+        ] if *cancelled_track == track_id && *changed_track == track_id
     ));
 }

--- a/crates/vibez-engine/src/engine_mute_event_tests.rs
+++ b/crates/vibez-engine/src/engine_mute_event_tests.rs
@@ -175,6 +175,50 @@ fn one_bar_mute_uses_the_next_bar_boundary() {
 }
 
 #[test]
+fn one_bar_mute_at_an_arrangement_loop_end_applies_on_the_wrap() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    cmd_tx.push(EngineCommand::SetSampleRate(8)).unwrap();
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx
+        .push(EngineCommand::AddTrack(track_id, "Track 1".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetArrangementLoopRegion { start: 0, end: 16 })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetArrangementLoop(true))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    engine.process(&mut [0.0], 1);
+    while event_rx.pop().is_ok() {}
+
+    cmd_tx
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::OneBar,
+        })
+        .unwrap();
+    for _ in 0..40 {
+        engine.process(&mut [0.0], 1);
+    }
+
+    assert!(
+        std::iter::from_fn(|| event_rx.pop().ok()).any(|event| matches!(
+            event,
+            EngineEvent::TrackMuteChanged {
+                track_id: event_track,
+                muted: true,
+                effective_at_samples: 16,
+            } if event_track == track_id
+        )),
+        "the loop wrap is the next traversable bar boundary"
+    );
+    assert!(engine.tracks()[0].mute);
+}
+
+#[test]
 fn stopping_cancels_a_pending_quantized_mute() {
     let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
     let track_id = TrackId::new();

--- a/crates/vibez-engine/src/engine_render.rs
+++ b/crates/vibez-engine/src/engine_render.rs
@@ -42,7 +42,7 @@ impl AudioEngine {
 
         let pos = self.transport.position();
         if let Some((loop_start, loop_end)) = self.transport.active_loop_region() {
-            if pos < loop_end && pos + frames as u64 > loop_end {
+            if pos < loop_end && pos + frames as u64 >= loop_end {
                 let first = (loop_end - pos) as usize;
                 let rest = frames - first;
                 self.render_multitrack_segment(
@@ -53,6 +53,10 @@ impl AudioEngine {
                     channels,
                     self.transport.active_loop_region(),
                 );
+                // The transport jumps directly from loop_end to loop_start.
+                // Apply work owned by that exact musical boundary before the
+                // clock wraps so it cannot remain pending forever.
+                self.apply_track_mutes_due(loop_end);
                 // Kill anything sounding across the boundary, then
                 // continue sample-accurately from the loop start.
                 for track in &mut self.tracks {

--- a/crates/vibez-engine/src/engine_render.rs
+++ b/crates/vibez-engine/src/engine_render.rs
@@ -91,6 +91,40 @@ impl AudioEngine {
         channels: usize,
         loop_region: Option<(u64, u64)>,
     ) {
+        let mut rendered_frames = 0usize;
+        while rendered_frames < frames {
+            let segment_start = repeat_pos.saturating_add(rendered_frames as u64);
+            self.apply_track_mutes_due(segment_start);
+            let segment_end = repeat_pos.saturating_add(frames as u64);
+            let next_boundary = self
+                .next_track_mute_boundary()
+                .filter(|boundary| *boundary > segment_start && *boundary < segment_end);
+            let segment_frames = next_boundary
+                .map(|boundary| (boundary - segment_start) as usize)
+                .unwrap_or(frames - rendered_frames);
+            let start = rendered_frames * channels;
+            let end = (rendered_frames + segment_frames) * channels;
+            self.render_multitrack_frames(
+                &mut output[start..end],
+                pos.saturating_add(rendered_frames as u64),
+                segment_start,
+                segment_frames,
+                channels,
+                loop_region,
+            );
+            rendered_frames += segment_frames;
+        }
+    }
+
+    fn render_multitrack_frames(
+        &mut self,
+        output: &mut [f32],
+        pos: u64,
+        repeat_pos: u64,
+        frames: usize,
+        channels: usize,
+        loop_region: Option<(u64, u64)>,
+    ) {
         let has_track_solo = any_solo(&self.tracks);
         let has_bus_solo = any_solo(&self.buses);
         let bpm = self.transport.bpm();

--- a/crates/vibez-engine/src/engine_section_queue.rs
+++ b/crates/vibez-engine/src/engine_section_queue.rs
@@ -276,7 +276,7 @@ impl AudioEngine {
         }
     }
 
-    fn next_grid_boundary(&self, now: u64, beats: f64) -> u64 {
+    pub(super) fn next_grid_boundary(&self, now: u64, beats: f64) -> u64 {
         if self.transport.bpm() <= 0.0 {
             return now;
         }

--- a/crates/vibez-engine/src/engine_section_queue.rs
+++ b/crates/vibez-engine/src/engine_section_queue.rs
@@ -73,12 +73,12 @@ impl AudioEngine {
             return;
         }
 
-        let effective_at_samples = match quantization {
-            SectionLaunchQuantization::Immediate => now,
-            SectionLaunchQuantization::OneBeat => self.next_grid_boundary(now, 1.0),
-            SectionLaunchQuantization::OneBar => self.next_grid_boundary(now, 4.0),
-            SectionLaunchQuantization::EndOfSection => self
-                .active_section
+        let effective_at_samples = if let Some(boundary) = quantization.musical_boundary() {
+            boundary
+                .beats()
+                .map_or(now, |beats| self.next_grid_boundary(now, beats))
+        } else {
+            self.active_section
                 .map(|active| {
                     now.saturating_add(
                         active
@@ -86,7 +86,7 @@ impl AudioEngine {
                             .saturating_sub(active.position_samples),
                     )
                 })
-                .unwrap_or(now),
+                .unwrap_or(now)
         };
 
         if effective_at_samples <= now {

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::id::{ClipId, SectionId, TrackId};
 use vibez_core::midi::InstrumentKind;
-use vibez_core::perform::{NoteRepeatRate, SectionLaunchQuantization, SwingAmount};
+use vibez_core::perform::{
+    NoteRepeatRate, SectionLaunchQuantization, SwingAmount, TrackMuteQuantization,
+};
 
 use crate::playback_source::{EngineClip, PreparedPlaybackSource, PreparedSectionPlaybackSource};
 
@@ -344,4 +346,44 @@ fn perform_bpm_is_locked_and_live_mute_survives_transition() {
         output[64..].iter().all(|sample| *sample == 0.0),
         "mute must remain closed after the queued Section transition"
     );
+}
+
+#[test]
+fn queued_track_mute_survives_a_section_transition_until_its_own_boundary() {
+    let (mut engine, mut commands, mut events, track_id) = playing_engine(0.4, 8.0);
+    commands
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::OneBar,
+        })
+        .unwrap();
+    let next_section = SectionId::new();
+    commands
+        .push(EngineCommand::QueueSection {
+            prepared: source(next_section, track_id, 8.0, 0.7),
+            quantization: SectionLaunchQuantization::OneBeat,
+        })
+        .unwrap();
+
+    engine.process(&mut [0.0; 20], 1);
+
+    let events: Vec<_> = std::iter::from_fn(|| events.pop().ok()).collect();
+    assert!(events.iter().any(|event| matches!(
+        event,
+        EngineEvent::SectionTransitioned {
+            section_id,
+            effective_at_samples: 4,
+            ..
+        } if *section_id == next_section
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        EngineEvent::TrackMuteChanged {
+            track_id: event_track,
+            muted: true,
+            effective_at_samples: 16,
+        } if *event_track == track_id
+    )));
+    assert!(engine.tracks()[0].mute);
 }

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -85,13 +85,21 @@ pub enum EngineEvent {
     },
 
     /// A track mute command became effective in the audio engine at this
-    /// absolute transport sample. This is the authoritative event later
-    /// Capture work consumes.
+    /// active engine-clock sample. This is the authoritative event Capture
+    /// consumes.
     TrackMuteChanged {
         track_id: TrackId,
         muted: bool,
         effective_at_samples: u64,
     },
+    /// A live Track Mute is waiting for an engine-owned musical boundary.
+    TrackMuteQueued {
+        track_id: TrackId,
+        muted: bool,
+        effective_at_samples: u64,
+    },
+    /// A second Pad Gesture cancelled the pending Track Mute.
+    TrackMuteQueueCancelled { track_id: TrackId },
     /// A manual control took precedence over automation, or automation
     /// was explicitly re-enabled.
     AutomationOverrideChanged {

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -21,6 +21,12 @@ pub(crate) use render_context::InstrumentRenderContext;
 const MUTE_RAMP_FRAMES: u32 = 64;
 
 #[derive(Debug, Clone, Copy)]
+pub(crate) struct QueuedTrackMute {
+    pub muted: bool,
+    pub effective_at_samples: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
 struct MuteRamp {
     gain: f32,
     target: f32,
@@ -107,6 +113,7 @@ pub struct EngineTrack {
     pub gain: f32,
     pub pan: f32,
     pub mute: bool,
+    pub(crate) queued_mute: Option<QueuedTrackMute>,
     automation_mute: Option<bool>,
     automation_overrides: AutomationOverrides,
     mute_ramp: MuteRamp,

--- a/crates/vibez-engine/src/mixer/channel_strip.rs
+++ b/crates/vibez-engine/src/mixer/channel_strip.rs
@@ -18,6 +18,7 @@ impl EngineTrack {
             gain: DEFAULT_TRACK_GAIN,
             pan: DEFAULT_TRACK_PAN,
             mute: false,
+            queued_mute: None,
             automation_mute: None,
             automation_overrides: AutomationOverrides::default(),
             mute_ramp: MuteRamp::default(),

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -727,16 +727,7 @@ mod perform_action_tests {
     use vibez_core::id::TrackId;
 
     fn snapshot(state: &AppState) -> ProjectSnapshot {
-        ProjectSnapshot {
-            project_tracks: Arc::clone(&state.project_tracks),
-            arrange_timeline: Arc::clone(&state.arrangement.timeline),
-            sections: Arc::clone(&state.perform.sections),
-            bpm: state.transport.bpm,
-            project_swing: state.perform.project_swing(),
-            loop_enabled: state.transport.loop_enabled,
-            loop_start_beats: state.transport.loop_start_beats,
-            loop_end_beats: state.transport.loop_end_beats,
-        }
+        state.project_snapshot()
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -18,13 +18,24 @@ fn apply_track_mute_request(
     history: &mut crate::state::UndoHistory,
     pre_edit_snapshot: crate::state::ProjectSnapshot,
     request: crate::domains::perform::TrackMuteRequest,
+    transport_playing: bool,
     engine: &mut impl crate::domains::EngineHandle,
 ) -> Option<String> {
-    project_tracks.find(request.track_id)?;
+    let track_name = project_tracks.find(request.track_id)?.name.clone();
+    if transport_playing
+        && request.quantization != vibez_core::perform::TrackMuteQuantization::Immediate
+    {
+        engine.send(EngineCommand::QueueTrackMute {
+            track_id: request.track_id,
+            muted: request.muted,
+            quantization: request.quantization,
+        });
+        return Some(track_name);
+    }
+
     history.push_edit(pre_edit_snapshot, None);
     let track = Arc::make_mut(project_tracks).find_mut(request.track_id)?;
     track.mute = request.muted;
-    let track_name = track.name.clone();
     engine.send(EngineCommand::SetTrackMute(request.track_id, request.muted));
     Some(track_name)
 }
@@ -107,6 +118,8 @@ impl App {
             self.state.status_text = "Perform settings saved".into();
         }
         if let Some(request) = action.track_mute_request {
+            let queued = self.state.transport.playing
+                && request.quantization != vibez_core::perform::TrackMuteQuantization::Immediate;
             let pre_edit_snapshot = self.take_snapshot();
             let changed = {
                 let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
@@ -115,15 +128,27 @@ impl App {
                     &mut self.state.project.history,
                     pre_edit_snapshot,
                     request,
+                    self.state.transport.playing,
                     &mut engine,
                 )
             };
             if let Some(track_name) = changed {
-                self.mark_project_dirty();
-                self.state.status_text = format!(
-                    "{} {track_name}",
-                    if request.muted { "Muted" } else { "Unmuted" }
-                );
+                if queued {
+                    self.state.status_text = format!(
+                        "{} {track_name}",
+                        if request.muted {
+                            "Mute queued for"
+                        } else {
+                            "Unmute queued for"
+                        }
+                    );
+                } else {
+                    self.mark_project_dirty();
+                    self.state.status_text = format!(
+                        "{} {track_name}",
+                        if request.muted { "Muted" } else { "Unmuted" }
+                    );
+                }
             }
         }
         if let Some(request) = action.track_swing_request {
@@ -731,7 +756,9 @@ mod perform_action_tests {
             crate::domains::perform::TrackMuteRequest {
                 track_id,
                 muted: true,
+                quantization: vibez_core::perform::TrackMuteQuantization::Immediate,
             },
+            false,
             &mut engine,
         );
 
@@ -759,13 +786,51 @@ mod perform_action_tests {
             crate::domains::perform::TrackMuteRequest {
                 track_id: TrackId::new(),
                 muted: true,
+                quantization: vibez_core::perform::TrackMuteQuantization::Immediate,
             },
+            false,
             &mut engine,
         );
 
         assert_eq!(name, None);
         assert!(state.project.history.undo.is_empty());
         assert!(engine.0.is_empty());
+    }
+
+    #[test]
+    fn running_quantized_mute_waits_for_engine_truth_before_editing_project_state() {
+        let track_id = TrackId::new();
+        let mut state = AppState::default();
+        Arc::make_mut(&mut state.project_tracks)
+            .tracks
+            .push(ProjectTrack::new(track_id, "Bass".into(), 0));
+        let mut engine = RecordingEngine::default();
+        let pre_edit_snapshot = snapshot(&state);
+
+        let name = apply_track_mute_request(
+            &mut state.project_tracks,
+            &mut state.project.history,
+            pre_edit_snapshot,
+            crate::domains::perform::TrackMuteRequest {
+                track_id,
+                muted: true,
+                quantization: vibez_core::perform::TrackMuteQuantization::OneBar,
+            },
+            true,
+            &mut engine,
+        );
+
+        assert_eq!(name.as_deref(), Some("Bass"));
+        assert!(!state.project_tracks.tracks[0].mute);
+        assert!(state.project.history.undo.is_empty());
+        assert!(matches!(
+            engine.0.as_slice(),
+            [EngineCommand::QueueTrackMute {
+                track_id: event_track,
+                muted: true,
+                quantization: vibez_core::perform::TrackMuteQuantization::OneBar,
+            }] if *event_track == track_id
+        ));
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/capture.rs
+++ b/crates/vibez-ui/src/app/capture.rs
@@ -576,16 +576,7 @@ mod tests {
     }
 
     fn snapshot(state: &AppState) -> ProjectSnapshot {
-        ProjectSnapshot {
-            project_tracks: Arc::clone(&state.project_tracks),
-            arrange_timeline: Arc::clone(&state.arrangement.timeline),
-            sections: Arc::clone(&state.perform.sections),
-            bpm: state.transport.bpm,
-            project_swing: state.perform.project_swing(),
-            loop_enabled: state.transport.loop_enabled,
-            loop_start_beats: state.transport.loop_start_beats,
-            loop_end_beats: state.transport.loop_end_beats,
-        }
+        state.project_snapshot()
     }
 
     fn audio_clip(position: u64, duration: u64) -> crate::state::UiClip {

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -5,9 +5,36 @@ use std::sync::Arc;
 use vibez_engine::events::EngineEvent;
 
 use crate::domains::perform::CapturedSectionSource;
-use crate::state::AuditionMode;
+use crate::state::{AuditionMode, ProjectSnapshot};
 
 use super::*;
+
+fn apply_track_mute_event(
+    state: &mut crate::state::AppState,
+    track_id: vibez_core::id::TrackId,
+    muted: bool,
+) -> bool {
+    let pending = state.perform.pending_track_mute(track_id).is_some();
+    if pending && state.project_tracks.find(track_id).is_some() {
+        let snapshot = ProjectSnapshot {
+            project_tracks: Arc::clone(&state.project_tracks),
+            arrange_timeline: Arc::clone(&state.arrangement.timeline),
+            sections: Arc::clone(&state.perform.sections),
+            bpm: state.transport.bpm,
+            project_swing: state.perform.project_swing(),
+            loop_enabled: state.transport.loop_enabled,
+            loop_start_beats: state.transport.loop_start_beats,
+            loop_end_beats: state.transport.loop_end_beats,
+        };
+        state.project.history.push_edit(snapshot, None);
+        state.project.dirty = true;
+    }
+    state.perform.take_pending_track_mute(track_id);
+    if let Some(track) = state.find_track_mut(track_id) {
+        track.mute = muted;
+    }
+    pending
+}
 
 impl App {
     pub(super) fn poll_engine_events(&mut self) {
@@ -40,6 +67,7 @@ impl App {
                         self.state.perform.queued_section = None;
                         self.state.perform.pending_section_boundary_samples = None;
                         self.state.perform.section_playhead_samples = 0;
+                        self.state.perform.clear_pending_track_mutes();
                     }
                     EngineEvent::PlaybackStarted => {
                         self.state.transport.playing = true;
@@ -87,9 +115,22 @@ impl App {
                             muted,
                             effective_at_samples,
                         );
-                        if let Some(track) = self.state.find_track_mut(track_id) {
-                            track.mute = muted;
-                        }
+                        apply_track_mute_event(&mut self.state, track_id, muted);
+                    }
+                    EngineEvent::TrackMuteQueued {
+                        track_id,
+                        muted,
+                        effective_at_samples,
+                    } => {
+                        self.state.perform.queue_track_mute_ui(
+                            track_id,
+                            muted,
+                            effective_at_samples,
+                        );
+                    }
+                    EngineEvent::TrackMuteQueueCancelled { track_id } => {
+                        self.state.perform.cancel_track_mute_ui(track_id);
+                        self.state.status_text = "Track Mute change cancelled".into();
                     }
                     EngineEvent::AutomationOverrideChanged {
                         track_id,
@@ -333,5 +374,33 @@ impl App {
         for completed in completed_captures {
             self.finish_performance_capture(completed);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::perform::PendingTrackMute;
+    use crate::state::ProjectTrack;
+    use vibez_core::id::TrackId;
+
+    #[test]
+    fn effective_quantized_mute_commits_one_undoable_project_edit() {
+        let track_id = TrackId::new();
+        let mut state = AppState::default();
+        Arc::make_mut(&mut state.project_tracks)
+            .tracks
+            .push(ProjectTrack::new(track_id, "Bass".into(), 0));
+        state.perform.queue_track_mute_ui(track_id, true, 48_000);
+
+        assert!(apply_track_mute_event(&mut state, track_id, true));
+        assert!(state.project_tracks.tracks[0].mute);
+        assert_eq!(state.project.history.undo.len(), 1);
+        let before = state.project.history.pop_undo().expect("mute undo");
+        assert!(!before.project_tracks.tracks[0].mute);
+        assert_eq!(
+            state.perform.pending_track_mute(track_id),
+            None::<PendingTrackMute>
+        );
     }
 }

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use vibez_engine::events::EngineEvent;
 
 use crate::domains::perform::CapturedSectionSource;
-use crate::state::{AuditionMode, ProjectSnapshot};
+use crate::state::AuditionMode;
 
 use super::*;
 
@@ -16,16 +16,7 @@ fn apply_track_mute_event(
 ) -> bool {
     let pending = state.perform.pending_track_mute(track_id).is_some();
     if pending && state.project_tracks.find(track_id).is_some() {
-        let snapshot = ProjectSnapshot {
-            project_tracks: Arc::clone(&state.project_tracks),
-            arrange_timeline: Arc::clone(&state.arrangement.timeline),
-            sections: Arc::clone(&state.perform.sections),
-            bpm: state.transport.bpm,
-            project_swing: state.perform.project_swing(),
-            loop_enabled: state.transport.loop_enabled,
-            loop_start_beats: state.transport.loop_start_beats,
-            loop_end_beats: state.transport.loop_end_beats,
-        };
+        let snapshot = state.project_snapshot();
         state.project.history.push_edit(snapshot, None);
         state.project.dirty = true;
     }
@@ -130,7 +121,7 @@ impl App {
                     }
                     EngineEvent::TrackMuteQueueCancelled { track_id } => {
                         self.state.perform.cancel_track_mute_ui(track_id);
-                        self.state.status_text = "Track Mute change cancelled".into();
+                        self.state.status_text = "Pending Track Mute cleared".into();
                     }
                     EngineEvent::AutomationOverrideChanged {
                         track_id,

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -295,6 +295,9 @@ impl App {
         state
             .perform
             .set_fixed_computer_velocity(ui_settings.fixed_computer_velocity);
+        state
+            .perform
+            .set_track_mute_quantization(ui_settings.track_mute_quantization);
 
         // Themes: scan the user's .vzt collection, then restore the
         // saved selection (built-in name or user theme name).

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -257,6 +257,7 @@ impl App {
         let settings = UiSettings {
             perform_input_mapping: self.state.perform.input_mapping.clone(),
             fixed_computer_velocity: self.state.perform.fixed_computer_velocity(),
+            track_mute_quantization: self.state.perform.track_mute_quantization(),
             sample_library_roots: self.state.browser.roots.clone(),
             sample_browser_open: self.state.browser.open,
             sample_browser_width: self.state.browser.dock_width,

--- a/crates/vibez-ui/src/app/project_replay.rs
+++ b/crates/vibez-ui/src/app/project_replay.rs
@@ -13,16 +13,7 @@ use super::*;
 
 impl App {
     pub(super) fn take_snapshot(&self) -> crate::state::ProjectSnapshot {
-        crate::state::ProjectSnapshot {
-            project_tracks: Arc::clone(&self.state.project_tracks),
-            arrange_timeline: Arc::clone(&self.state.arrangement.timeline),
-            sections: Arc::clone(&self.state.perform.sections),
-            bpm: self.state.transport.bpm,
-            project_swing: self.state.perform.project_swing(),
-            loop_enabled: self.state.transport.loop_enabled,
-            loop_start_beats: self.state.transport.loop_start_beats,
-            loop_end_beats: self.state.transport.loop_end_beats,
-        }
+        self.state.project_snapshot()
     }
 
     pub(super) fn push_undo_snapshot(&mut self, gesture: Option<crate::state::UndoGestureId>) {

--- a/crates/vibez-ui/src/app/views_perform_pads.rs
+++ b/crates/vibez-ui/src/app/views_perform_pads.rs
@@ -1,7 +1,8 @@
 //! Pad Surface rendering for the Perform workspace.
 
 use iced::widget::{
-    button, center, column, container, horizontal_space, mouse_area, row, stack, text, tooltip,
+    button, center, column, container, horizontal_space, mouse_area, pick_list, row, stack, text,
+    tooltip,
 };
 use iced::{Element, Length, Shadow, Theme, Vector};
 
@@ -14,6 +15,7 @@ use crate::icons;
 use crate::message::Message;
 use crate::theme as th;
 use crate::typography::{PERFORM_DISPLAY, PERFORM_LABEL, PERFORM_TECH, PERFORM_TECH_STRONG};
+use vibez_core::perform::TrackMuteQuantization;
 
 fn perform_bank_button(
     label: &'static str,
@@ -150,9 +152,33 @@ impl App {
             ]
             .spacing(5)
             .align_y(iced::Alignment::Center);
-            row![heading, horizontal_space(), bank_navigation]
+            if mode == PerformMode::TrackMutes {
+                let quantization = pick_list(
+                    TrackMuteQuantization::ALL,
+                    Some(self.state.perform.track_mute_quantization()),
+                    |value| Message::Perform(PerformMsg::SetTrackMuteQuantization(value)),
+                )
+                .width(Length::Fixed(104.0))
+                .padding([4, 7])
+                .text_size(9);
+                row![
+                    heading,
+                    horizontal_space(),
+                    text("MUTE")
+                        .font(PERFORM_TECH)
+                        .size(9)
+                        .color(th::text_dim()),
+                    quantization,
+                    bank_navigation
+                ]
+                .spacing(7)
                 .align_y(iced::Alignment::End)
                 .into()
+            } else {
+                row![heading, horizontal_space(), bank_navigation]
+                    .align_y(iced::Alignment::End)
+                    .into()
+            }
         };
 
         let pad_grid_height = perform_pad_grid_height(self.state.view.window_height)
@@ -260,6 +286,8 @@ impl App {
                     .track_for_mute_pad(position, &self.state.project_tracks.tracks)
             })
             .flatten();
+        let pending_mute =
+            mute_track.and_then(|track| self.state.perform.pending_track_mute(track.id));
         let instrument_target = (mode == PerformMode::Instrument
             && self.state.perform.instrument_target_overlay)
             .then(|| {
@@ -313,6 +341,18 @@ impl App {
             },
             PerformMode::TrackMutes => {
                 if let Some(track) = mute_track {
+                    let state = if let Some(pending) = pending_mute {
+                        let beat = pending.effective_at_samples as f64 * self.state.transport.bpm
+                            / (self.state.transport.sample_rate as f64 * 60.0);
+                        format!(
+                            "PENDING {} @ BEAT {beat:.2}",
+                            if pending.muted { "MUTE" } else { "LIVE" }
+                        )
+                    } else if track.mute {
+                        "MUTED".to_string()
+                    } else {
+                        "LIVE".to_string()
+                    };
                     (
                         track.name.clone(),
                         format!(
@@ -322,7 +362,7 @@ impl App {
                             } else {
                                 "AUDIO"
                             },
-                            if track.mute { "MUTED" } else { "LIVE" }
+                            state
                         ),
                         th::track_color(track.color_index),
                         track.mute,
@@ -427,6 +467,8 @@ impl App {
                             th::blend(th::accent_dim(), color, 0.35)
                         } else if queued {
                             th::blend(th::accent_dim(), th::bg_hover(), 0.42)
+                        } else if pending_mute.is_some() {
+                            th::blend(th::accent_dim(), color, 0.24)
                         } else if muted {
                             th::blend(th::mute_active(), color, 0.28)
                         } else if selected {
@@ -445,6 +487,8 @@ impl App {
                     th::accent()
                 } else if queued || selected {
                     th::accent_dim()
+                } else if pending_mute.is_some() {
+                    th::accent()
                 } else if muted {
                     th::mute_active()
                 } else {

--- a/crates/vibez-ui/src/app/views_perform_pads.rs
+++ b/crates/vibez-ui/src/app/views_perform_pads.rs
@@ -9,13 +9,28 @@ use iced::{Element, Length, Shadow, Theme, Vector};
 use super::views_perform::{perform_pad_grid_height, perform_tool_button};
 use super::*;
 use crate::domains::perform::{
-    PadPosition, PerformEditorFocus, PerformMode, PerformMsg, SixteenLevelsParameter,
+    PadPosition, PendingTrackMute, PerformEditorFocus, PerformMode, PerformMsg,
+    SixteenLevelsParameter,
 };
 use crate::icons;
 use crate::message::Message;
 use crate::theme as th;
 use crate::typography::{PERFORM_DISPLAY, PERFORM_LABEL, PERFORM_TECH, PERFORM_TECH_STRONG};
 use vibez_core::perform::TrackMuteQuantization;
+
+fn pending_track_mute_label(
+    pending: PendingTrackMute,
+    current_samples: u64,
+    bpm: f64,
+    sample_rate: u32,
+) -> String {
+    let remaining_samples = pending.effective_at_samples.saturating_sub(current_samples);
+    let remaining_beats = remaining_samples as f64 * bpm / (f64::from(sample_rate.max(1)) * 60.0);
+    format!(
+        "PENDING {} · IN {remaining_beats:.2} BEATS",
+        if pending.muted { "MUTE" } else { "LIVE" }
+    )
+}
 
 fn perform_bank_button(
     label: &'static str,
@@ -342,11 +357,16 @@ impl App {
             PerformMode::TrackMutes => {
                 if let Some(track) = mute_track {
                     let state = if let Some(pending) = pending_mute {
-                        let beat = pending.effective_at_samples as f64 * self.state.transport.bpm
-                            / (self.state.transport.sample_rate as f64 * 60.0);
-                        format!(
-                            "PENDING {} @ BEAT {beat:.2}",
-                            if pending.muted { "MUTE" } else { "LIVE" }
+                        let current_samples = if self.state.perform.playing_section.is_some() {
+                            self.state.perform.performance_position_samples
+                        } else {
+                            self.state.transport.position_samples
+                        };
+                        pending_track_mute_label(
+                            pending,
+                            current_samples,
+                            self.state.transport.bpm,
+                            self.state.transport.sample_rate,
                         )
                     } else if track.mute {
                         "MUTED".to_string()
@@ -579,5 +599,37 @@ impl App {
             }
             _ => pad,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pending_track_mute_label;
+    use crate::domains::perform::PendingTrackMute;
+
+    #[test]
+    fn pending_track_mute_reports_time_remaining_in_the_active_clock() {
+        let pending = PendingTrackMute {
+            muted: true,
+            effective_at_samples: 96_000,
+        };
+
+        assert_eq!(
+            pending_track_mute_label(pending, 72_000, 120.0, 48_000),
+            "PENDING MUTE · IN 1.00 BEATS"
+        );
+    }
+
+    #[test]
+    fn overdue_pending_track_mute_never_reports_negative_time() {
+        let pending = PendingTrackMute {
+            muted: false,
+            effective_at_samples: 48_000,
+        };
+
+        assert_eq!(
+            pending_track_mute_label(pending, 72_000, 120.0, 48_000),
+            "PENDING LIVE · IN 0.00 BEATS"
+        );
     }
 }

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use vibez_core::id::{SectionId, TrackId};
-use vibez_core::perform::{NoteRepeatRate, SwingAmount, SwingOffset};
+use vibez_core::perform::{NoteRepeatRate, SwingAmount, SwingOffset, TrackMuteQuantization};
 use vibez_project::SectionLaunchQuantization;
 
 use super::EngineHandle;
@@ -20,6 +20,7 @@ mod instrument;
 mod note_repeat;
 pub(crate) mod section_record;
 mod sections;
+mod track_mutes;
 pub use capture::{
     CaptureAction, CaptureMsg, CapturePhase, CaptureState, CapturedSectionSource,
     MaterializedCapture,
@@ -32,6 +33,7 @@ pub use section_record::{
     SectionRecordMsg, SectionRecordPhase, SectionRecordQuantization, SectionRecordStartRequest,
 };
 pub use sections::{Section, SectionStore, SectionTimelineEditor, TimelineContentLocation};
+pub use track_mutes::{PendingTrackMute, TrackMuteRequest};
 
 /// The three Perform Modes exposed in V1. Macros stays absent until its
 /// behavior and Capture semantics are defined.
@@ -184,6 +186,8 @@ pub struct PerformState {
     note_repeat_momentary: bool,
     note_repeat_momentary_key_id: Option<String>,
     note_repeat_latched: bool,
+    track_mute_quantization: TrackMuteQuantization,
+    pending_track_mutes: HashMap<TrackId, PendingTrackMute>,
     pub capture: CaptureState,
     pub section_record: section_record::SectionRecordState,
     pub sections: Arc<SectionStore>,
@@ -235,6 +239,7 @@ pub enum PerformMsg {
     },
     PreviousBank,
     NextBank,
+    SetTrackMuteQuantization(TrackMuteQuantization),
     ToggleTrackMuteFromPad(PadPosition),
     SetInstrumentTargetOverlay(bool),
     SelectInstrumentTarget(TrackId),
@@ -297,14 +302,6 @@ pub struct PerformCtx<'a> {
     pub workspace_visible: bool,
     pub project_tracks: &'a [ProjectTrack],
     pub selected_project_track: Option<TrackId>,
-}
-
-/// A semantic mute request resolved by Perform against a stable pad slot.
-/// The router applies it to the single shared Project Track state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TrackMuteRequest {
-    pub track_id: TrackId,
-    pub muted: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -379,6 +376,7 @@ impl PerformState {
         Some(TrackMuteRequest {
             track_id,
             muted: !track.mute,
+            quantization: self.track_mute_quantization,
         })
     }
 
@@ -653,6 +651,13 @@ impl PerformState {
                         }
                     }
                 }
+            }
+            PerformMsg::SetTrackMuteQuantization(quantization) => {
+                self.track_mute_quantization = quantization;
+                return PerformAction {
+                    persist_settings: true,
+                    ..PerformAction::default()
+                };
             }
             PerformMsg::ToggleTrackMuteFromPad(position) => {
                 if ctx.workspace_visible && self.mode == PerformMode::TrackMutes {
@@ -947,3 +952,7 @@ mod focus_tests;
 #[cfg(test)]
 #[path = "perform_note_repeat_tests.rs"]
 mod note_repeat_tests;
+
+#[cfg(test)]
+#[path = "perform_track_mute_tests.rs"]
+mod track_mute_tests;

--- a/crates/vibez-ui/src/domains/perform/track_mutes.rs
+++ b/crates/vibez-ui/src/domains/perform/track_mutes.rs
@@ -1,0 +1,59 @@
+//! Live Track Mute interaction state mirrored from engine-owned boundaries.
+
+use super::*;
+
+/// A semantic mute request resolved by Perform against a stable pad slot.
+/// The router applies it to the single shared Project Track state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrackMuteRequest {
+    pub track_id: TrackId,
+    pub muted: bool,
+    pub quantization: TrackMuteQuantization,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PendingTrackMute {
+    pub muted: bool,
+    pub effective_at_samples: u64,
+}
+
+impl PerformState {
+    pub const fn track_mute_quantization(&self) -> TrackMuteQuantization {
+        self.track_mute_quantization
+    }
+
+    pub fn set_track_mute_quantization(&mut self, quantization: TrackMuteQuantization) {
+        self.track_mute_quantization = quantization;
+    }
+
+    pub fn queue_track_mute_ui(
+        &mut self,
+        track_id: TrackId,
+        muted: bool,
+        effective_at_samples: u64,
+    ) {
+        self.pending_track_mutes.insert(
+            track_id,
+            PendingTrackMute {
+                muted,
+                effective_at_samples,
+            },
+        );
+    }
+
+    pub fn cancel_track_mute_ui(&mut self, track_id: TrackId) {
+        self.pending_track_mutes.remove(&track_id);
+    }
+
+    pub fn pending_track_mute(&self, track_id: TrackId) -> Option<PendingTrackMute> {
+        self.pending_track_mutes.get(&track_id).copied()
+    }
+
+    pub fn take_pending_track_mute(&mut self, track_id: TrackId) -> Option<PendingTrackMute> {
+        self.pending_track_mutes.remove(&track_id)
+    }
+
+    pub fn clear_pending_track_mutes(&mut self) {
+        self.pending_track_mutes.clear();
+    }
+}

--- a/crates/vibez-ui/src/domains/perform_tests.rs
+++ b/crates/vibez-ui/src/domains/perform_tests.rs
@@ -796,6 +796,7 @@ fn track_mute_mode_resolves_keyboard_press_to_shared_track_request_once() {
         Some(TrackMuteRequest {
             track_id: tracks[0].id,
             muted: true,
+            quantization: TrackMuteQuantization::Immediate,
         })
     );
     assert!(repeat.track_mute_request.is_none());
@@ -853,6 +854,7 @@ fn pointer_pad_uses_the_same_track_mute_resolution() {
         Some(TrackMuteRequest {
             track_id: tracks[0].id,
             muted: false,
+            quantization: TrackMuteQuantization::Immediate,
         })
     );
 }

--- a/crates/vibez-ui/src/domains/perform_track_mute_tests.rs
+++ b/crates/vibez-ui/src/domains/perform_track_mute_tests.rs
@@ -1,0 +1,38 @@
+use super::super::test_support::RecordingEngine;
+use super::*;
+
+#[test]
+fn pad_request_uses_the_persisted_quantization_choice() {
+    let tracks = vec![ProjectTrack::new(TrackId::new(), "Bass".into(), 0)];
+    let mut state = PerformState {
+        mode: PerformMode::TrackMutes,
+        ..PerformState::default()
+    };
+    let mut engine = RecordingEngine::default();
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        project_tracks: &tracks,
+        selected_project_track: None,
+    };
+
+    let preference = state.update(
+        PerformMsg::SetTrackMuteQuantization(TrackMuteQuantization::OneBar),
+        &mut engine,
+        ctx,
+    );
+    let gesture = state.update(
+        PerformMsg::ToggleTrackMuteFromPad(PadPosition::ALL[0]),
+        &mut engine,
+        ctx,
+    );
+
+    assert!(preference.persist_settings);
+    assert_eq!(
+        gesture.track_mute_request,
+        Some(TrackMuteRequest {
+            track_id: tracks[0].id,
+            muted: true,
+            quantization: TrackMuteQuantization::OneBar,
+        })
+    );
+}

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -538,6 +538,21 @@ pub fn default_drum_rack_pads() -> Vec<UiDrumPad> {
 }
 
 impl AppState {
+    /// Capture the complete canonical project state shared by Undo, Capture,
+    /// engine-event commits, and project replay.
+    pub fn project_snapshot(&self) -> ProjectSnapshot {
+        ProjectSnapshot {
+            project_tracks: Arc::clone(&self.project_tracks),
+            arrange_timeline: Arc::clone(&self.arrangement.timeline),
+            sections: Arc::clone(&self.perform.sections),
+            bpm: self.transport.bpm,
+            project_swing: self.perform.project_swing(),
+            loop_enabled: self.transport.loop_enabled,
+            loop_start_beats: self.transport.loop_start_beats,
+            loop_end_beats: self.transport.loop_end_beats,
+        }
+    }
+
     pub fn apply_audio_stream_event(
         &mut self,
         event: vibez_audio_io::audio_stream::AudioStreamEvent,

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -15,16 +15,7 @@ use super::{
 };
 
 fn snapshot(state: &AppState) -> ProjectSnapshot {
-    ProjectSnapshot {
-        project_tracks: Arc::clone(&state.project_tracks),
-        arrange_timeline: Arc::clone(&state.arrangement.timeline),
-        sections: Arc::clone(&state.perform.sections),
-        bpm: state.transport.bpm,
-        project_swing: state.perform.project_swing(),
-        loop_enabled: state.transport.loop_enabled,
-        loop_start_beats: state.transport.loop_start_beats,
-        loop_end_beats: state.transport.loop_end_beats,
-    }
+    state.project_snapshot()
 }
 
 fn apply_snapshot(state: &mut AppState, snapshot: ProjectSnapshot) {

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -9,6 +9,8 @@ pub struct UiSettings {
     #[serde(default = "default_fixed_computer_velocity")]
     pub fixed_computer_velocity: u8,
     #[serde(default)]
+    pub track_mute_quantization: vibez_core::perform::TrackMuteQuantization,
+    #[serde(default)]
     pub sample_library_roots: Vec<PathBuf>,
     #[serde(default = "default_sample_browser_open")]
     pub sample_browser_open: bool,
@@ -58,6 +60,7 @@ impl Default for UiSettings {
         Self {
             perform_input_mapping: crate::domains::perform::PerformInputMapping::default(),
             fixed_computer_velocity: default_fixed_computer_velocity(),
+            track_mute_quantization: vibez_core::perform::TrackMuteQuantization::default(),
             sample_library_roots: Vec::new(),
             sample_browser_open: default_sample_browser_open(),
             sample_browser_width: default_sample_browser_width(),
@@ -316,8 +319,31 @@ mod tests {
     }
 
     #[test]
+    fn track_mute_quantization_defaults_to_immediate_and_roundtrips_globally() {
+        use vibez_core::perform::TrackMuteQuantization;
+
+        let old: UiSettings = serde_json::from_str("{}").unwrap();
+        assert_eq!(
+            old.track_mute_quantization,
+            TrackMuteQuantization::Immediate
+        );
+
+        let settings = UiSettings {
+            track_mute_quantization: TrackMuteQuantization::OneBar,
+            ..UiSettings::default()
+        };
+        let loaded: UiSettings =
+            serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
+        assert_eq!(
+            loaded.track_mute_quantization,
+            TrackMuteQuantization::OneBar
+        );
+    }
+
+    #[test]
     fn rebinding_global_input_does_not_change_project_bytes() {
         use crate::domains::perform::{ComputerKey, PadPosition};
+        use vibez_core::perform::TrackMuteQuantization;
 
         let project = vibez_project::Project::default();
         let before = serde_json::to_vec(&project).unwrap();
@@ -325,6 +351,7 @@ mod tests {
         settings
             .perform_input_mapping
             .rebind(PadPosition::ALL[0], ComputerKey::Y);
+        settings.track_mute_quantization = TrackMuteQuantization::OneBar;
         let after = serde_json::to_vec(&project).unwrap();
 
         assert_eq!(before, after);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -278,13 +278,22 @@ Swing supplies the effective amount, and `OFF | 1/8 | 1/16` decides whether and
 on which grid that individual clip follows it. With no MIDI clip selected, the
 Track control remains available but clip application is withheld.
 
-Track mute commands become authoritative when the audio callback drains them.
-The engine emits `EngineEvent::TrackMuteChanged` with the effective state and
-absolute transport sample; the UI mirrors that result into the shared Project
-Track and an active Capture log. `track_mute` automation is stepped: it imposes
-nothing before its first point and changes state at exact in-buffer sample
-boundaries. Both manual and automated mute feed one post-effects, pre-send
-anti-click ramp, so playback gates tails exactly like the performed mute.
+Track Mute Pad Gestures use a global `Immediate | 1 Beat | 1 Bar` interaction
+preference; `Immediate` is the compatibility default and stopped transport
+always applies directly. During playback the UI sends the requested state and
+quantization without mutating the Project Track. Each shared engine channel
+holds at most one allocation-free pending change, resolves its musical boundary
+from the active engine clock, and splits rendering at that exact sample. A
+second pre-boundary gesture cancels it. Queue, cancellation, and effective
+events mirror pending UI state, while only `EngineEvent::TrackMuteChanged`
+updates the Project Track, opens the undo step, and enters an active Capture
+log. The pending state survives Section transitions because Track Mute remains
+live Perform state rather than Section content.
+
+`track_mute` automation is stepped: it imposes nothing before its first point
+and changes state at exact in-buffer sample boundaries. Both manual and
+automated mute feed one post-effects, pre-send anti-click ramp, so playback
+gates tails exactly like the performed mute.
 
 Automation overrides live beside evaluation in the shared `EngineTrack`
 channel strip. A manual mixer or Perform-pad mute on a track with a mute lane


### PR DESCRIPTION
## Summary

- add a global Immediate / 1 Beat / 1 Bar Track Mute timing preference, persisted in UI settings
- queue running beat/bar gestures on engine-owned sample boundaries, with repeated-gesture cancellation and stopped-transport immediacy
- materialize the effective change as one undoable project mutation and Capture event at the exact audible sample
- expose clear pending/effective pad state and document the engine/UI ownership protocol

## TDD evidence

- red: exact one-beat mute boundary had no quantization type or engine command
- green: sample-exact boundary split and effective engine event
- red/green cycles also covered stop cancellation, persisted default, domain request routing, deferred project mutation, one effective undo step, exact-grid ownership, and immediate-over-pending cancellation

## Verification

- `CARGO_TARGET_DIR=/home/alexander/Code/Apps/vibez-targets/card-15 nice -n 10 cargo test --workspace -j 4`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/home/alexander/Code/Apps/vibez-targets/card-15 nice -n 10 cargo clippy --workspace -j 4 -- -D warnings`
- `git diff --check` and the 1,000-line crossing audit
- isolated Xvfb producer pass: stopped immediate mute + undo; 1 Bar pending/effective; repeated-pad cancellation; preference persistence after restart

## Producer demo

1. Open Perform > Track Mutes and confirm the timing menu offers Immediate, 1 Beat, and 1 Bar.
2. While stopped, select 1 Bar and press a populated mute pad; confirm it changes immediately and Undo restores it.
3. Start transport, press the same pad, and confirm the pad shows a pending target and beat.
4. Let the boundary pass; confirm the pad becomes effectively muted exactly on the bar.
5. Queue the opposite change and press again before the boundary; confirm pending state clears and the current mute remains.
6. Restart Vibez and confirm the global timing preference is restored.

No merge requested.