### PR TITLE
Perform Card 40: paste clips at the focused playhead

### DIFF
--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -85,6 +85,9 @@ impl App {
             // only computes the cross-domain context, routes the
             // message, and applies the returned action.
             Message::Transport(msg) => {
+                if self.place_focused_section_playhead(&msg) {
+                    return Task::none();
+                }
                 let stops_perform = matches!(&msg, crate::domains::transport::TransportMsg::Stop)
                     || matches!(
                         &msg,
@@ -140,14 +143,21 @@ impl App {
                 let clipboard_snapshot = msg
                     .is_clipboard_project_edit()
                     .then(|| self.take_snapshot());
+                let playhead_beats = self.focused_editor_playhead_beats();
+                let samples_per_beat = if self.state.transport.bpm > 0.0 {
+                    60.0 * self.state.transport.sample_rate as f64 / self.state.transport.bpm
+                } else {
+                    0.0
+                };
+                let playhead_samples = if self.focused_editor_is_section() {
+                    (playhead_beats * samples_per_beat).round().max(0.0) as u64
+                } else {
+                    self.state.transport.position_samples
+                };
                 let ctx = crate::domains::arrangement::ArrangementCtx {
-                    samples_per_beat: if self.state.transport.bpm > 0.0 {
-                        60.0 * self.state.transport.sample_rate as f64 / self.state.transport.bpm
-                    } else {
-                        0.0
-                    },
-                    playhead_samples: self.state.transport.position_samples,
-                    playhead_beats: self.state.position_beats(),
+                    samples_per_beat,
+                    playhead_samples,
+                    playhead_beats,
                 };
                 let action = self.route_arrangement_editor_message(msg, ctx);
                 if let (true, Some(snapshot)) = (action.mark_dirty, clipboard_snapshot) {

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -18,6 +18,19 @@ use super::*;
 
 impl App {
     pub(super) fn update(&mut self, message: Message) -> Task<Message> {
+        let message = match message {
+            Message::SectionTimeline(edit) => {
+                if super::update_timeline::section_timeline_claims_focus(
+                    self.state.view.workspace,
+                    self.state.perform.selected_section.is_some(),
+                ) {
+                    self.state.perform.editor_focus =
+                        crate::domains::perform::PerformEditorFocus::SectionConstruction;
+                }
+                *edit
+            }
+            message => message,
+        };
         let (message, undo_gesture) = match message {
             Message::UndoGesture { id, edit } => (*edit, Some(id)),
             message => (message, None),
@@ -67,6 +80,9 @@ impl App {
         }
 
         match message {
+            Message::SectionTimeline(_) => {
+                unreachable!("section timeline wrappers are removed before routing")
+            }
             Message::MenuItemSelected(overlay, action) => {
                 let task = self.update(*action);
                 menu_lifecycle::dismiss(&mut self.state, overlay);

--- a/crates/vibez-ui/src/app/update_timeline.rs
+++ b/crates/vibez-ui/src/app/update_timeline.rs
@@ -21,6 +21,10 @@ fn clipboard_targets_section(
         && focus == PerformEditorFocus::SectionConstruction
 }
 
+pub(super) fn section_timeline_claims_focus(workspace: Workspace, selected_section: bool) -> bool {
+    workspace == Workspace::Perform && selected_section
+}
+
 fn focused_timeline_playhead_beats(
     workspace: Workspace,
     selected_section: bool,
@@ -62,7 +66,7 @@ impl App {
             self.state.perform.selected_section.is_some(),
             self.state.perform.editor_focus,
             self.state.position_beats(),
-            self.state.perform.section_editor.editor().playhead_beats,
+            self.state.perform.section_editor.edit_cursor_beats(),
         )
     }
 
@@ -78,9 +82,7 @@ impl App {
         ) else {
             return false;
         };
-        let editor = self.state.perform.section_editor.editor_mut();
-        editor.playhead_beats = beat;
-        editor.time_selection_active = false;
+        self.state.perform.section_editor.place_edit_cursor(beat);
         true
     }
 
@@ -372,5 +374,12 @@ mod clipboard_focus_tests {
             None,
             "hover and unrelated transport messages do not move the cursor"
         );
+    }
+
+    #[test]
+    fn section_timeline_messages_claim_focus_only_for_a_visible_selected_section() {
+        assert!(section_timeline_claims_focus(Workspace::Perform, true));
+        assert!(!section_timeline_claims_focus(Workspace::Arrange, true));
+        assert!(!section_timeline_claims_focus(Workspace::Perform, false));
     }
 }

--- a/crates/vibez-ui/src/app/update_timeline.rs
+++ b/crates/vibez-ui/src/app/update_timeline.rs
@@ -21,7 +21,69 @@ fn clipboard_targets_section(
         && focus == PerformEditorFocus::SectionConstruction
 }
 
+fn focused_timeline_playhead_beats(
+    workspace: Workspace,
+    selected_section: bool,
+    focus: PerformEditorFocus,
+    arrange_playhead_beats: f64,
+    section_playhead_beats: f64,
+) -> f64 {
+    if clipboard_targets_section(workspace, selected_section, focus) {
+        section_playhead_beats
+    } else {
+        arrange_playhead_beats
+    }
+}
+
+fn focused_section_seek_beat(
+    workspace: Workspace,
+    selected_section: bool,
+    focus: PerformEditorFocus,
+    msg: &crate::domains::transport::TransportMsg,
+) -> Option<f64> {
+    let crate::domains::transport::TransportMsg::SeekToBeat(beat) = msg else {
+        return None;
+    };
+    clipboard_targets_section(workspace, selected_section, focus).then(|| beat.max(0.0))
+}
+
 impl App {
+    pub(super) fn focused_editor_is_section(&self) -> bool {
+        clipboard_targets_section(
+            self.state.view.workspace,
+            self.state.perform.selected_section.is_some(),
+            self.state.perform.editor_focus,
+        )
+    }
+
+    pub(super) fn focused_editor_playhead_beats(&self) -> f64 {
+        focused_timeline_playhead_beats(
+            self.state.view.workspace,
+            self.state.perform.selected_section.is_some(),
+            self.state.perform.editor_focus,
+            self.state.position_beats(),
+            self.state.perform.section_editor.editor().playhead_beats,
+        )
+    }
+
+    pub(super) fn place_focused_section_playhead(
+        &mut self,
+        msg: &crate::domains::transport::TransportMsg,
+    ) -> bool {
+        let Some(beat) = focused_section_seek_beat(
+            self.state.view.workspace,
+            self.state.perform.selected_section.is_some(),
+            self.state.perform.editor_focus,
+            msg,
+        ) else {
+            return false;
+        };
+        let editor = self.state.perform.section_editor.editor_mut();
+        editor.playhead_beats = beat;
+        editor.time_selection_active = false;
+        true
+    }
+
     pub(super) fn route_automation_editor_message(
         &mut self,
         msg: AutomationMsg,
@@ -241,5 +303,74 @@ mod clipboard_focus_tests {
             false,
             PerformEditorFocus::SectionConstruction,
         ));
+    }
+
+    #[test]
+    fn paste_playhead_follows_arrange_or_selected_section_editor_focus() {
+        assert_eq!(
+            focused_timeline_playhead_beats(
+                Workspace::Arrange,
+                true,
+                PerformEditorFocus::SectionConstruction,
+                5.0,
+                11.0,
+            ),
+            5.0
+        );
+        assert_eq!(
+            focused_timeline_playhead_beats(
+                Workspace::Perform,
+                true,
+                PerformEditorFocus::SectionConstruction,
+                5.0,
+                11.0,
+            ),
+            11.0
+        );
+        assert_eq!(
+            focused_timeline_playhead_beats(
+                Workspace::Perform,
+                true,
+                PerformEditorFocus::PadSurface,
+                5.0,
+                11.0,
+            ),
+            5.0,
+            "playing a Section must not redirect Arrange-focused paste"
+        );
+    }
+
+    #[test]
+    fn pointer_seek_places_only_the_focused_section_edit_cursor() {
+        use crate::domains::transport::TransportMsg;
+
+        assert_eq!(
+            focused_section_seek_beat(
+                Workspace::Perform,
+                true,
+                PerformEditorFocus::SectionConstruction,
+                &TransportMsg::SeekToBeat(13.0),
+            ),
+            Some(13.0)
+        );
+        assert_eq!(
+            focused_section_seek_beat(
+                Workspace::Perform,
+                true,
+                PerformEditorFocus::PadSurface,
+                &TransportMsg::SeekToBeat(13.0),
+            ),
+            None
+        );
+        assert_eq!(
+            focused_section_seek_beat(
+                Workspace::Perform,
+                true,
+                PerformEditorFocus::SectionConstruction,
+                &TransportMsg::Play,
+            ),
+            None,
+            "hover and unrelated transport messages do not move the cursor"
+        );
     }
 }

--- a/crates/vibez-ui/src/app/views_perform_sections.rs
+++ b/crates/vibez-ui/src/app/views_perform_sections.rs
@@ -388,7 +388,7 @@ impl App {
                 let mut clip_canvas = TrackClipCanvas::from_track(
                     track,
                     content,
-                    editor.playhead_beats,
+                    self.state.perform.section_editor.edit_cursor_beats(),
                     2.0,
                     self.state.view.grid_config(),
                     0.0,
@@ -443,28 +443,30 @@ impl App {
                 let grid = self.state.view.grid_config();
                 let compatible = !track.kind.is_midi();
                 gutters = gutters.push(gutter);
-                let clip_lane: Element<'_, Message> = if self.state.browser.drag_source.is_some() {
-                    mouse_area(
-                        canvas(clip_canvas)
-                            .width(Length::Fixed(timeline_width))
-                            .height(Length::Fixed(row_height)),
-                    )
-                    .on_move(move |point| {
-                        Message::Browser(BrowserMsg::DragHoverTrack {
-                            track_id,
-                            beat: grid
-                                .snap_beat(geometry.x_to_beat(point.x), geometry.pixels_per_beat())
-                                .max(0.0),
-                            compatible,
-                        })
-                    })
-                    .on_exit(Message::Browser(BrowserMsg::ClearDragTarget))
-                    .into()
-                } else {
+                let focused_clip_canvas: Element<'_, Message> = Element::from(
                     canvas(clip_canvas)
                         .width(Length::Fixed(timeline_width))
-                        .height(Length::Fixed(row_height))
+                        .height(Length::Fixed(row_height)),
+                )
+                .map(|message| Message::SectionTimeline(Box::new(message)));
+                let clip_lane: Element<'_, Message> = if self.state.browser.drag_source.is_some() {
+                    mouse_area(focused_clip_canvas)
+                        .on_move(move |point| {
+                            Message::Browser(BrowserMsg::DragHoverTrack {
+                                track_id,
+                                beat: grid
+                                    .snap_beat(
+                                        geometry.x_to_beat(point.x),
+                                        geometry.pixels_per_beat(),
+                                    )
+                                    .max(0.0),
+                                compatible,
+                            })
+                        })
+                        .on_exit(Message::Browser(BrowserMsg::ClearDragTarget))
                         .into()
+                } else {
+                    focused_clip_canvas
                 };
                 lanes = lanes.push(clip_lane);
                 content_height += row_height;

--- a/crates/vibez-ui/src/app/views_perform_sections.rs
+++ b/crates/vibez-ui/src/app/views_perform_sections.rs
@@ -388,7 +388,7 @@ impl App {
                 let mut clip_canvas = TrackClipCanvas::from_track(
                     track,
                     content,
-                    -1.0,
+                    editor.playhead_beats,
                     2.0,
                     self.state.view.grid_config(),
                     0.0,

--- a/crates/vibez-ui/src/domains/arrangement/clipboard.rs
+++ b/crates/vibez-ui/src/domains/arrangement/clipboard.rs
@@ -32,6 +32,14 @@ impl ClipboardClip {
             Self::Audio { track_offset, .. } | Self::Note { track_offset, .. } => *track_offset,
         }
     }
+
+    fn position_beats(&self) -> f64 {
+        match self {
+            Self::Audio { position_beats, .. } | Self::Note { position_beats, .. } => {
+                *position_beats
+            }
+        }
+    }
 }
 
 impl TimelineEditorState {
@@ -325,14 +333,19 @@ impl TimelineEditorState {
             destinations.push(track.id);
         }
 
+        let earliest_position_beats = clipboard
+            .clips
+            .iter()
+            .map(ClipboardClip::position_beats)
+            .min_by(f64::total_cmp)
+            .unwrap_or(0.0);
+        let paste_anchor_beats = ctx.playhead_beats.max(0.0);
         let mut selected = HashSet::new();
         for (entry, track_id) in clipboard.clips.iter().cloned().zip(destinations) {
+            let position_beats =
+                paste_anchor_beats + (entry.position_beats() - earliest_position_beats);
             match entry {
-                ClipboardClip::Audio {
-                    position_beats,
-                    mut clip,
-                    ..
-                } => {
+                ClipboardClip::Audio { mut clip, .. } => {
                     clip.id = ClipId::new();
                     clip.position = (position_beats * ctx.samples_per_beat).round().max(0.0) as u64;
                     engine.send(EngineCommand::AddClip {
@@ -355,11 +368,7 @@ impl TimelineEditorState {
                         .clips
                         .push(clip);
                 }
-                ClipboardClip::Note {
-                    position_beats,
-                    mut clip,
-                    ..
-                } => {
+                ClipboardClip::Note { mut clip, .. } => {
                     clip.id = ClipId::new();
                     clip.position_beats = position_beats;
                     clip.selected_notes.clear();

--- a/crates/vibez-ui/src/domains/arrangement/clipboard_tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/clipboard_tests.rs
@@ -376,7 +376,11 @@ fn cross_section_paste_uses_selected_section_and_keeps_out_of_bounds_material() 
     };
 
     let mut source_editor = SectionTimelineEditor::default();
-    source_editor.load(Arc::clone(&source_section.timeline), Some(source_track));
+    source_editor.load(
+        source_section.id,
+        Arc::clone(&source_section.timeline),
+        Some(source_track),
+    );
     source_editor
         .editor_mut()
         .selected_clips
@@ -388,6 +392,7 @@ fn cross_section_paste_uses_selected_section_and_keeps_out_of_bounds_material() 
 
     let mut destination_editor = SectionTimelineEditor::default();
     destination_editor.load(
+        destination_section.id,
         Arc::clone(&destination_section.timeline),
         Some(destination_track),
     );
@@ -411,5 +416,101 @@ fn cross_section_paste_uses_selected_section_and_keeps_out_of_bounds_material() 
     assert_eq!(
         source_section.timeline.get(source_track).unwrap().clips[0].id,
         source_id
+    );
+}
+
+#[test]
+fn section_paste_after_undo_reload_keeps_the_same_edit_cursor_anchor() {
+    let project = project_tracks(&[TrackKind::Audio, TrackKind::Audio]);
+    let source_track = project.tracks[0].id;
+    let destination_track = project.tracks[1].id;
+    let source_clip = audio_clip(200);
+    let source_id = source_clip.id;
+    let mut source_section = Section::new(0);
+    Arc::make_mut(&mut source_section.timeline)
+        .ensure(source_track)
+        .clips
+        .push(source_clip);
+    let destination_section = Section::new(1);
+    let mut clipboard = ClipClipboard::default();
+    let mut source_editor = SectionTimelineEditor::default();
+    source_editor.load(
+        source_section.id,
+        Arc::clone(&source_section.timeline),
+        Some(source_track),
+    );
+    source_editor
+        .editor_mut()
+        .selected_clips
+        .insert(ArrangementSelection::AudioClip {
+            track_id: source_track,
+            clip_id: source_id,
+        });
+    copy(
+        source_editor.editor_mut(),
+        &project,
+        &mut clipboard,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..ArrangementCtx::default()
+        },
+    );
+
+    let empty_timeline = Arc::clone(&destination_section.timeline);
+    let mut destination_editor = SectionTimelineEditor::default();
+    destination_editor.load(
+        destination_section.id,
+        Arc::clone(&empty_timeline),
+        Some(destination_track),
+    );
+    destination_editor.place_edit_cursor(8.0);
+    let paste_ctx = ArrangementCtx {
+        samples_per_beat: 100.0,
+        playhead_beats: destination_editor.edit_cursor_beats(),
+        ..ArrangementCtx::default()
+    };
+    paste(
+        destination_editor.editor_mut(),
+        &project,
+        &mut clipboard,
+        paste_ctx,
+    );
+    assert_eq!(
+        destination_editor
+            .editor()
+            .timeline
+            .get(destination_track)
+            .unwrap()
+            .clips[0]
+            .position,
+        800
+    );
+
+    destination_editor.load(
+        destination_section.id,
+        empty_timeline,
+        Some(destination_track),
+    );
+    assert_eq!(destination_editor.edit_cursor_beats(), 8.0);
+    let paste_ctx = ArrangementCtx {
+        samples_per_beat: 100.0,
+        playhead_beats: destination_editor.edit_cursor_beats(),
+        ..ArrangementCtx::default()
+    };
+    paste(
+        destination_editor.editor_mut(),
+        &project,
+        &mut clipboard,
+        paste_ctx,
+    );
+    assert_eq!(
+        destination_editor
+            .editor()
+            .timeline
+            .get(destination_track)
+            .unwrap()
+            .clips[0]
+            .position,
+        800
     );
 }

--- a/crates/vibez-ui/src/domains/arrangement/clipboard_tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/clipboard_tests.rs
@@ -113,7 +113,7 @@ fn paste(
 }
 
 #[test]
-fn audio_cross_timeline_paste_remints_identity_shares_media_and_keeps_position() {
+fn audio_cross_timeline_paste_remints_identity_and_anchors_at_playhead() {
     let project = project_tracks(&[TrackKind::Audio, TrackKind::Audio]);
     let source_track = project.tracks[0].id;
     let destination_track = project.tracks[1].id;
@@ -152,7 +152,7 @@ fn audio_cross_timeline_paste_remints_identity_shares_media_and_keeps_position()
         .unwrap()
         .clips[0];
     assert_ne!(pasted.id, source_id);
-    assert_eq!(pasted.position, 600);
+    assert_eq!(pasted.position, 9_000);
     assert!(Arc::ptr_eq(&pasted.audio, &media));
     assert_eq!(
         source_editor.timeline.get(source_track).unwrap().clips[0].id,
@@ -161,7 +161,7 @@ fn audio_cross_timeline_paste_remints_identity_shares_media_and_keeps_position()
 }
 
 #[test]
-fn midi_cross_timeline_paste_remints_identity_and_preserves_notes_and_position() {
+fn midi_cross_timeline_paste_remints_identity_and_preserves_notes_at_playhead() {
     let project = project_tracks(&[TrackKind::Midi, TrackKind::Midi]);
     let source_track = project.tracks[0].id;
     let destination_track = project.tracks[1].id;
@@ -196,6 +196,7 @@ fn midi_cross_timeline_paste_remints_identity_and_preserves_notes_and_position()
         &mut clipboard,
         ArrangementCtx {
             samples_per_beat: 100.0,
+            playhead_beats: 12.0,
             ..ArrangementCtx::default()
         },
     );
@@ -207,7 +208,7 @@ fn midi_cross_timeline_paste_remints_identity_and_preserves_notes_and_position()
         .unwrap()
         .note_clips[0];
     assert_ne!(pasted.id, source_id);
-    assert_eq!(pasted.position_beats, 7.5);
+    assert_eq!(pasted.position_beats, 12.0);
     assert_eq!(pasted.notes[0].start_beat, 0.25);
     assert!(pasted.selected_notes.is_empty());
 }
@@ -254,6 +255,7 @@ fn multi_track_paste_maps_relative_tracks_atomically_and_preserves_clip_timing()
     let mut clipboard = ClipClipboard::default();
     let ctx = ArrangementCtx {
         samples_per_beat: 100.0,
+        playhead_beats: 8.0,
         ..ArrangementCtx::default()
     };
     copy(&mut source_editor, &project, &mut clipboard, ctx);
@@ -274,7 +276,7 @@ fn multi_track_paste_maps_relative_tracks_atomically_and_preserves_clip_timing()
         .map(|clip| clip.position)
         .collect();
     audio_positions.sort_unstable();
-    assert_eq!(audio_positions, vec![200, 500]);
+    assert_eq!(audio_positions, vec![800, 1_100]);
     assert_eq!(
         destination_editor
             .timeline
@@ -282,7 +284,7 @@ fn multi_track_paste_maps_relative_tracks_atomically_and_preserves_clip_timing()
             .unwrap()
             .note_clips[0]
             .position_beats,
-        3.0
+        9.0
     );
 }
 
@@ -315,6 +317,7 @@ fn incompatible_or_truncated_mapping_fails_without_changing_timeline_or_clipboar
     let mut clipboard = ClipClipboard::default();
     let ctx = ArrangementCtx {
         samples_per_beat: 100.0,
+        playhead_beats: 8.0,
         ..ArrangementCtx::default()
     };
     copy(&mut source_editor, &project, &mut clipboard, ctx);
@@ -368,6 +371,7 @@ fn cross_section_paste_uses_selected_section_and_keeps_out_of_bounds_material() 
     let mut clipboard = ClipClipboard::default();
     let ctx = ArrangementCtx {
         samples_per_beat: 100.0,
+        playhead_beats: 8.0,
         ..ArrangementCtx::default()
     };
 
@@ -401,9 +405,9 @@ fn cross_section_paste_uses_selected_section_and_keeps_out_of_bounds_material() 
         .get(destination_track)
         .unwrap()
         .clips[0];
-    assert_eq!(pasted.position, 600);
+    assert_eq!(pasted.position, 800);
     assert_ne!(pasted.id, source_id);
-    assert!(!destination_section.contains_playable_beat(6.0));
+    assert!(!destination_section.contains_playable_beat(8.0));
     assert_eq!(
         source_section.timeline.get(source_track).unwrap().clips[0].id,
         source_id

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -506,7 +506,7 @@ fn submit_clip_bpm_parses_and_rejects_garbage() {
 }
 
 #[test]
-fn copy_and_paste_multiple_clips_preserves_original_positions_and_loops() {
+fn copy_and_paste_multiple_clips_anchors_at_playhead_and_preserves_offsets_and_loops() {
     let mut a = arrangement_with_tracks(1);
     let (tid, first) = add_audio_clip(&mut a, 0, 0, 100);
     let (_, second) = add_audio_clip(&mut a, 0, 200, 100);
@@ -531,8 +531,8 @@ fn copy_and_paste_multiple_clips_preserves_original_positions_and_loops() {
     assert_eq!(a.tracks[0].clips.len(), 4);
     let mut pasted: Vec<_> = a.tracks[0].clips[2..].iter().collect();
     pasted.sort_by_key(|clip| clip.position);
-    assert_eq!(pasted[0].position, 0);
-    assert_eq!(pasted[1].position, 200);
+    assert_eq!(pasted[0].position, 1_000);
+    assert_eq!(pasted[1].position, 1_200);
     assert!(pasted[0].loop_enabled);
     assert!(pasted.iter().all(|clip| clip.name == "Clip"));
     assert_eq!(a.selected_clips.len(), 2);
@@ -582,11 +582,11 @@ fn partial_time_selection_copies_audio_and_trimmed_midi() {
     a.update(ArrangementMsg::PasteClips, &mut engine, ctx);
 
     let audio = a.find_track(audio_tid).unwrap().clips.last().unwrap();
-    assert_eq!(audio.position, 200);
+    assert_eq!(audio.position, 1_000);
     assert_eq!(audio.duration, 300);
     assert_eq!(audio.source_offset, 100);
     let notes = a.find_track(midi_tid).unwrap().note_clips.last().unwrap();
-    assert_eq!(notes.position_beats, 2.0);
+    assert_eq!(notes.position_beats, 10.0);
     assert_eq!(notes.duration_beats, 3.0);
     assert_eq!(notes.notes[0].start_beat, 0.0);
     assert_eq!(notes.notes[0].duration_beats, 2.0);

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -904,7 +904,7 @@ impl PerformState {
         if let Some(section) = self.sections.by_id(id) {
             self.selected_section = Some(id);
             self.section_editor
-                .load(Arc::clone(&section.timeline), selected_track);
+                .load(id, Arc::clone(&section.timeline), selected_track);
             self.editing_section_name = None;
             self.section_name_edit = section.name.clone();
             self.editor_focus = PerformEditorFocus::SectionConstruction;
@@ -918,7 +918,7 @@ impl PerformState {
     pub fn sync_selected_section_editor(&mut self, selected_track: Option<TrackId>) {
         if let Some(section) = self.selected_section.and_then(|id| self.sections.by_id(id)) {
             self.section_editor
-                .load(Arc::clone(&section.timeline), selected_track);
+                .load(section.id, Arc::clone(&section.timeline), selected_track);
         } else {
             self.selected_section = None;
             self.section_editor.clear();

--- a/crates/vibez-ui/src/domains/perform/sections.rs
+++ b/crates/vibez-ui/src/domains/perform/sections.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use vibez_core::id::{ClipId, LaneId, SectionId, TrackId};
@@ -19,24 +20,48 @@ pub const MAX_SECTION_LENGTH_BEATS: f64 = 1024.0;
 ///
 /// Persisted Section content remains in [`Section::timeline`]. Selection and
 /// pointer interaction state stay outside the canonical Section store and are
-/// reset when a different Section is selected. The application owns the one
-/// clipboard shared with Arrange.
+/// reset when a different Section is selected. Per-Section edit cursors stay
+/// here across selection changes and canonical project reloads. The
+/// application owns the one clipboard shared with Arrange.
 #[derive(Debug, Default)]
 pub struct SectionTimelineEditor {
     editor: TimelineEditorState,
+    loaded_section: Option<SectionId>,
+    edit_cursors: HashMap<SectionId, f64>,
 }
 
 impl SectionTimelineEditor {
-    pub fn load(&mut self, timeline: Arc<ArrangementTimeline>, selected_track: Option<TrackId>) {
+    pub fn load(
+        &mut self,
+        section_id: SectionId,
+        timeline: Arc<ArrangementTimeline>,
+        selected_track: Option<TrackId>,
+    ) {
         self.editor = TimelineEditorState {
             timeline,
             selected_track,
             ..TimelineEditorState::default()
         };
+        self.loaded_section = Some(section_id);
+        self.edit_cursors.entry(section_id).or_insert(0.0);
     }
 
     pub fn clear(&mut self) {
         self.editor = TimelineEditorState::default();
+        self.loaded_section = None;
+    }
+
+    pub fn edit_cursor_beats(&self) -> f64 {
+        self.loaded_section
+            .and_then(|section_id| self.edit_cursors.get(&section_id).copied())
+            .unwrap_or(0.0)
+    }
+
+    pub fn place_edit_cursor(&mut self, beat: f64) {
+        if let Some(section_id) = self.loaded_section {
+            self.edit_cursors.insert(section_id, beat.max(0.0));
+        }
+        self.editor.time_selection_active = false;
     }
 
     pub fn editor(&self) -> &TimelineEditorState {
@@ -310,7 +335,11 @@ mod tests {
         let track_id = TrackId::new();
         let mut arrange = ArrangementState::default();
         let mut section = SectionTimelineEditor::default();
-        section.load(Arc::new(ArrangementTimeline::default()), Some(track_id));
+        section.load(
+            SectionId::new(),
+            Arc::new(ArrangementTimeline::default()),
+            Some(track_id),
+        );
 
         Arc::make_mut(&mut section.editor_mut().timeline)
             .ensure(track_id)
@@ -358,6 +387,31 @@ mod tests {
         let section_clip = &section.editor().timeline.get(track_id).unwrap().note_clips[0];
         assert_eq!(section_clip.name, "Section Pattern");
         assert_eq!(section_clip.position_beats, 0.0);
+    }
+
+    #[test]
+    fn section_edit_cursor_survives_reload_and_is_remembered_per_section() {
+        let first_id = SectionId::new();
+        let second_id = SectionId::new();
+        let first_timeline = Arc::new(ArrangementTimeline::default());
+        let second_timeline = Arc::new(ArrangementTimeline::default());
+        let mut editor = SectionTimelineEditor::default();
+
+        editor.load(first_id, Arc::clone(&first_timeline), None);
+        editor.place_edit_cursor(12.0);
+        editor.load(first_id, Arc::clone(&first_timeline), None);
+        assert_eq!(
+            editor.edit_cursor_beats(),
+            12.0,
+            "undo, redo, and project replay reload the selected Section"
+        );
+
+        editor.load(second_id, Arc::clone(&second_timeline), None);
+        editor.place_edit_cursor(3.0);
+        editor.load(first_id, first_timeline, None);
+        assert_eq!(editor.edit_cursor_beats(), 12.0);
+        editor.load(second_id, second_timeline, None);
+        assert_eq!(editor.edit_cursor_beats(), 3.0);
     }
 
     #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -263,6 +263,9 @@ pub struct ProjectSaveResult {
 
 #[derive(Debug, Clone)]
 pub enum Message {
+    /// A message emitted by the selected Section's timeline surface. The
+    /// router focuses that editor before dispatching the enclosed action.
+    SectionTimeline(Box<Message>),
     /// A menu item was chosen. The router dispatches the action, then closes
     /// only the overlay that produced it.
     MenuItemSelected(MenuOverlay, Box<Message>),

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -329,6 +329,9 @@ pub type ArrangementTimeline = TimelineContent;
 pub struct TimelineEditorState {
     pub timeline: Arc<TimelineContent>,
     pub selected_track: Option<TrackId>,
+    /// Runtime edit cursor for this resolved timeline. Section editors keep
+    /// this independent from both Arrange transport and Section playback.
+    pub playhead_beats: f64,
     pub selected_clips: HashSet<ArrangementSelection>,
     pub selected_note_clip: Option<(TrackId, ClipId)>,
     // Time selection (visible brackets; independent from the loop).
@@ -350,6 +353,7 @@ impl Default for TimelineEditorState {
         Self {
             timeline: Arc::new(TimelineContent::default()),
             selected_track: None,
+            playhead_beats: 0.0,
             selected_clips: HashSet::new(),
             selected_note_clip: None,
             time_selection_active: false,

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -329,9 +329,6 @@ pub type ArrangementTimeline = TimelineContent;
 pub struct TimelineEditorState {
     pub timeline: Arc<TimelineContent>,
     pub selected_track: Option<TrackId>,
-    /// Runtime edit cursor for this resolved timeline. Section editors keep
-    /// this independent from both Arrange transport and Section playback.
-    pub playhead_beats: f64,
     pub selected_clips: HashSet<ArrangementSelection>,
     pub selected_note_clip: Option<(TrackId, ClipId)>,
     // Time selection (visible brackets; independent from the loop).
@@ -353,7 +350,6 @@ impl Default for TimelineEditorState {
         Self {
             timeline: Arc::new(TimelineContent::default()),
             selected_track: None,
-            playhead_beats: 0.0,
             selected_clips: HashSet::new(),
             selected_note_clip: None,
             time_selection_active: false,

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -507,6 +507,7 @@ fn cut_and_each_paste_are_separate_undo_steps_while_clipboard_survives_undo() {
     let project_tracks = Arc::clone(&state.project_tracks);
     let ctx = ArrangementCtx {
         samples_per_beat: 100.0,
+        playhead_beats: 7.0,
         ..ArrangementCtx::default()
     };
     let mut engine = RecordingEngine::default();
@@ -552,6 +553,11 @@ fn cut_and_each_paste_are_separate_undo_steps_while_clipboard_survives_undo() {
     state.project.history.push_edit(before_second_paste, None);
     assert_eq!(state.project.history.undo.len(), 3);
     assert_eq!(state.clip_clipboard.clips.len(), 1);
+    let pasted = &state.arrangement.timeline.get(track_id).unwrap().clips;
+    assert_eq!(pasted.len(), 2);
+    assert!(pasted.iter().all(|clip| clip.position == 700));
+    assert_ne!(pasted[0].id, pasted[1].id);
+    assert!(pasted.iter().all(|clip| clip.id != source_id));
 
     undo_once(&mut state);
     assert_eq!(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -316,9 +316,10 @@ Clip clipboard shared by Arrange and every Section editor. The application
 resolves clipboard shortcuts and the paste playhead from the focused editor,
 then supplies both at the editor boundary. The earliest clipboard Clip anchors
 at that playhead and all other musical and Track offsets remain relative.
-Arrange uses its transport edit cursor; each runtime Section editor owns an
-independent edit cursor so selected and playing Sections cannot redirect one
-another. `ArrangementState` is a thin adapter that retains Arrange's Project
+Arrange uses its transport edit cursor; the runtime Section editor remembers
+an independent edit cursor per Section across selection changes and canonical
+reloads, so selected and playing Sections cannot redirect one another.
+`ArrangementState` is a thin adapter that retains Arrange's Project
 Track/channel controls and implements `TimelineEditorAdapter` to resolve its
 editor. The editor never asks which workspace is active and contains no
 `Arrange | Section` branch.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -313,11 +313,15 @@ owns clip/note selection, time selection, and other timeline-local interaction
 state; clip operations, piano-roll editing, automation editing, and timeline
 view behavior receive this already-resolved target. `AppState` owns one runtime
 Clip clipboard shared by Arrange and every Section editor. The application
-resolves clipboard shortcuts from the focused editor and supplies that
-clipboard at the editor boundary. `ArrangementState` is a thin adapter that
-retains Arrange's Project Track/channel controls and implements
-`TimelineEditorAdapter` to resolve its editor. The editor never asks which
-workspace is active and contains no `Arrange | Section` branch.
+resolves clipboard shortcuts and the paste playhead from the focused editor,
+then supplies both at the editor boundary. The earliest clipboard Clip anchors
+at that playhead and all other musical and Track offsets remain relative.
+Arrange uses its transport edit cursor; each runtime Section editor owns an
+independent edit cursor so selected and playing Sections cannot redirect one
+another. `ArrangementState` is a thin adapter that retains Arrange's Project
+Track/channel controls and implements `TimelineEditorAdapter` to resolve its
+editor. The editor never asks which workspace is active and contains no
+`Arrange | Section` branch.
 
 The selected Perform Section provides the editor adapter through a
 runtime-only `SectionTimelineEditor`. Selecting a Section resolves its


### PR DESCRIPTION
## Summary

- anchor the earliest copied Clip at the focused timeline playhead and preserve every musical and relative-Track offset
- give selected Section construction an independent runtime edit cursor, while Arrange retains its exact transport edit cursor
- preserve atomic compatibility checks, reminted identity, out-of-bound Section content, and one-undo-step paste behavior
- revise the architecture contract for focus-owned clipboard placement

## TDD evidence

- red: cross-timeline audio paste stayed at source sample 600 instead of focused sample 9000
- green: one earliest-beat anchor shifts audio and MIDI entries together after compatibility validation
- red: focus routing had no Section-owned playhead resolver
- green: focused Arrange/Section cursor resolution, selected-not-playing Section targeting, and pointer-seek isolation
- regression coverage includes multi-Track spacing, time-selection fragments, incompatible atomic failure, repeated reminting, out-of-bound Section content, and cut/paste Undo

## Verification

- `CARGO_TARGET_DIR=/home/alexander/Code/Apps/vibez-targets/card-15 nice -n 10 cargo test --workspace -j 4`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/home/alexander/Code/Apps/vibez-targets/card-15 nice -n 10 cargo clippy --workspace -j 4 -- -D warnings`
- `git diff --check`, architecture documentation, and the 1,000-line crossing audit
- isolated Xvfb producer pass with a freshly built binary; no physical desktop used

## Producer demo

1. In Arrange, create or select two compatible Clips on adjacent Tracks at different source positions.
2. Multi-select and copy them, click a later empty position on the first destination Track, and paste.
3. Confirm the earliest Clip begins at the white edit cursor and the second keeps both its musical and Track offset.
4. Undo and redo; confirm both pasted Clips leave and return together.
5. Copy the same phrase, open a selected Section, click its construction timeline, and paste.
6. Confirm the Section cursor—not Arrange or a playing Section—owns the anchor; scroll to verify later material remains stored at the Section edge.
7. Try an incompatible destination and confirm the visible failure leaves the timeline unchanged.

No merge requested.