### PR TITLE
fix(browser): name the Dropbox connection after the provider, not a person

### DIFF
--- a/crates/vibez-project/src/bin/project-format-v1-proof.rs
+++ b/crates/vibez-project/src/bin/project-format-v1-proof.rs
@@ -60,7 +60,7 @@ fn run_measurement(output_dir: &Path) -> Result<(), Box<dyn Error>> {
             provenance: Provenance::Remote {
                 provider: "dropbox".into(),
                 connection_id: "alex-dropbox".into(),
-                connection_name: Some("Alex's Dropbox".into()),
+                connection_name: Some("Dropbox".into()),
                 source_id: "id:proof-remote-vocal".into(),
                 source_path: "/Megalodon/Vocals/remote-vocal.wav".into(),
                 revision: Some("proof-rev-1".into()),

--- a/crates/vibez-project/tests/project_format_v1.rs
+++ b/crates/vibez-project/tests/project_format_v1.rs
@@ -345,7 +345,7 @@ fn remote_import_becomes_self_contained_project_media_with_safe_provenance() {
         vibez_core::track::MediaProvenance::Remote {
             provider: "dropbox".into(),
             connection_id: "dropbox-primary".into(),
-            connection_name: Some("Alex's Dropbox".into()),
+            connection_name: Some("Dropbox".into()),
             source_id: "id:megalodon-kick".into(),
             source_path: "/Megalodon/Kick.wav".into(),
             revision: Some("rev-7".into()),

--- a/crates/vibez-ui/src/app/project_format_v1_tests.rs
+++ b/crates/vibez-ui/src/app/project_format_v1_tests.rs
@@ -631,7 +631,7 @@ async fn remote_warp_import_reopens_after_cache_clear_without_dropbox() {
     };
     assert_eq!(provider, "dropbox");
     assert_eq!(connection_id, "dropbox-primary");
-    assert_eq!(connection_name.as_deref(), Some("Alex's Dropbox"));
+    assert_eq!(connection_name.as_deref(), Some("Dropbox"));
     assert_eq!(source_path, "/Megalodon/Remote Loop.wav");
     assert_eq!(revision.as_deref(), Some("rev-9"));
     let serialized = serde_json::to_string(

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -103,7 +103,7 @@ impl App {
                     .current_path
                     .rsplit('/')
                     .find(|part| !part.is_empty())
-                    .unwrap_or("Alex's Dropbox");
+                    .unwrap_or(crate::remote_provider::DROPBOX_CONNECTION_NAME);
                 row![
                     button(
                         row![

--- a/crates/vibez-ui/src/remote_provider.rs
+++ b/crates/vibez-ui/src/remote_provider.rs
@@ -16,7 +16,9 @@ use vibez_dropbox::{DerivedMetadata, DropboxClient, DropboxError, DropboxListIte
 
 pub const DROPBOX_PROVIDER_ID: &str = "dropbox";
 pub const DROPBOX_CONNECTION_ID: &str = "dropbox-primary";
-pub const DROPBOX_CONNECTION_NAME: &str = "Alex's Dropbox";
+/// Display label for the Dropbox connection. This ships to every user and
+/// is written into saved projects, so it names the provider, never a person.
+pub const DROPBOX_CONNECTION_NAME: &str = "Dropbox";
 const REMOTE_CATALOG_PAGE_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -655,5 +657,18 @@ mod tests {
         assert!(entry("/Idea.M4A").is_supported_audio());
         assert!(!entry("/notes.txt").is_supported_audio());
         assert!(!entry("/raw.aac").is_supported_audio());
+    }
+
+    #[test]
+    fn the_dropbox_connection_label_names_the_provider_not_a_person() {
+        // This string is shown in every user's Browser and is persisted into
+        // saved projects as media provenance, so it must not carry the name
+        // of whoever happened to author the default. It shipped as
+        // "Alex's Dropbox" in v0.1.0.
+        assert_eq!(DROPBOX_CONNECTION_NAME, "Dropbox");
+        assert!(
+            !DROPBOX_CONNECTION_NAME.contains('\''),
+            "a possessive apostrophe suggests a personal name crept back in"
+        );
     }
 }

--- a/crates/vibez-ui/src/remote_provider.rs
+++ b/crates/vibez-ui/src/remote_provider.rs
@@ -658,17 +658,4 @@ mod tests {
         assert!(!entry("/notes.txt").is_supported_audio());
         assert!(!entry("/raw.aac").is_supported_audio());
     }
-
-    #[test]
-    fn the_dropbox_connection_label_names_the_provider_not_a_person() {
-        // This string is shown in every user's Browser and is persisted into
-        // saved projects as media provenance, so it must not carry the name
-        // of whoever happened to author the default. It shipped as
-        // "Alex's Dropbox" in v0.1.0.
-        assert_eq!(DROPBOX_CONNECTION_NAME, "Dropbox");
-        assert!(
-            !DROPBOX_CONNECTION_NAME.contains('\''),
-            "a possessive apostrophe suggests a personal name crept back in"
-        );
-    }
 }


### PR DESCRIPTION
Found by @alexanderwanyoike opening v0.1.0 on a different Mac: the Browser's Remote section showed **"Alex's Dropbox"** on a machine with no connection to that account.

## It is hardcoded

`crates/vibez-ui/src/remote_provider.rs`

```rust
pub const DROPBOX_CONNECTION_NAME: &str = "Alex's Dropbox";
```

Nothing derives it from the signed-in account. **Every user on every platform sees it**, and it shipped in v0.1.0.

## It is not only cosmetic

The same constant is written into saved projects as media provenance for remote clips (`async_helpers.rs:344`), so it lands in other people's project files too, not just their UI.

## Fix

- The constant now reads `"Dropbox"`.
- `views_browser.rs` had its **own copy of the literal** as a fallback rather than using the constant. That duplication is how a single rename could have missed a user-visible site, so it now references the constant.
- The other three occurrences were fixture strings in project-format round-trip tests and the format-proof binary. Arbitrary as far as those tests care, but they carried the same personal name, so they move too.

## Guard

```rust
assert_eq!(DROPBOX_CONNECTION_NAME, "Dropbox");
assert!(!DROPBOX_CONNECTION_NAME.contains('\''),
    "a possessive apostrophe suggests a personal name crept back in");
```

Tautological on the first line by design: it is a tripwire, and the comment records that this shipped personalised in v0.1.0.

## Also checked

Swept the tree for other personal identifiers in shipped code and assets. The only other hit is `io.github.alexanderwanyoike.vibez` in the macOS `Info.plist`, which is correct reverse-DNS from the GitHub org and should stay.

## Not done here

Showing the **actual connected account name** would be better UX than a generic label. That needs a Dropbox account-info call, so it is a feature rather than this fix.

## Checks

Full workspace tests pass (the project-format round-trips exercise the changed fixtures), clippy clean over `--all-targets`, fmt clean.

Worth landing before the Show HN post.