### PR TITLE
Perform Card 41: bring Section navigation to Arrange parity

### DIFF
--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -13,6 +13,9 @@ use crate::state::{ArrangementSelection, DetailPanelTab, UiEffect};
 
 use super::*;
 
+/// Keep edge-scroll activation inside the window border/shadow hit area.
+const TIMELINE_WINDOW_EDGE_INSET: f32 = 8.0;
+
 fn apply_track_mute_request(
     project_tracks: &mut Arc<crate::state::ProjectTracksState>,
     history: &mut crate::state::UndoHistory,
@@ -686,7 +689,7 @@ impl App {
         // A stationary pointer does not produce canvas events. Drive the
         // active editor's bounded edge-scroll from the 60fps UI clock.
         let cursor_x = self.state.view.cursor_x;
-        let right_boundary = (self.state.view.window_width - 8.0).max(1.0);
+        let right_boundary = (self.state.view.window_width - TIMELINE_WINDOW_EDGE_INSET).max(1.0);
         let section_drag = self.state.view.workspace == crate::state::Workspace::Perform
             && self
                 .state

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -177,7 +177,16 @@ impl App {
             self.state.view.detail_panel_tab = DetailPanelTab::Clip;
         }
         if let Some(beat) = action.scroll_to_beat {
-            self.auto_scroll_to_beat(beat);
+            if !self.state.arrangement.drag_resize_active
+                && !self
+                    .state
+                    .perform
+                    .section_editor
+                    .editor()
+                    .drag_resize_active
+            {
+                self.auto_scroll_to_beat(beat);
+            }
         }
         if let Some((start, end)) = action.loop_from_selection {
             let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
@@ -241,6 +250,11 @@ impl App {
         }
         if action.end_drag_resize {
             self.state.arrangement.drag_resize_active = false;
+            self.state
+                .perform
+                .section_editor
+                .editor_mut()
+                .drag_resize_active = false;
         }
         if action.close_device_menu {
             self.state.devices.context_menu = None;
@@ -359,7 +373,16 @@ impl App {
             }
         }
         if let Some(beat) = action.scroll_to_beat {
-            self.auto_scroll_to_beat(beat);
+            if !self.state.arrangement.drag_resize_active
+                && !self
+                    .state
+                    .perform
+                    .section_editor
+                    .editor()
+                    .drag_resize_active
+            {
+                self.auto_scroll_to_beat(beat);
+            }
         }
         if action.drag_resize_active {
             if self.state.view.workspace == crate::state::Workspace::Perform
@@ -660,34 +683,62 @@ impl App {
         vibez_plugin_host::poll_clap_events();
         let export_task = self.poll_export();
 
-        // Tick-driven auto-scroll: when dragging a clip and cursor is near the
-        // window edge, continuously scroll the arrangement. The canvas can't
-        // generate new events when the cursor is stationary at the screen edge,
-        // so this tick loop drives the scrolling at 60fps.
-        if self.state.arrangement.drag_resize_active {
-            let edge_zone = 60.0_f32;
-            // Right edge: estimate window right ~= track header + canvas
-            // Use cursor_x relative to a conservative right boundary
-            let right_boundary = 1600.0_f32; // reasonable default
-            if self.state.view.cursor_x > right_boundary - edge_zone {
-                let overshoot = ((self.state.view.cursor_x - (right_boundary - edge_zone))
-                    / edge_zone)
-                    .clamp(0.0, 3.0) as f64;
-                let delta = overshoot * 2.0;
-                let total = self.state.total_beats();
-                self.state.view.scroll_offset_beats =
-                    (self.state.view.scroll_offset_beats + delta).clamp(0.0, total);
+        // A stationary pointer does not produce canvas events. Drive the
+        // active editor's bounded edge-scroll from the 60fps UI clock.
+        let cursor_x = self.state.view.cursor_x;
+        let right_boundary = (self.state.view.window_width - 8.0).max(1.0);
+        let section_drag = self.state.view.workspace == crate::state::Workspace::Perform
+            && self
+                .state
+                .perform
+                .section_editor
+                .editor()
+                .drag_resize_active;
+        if section_drag {
+            let viewport_width = self.section_timeline_viewport_width();
+            let left_boundary = (right_boundary - viewport_width).max(0.0);
+            let velocity = crate::timeline_geometry::edge_scroll_velocity(
+                cursor_x,
+                left_boundary,
+                right_boundary,
+            );
+            if velocity != 0.0 {
+                let total_beats = self
+                    .state
+                    .perform
+                    .selected_section
+                    .and_then(|id| self.state.perform.sections.by_id(id))
+                    .map_or(0.0, |section| section.length_beats);
+                self.state.perform.section_editor.viewport_mut().scroll_by(
+                    velocity / 60.0,
+                    total_beats,
+                    viewport_width,
+                );
             }
-            // Left edge
-            let left_boundary = 230.0_f32; // ~track header width
-            if self.state.view.cursor_x < left_boundary + edge_zone
-                && self.state.view.scroll_offset_beats > 0.0
-            {
-                let overshoot = ((left_boundary + edge_zone - self.state.view.cursor_x) / edge_zone)
-                    .clamp(0.0, 3.0) as f64;
-                let delta = overshoot * 2.0;
-                self.state.view.scroll_offset_beats =
-                    (self.state.view.scroll_offset_beats - delta).max(0.0);
+        } else if self.state.arrangement.drag_resize_active {
+            let browser_width = if self.state.browser.open {
+                self.state
+                    .browser
+                    .effective_dock_width(self.state.view.window_width)
+                    + super::views_shell::HORIZONTAL_PANE_SPLITTER_WIDTH
+            } else {
+                0.0
+            };
+            let left_boundary =
+                browser_width + crate::widgets::track_header::TRACK_HEADER_TOTAL_WIDTH;
+            let viewport_width = (right_boundary - left_boundary).max(1.0);
+            let velocity = crate::timeline_geometry::edge_scroll_velocity(
+                cursor_x,
+                left_boundary,
+                right_boundary,
+            );
+            if velocity != 0.0 {
+                let mut viewport = crate::timeline_geometry::TimelineViewport::new(
+                    self.state.view.zoom_level,
+                    self.state.view.scroll_offset_beats,
+                );
+                viewport.scroll_by(velocity / 60.0, self.state.total_beats(), viewport_width);
+                self.state.view.scroll_offset_beats = viewport.scroll_offset_beats;
             }
         }
         export_task

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -473,6 +473,17 @@ impl App {
                 .pixels_per_beat();
             }
         }
+        if self.state.view.workspace == crate::state::Workspace::Perform
+            && self.state.perform.selected_section.is_some()
+        {
+            return self
+                .state
+                .perform
+                .section_editor
+                .viewport()
+                .geometry()
+                .pixels_per_beat();
+        }
         crate::timeline_geometry::TimelineGeometry::from_zoom(
             self.state.view.zoom_level,
             self.state.view.scroll_offset_beats,

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -18,6 +18,19 @@ use super::*;
 
 impl App {
     pub(super) fn update(&mut self, message: Message) -> Task<Message> {
+        let message = match message {
+            Message::SectionTimeline(edit) => {
+                if super::update_timeline::section_timeline_claims_focus(
+                    self.state.view.workspace,
+                    self.state.perform.selected_section.is_some(),
+                ) {
+                    self.state.perform.editor_focus =
+                        crate::domains::perform::PerformEditorFocus::SectionConstruction;
+                }
+                *edit
+            }
+            message => message,
+        };
         let (message, undo_gesture) = match message {
             Message::UndoGesture { id, edit } => (*edit, Some(id)),
             message => (message, None),
@@ -67,6 +80,9 @@ impl App {
         }
 
         match message {
+            Message::SectionTimeline(_) => {
+                unreachable!("section timeline wrappers are removed before routing")
+            }
             Message::MenuItemSelected(overlay, action) => {
                 let task = self.update(*action);
                 menu_lifecycle::dismiss(&mut self.state, overlay);
@@ -85,6 +101,9 @@ impl App {
             // only computes the cross-domain context, routes the
             // message, and applies the returned action.
             Message::Transport(msg) => {
+                if self.place_focused_section_playhead(&msg) {
+                    return Task::none();
+                }
                 let stops_perform = matches!(&msg, crate::domains::transport::TransportMsg::Stop)
                     || matches!(
                         &msg,

--- a/crates/vibez-ui/src/app/update_timeline.rs
+++ b/crates/vibez-ui/src/app/update_timeline.rs
@@ -21,7 +21,39 @@ fn clipboard_targets_section(
         && focus == PerformEditorFocus::SectionConstruction
 }
 
+fn focused_section_seek_beat(
+    workspace: Workspace,
+    selected_section: bool,
+    focus: PerformEditorFocus,
+    msg: &crate::domains::transport::TransportMsg,
+) -> Option<f64> {
+    let crate::domains::transport::TransportMsg::SeekToBeat(beat) = msg else {
+        return None;
+    };
+    clipboard_targets_section(workspace, selected_section, focus).then(|| beat.max(0.0))
+}
+
+pub(super) fn section_timeline_claims_focus(workspace: Workspace, selected_section: bool) -> bool {
+    workspace == Workspace::Perform && selected_section
+}
+
 impl App {
+    pub(super) fn place_focused_section_playhead(
+        &mut self,
+        msg: &crate::domains::transport::TransportMsg,
+    ) -> bool {
+        let Some(beat) = focused_section_seek_beat(
+            self.state.view.workspace,
+            self.state.perform.selected_section.is_some(),
+            self.state.perform.editor_focus,
+            msg,
+        ) else {
+            return false;
+        };
+        self.state.perform.section_editor.place_edit_cursor(beat);
+        true
+    }
+
     pub(super) fn route_automation_editor_message(
         &mut self,
         msg: AutomationMsg,
@@ -241,5 +273,29 @@ mod clipboard_focus_tests {
             false,
             PerformEditorFocus::SectionConstruction,
         ));
+    }
+
+    #[test]
+    fn section_ruler_seek_targets_the_section_edit_cursor_not_arrange() {
+        use crate::domains::transport::TransportMsg;
+
+        assert_eq!(
+            focused_section_seek_beat(
+                Workspace::Perform,
+                true,
+                PerformEditorFocus::SectionConstruction,
+                &TransportMsg::SeekToBeat(13.0),
+            ),
+            Some(13.0)
+        );
+        assert_eq!(
+            focused_section_seek_beat(
+                Workspace::Arrange,
+                true,
+                PerformEditorFocus::SectionConstruction,
+                &TransportMsg::SeekToBeat(13.0),
+            ),
+            None
+        );
     }
 }

--- a/crates/vibez-ui/src/app/update_view.rs
+++ b/crates/vibez-ui/src/app/update_view.rs
@@ -1,12 +1,64 @@
 //! Routes View messages and their Browser/Perform resize side effects.
 
 use crate::domains::browser::BrowserMsg;
+use crate::domains::perform::PerformEditorFocus;
 use crate::domains::timeline_editor::TimelineEditorAdapter;
 use crate::domains::view::ViewMsg;
+use crate::state::Workspace;
+use crate::timeline_geometry::{TimelineGeometry, BASE_PIXELS_PER_BEAT};
 
 use super::*;
 
 impl App {
+    fn route_section_timeline_navigation(&mut self, msg: &ViewMsg) -> bool {
+        if self.state.view.workspace != Workspace::Perform
+            || self.state.perform.editor_focus != PerformEditorFocus::SectionConstruction
+        {
+            return false;
+        }
+        let Some(total_beats) = self
+            .state
+            .perform
+            .selected_section
+            .and_then(|id| self.state.perform.sections.by_id(id))
+            .map(|section| section.length_beats)
+        else {
+            return false;
+        };
+        let viewport_width = self.section_timeline_viewport_width();
+        let viewport = self.state.perform.section_editor.viewport_mut();
+        match msg {
+            ViewMsg::ZoomIn => {
+                viewport.zoom_around(1.25, viewport_width / 2.0, total_beats, viewport_width)
+            }
+            ViewMsg::ZoomOut => viewport.zoom_around(
+                1.0 / 1.25,
+                viewport_width / 2.0,
+                total_beats,
+                viewport_width,
+            ),
+            ViewMsg::SetZoom(level) => {
+                let factor = level.clamp(0.01, 16.0) / viewport.zoom_level;
+                viewport.zoom_around(factor, viewport_width / 2.0, total_beats, viewport_width);
+            }
+            ViewMsg::ZoomAround { factor, anchor_x } => {
+                viewport.zoom_around(*factor, *anchor_x, total_beats, viewport_width);
+            }
+            ViewMsg::ZoomToFit => {
+                let target_ppb =
+                    TimelineGeometry::fitted(total_beats, viewport_width, 0.0).pixels_per_beat();
+                viewport.zoom_level = (target_ppb / BASE_PIXELS_PER_BEAT).clamp(0.01, 16.0);
+                viewport.scroll_offset_beats = 0.0;
+                viewport.clamp(total_beats, viewport_width);
+            }
+            ViewMsg::ScrollArrangement(delta) => {
+                viewport.scroll_by(*delta, total_beats, viewport_width);
+            }
+            _ => return false,
+        }
+        true
+    }
+
     pub(super) fn route_view_message(&mut self, msg: ViewMsg) -> Task<Message> {
         if matches!(&msg, ViewMsg::ToggleEditMenu) {
             self.state.project.file_menu_open = false;
@@ -91,6 +143,9 @@ impl App {
             if let Some(status) = action.status {
                 self.state.status_text = status;
             }
+        }
+        if self.route_section_timeline_navigation(&msg) {
+            return Task::none();
         }
         let ctx = crate::domains::view::ViewCtx {
             total_beats: self.state.total_beats(),

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -21,7 +21,6 @@ const PAD_SURFACE_MIN_WIDTH: f32 = 320.0;
 const SECTION_CONSTRUCTION_MIN_WIDTH: f32 = 460.0;
 const SECTION_TOOLBAR_INLINE_MIN_WIDTH: f32 = 640.0;
 pub(super) const SECTION_TRACK_GUTTER_WIDTH: f32 = 112.0;
-pub(super) const SECTION_BAR_WIDTH: f32 = 160.0;
 
 pub(super) fn perform_tool_button(
     icon: char,
@@ -118,9 +117,7 @@ impl App {
         let workspace_width = self.perform_workspace_width();
         let surface_width =
             effective_perform_surface_width(self.state.view.perform_surface_width, workspace_width);
-        let section_width =
-            (workspace_width - surface_width - super::views_shell::HORIZONTAL_PANE_SPLITTER_WIDTH)
-                .max(0.0);
+        let section_width = self.section_construction_width();
         let mode_selector = self.view_perform_mode_selector(surface_width);
         let pad_surface = self.view_pad_surface(surface_width);
         let section_construction = self.view_section_construction(section_width);
@@ -161,6 +158,18 @@ impl App {
             0.0
         };
         (self.state.view.window_width - browser_width).max(0.0)
+    }
+
+    pub(super) fn section_construction_width(&self) -> f32 {
+        let workspace_width = self.perform_workspace_width();
+        let surface_width =
+            effective_perform_surface_width(self.state.view.perform_surface_width, workspace_width);
+        (workspace_width - surface_width - super::views_shell::HORIZONTAL_PANE_SPLITTER_WIDTH)
+            .max(0.0)
+    }
+
+    pub(super) fn section_timeline_viewport_width(&self) -> f32 {
+        (self.section_construction_width() - SECTION_TRACK_GUTTER_WIDTH - 8.0).max(1.0)
     }
 
     pub(super) fn perform_surface_drag_width(&self, cursor_x: f32) -> f32 {

--- a/crates/vibez-ui/src/app/views_perform.rs
+++ b/crates/vibez-ui/src/app/views_perform.rs
@@ -21,6 +21,10 @@ const PAD_SURFACE_MIN_WIDTH: f32 = 320.0;
 const SECTION_CONSTRUCTION_MIN_WIDTH: f32 = 460.0;
 const SECTION_TOOLBAR_INLINE_MIN_WIDTH: f32 = 640.0;
 pub(super) const SECTION_TRACK_GUTTER_WIDTH: f32 = 112.0;
+pub(super) const SECTION_SCROLLBAR_WIDTH: u16 = 5;
+pub(super) const SECTION_SCROLLBAR_SPACING: u16 = 1;
+pub(super) const SECTION_SCROLLBAR_RESERVATION: f32 =
+    (SECTION_SCROLLBAR_WIDTH + SECTION_SCROLLBAR_SPACING) as f32;
 
 pub(super) fn perform_tool_button(
     icon: char,
@@ -169,7 +173,10 @@ impl App {
     }
 
     pub(super) fn section_timeline_viewport_width(&self) -> f32 {
-        (self.section_construction_width() - SECTION_TRACK_GUTTER_WIDTH - 8.0).max(1.0)
+        (self.section_construction_width()
+            - SECTION_TRACK_GUTTER_WIDTH
+            - SECTION_SCROLLBAR_RESERVATION)
+            .max(1.0)
     }
 
     pub(super) fn perform_surface_drag_width(&self, cursor_x: f32) -> f32 {

--- a/crates/vibez-ui/src/app/views_perform_sections.rs
+++ b/crates/vibez-ui/src/app/views_perform_sections.rs
@@ -3,8 +3,7 @@
 use std::collections::HashSet;
 
 use iced::widget::{
-    button, canvas, center, column, container, horizontal_space, mouse_area, row, scrollable,
-    stack, text,
+    button, canvas, center, column, container, horizontal_space, mouse_area, row, scrollable, text,
 };
 use iced::{Element, Length, Theme};
 
@@ -16,18 +15,23 @@ use crate::message::Message;
 use crate::state::{ArrangementSelection, TrackTimelineContent};
 use crate::theme as th;
 use crate::typography::{PERFORM_DISPLAY, PERFORM_LABEL, PERFORM_TECH, PERFORM_TECH_STRONG};
-use crate::widgets::timeline::{TimelineNoteClip, TrackClipCanvas};
+use crate::widgets::timeline::{
+    ArrangementMinimap, MinimapTrack, RulerWidget, TimelineNoteClip, TrackClipCanvas,
+};
 
 use super::views_automation::AutomationLaneLayout;
-use super::views_perform::{SECTION_BAR_WIDTH, SECTION_TRACK_GUTTER_WIDTH};
+use super::views_perform::SECTION_TRACK_GUTTER_WIDTH;
 use super::*;
 
-fn section_clip_materialization_width(timeline_width: f32) -> f32 {
-    // Section construction uses a full-width canvas inside a parent-owned
-    // horizontal scrollable. Unlike Arrange, the canvas has no beat scroll
-    // offset of its own, so viewport culling must cover the entire canvas;
-    // otherwise later clips exist in the model but are omitted before draw.
-    timeline_width.max(1.0)
+const SECTION_RULER_HEIGHT: f32 = 28.0;
+const SECTION_MINIMAP_HEIGHT: f32 = 40.0;
+
+fn section_clip_materialization_width(viewport_width: f32) -> f32 {
+    viewport_width.max(1.0)
+}
+
+const fn section_navigation_header_height() -> f32 {
+    SECTION_RULER_HEIGHT + SECTION_MINIMAP_HEIGHT
 }
 
 impl App {
@@ -40,12 +44,9 @@ impl App {
         let toolbar = self.view_section_toolbar(selected, section_width);
         let editor = self.state.perform.section_editor.editor();
         let recording_preview = self.state.perform.section_record.live_preview();
-        let bar_count = selected
-            .map(|section| (section.length_beats / 4.0).round() as usize)
-            .unwrap_or(4)
-            .max(1);
         let total_beats = selected.map_or(16.0, |section| section.length_beats);
-        let timeline_width = SECTION_BAR_WIDTH * bar_count as f32;
+        let viewport = *self.state.perform.section_editor.viewport();
+        let viewport_width = (section_width - SECTION_TRACK_GUTTER_WIDTH - 8.0).max(1.0);
         let row_height = if self.state.perform.section_timeline_expanded {
             78.0
         } else {
@@ -128,7 +129,7 @@ impl App {
                 .spacing(3),
             )
             .width(Length::Fixed(SECTION_TRACK_GUTTER_WIDTH))
-            .height(Length::Fixed(32.0))
+            .height(Length::Fixed(SECTION_RULER_HEIGHT))
             .padding([6, 9])
             .style(|_theme: &Theme| container::Style {
                 background: Some(th::bg_surface().into()),
@@ -139,32 +140,93 @@ impl App {
                 },
                 ..Default::default()
             });
+            let playhead_beats = if self.state.perform.playing_section == Some(section_id) {
+                let samples_per_beat = self.state.transport.sample_rate.max(1) as f64 * 60.0
+                    / self.state.transport.bpm.max(f64::EPSILON);
+                self.state.perform.section_playhead_samples as f64 / samples_per_beat
+            } else {
+                -1.0
+            };
+            let ruler = RulerWidget {
+                playhead_beats,
+                bpm: self.state.transport.bpm,
+                zoom_level: viewport.zoom_level,
+                grid: self.state.view.grid_config(),
+                scroll_offset_beats: viewport.scroll_offset_beats,
+                total_beats,
+                loop_enabled: selected_section.looping,
+                loop_start_beats: 0.0,
+                loop_end_beats: total_beats,
+                time_selection_active: editor.time_selection_active,
+                selection_start_beats: editor.selection_start_beats,
+                selection_end_beats: editor.selection_end_beats,
+            };
+            let ruler_canvas: Element<'_, Message> = canvas(ruler)
+                .width(Length::Fill)
+                .height(Length::Fixed(SECTION_RULER_HEIGHT))
+                .into();
+            let ruler_row = row![ruler_gutter, ruler_canvas].width(Length::Fill);
 
-            let mut ruler_marks = row![]
-                .width(Length::Fixed(timeline_width))
-                .height(Length::Fixed(32.0));
-            for bar in 0..bar_count {
-                ruler_marks = ruler_marks.push(
-                    container(
-                        text((bar + 1).to_string())
-                            .font(PERFORM_TECH_STRONG)
-                            .size(10)
-                            .color(th::text_dim()),
-                    )
-                    .width(Length::Fixed(SECTION_BAR_WIDTH))
-                    .height(Length::Fixed(32.0))
-                    .padding([8, 10])
-                    .style(|_theme: &Theme| container::Style {
-                        background: Some(th::bg_dark().into()),
-                        border: iced::Border {
-                            color: th::perform_grid_line(),
-                            width: 1.0,
-                            radius: 0.0.into(),
-                        },
-                        ..Default::default()
-                    }),
-                );
-            }
+            let samples_per_beat = self.state.transport.sample_rate.max(1) as f64 * 60.0
+                / self.state.transport.bpm.max(f64::EPSILON);
+            let minimap = ArrangementMinimap {
+                total_beats,
+                scroll_offset_beats: viewport.scroll_offset_beats,
+                zoom_level: viewport.zoom_level,
+                playhead_beats,
+                bpm: self.state.transport.bpm,
+                loop_enabled: selected_section.looping,
+                loop_start_beats: 0.0,
+                loop_end_beats: total_beats,
+                tracks: self
+                    .state
+                    .project_tracks
+                    .tracks
+                    .iter()
+                    .map(|track| {
+                        let content = editor.timeline.get(track.id);
+                        let mut clips: Vec<_> = content
+                            .into_iter()
+                            .flat_map(|content| {
+                                content.clips.iter().map(|clip| {
+                                    (
+                                        clip.position as f64 / samples_per_beat,
+                                        clip.duration as f64 / samples_per_beat,
+                                    )
+                                })
+                            })
+                            .collect();
+                        clips.extend(content.into_iter().flat_map(|content| {
+                            content
+                                .note_clips
+                                .iter()
+                                .map(|clip| (clip.position_beats, clip.duration_beats))
+                        }));
+                        MinimapTrack {
+                            color: th::track_color(track.color_index),
+                            clips,
+                        }
+                    })
+                    .collect(),
+            };
+            let minimap_gutter = container(text("SECTION OVERVIEW").font(PERFORM_TECH).size(7))
+                .width(Length::Fixed(SECTION_TRACK_GUTTER_WIDTH))
+                .height(Length::Fixed(SECTION_MINIMAP_HEIGHT))
+                .padding([13, 9])
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(th::bg_surface().into()),
+                    border: iced::Border {
+                        color: th::perform_grid_line(),
+                        width: 1.0,
+                        radius: 0.0.into(),
+                    },
+                    ..Default::default()
+                });
+            let minimap_canvas: Element<'_, Message> = canvas(minimap)
+                .width(Length::Fill)
+                .height(Length::Fixed(SECTION_MINIMAP_HEIGHT))
+                .into();
+            let minimap_row = row![minimap_gutter, minimap_canvas].width(Length::Fill);
 
             let track_ids: Vec<_> = self
                 .state
@@ -182,9 +244,7 @@ impl App {
                 .collect();
             let total_tracks = track_ids.len();
             let empty_content = TrackTimelineContent::default();
-            let mut gutters = column![];
-            let mut lanes = column![].width(Length::Fixed(timeline_width));
-            let mut content_height = 32.0;
+            let mut track_rows = column![].width(Length::Fill);
 
             for (index, track) in self.state.project_tracks.tracks.iter().enumerate() {
                 let content = editor.timeline.get(track.id).unwrap_or(&empty_content);
@@ -388,11 +448,11 @@ impl App {
                 let mut clip_canvas = TrackClipCanvas::from_track(
                     track,
                     content,
-                    -1.0,
-                    2.0,
+                    playhead_beats,
+                    viewport.zoom_level,
                     self.state.view.grid_config(),
-                    0.0,
-                    section_clip_materialization_width(timeline_width),
+                    viewport.scroll_offset_beats,
+                    section_clip_materialization_width(viewport_width),
                     total_beats,
                     self.state.transport.sample_rate,
                     selected_track,
@@ -439,14 +499,13 @@ impl App {
                         loop_end_beats: 0.0,
                     });
                 }
-                let geometry = crate::timeline_geometry::TimelineGeometry::from_zoom(2.0, 0.0);
+                let geometry = viewport.geometry();
                 let grid = self.state.view.grid_config();
                 let compatible = !track.kind.is_midi();
-                gutters = gutters.push(gutter);
                 let clip_lane: Element<'_, Message> = if self.state.browser.drag_source.is_some() {
                     mouse_area(
                         canvas(clip_canvas)
-                            .width(Length::Fixed(timeline_width))
+                            .width(Length::Fill)
                             .height(Length::Fixed(row_height)),
                     )
                     .on_move(move |point| {
@@ -462,78 +521,42 @@ impl App {
                     .into()
                 } else {
                     canvas(clip_canvas)
-                        .width(Length::Fixed(timeline_width))
+                        .width(Length::Fill)
                         .height(Length::Fixed(row_height))
                         .into()
                 };
-                lanes = lanes.push(clip_lane);
-                content_height += row_height;
+                track_rows = track_rows.push(
+                    row![gutter, clip_lane]
+                        .width(Length::Fill)
+                        .height(Length::Fixed(row_height)),
+                );
 
                 if automation_open {
                     let layout = AutomationLaneLayout {
                         header_width: SECTION_TRACK_GUTTER_WIDTH,
-                        body_width: Some(timeline_width),
-                        zoom_level: 2.0,
-                        scroll_offset_beats: 0.0,
+                        body_width: None,
+                        zoom_level: viewport.zoom_level,
+                        scroll_offset_beats: viewport.scroll_offset_beats,
                     };
                     for part in
                         self.automation_lane_parts(track, &content.automation, track_color, layout)
                     {
-                        gutters = gutters.push(part.header);
-                        lanes = lanes.push(part.body);
-                        content_height += part.height;
+                        track_rows = track_rows.push(
+                            row![part.header, part.body]
+                                .width(Length::Fill)
+                                .height(Length::Fixed(part.height)),
+                        );
                     }
                 }
             }
 
-            let fixed_gutter =
-                column![ruler_gutter, gutters].width(Length::Fixed(SECTION_TRACK_GUTTER_WIDTH));
-            let timeline_base: Element<'_, Message> = container(column![ruler_marks, lanes])
-                .width(Length::Fixed(timeline_width))
-                .height(Length::Fixed(content_height))
-                .style(|_theme: &Theme| container::Style {
-                    background: Some(th::display_bg().into()),
-                    ..Default::default()
-                })
-                .into();
-            let timeline_content: Element<'_, Message> =
-                if self.state.perform.playing_section == Some(section_id) {
-                    let fraction = super::views_perform_playhead::section_playhead_fraction(
-                        self.state.perform.section_playhead_samples,
-                        selected_section.length_beats,
-                        self.state.transport.bpm,
-                        self.state.transport.sample_rate,
-                    );
-                    let playhead = row![
-                        horizontal_space().width(Length::Fixed(timeline_width * fraction)),
-                        super::views_perform_playhead::section_playhead_line(Length::Fixed(
-                            content_height,
-                        )),
-                    ]
-                    .width(Length::Fixed(timeline_width))
-                    .height(Length::Fixed(content_height));
-                    stack![timeline_base, playhead]
-                        .width(Length::Fixed(timeline_width))
-                        .height(Length::Fixed(content_height))
-                        .into()
-                } else {
-                    timeline_base
-                };
-            let scrolling_timeline = scrollable::Scrollable::with_direction(
-                timeline_content,
-                scrollable::Direction::Horizontal(
-                    scrollable::Scrollbar::new()
-                        .width(5)
-                        .scroller_width(5)
-                        .spacing(1),
-                ),
-            )
-            .width(Length::Fill)
-            .height(Length::Fixed(content_height));
-            scrollable::Scrollable::with_direction(
-                row![fixed_gutter, scrolling_timeline]
+            let body = scrollable::Scrollable::with_direction(
+                container(track_rows)
                     .width(Length::Fill)
-                    .height(Length::Fixed(content_height)),
+                    .style(|_theme: &Theme| container::Style {
+                        background: Some(th::display_bg().into()),
+                        ..Default::default()
+                    }),
                 scrollable::Direction::Vertical(
                     scrollable::Scrollbar::new()
                         .width(5)
@@ -542,8 +565,14 @@ impl App {
                 ),
             )
             .width(Length::Fill)
-            .height(Length::Fill)
-            .into()
+            .height(Length::Fill);
+            let navigation_header = column![ruler_row, minimap_row]
+                .width(Length::Fill)
+                .height(Length::Fixed(section_navigation_header_height()));
+            column![navigation_header, body]
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into()
         };
 
         let construction = container(column![toolbar, timeline].height(Length::Fill))
@@ -569,16 +598,36 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::section_clip_materialization_width;
+    use super::{
+        section_clip_materialization_width, section_navigation_header_height,
+        SECTION_MINIMAP_HEIGHT, SECTION_RULER_HEIGHT,
+    };
+    use crate::timeline_geometry::TimelineViewport;
 
     #[test]
-    fn horizontally_scrolled_section_materializes_its_full_timeline() {
-        let eight_bar_timeline_width = 1_280.0;
-
+    fn long_section_materialization_stays_bounded_to_the_visible_viewport() {
         assert_eq!(
-            section_clip_materialization_width(eight_bar_timeline_width),
-            eight_bar_timeline_width,
-            "late split fragments must exist in the canvas before the parent scroll reveals them"
+            section_clip_materialization_width(824.0),
+            824.0,
+            "timeline length must not expand the canvas beyond the visible viewport"
         );
+    }
+
+    #[test]
+    fn ruler_and_minimap_form_one_sticky_header_above_the_track_scroller() {
+        assert_eq!(
+            section_navigation_header_height(),
+            SECTION_RULER_HEIGHT + SECTION_MINIMAP_HEIGHT
+        );
+    }
+
+    #[test]
+    fn section_playhead_and_lanes_share_the_same_viewport_alignment() {
+        let viewport = TimelineViewport::new(3.0, 9.5);
+        let beat = 13.25;
+        let ruler_x = viewport.geometry().beat_to_x(beat);
+        let lane_x = viewport.geometry().beat_to_x(beat);
+
+        assert_eq!(ruler_x, lane_x);
     }
 }

--- a/crates/vibez-ui/src/app/views_perform_sections.rs
+++ b/crates/vibez-ui/src/app/views_perform_sections.rs
@@ -20,15 +20,13 @@ use crate::widgets::timeline::{
 };
 
 use super::views_automation::AutomationLaneLayout;
-use super::views_perform::SECTION_TRACK_GUTTER_WIDTH;
+use super::views_perform::{
+    SECTION_SCROLLBAR_SPACING, SECTION_SCROLLBAR_WIDTH, SECTION_TRACK_GUTTER_WIDTH,
+};
 use super::*;
 
 const SECTION_RULER_HEIGHT: f32 = 28.0;
 const SECTION_MINIMAP_HEIGHT: f32 = 40.0;
-
-fn section_clip_materialization_width(viewport_width: f32) -> f32 {
-    viewport_width.max(1.0)
-}
 
 const fn section_navigation_header_height() -> f32 {
     SECTION_RULER_HEIGHT + SECTION_MINIMAP_HEIGHT
@@ -46,7 +44,10 @@ impl App {
         let recording_preview = self.state.perform.section_record.live_preview();
         let total_beats = selected.map_or(16.0, |section| section.length_beats);
         let viewport = *self.state.perform.section_editor.viewport();
-        let viewport_width = (section_width - SECTION_TRACK_GUTTER_WIDTH - 8.0).max(1.0);
+        let viewport_width = (section_width
+            - SECTION_TRACK_GUTTER_WIDTH
+            - super::views_perform::SECTION_SCROLLBAR_RESERVATION)
+            .max(1.0);
         let row_height = if self.state.perform.section_timeline_expanded {
             78.0
         } else {
@@ -140,15 +141,16 @@ impl App {
                 },
                 ..Default::default()
             });
-            let playhead_beats = if self.state.perform.playing_section == Some(section_id) {
+            let playback_playhead_beats = if self.state.perform.playing_section == Some(section_id)
+            {
                 let samples_per_beat = self.state.transport.sample_rate.max(1) as f64 * 60.0
                     / self.state.transport.bpm.max(f64::EPSILON);
-                self.state.perform.section_playhead_samples as f64 / samples_per_beat
+                Some(self.state.perform.section_playhead_samples as f64 / samples_per_beat)
             } else {
-                -1.0
+                None
             };
             let ruler = RulerWidget {
-                playhead_beats,
+                playhead_beats: playback_playhead_beats.unwrap_or(-1.0),
                 bpm: self.state.transport.bpm,
                 zoom_level: viewport.zoom_level,
                 grid: self.state.view.grid_config(),
@@ -161,10 +163,12 @@ impl App {
                 selection_start_beats: editor.selection_start_beats,
                 selection_end_beats: editor.selection_end_beats,
             };
-            let ruler_canvas: Element<'_, Message> = canvas(ruler)
-                .width(Length::Fill)
-                .height(Length::Fixed(SECTION_RULER_HEIGHT))
-                .into();
+            let ruler_canvas: Element<'_, Message> = Element::from(
+                canvas(ruler)
+                    .width(Length::Fill)
+                    .height(Length::Fixed(SECTION_RULER_HEIGHT)),
+            )
+            .map(|message| Message::SectionTimeline(Box::new(message)));
             let ruler_row = row![ruler_gutter, ruler_canvas].width(Length::Fill);
 
             let samples_per_beat = self.state.transport.sample_rate.max(1) as f64 * 60.0
@@ -173,7 +177,7 @@ impl App {
                 total_beats,
                 scroll_offset_beats: viewport.scroll_offset_beats,
                 zoom_level: viewport.zoom_level,
-                playhead_beats,
+                playhead_beats: playback_playhead_beats.unwrap_or(-1.0),
                 bpm: self.state.transport.bpm,
                 loop_enabled: selected_section.looping,
                 loop_start_beats: 0.0,
@@ -222,10 +226,12 @@ impl App {
                     },
                     ..Default::default()
                 });
-            let minimap_canvas: Element<'_, Message> = canvas(minimap)
-                .width(Length::Fill)
-                .height(Length::Fixed(SECTION_MINIMAP_HEIGHT))
-                .into();
+            let minimap_canvas: Element<'_, Message> = Element::from(
+                canvas(minimap)
+                    .width(Length::Fill)
+                    .height(Length::Fixed(SECTION_MINIMAP_HEIGHT)),
+            )
+            .map(|message| Message::SectionTimeline(Box::new(message)));
             let minimap_row = row![minimap_gutter, minimap_canvas].width(Length::Fill);
 
             let track_ids: Vec<_> = self
@@ -448,11 +454,11 @@ impl App {
                 let mut clip_canvas = TrackClipCanvas::from_track(
                     track,
                     content,
-                    playhead_beats,
+                    self.state.perform.section_editor.edit_cursor_beats(),
                     viewport.zoom_level,
                     self.state.view.grid_config(),
                     viewport.scroll_offset_beats,
-                    section_clip_materialization_width(viewport_width),
+                    viewport_width,
                     total_beats,
                     self.state.transport.sample_rate,
                     selected_track,
@@ -499,31 +505,34 @@ impl App {
                         loop_end_beats: 0.0,
                     });
                 }
+                clip_canvas = clip_canvas.with_playback_playhead(playback_playhead_beats);
                 let geometry = viewport.geometry();
                 let grid = self.state.view.grid_config();
                 let compatible = !track.kind.is_midi();
-                let clip_lane: Element<'_, Message> = if self.state.browser.drag_source.is_some() {
-                    mouse_area(
-                        canvas(clip_canvas)
-                            .width(Length::Fill)
-                            .height(Length::Fixed(row_height)),
-                    )
-                    .on_move(move |point| {
-                        Message::Browser(BrowserMsg::DragHoverTrack {
-                            track_id,
-                            beat: grid
-                                .snap_beat(geometry.x_to_beat(point.x), geometry.pixels_per_beat())
-                                .max(0.0),
-                            compatible,
-                        })
-                    })
-                    .on_exit(Message::Browser(BrowserMsg::ClearDragTarget))
-                    .into()
-                } else {
+                let focused_clip_canvas: Element<'_, Message> = Element::from(
                     canvas(clip_canvas)
                         .width(Length::Fill)
-                        .height(Length::Fixed(row_height))
+                        .height(Length::Fixed(row_height)),
+                )
+                .map(|message| Message::SectionTimeline(Box::new(message)));
+                let clip_lane: Element<'_, Message> = if self.state.browser.drag_source.is_some() {
+                    mouse_area(focused_clip_canvas)
+                        .on_move(move |point| {
+                            Message::Browser(BrowserMsg::DragHoverTrack {
+                                track_id,
+                                beat: grid
+                                    .snap_beat(
+                                        geometry.x_to_beat(point.x),
+                                        geometry.pixels_per_beat(),
+                                    )
+                                    .max(0.0),
+                                compatible,
+                            })
+                        })
+                        .on_exit(Message::Browser(BrowserMsg::ClearDragTarget))
                         .into()
+                } else {
+                    focused_clip_canvas
                 };
                 track_rows = track_rows.push(
                     row![gutter, clip_lane]
@@ -559,9 +568,9 @@ impl App {
                     }),
                 scrollable::Direction::Vertical(
                     scrollable::Scrollbar::new()
-                        .width(5)
-                        .scroller_width(5)
-                        .spacing(1),
+                        .width(SECTION_SCROLLBAR_WIDTH)
+                        .scroller_width(SECTION_SCROLLBAR_WIDTH)
+                        .spacing(SECTION_SCROLLBAR_SPACING),
                 ),
             )
             .width(Length::Fill)
@@ -593,41 +602,5 @@ impl App {
                 PerformEditorFocus::SectionConstruction,
             )))
             .into()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        section_clip_materialization_width, section_navigation_header_height,
-        SECTION_MINIMAP_HEIGHT, SECTION_RULER_HEIGHT,
-    };
-    use crate::timeline_geometry::TimelineViewport;
-
-    #[test]
-    fn long_section_materialization_stays_bounded_to_the_visible_viewport() {
-        assert_eq!(
-            section_clip_materialization_width(824.0),
-            824.0,
-            "timeline length must not expand the canvas beyond the visible viewport"
-        );
-    }
-
-    #[test]
-    fn ruler_and_minimap_form_one_sticky_header_above_the_track_scroller() {
-        assert_eq!(
-            section_navigation_header_height(),
-            SECTION_RULER_HEIGHT + SECTION_MINIMAP_HEIGHT
-        );
-    }
-
-    #[test]
-    fn section_playhead_and_lanes_share_the_same_viewport_alignment() {
-        let viewport = TimelineViewport::new(3.0, 9.5);
-        let beat = 13.25;
-        let ruler_x = viewport.geometry().beat_to_x(beat);
-        let lane_x = viewport.geometry().beat_to_x(beat);
-
-        assert_eq!(ruler_x, lane_x);
     }
 }

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -483,6 +483,7 @@ impl PerformState {
             }
             PerformMsg::DeleteSection(id) => {
                 if ctx.workspace_visible && Arc::make_mut(&mut self.sections).remove(id).is_some() {
+                    self.section_editor.remove_viewport(id);
                     if self.selected_section == Some(id) {
                         self.selected_section = None;
                         self.section_editor.clear();
@@ -904,7 +905,7 @@ impl PerformState {
         if let Some(section) = self.sections.by_id(id) {
             self.selected_section = Some(id);
             self.section_editor
-                .load(Arc::clone(&section.timeline), selected_track);
+                .load_section(id, Arc::clone(&section.timeline), selected_track);
             self.editing_section_name = None;
             self.section_name_edit = section.name.clone();
             self.editor_focus = PerformEditorFocus::SectionConstruction;
@@ -917,8 +918,11 @@ impl PerformState {
 
     pub fn sync_selected_section_editor(&mut self, selected_track: Option<TrackId>) {
         if let Some(section) = self.selected_section.and_then(|id| self.sections.by_id(id)) {
-            self.section_editor
-                .load(Arc::clone(&section.timeline), selected_track);
+            self.section_editor.load_section(
+                section.id,
+                Arc::clone(&section.timeline),
+                selected_track,
+            );
         } else {
             self.selected_section = None;
             self.section_editor.clear();

--- a/crates/vibez-ui/src/domains/perform/sections.rs
+++ b/crates/vibez-ui/src/domains/perform/sections.rs
@@ -29,6 +29,7 @@ pub struct SectionTimelineEditor {
     active_section: Option<SectionId>,
     viewport: TimelineViewport,
     viewports: HashMap<SectionId, TimelineViewport>,
+    edit_cursors: HashMap<SectionId, f64>,
 }
 
 impl SectionTimelineEditor {
@@ -49,6 +50,7 @@ impl SectionTimelineEditor {
         self.store_active_viewport();
         self.active_section = Some(section_id);
         self.viewport = self.viewports.get(&section_id).copied().unwrap_or_default();
+        self.edit_cursors.entry(section_id).or_insert(0.0);
         self.load(timeline, selected_track);
     }
 
@@ -75,8 +77,22 @@ impl SectionTimelineEditor {
         &mut self.viewport
     }
 
+    pub fn edit_cursor_beats(&self) -> f64 {
+        self.active_section
+            .and_then(|section_id| self.edit_cursors.get(&section_id).copied())
+            .unwrap_or(0.0)
+    }
+
+    pub fn place_edit_cursor(&mut self, beat: f64) {
+        if let Some(section_id) = self.active_section {
+            self.edit_cursors.insert(section_id, beat.max(0.0));
+        }
+        self.editor.time_selection_active = false;
+    }
+
     pub fn remove_viewport(&mut self, section_id: SectionId) {
         self.viewports.remove(&section_id);
+        self.edit_cursors.remove(&section_id);
         if self.active_section == Some(section_id) {
             self.active_section = None;
             self.viewport = TimelineViewport::default();
@@ -411,13 +427,19 @@ mod tests {
         editor.load_section(first, Arc::new(ArrangementTimeline::default()), None);
         editor.viewport_mut().zoom_level = 4.0;
         editor.viewport_mut().scroll_offset_beats = 12.0;
+        editor.place_edit_cursor(9.0);
         editor.load_section(second, Arc::new(ArrangementTimeline::default()), None);
         assert_eq!(editor.viewport().zoom_level, 2.0);
         assert_eq!(editor.viewport().scroll_offset_beats, 0.0);
+        assert_eq!(editor.edit_cursor_beats(), 0.0);
+        editor.place_edit_cursor(3.0);
 
         editor.load_section(first, Arc::new(ArrangementTimeline::default()), None);
         assert_eq!(editor.viewport().zoom_level, 4.0);
         assert_eq!(editor.viewport().scroll_offset_beats, 12.0);
+        assert_eq!(editor.edit_cursor_beats(), 9.0);
+        editor.load_section(second, Arc::new(ArrangementTimeline::default()), None);
+        assert_eq!(editor.edit_cursor_beats(), 3.0);
     }
 
     #[test]

--- a/crates/vibez-ui/src/domains/perform/sections.rs
+++ b/crates/vibez-ui/src/domains/perform/sections.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use vibez_core::id::{ClipId, LaneId, SectionId, TrackId};
@@ -10,6 +11,7 @@ use crate::domains::timeline_editor::TimelineEditorAdapter;
 use crate::state::{
     ArrangementTimeline, ResolvedTimeline, ResolvedTimelineMut, TimelineEditorState,
 };
+use crate::timeline_geometry::TimelineViewport;
 
 pub const DEFAULT_SECTION_LENGTH_BEATS: f64 = 16.0;
 pub const MIN_SECTION_LENGTH_BEATS: f64 = 4.0;
@@ -24,6 +26,9 @@ pub const MAX_SECTION_LENGTH_BEATS: f64 = 1024.0;
 #[derive(Debug, Default)]
 pub struct SectionTimelineEditor {
     editor: TimelineEditorState,
+    active_section: Option<SectionId>,
+    viewport: TimelineViewport,
+    viewports: HashMap<SectionId, TimelineViewport>,
 }
 
 impl SectionTimelineEditor {
@@ -35,7 +40,22 @@ impl SectionTimelineEditor {
         };
     }
 
+    pub fn load_section(
+        &mut self,
+        section_id: SectionId,
+        timeline: Arc<ArrangementTimeline>,
+        selected_track: Option<TrackId>,
+    ) {
+        self.store_active_viewport();
+        self.active_section = Some(section_id);
+        self.viewport = self.viewports.get(&section_id).copied().unwrap_or_default();
+        self.load(timeline, selected_track);
+    }
+
     pub fn clear(&mut self) {
+        self.store_active_viewport();
+        self.active_section = None;
+        self.viewport = TimelineViewport::default();
         self.editor = TimelineEditorState::default();
     }
 
@@ -45,6 +65,28 @@ impl SectionTimelineEditor {
 
     pub fn editor_mut(&mut self) -> &mut TimelineEditorState {
         &mut self.editor
+    }
+
+    pub const fn viewport(&self) -> &TimelineViewport {
+        &self.viewport
+    }
+
+    pub fn viewport_mut(&mut self) -> &mut TimelineViewport {
+        &mut self.viewport
+    }
+
+    pub fn remove_viewport(&mut self, section_id: SectionId) {
+        self.viewports.remove(&section_id);
+        if self.active_section == Some(section_id) {
+            self.active_section = None;
+            self.viewport = TimelineViewport::default();
+        }
+    }
+
+    fn store_active_viewport(&mut self) {
+        if let Some(section_id) = self.active_section {
+            self.viewports.insert(section_id, self.viewport);
+        }
     }
 }
 
@@ -358,6 +400,24 @@ mod tests {
         let section_clip = &section.editor().timeline.get(track_id).unwrap().note_clips[0];
         assert_eq!(section_clip.name, "Section Pattern");
         assert_eq!(section_clip.position_beats, 0.0);
+    }
+
+    #[test]
+    fn every_section_restores_its_independent_runtime_viewport() {
+        let first = SectionId::new();
+        let second = SectionId::new();
+        let mut editor = SectionTimelineEditor::default();
+
+        editor.load_section(first, Arc::new(ArrangementTimeline::default()), None);
+        editor.viewport_mut().zoom_level = 4.0;
+        editor.viewport_mut().scroll_offset_beats = 12.0;
+        editor.load_section(second, Arc::new(ArrangementTimeline::default()), None);
+        assert_eq!(editor.viewport().zoom_level, 2.0);
+        assert_eq!(editor.viewport().scroll_offset_beats, 0.0);
+
+        editor.load_section(first, Arc::new(ArrangementTimeline::default()), None);
+        assert_eq!(editor.viewport().zoom_level, 4.0);
+        assert_eq!(editor.viewport().scroll_offset_beats, 12.0);
     }
 
     #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -263,6 +263,9 @@ pub struct ProjectSaveResult {
 
 #[derive(Debug, Clone)]
 pub enum Message {
+    /// A message emitted by one of the selected Section timeline canvases.
+    /// The router focuses that editor before dispatching the enclosed action.
+    SectionTimeline(Box<Message>),
     /// A menu item was chosen. The router dispatches the action, then closes
     /// only the overlay that produced it.
     MenuItemSelected(MenuOverlay, Box<Message>),

--- a/crates/vibez-ui/src/timeline_geometry.rs
+++ b/crates/vibez-ui/src/timeline_geometry.rs
@@ -4,6 +4,8 @@
 pub const BASE_PIXELS_PER_BEAT: f32 = 20.0;
 const WHEEL_LINE_PIXELS: f32 = 40.0;
 const ZOOM_SENSITIVITY: f32 = 0.003;
+pub const EDGE_SCROLL_ZONE_PIXELS: f32 = 64.0;
+pub const MAX_EDGE_SCROLL_BEATS_PER_SECOND: f64 = 8.0;
 
 /// Normalise line- and pixel-based wheel input to physical-ish pixels.
 pub fn wheel_delta_pixels(delta: iced::mouse::ScrollDelta) -> (f32, f32) {
@@ -16,6 +18,95 @@ pub fn wheel_delta_pixels(delta: iced::mouse::ScrollDelta) -> (f32, f32) {
 /// Continuous zoom factor for a wheel or trackpad delta.
 pub fn zoom_factor_from_pixels(pixels: f32) -> f32 {
     (pixels * ZOOM_SENSITIVITY).clamp(-0.5, 0.5).exp()
+}
+
+/// Signed edge-scroll speed for a screen-space lane viewport.
+///
+/// The quadratic ramp is deliberately gentle at the inner edge while still
+/// reaching a fixed musical maximum at and beyond the viewport boundary.
+pub fn edge_scroll_velocity(cursor_x: f32, left: f32, right: f32) -> f64 {
+    if !cursor_x.is_finite() || !left.is_finite() || !right.is_finite() || right <= left {
+        return 0.0;
+    }
+    let left_proximity =
+        ((left + EDGE_SCROLL_ZONE_PIXELS - cursor_x) / EDGE_SCROLL_ZONE_PIXELS).clamp(0.0, 1.0);
+    if left_proximity > 0.0 {
+        return -MAX_EDGE_SCROLL_BEATS_PER_SECOND * f64::from(left_proximity * left_proximity);
+    }
+    let right_proximity =
+        ((cursor_x - (right - EDGE_SCROLL_ZONE_PIXELS)) / EDGE_SCROLL_ZONE_PIXELS).clamp(0.0, 1.0);
+    MAX_EDGE_SCROLL_BEATS_PER_SECOND * f64::from(right_proximity * right_proximity)
+}
+
+/// Resolve a move drag after the viewport has panned since pointer-down.
+pub fn compensated_drag_beat(
+    original_beat: f64,
+    pointer_delta_pixels: f32,
+    pixels_per_beat: f32,
+    start_scroll_beats: f64,
+    current_scroll_beats: f64,
+) -> f64 {
+    let pointer_delta_beats =
+        f64::from(pointer_delta_pixels) / f64::from(pixels_per_beat.max(f32::EPSILON));
+    original_beat + pointer_delta_beats + (current_scroll_beats - start_scroll_beats)
+}
+
+/// Runtime horizontal navigation state for one timeline editor.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TimelineViewport {
+    pub zoom_level: f32,
+    pub scroll_offset_beats: f64,
+}
+
+impl TimelineViewport {
+    pub const fn new(zoom_level: f32, scroll_offset_beats: f64) -> Self {
+        Self {
+            zoom_level,
+            scroll_offset_beats,
+        }
+    }
+
+    pub fn geometry(self) -> TimelineGeometry {
+        TimelineGeometry::from_zoom(self.zoom_level, self.scroll_offset_beats)
+    }
+
+    pub fn scroll_by(&mut self, delta_beats: f64, total_beats: f64, viewport_width: f32) {
+        self.scroll_offset_beats = (self.scroll_offset_beats + delta_beats)
+            .clamp(0.0, self.max_scroll(total_beats, viewport_width));
+    }
+
+    pub fn zoom_around(
+        &mut self,
+        factor: f32,
+        anchor_x: f32,
+        total_beats: f64,
+        viewport_width: f32,
+    ) {
+        if !factor.is_finite() || factor <= 0.0 {
+            return;
+        }
+        let anchor_x = anchor_x.clamp(0.0, viewport_width.max(0.0));
+        let anchor_beat = self.geometry().x_to_beat(anchor_x);
+        self.zoom_level = (self.zoom_level * factor).clamp(0.01, 16.0);
+        self.scroll_offset_beats = anchor_beat - self.geometry().beats_for_width(anchor_x);
+        self.clamp(total_beats, viewport_width);
+    }
+
+    pub fn clamp(&mut self, total_beats: f64, viewport_width: f32) {
+        self.scroll_offset_beats = self
+            .scroll_offset_beats
+            .clamp(0.0, self.max_scroll(total_beats, viewport_width));
+    }
+
+    pub fn max_scroll(self, total_beats: f64, viewport_width: f32) -> f64 {
+        (total_beats.max(0.0) - self.geometry().visible_beats(viewport_width)).max(0.0)
+    }
+}
+
+impl Default for TimelineViewport {
+    fn default() -> Self {
+        Self::new(2.0, 0.0)
+    }
 }
 
 /// A resolved horizontal timeline viewport.
@@ -103,5 +194,42 @@ mod tests {
         let one_pixel = zoom_factor_from_pixels(1.0);
         assert!(one_pixel > 1.0 && one_pixel < 1.01);
         assert!((one_pixel * zoom_factor_from_pixels(-1.0) - 1.0).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn edge_scroll_velocity_is_zero_outside_the_zone_and_conservatively_bounded() {
+        assert_eq!(edge_scroll_velocity(400.0, 100.0, 900.0), 0.0);
+        assert_eq!(edge_scroll_velocity(200.0, 100.0, 900.0), 0.0);
+        assert!(edge_scroll_velocity(890.0, 100.0, 900.0) > 0.0);
+        assert!(edge_scroll_velocity(110.0, 100.0, 900.0) < 0.0);
+        assert!(edge_scroll_velocity(2_000.0, 100.0, 900.0).abs() <= 8.0);
+    }
+
+    #[test]
+    fn move_drag_compensates_for_viewport_motion_under_a_stationary_pointer() {
+        assert_eq!(
+            compensated_drag_beat(12.0, 160.0, 80.0, 4.0, 7.0),
+            17.0,
+            "two pointer beats plus three auto-scrolled beats must move the Clip five beats"
+        );
+    }
+
+    #[test]
+    fn explicit_viewport_zoom_keeps_the_pointer_on_the_same_beat() {
+        let mut viewport = TimelineViewport::new(2.0, 4.0);
+        let before = viewport.geometry().x_to_beat(300.0);
+
+        viewport.zoom_around(2.0, 300.0, 64.0, 800.0);
+
+        assert!((viewport.geometry().x_to_beat(300.0) - before).abs() < 1.0e-9);
+    }
+
+    #[test]
+    fn explicit_viewport_clamps_to_the_last_full_view() {
+        let mut viewport = TimelineViewport::new(2.0, 0.0);
+        viewport.scroll_by(1_000.0, 64.0, 800.0);
+        assert_eq!(viewport.scroll_offset_beats, 44.0);
+        viewport.scroll_by(-1_000.0, 64.0, 800.0);
+        assert_eq!(viewport.scroll_offset_beats, 0.0);
     }
 }

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -31,6 +31,7 @@ pub enum ClipDragAction {
         is_note_clip: bool,
         /// Initial local x pixel where the drag started.
         start_local_x: f32,
+        start_scroll_beats: f64,
         original_position_beats: f64,
         start_y: f32,
     },
@@ -412,6 +413,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 clip_id,
                                 is_note_clip,
                                 start_local_x: pos.x,
+                                start_scroll_beats: self.scroll_offset_beats,
                                 original_position_beats: pos_beats,
                                 start_y: pos.y,
                             });
@@ -576,12 +578,19 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                 clip_id,
                                 is_note_clip,
                                 start_local_x,
+                                start_scroll_beats,
                                 original_position_beats,
                                 start_y,
                             } => {
                                 let delta_px = local_x - start_local_x;
-                                let delta_beats = geometry.beats_for_width(delta_px);
-                                let new_pos = (original_position_beats + delta_beats).max(0.0);
+                                let new_pos = crate::timeline_geometry::compensated_drag_beat(
+                                    *original_position_beats,
+                                    delta_px,
+                                    geometry.pixels_per_beat(),
+                                    *start_scroll_beats,
+                                    self.scroll_offset_beats,
+                                )
+                                .max(0.0);
 
                                 let snapped = self.snapped_beat(new_pos);
 

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -74,7 +74,10 @@ pub struct TrackClipCanvas {
     /// Transient Section Record visualization. It is deliberately excluded
     /// from hit testing and edit messages.
     pub recording_preview: Option<TimelineNoteClip>,
+    /// Primary edit cursor (or Arrange's shared transport/edit cursor).
     pub playhead_beats: f64,
+    /// Section playback truth, rendered independently from the edit cursor.
+    pub playback_playhead_beats: Option<f64>,
     pub zoom_level: f32,
     pub grid: GridConfig,
     pub scroll_offset_beats: f64,
@@ -207,6 +210,7 @@ impl TrackClipCanvas {
             note_clips,
             recording_preview: None,
             playhead_beats,
+            playback_playhead_beats: None,
             zoom_level,
             grid,
             scroll_offset_beats,
@@ -232,6 +236,11 @@ impl TrackClipCanvas {
 
     pub fn with_recording_preview(mut self, preview: TimelineNoteClip) -> Self {
         self.recording_preview = Some(preview);
+        self
+    }
+
+    pub fn with_playback_playhead(mut self, playback_playhead_beats: Option<f64>) -> Self {
+        self.playback_playhead_beats = playback_playhead_beats;
         self
     }
 
@@ -862,6 +871,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::widgets::timeline::RulerWidget;
     use iced::keyboard::key::{Code, Physical};
     use iced::keyboard::{Event, Key, Location, Modifiers};
     use iced::{Point, Size};
@@ -869,6 +879,16 @@ mod tests {
     use vibez_core::perform::GrooveGrid;
 
     fn track_canvas(content: &TrackTimelineContent, zoom_level: f32) -> TrackClipCanvas {
+        track_canvas_at(content, zoom_level, 0.0, 800.0, 16.0)
+    }
+
+    fn track_canvas_at(
+        content: &TrackTimelineContent,
+        zoom_level: f32,
+        scroll_offset_beats: f64,
+        viewport_width: f32,
+        total_beats: f64,
+    ) -> TrackClipCanvas {
         let track_id = TrackId::new();
         let track = ProjectTrack::new(track_id, "Track 1".into(), 0);
         TrackClipCanvas::from_track(
@@ -877,9 +897,9 @@ mod tests {
             0.0,
             zoom_level,
             GridConfig::new(crate::state::SnapGrid::EIGHTH, true, false, 0),
-            0.0,
-            800.0,
-            16.0,
+            scroll_offset_beats,
+            viewport_width,
+            total_beats,
             44_100,
             true,
             Color::BLACK,
@@ -953,6 +973,56 @@ mod tests {
         assert_eq!(canvas.note_clips.len(), 1);
         assert_eq!(canvas.note_clips[0].clip_id, visible_id);
         assert_eq!(canvas.note_clips[0].notes.len(), 64);
+    }
+
+    #[test]
+    fn scrolled_long_section_materializes_visible_split_midi_fragments() {
+        let mut content = TrackTimelineContent::default();
+        content.note_clips.push(note_clip(0.0));
+        let mut left_fragment = note_clip(96.0);
+        left_fragment.duration_beats = 4.0;
+        let left_id = left_fragment.id;
+        let mut right_fragment = note_clip(100.0);
+        right_fragment.duration_beats = 4.0;
+        let right_id = right_fragment.id;
+        content.note_clips.push(left_fragment);
+        content.note_clips.push(right_fragment);
+
+        let canvas = track_canvas_at(&content, 2.0, 94.0, 480.0, 128.0);
+        let materialized: HashSet<_> = canvas.note_clips.iter().map(|clip| clip.clip_id).collect();
+
+        assert_eq!(materialized, HashSet::from([left_id, right_id]));
+    }
+
+    #[test]
+    fn independently_constructed_ruler_and_lane_align_from_the_same_viewport() {
+        let mut lane = empty_track_canvas();
+        lane.zoom_level = 3.0;
+        lane.scroll_offset_beats = 9.5;
+        let ruler = RulerWidget {
+            playhead_beats: -1.0,
+            bpm: 120.0,
+            zoom_level: 3.0,
+            grid: GridConfig::new(crate::state::SnapGrid::EIGHTH, true, false, 0),
+            scroll_offset_beats: 9.5,
+            total_beats: 64.0,
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 64.0,
+            time_selection_active: false,
+            selection_start_beats: 0.0,
+            selection_end_beats: 0.0,
+        };
+
+        assert_eq!(ruler.beat_to_x(13.25, 800.0), lane.beat_to_x(13.25));
+    }
+
+    #[test]
+    fn section_lane_keeps_edit_cursor_and_playback_playhead_distinct() {
+        let canvas = empty_track_canvas().with_playback_playhead(Some(7.5));
+
+        assert_eq!(canvas.playhead_beats, 0.0);
+        assert_eq!(canvas.playback_playhead_beats, Some(7.5));
     }
 
     #[test]

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -555,7 +555,26 @@ impl TrackClipCanvas {
             }
         }
 
-        // Playhead overlay
+        // A playing Section has an engine-owned playback marker in addition
+        // to its runtime edit cursor. Draw it first and in the accent colour
+        // so overlapping markers remain recognisable.
+        if let Some(playback_beat) = self.playback_playhead_beats {
+            let playback_x = self.beat_to_x(playback_beat);
+            if playback_x >= 0.0 && playback_x <= w {
+                let playback_line = canvas::Path::line(
+                    iced::Point::new(playback_x, 0.0),
+                    iced::Point::new(playback_x, h),
+                );
+                frame.stroke(
+                    &playback_line,
+                    canvas::Stroke::default()
+                        .with_color(theme::with_alpha(theme::accent(), 0.8))
+                        .with_width(3.0),
+                );
+            }
+        }
+
+        // Edit cursor overlay (Arrange uses its shared transport/edit cursor).
         let playhead_x = self.beat_to_x(self.playhead_beats);
         if playhead_x >= 0.0 && playhead_x <= w {
             let playhead_line = canvas::Path::line(

--- a/crates/vibez-ui/src/widgets/timeline/ruler.rs
+++ b/crates/vibez-ui/src/widgets/timeline/ruler.rs
@@ -55,7 +55,7 @@ impl RulerWidget {
         self.geometry().visible_beats(width)
     }
 
-    fn beat_to_x(&self, beat: f64, _width: f32) -> f32 {
+    pub(crate) fn beat_to_x(&self, beat: f64, _width: f32) -> f32 {
         self.geometry().beat_to_x(beat)
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -323,7 +323,11 @@ The selected Perform Section provides the editor adapter through a
 runtime-only `SectionTimelineEditor`. Selecting a Section resolves its
 persisted Timeline Content into the adapter while preserving the project-wide
 Project Track selection; clip and piano-roll selection remain local to the
-resolved Section editor. Every edit commits the adapter's copy-on-write
+resolved Section editor. The adapter also retains an independent runtime-only
+`TimelineViewport` for every Section. Section ruler, minimap, clip lanes,
+automation, recording preview, and playhead all resolve through that viewport;
+the ruler and minimap sit outside the vertically scrolling Track body. Every
+edit commits the adapter's copy-on-write
 Timeline Content back into the selected Section store for undo and project
 persistence. Section authoring still uses a discarding engine handle so edits
 to a selected, non-playing Section cannot mutate either resident audio source;
@@ -333,8 +337,11 @@ Every horizontal editor surface uses `TimelineGeometry` for beat-to-pixel,
 pixel-to-beat, fitted viewport, visible-range, and beat-width conversions.
 Ruler, clip lanes, automation, piano roll, minimap, drag/drop, and auto-scroll
 therefore share one geometry implementation even when they use different
-resolved scales. A generic conformance harness currently runs against the
-Arrange adapter and is reusable unchanged by the Section adapter.
+resolved scales. Clip gestures compensate for viewport motion, while one
+tick-driven edge-zone policy scrolls only the active Arrange or Section
+viewport at a bounded musical rate. A generic conformance harness currently
+runs against the Arrange adapter and is reusable unchanged by the Section
+adapter.
 
 ```mermaid
 flowchart LR

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -324,10 +324,11 @@ runtime-only `SectionTimelineEditor`. Selecting a Section resolves its
 persisted Timeline Content into the adapter while preserving the project-wide
 Project Track selection; clip and piano-roll selection remain local to the
 resolved Section editor. The adapter also retains an independent runtime-only
-`TimelineViewport` for every Section. Section ruler, minimap, clip lanes,
-automation, recording preview, and playhead all resolve through that viewport;
-the ruler and minimap sit outside the vertically scrolling Track body. Every
-edit commits the adapter's copy-on-write
+`TimelineViewport` and edit cursor for every Section. Section ruler, minimap,
+clip lanes, automation, recording preview, edit cursor, and engine-owned
+playback playhead all resolve through that viewport; edit and playback markers
+remain distinct. The ruler and minimap sit outside the vertically scrolling
+Track body. Every edit commits the adapter's copy-on-write
 Timeline Content back into the selected Section store for undo and project
 persistence. Section authoring still uses a discarding engine handle so edits
 to a selected, non-playing Section cannot mutate either resident audio source;


### PR DESCRIPTION
## Outcome

Brings Section construction navigation to Arrange parity without sharing
viewport state with Arrange or another Section:

- continuous pointer-anchored zoom, horizontal wheel/trackpad pan,
  middle-drag pan, zoom-to-fit, and last-full-view clamping
- an Arrange-style ruler and minimap fixed above the vertically scrolling
  Track body
- one viewport geometry for ruler, minimap, lanes, automation, recording
  preview, playhead, drag/drop, and bounded materialization
- a smooth quadratic 64 px edge zone capped at 8 beats/second
- drag compensation for viewport movement, with release/zone exit stopping
  edge-scroll immediately

Each Section keeps an independent runtime-only viewport. Project bytes and
Arrange/Section content ownership are unchanged.

## Diagnosis

The previous behavior had two competing scroll paths:

1. action-driven auto-scroll used a hard-coded 1400 px Arrange canvas and
   jumped on every drag update;
2. the 60 fps path used hard-coded 1600/230 px edges and could advance up to
   120 beats/second.

Section drags set the Section editor's drag flag, so they missed the tick path,
while action routing could still mutate the unrelated Arrange viewport. A move
drag then reinterpreted its pointer through the changed viewport. This PR gives
the focused editor one explicit viewport and one bounded tick policy.

## TDD evidence

Red tests were added first for:

- edge-zone velocity and the conservative maximum
- move-drag compensation after viewport motion
- pointer-anchored zoom and last-full-view clamping
- independent viewport restoration for each Section
- sticky navigation-header structure
- playhead/lane geometry alignment
- viewport-bounded long-Section materialization

All are green in the final suite.

## Validation

- `cargo test -p vibez-ui -j 4` — 401 passed
- `cargo test --workspace -j 4` — passed, 0 failed
- `cargo check --workspace -j 4` — passed
- `cargo clippy --workspace -j 4 -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- architecture documentation updated
- no new Rust file crossed the repository's 1,000-line threshold
- isolated Xvfb dogfood used the current binary; no physical desktop was used
- [cross-platform CI run 30172419488](https://github.com/alexanderwanyoike/vibez/actions/runs/30172419488)
  — all eight Check, Test, Clippy, and Format jobs passed on Ubuntu, macOS, and
  Windows

Xvfb evidence is retained at
`/home/alexander/Code/Apps/vibez-demo-artifacts/card-41-section-navigation/`.
It covers a 12-bar Section, ten Tracks, sticky vertical scrolling,
pointer-anchored zoom, pan in both directions, per-Section viewport restoration,
navigation during playback, and a held edge resize.

## Producer demo checklist

1. Create at least ten Project Tracks, enter Perform, and create Section 01.
2. Extend Section 01 to 12 bars.
3. Hover a lane and Shift-scroll around a recognisable bar; confirm that bar
   stays under the pointer while ruler, minimap, and lanes zoom together.
4. Plain-scroll horizontally in both directions, then middle-drag the lane;
   confirm smooth pan and stable end clamping.
5. Scroll vertically from the Track gutter to the last Track; confirm the
   ruler and minimap remain visible and horizontally aligned.
6. Create Section 02, change its viewport, switch between Sections 01 and 02,
   and confirm each restores its own zoom and pan.
7. Launch Section 01 and repeatedly zoom, pan, and vertically scroll; confirm
   playback and the local Section playhead keep advancing without UI stalls.
8. Add a MIDI Clip, zoom in, and drag its move or right-edge handle into both
   viewport edge zones. Hold briefly, leave the zone, and release. Confirm
   scrolling ramps gently, stops immediately, and the edit lands under the
   pointer without extra bars.

## Delivery isolation

This PR targets `dev` directly and contains one Card 41 commit based on
`045ae1ebe6b05eb213a40d09963985276547806a`. It does not contain Card 39 or
Card 40.
