### PR TITLE
ci: lint test code too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install Linux dependencies
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev
-      - run: cargo clippy --workspace -- -D warnings
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   fmt:
     name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install Linux dependencies
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy --workspace --all-targets --exclude vibez-plugin-host -- -D warnings
+      # vibez-plugin-host stays at lib-only lint coverage on purpose. Its tests
+      # drive the VST3 vtable ABI directly, where a cast that looks redundant
+      # on x86_64 is load-bearing on targets whose c_char is u8. Do not widen
+      # this to --all-targets and "fix" what it then reports.
+      - run: cargo clippy -p vibez-plugin-host -- -D warnings
 
   fmt:
     name: Format

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ and warping work, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 ## Contributing
 
 Issues and pull requests are welcome. CI must stay green on Linux, macOS, and
-Windows (`cargo test --workspace` and
-`cargo clippy --workspace --all-targets -- -D warnings`). Note `--all-targets`:
-lints apply to test code too.
+Windows: `cargo test --workspace`, and Clippy with `-D warnings` over
+`--all-targets`, so lints apply to test code too. `vibez-plugin-host` is
+deliberately excluded from `--all-targets`; its tests drive the VST3 vtable ABI
+where a redundant-looking cast can be load-bearing on another target.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ and warping work, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 ## Contributing
 
 Issues and pull requests are welcome. CI must stay green on Linux, macOS, and
-Windows (`cargo test --workspace` and `cargo clippy --workspace -- -D warnings`).
+Windows (`cargo test --workspace` and
+`cargo clippy --workspace --all-targets -- -D warnings`). Note `--all-targets`:
+lints apply to test code too.
 
 ## License
 

--- a/crates/vibez-engine/src/engine_note_repeat_tests.rs
+++ b/crates/vibez-engine/src/engine_note_repeat_tests.rs
@@ -128,7 +128,7 @@ fn stopped_repeat_pads_share_one_anchor_until_the_last_pad_stops() {
             rate: NoteRepeatRate::Sixteenth,
         })
         .unwrap();
-    engine.process(&mut vec![0.0; 10 * 2], 2);
+    engine.process(&mut [0.0; 10 * 2], 2);
     assert_eq!(repeat_events(&mut events), vec![(42, 29)]);
 
     commands
@@ -153,7 +153,7 @@ fn stopped_repeat_pads_share_one_anchor_until_the_last_pad_stops() {
         .push(EngineCommand::StopNoteRepeat { id: 1, track_id })
         .unwrap();
     engine.process(&mut [], 2);
-    engine.process(&mut vec![0.0; 7 * 2], 2);
+    engine.process(&mut [0.0; 7 * 2], 2);
     commands
         .push(EngineCommand::StartNoteRepeat {
             id: 2,
@@ -205,7 +205,7 @@ fn project_swing_changes_wait_for_the_next_stopped_pair_and_preserve_the_anchor(
             rate: NoteRepeatRate::Sixteenth,
         })
         .unwrap();
-    engine.process(&mut vec![0.0; 10 * 2], 2);
+    engine.process(&mut [0.0; 10 * 2], 2);
     assert_eq!(repeat_timestamps(&mut events), vec![29]);
 
     commands

--- a/crates/vibez-engine/src/engine_section_playback_tests.rs
+++ b/crates/vibez-engine/src/engine_section_playback_tests.rs
@@ -312,7 +312,7 @@ fn non_looping_section_returns_to_arrangement_source_after_ending() {
         .push(EngineCommand::AddTrack(track_id, "Audio".into()))
         .unwrap();
     engine.process(&mut [], 1);
-    engine.tracks[0].playback_source = Box::new(PreparedPlaybackSource::new(
+    *engine.tracks[0].playback_source = PreparedPlaybackSource::new(
         vec![EngineClip {
             id: ClipId::new(),
             audio: constant_audio(16, 0.75),
@@ -325,7 +325,7 @@ fn non_looping_section_returns_to_arrangement_source_after_ending() {
         }],
         Vec::new(),
         Vec::new(),
-    ));
+    );
     commands
         .push(EngineCommand::LaunchSection(Box::new(
             PreparedSectionPlaybackSource::new(

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -120,7 +120,7 @@ fn immediate_section_launch_reanchors_held_repeat_to_the_section_downbeat() {
             rate: NoteRepeatRate::Sixteenth,
         })
         .unwrap();
-    engine.process(&mut vec![0.0; 2], 2);
+    engine.process(&mut [0.0; 2], 2);
     while events.pop().is_ok() {}
 
     commands

--- a/crates/vibez-engine/src/engine_section_record_tests.rs
+++ b/crates/vibez-engine/src/engine_section_record_tests.rs
@@ -395,11 +395,11 @@ fn note_at_block_start_boundary_is_reported_after_recording_starts() {
                 ..
             } => Some(("record-started", effective_at_samples)),
             EngineEvent::InstrumentNoteInput {
-                pitch,
+                pitch: 42,
                 on: true,
                 effective_at_samples,
                 ..
-            } if pitch == 42 => Some(("note-on", effective_at_samples)),
+            } => Some(("note-on", effective_at_samples)),
             _ => None,
         })
         .collect();

--- a/crates/vibez-plugin-host/src/vst3_host/host_context.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/host_context.rs
@@ -525,9 +525,7 @@ mod tests {
             assert_eq!(hr, K_RESULT_OK);
             let msg = obj as *mut Message;
 
-            // The VST3 ABI takes char8 (i8) rather than c_char, which is u8 on
-            // some targets, so cast explicitly rather than relying on `as`.
-            set_message_id(msg, c"JuceVST3EditController".as_ptr().cast::<i8>());
+            set_message_id(msg, c"JuceVST3EditController".as_ptr() as *const i8);
             let id = get_message_id(msg);
             assert_eq!(
                 std::ffi::CStr::from_ptr(id as *const std::os::raw::c_char)
@@ -538,7 +536,7 @@ mod tests {
 
             let attrs = get_attributes(msg);
             assert!(!attrs.is_null());
-            let key = c"JuceVST3EditController".as_ptr().cast::<i8>();
+            let key = c"JuceVST3EditController".as_ptr() as *const i8;
             assert_eq!(set_int(attrs, key, 0x1234), K_RESULT_OK);
             let mut out = 0i64;
             assert_eq!(get_int(attrs, key, &mut out), K_RESULT_OK);

--- a/crates/vibez-plugin-host/src/vst3_host/host_context.rs
+++ b/crates/vibez-plugin-host/src/vst3_host/host_context.rs
@@ -525,7 +525,9 @@ mod tests {
             assert_eq!(hr, K_RESULT_OK);
             let msg = obj as *mut Message;
 
-            set_message_id(msg, c"JuceVST3EditController".as_ptr() as *const i8);
+            // The VST3 ABI takes char8 (i8) rather than c_char, which is u8 on
+            // some targets, so cast explicitly rather than relying on `as`.
+            set_message_id(msg, c"JuceVST3EditController".as_ptr().cast::<i8>());
             let id = get_message_id(msg);
             assert_eq!(
                 std::ffi::CStr::from_ptr(id as *const std::os::raw::c_char)
@@ -536,7 +538,7 @@ mod tests {
 
             let attrs = get_attributes(msg);
             assert!(!attrs.is_null());
-            let key = c"JuceVST3EditController".as_ptr() as *const i8;
+            let key = c"JuceVST3EditController".as_ptr().cast::<i8>();
             assert_eq!(set_int(attrs, key, 0x1234), K_RESULT_OK);
             let mut out = 0i64;
             assert_eq!(get_int(attrs, key, &mut out), K_RESULT_OK);

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -147,6 +147,16 @@ fn default_warp_confidence_threshold() -> f32 {
 }
 
 #[cfg(test)]
+impl UiSettings {
+    fn input_mapping_key(
+        &self,
+        position: crate::domains::perform::PadPosition,
+    ) -> crate::domains::perform::ComputerKey {
+        self.perform_input_mapping.key_for(position)
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -359,15 +369,5 @@ mod tests {
             settings.perform_input_mapping,
             crate::domains::perform::PerformInputMapping::default()
         );
-    }
-}
-
-#[cfg(test)]
-impl UiSettings {
-    fn input_mapping_key(
-        &self,
-        position: crate::domains::perform::PadPosition,
-    ) -> crate::domains::perform::ComputerKey {
-        self.perform_input_mapping.key_for(position)
     }
 }


### PR DESCRIPTION
## Summary

The Clippy job runs `cargo clippy --workspace -- -D warnings`, which covers libs and bins only. Every test target in the workspace, roughly 11k lines, has never been linted. Nine violations had accumulated there unnoticed.

This adds `--all-targets` everywhere except `vibez-plugin-host`, and fixes what it reports.

## vibez-plugin-host is deliberately excluded

Two of the nine violations were in the VST3 host's tests. Widening the gate is not worth touching VST3 code at all, so that crate keeps exactly the lint coverage it had before this branch, as its own lib-only invocation:

```yaml
- run: cargo clippy --workspace --all-targets --exclude vibez-plugin-host -- -D warnings
- run: cargo clippy -p vibez-plugin-host -- -D warnings
```

The reason is in a comment above it so nobody widens it later. In short: those tests drive COM vtables directly, `c"...".as_ptr()` yields `*const c_char`, and the VST3 ABI wants `char8` which is `i8`. Same type on x86_64, which is why Clippy calls the cast unnecessary, but not on targets where `c_char` is `u8`. Being wrong there means silent plugin misbehaviour rather than a failing test.

## The fixes

| Lint | Where | Fix |
|---|---|---|
| `useless_vec` x4 | `engine_note_repeat_tests.rs`, `engine_section_queue_tests.rs` | `&mut vec![0.0; N]` render buffers become arrays |
| `replace_box` | `engine_section_playback_tests.rs:315` | assign through the existing `Box` instead of allocating a new one |
| `redundant_guard` | `engine_section_record_tests.rs:402` | match `pitch: 42` in the pattern instead of guarding on it |
| `items_after_test_module` | `ui_settings.rs:366` | move the test-only `impl UiSettings` above `mod tests` |

The `useless_vec` fix is not mechanical, and worth a second look. Only the const-length buffers can become arrays. `engine.process(&mut vec![0.0; position * 2], 2)` on line 90 looks identical but `position` is a runtime binding, so it is not a valid array length and Clippy correctly leaves it alone. I applied the change to the four flagged lines only.

## Test plan

- [x] `cargo clippy --workspace --all-targets --exclude vibez-plugin-host -- -D warnings` clean
- [x] `cargo clippy -p vibez-plugin-host -- -D warnings` clean
- [x] `cargo test --workspace` passes, 916 tests, no change in count
- [x] `cargo fmt --all -- --check` clean
- [x] No file under `crates/vibez-plugin-host/` is touched

README's Contributing section quotes the command CI actually runs, including why plugin-host is excluded. Kept separate from #114 per your call; the overlap in README is in a section #114 does not touch, so both merge cleanly in either order.
