### PR TITLE
docs: trim the MIDI note to one bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,20 +74,10 @@ selected one.
 
 - **Sample browser** with local library indexing, audition, and Dropbox
 - **Project save/load, undo/redo, and WAV export** from the master bus
+- **Partial MIDI support**: one input port at a time, notes only, into the
+  selected instrument track. More is planned for later versions
 - Real-time safe audio engine: lock-free and allocation-free in the audio
   callback
-
-### No MIDI hardware support yet
-
-Worth being blunt about, because a DAW README saying "MIDI" implies far more
-than is here. There is one narrow path: a single input port at a time, notes
-only, played into whichever instrument track is selected.
-
-There is no MIDI recording, no MIDI output, no `.mid` file import, no
-controller mapping, and no way to use more than one device at once. Perform's
-pads are computer keys for the same reason. Multiple input ports, `.vdc`
-controller profiles, and MIDI settings are the next milestone, and they are
-what will make Perform playable on hardware.
 
 ## Status
 


### PR DESCRIPTION
## Summary

The MIDI section was longer than the feature it described, and it lectured the reader about what a DAW README implies rather than just saying what works. Replaced with one bullet in the existing list:

> - **Partial MIDI support**: one input port at a time, notes only, into the selected instrument track. More is planned for later versions

Net 12 lines removed, 2 added. The one-sentence note in the Perform section about pads being computer keys stays, since that one is about Perform rather than about MIDI.

## Note on where this lands

Targets `dev`, so it will not reach the repo landing page until the next release, since the landing page renders `main`. v0.1.0 shipped with the long version. Say the word if you want it on `main` now instead and I will send it straight there.