### PR TITLE
feat(site): track the latest release instead of hardcoding the version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,12 @@
 name: Deploy site to GitHub Pages
 
-# The landing page is plain HTML in site/, so there is nothing to build:
-# the job uploads that directory and Pages serves it.
+# The landing page is plain HTML in site/. There is no build step and no
+# dependencies: the only processing is substituting the current release
+# version into the page, so the download links never have to be edited by
+# hand when a release goes out.
+#
+# site/index.html carries __VERSION__ and __RELEASE_DATE__ placeholders,
+# the same convention packaging/macos/Info.plist already uses.
 
 on:
   push:
@@ -9,6 +14,10 @@ on:
     paths:
       - 'site/**'
       - '.github/workflows/pages.yml'
+  # Redeploy when a release is published so the page follows the newest
+  # version without a commit.
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -33,9 +42,47 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
+      - name: Stage the site with the current release version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # The newest published, non-draft release. Release assets are named
+          # from the tag, so this is what the download links must point at.
+          release=$(gh release view --repo "$GITHUB_REPOSITORY" \
+            --json tagName,publishedAt,assets)
+
+          tag=$(jq -r '.tagName' <<<"$release")
+          published=$(jq -r '.publishedAt' <<<"$release")
+          assets=$(jq -r '.assets | length' <<<"$release")
+
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "::error::No published release found; refusing to deploy a page with placeholder links."
+            exit 1
+          fi
+          if [ "$assets" -eq 0 ]; then
+            echo "::error::Release $tag has no assets; every download link would 404."
+            exit 1
+          fi
+
+          date_human=$(date -u -d "$published" '+%-d %B %Y')
+          echo "Publishing site for $tag ($date_human, $assets assets)"
+
+          mkdir -p _site
+          cp -R site/. _site/
+          sed -i "s|__VERSION__|${tag}|g; s|__RELEASE_DATE__|${date_human}|g" _site/index.html
+
+          # A surviving placeholder means a rename broke the substitution and
+          # would ship literal __VERSION__ text to users.
+          if grep -q '__VERSION__\|__RELEASE_DATE__' _site/index.html; then
+            echo "::error::Placeholder left unsubstituted in _site/index.html"
+            exit 1
+          fi
+
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: site
+          path: _site
 
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/site/index.html
+++ b/site/index.html
@@ -326,7 +326,7 @@ footer a:hover { color: var(--text); }
 <header class="rail">
   <div class="rail-in">
     <span class="wordmark">vibez</span>
-    <span class="ver">v0.1.1</span>
+    <span class="ver">__VERSION__</span>
     <nav>
       <a href="#perform">Perform</a>
       <a href="#arrange">Arrange</a>
@@ -356,7 +356,7 @@ footer a:hover { color: var(--text); }
         turns a live performance into editable arrangement.
       </p>
       <div class="cta">
-        <a class="btn" href="#download">Download v0.1.1</a>
+        <a class="btn" href="#download">Download __VERSION__</a>
         <a class="btn-2" href="https://github.com/alexanderwanyoike/vibez">Source on GitHub</a>
         <span class="plat">Linux &middot; macOS &middot; Windows &middot; GPL-3.0</span>
       </div>
@@ -591,7 +591,7 @@ footer a:hover { color: var(--text); }
       <div class="band-head">
         <span class="stripe" style="background: var(--chords)"></span>
         <h2>What it does not do yet</h2>
-        <span class="role">v0.1.1</span>
+        <span class="role">__VERSION__</span>
       </div>
       <p class="lede">
         It is an alpha and worth saying so plainly. Linux is the primary development platform;
@@ -618,8 +618,8 @@ footer a:hover { color: var(--text); }
     <section class="dl" id="download">
       <div class="band-head">
         <span class="stripe" style="background: var(--blue)"></span>
-        <h2>Download v0.1.1</h2>
-        <span class="role">Released 29 July 2026</span>
+        <h2>Download __VERSION__</h2>
+        <span class="role">Released __RELEASE_DATE__</span>
       </div>
       <p class="lede">
         Direct downloads. Nothing is code signed yet, so macOS and Windows will both want a word
@@ -634,14 +634,14 @@ footer a:hover { color: var(--text); }
           </header>
           <p class="arch">x86_64</p>
           <div class="dllinks">
-            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-linux-x86_64.AppImage"><span>AppImage</span><span class="sz">13 MB</span></a>
-            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-linux-x86_64.deb"><span>.deb</span><span class="sz">8 MB</span></a>
-            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-linux-x86_64.tar.gz"><span>.tar.gz</span><span class="sz">13 MB</span></a>
+            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-linux-x86_64.AppImage"><span>AppImage</span><span class="sz">13 MB</span></a>
+            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-linux-x86_64.deb"><span>.deb</span><span class="sz">8 MB</span></a>
+            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-linux-x86_64.tar.gz"><span>.tar.gz</span><span class="sz">13 MB</span></a>
           </div>
           <p class="dlnote">
             Make the AppImage executable first:
-            <code class="cmdblock">chmod +x vibez-v0.1.1-linux-x86_64.AppImage
-./vibez-v0.1.1-linux-x86_64.AppImage</code>
+            <code class="cmdblock">chmod +x vibez-__VERSION__-linux-x86_64.AppImage
+./vibez-__VERSION__-linux-x86_64.AppImage</code>
           </p>
         </div>
 
@@ -652,8 +652,8 @@ footer a:hover { color: var(--text); }
           </header>
           <p class="arch">Apple silicon and Intel</p>
           <div class="dllinks">
-            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-macos-arm64.dmg"><span>Apple silicon</span><span class="sz">10 MB</span></a>
-            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-macos-x86_64.dmg"><span>Intel</span><span class="sz">11 MB</span></a>
+            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-macos-arm64.dmg"><span>Apple silicon</span><span class="sz">10 MB</span></a>
+            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-macos-x86_64.dmg"><span>Intel</span><span class="sz">11 MB</span></a>
           </div>
           <p class="dlnote">
             vibez is not notarised with Apple, so macOS will refuse to open it. After dragging it
@@ -671,8 +671,8 @@ footer a:hover { color: var(--text); }
           </header>
           <p class="arch">x86_64</p>
           <div class="dllinks">
-            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-windows-x86_64-setup.exe"><span>Installer</span><span class="sz">9 MB</span></a>
-            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-windows-x86_64.zip"><span>Portable .zip</span><span class="sz">10 MB</span></a>
+            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-windows-x86_64-setup.exe"><span>Installer</span><span class="sz">9 MB</span></a>
+            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-windows-x86_64.zip"><span>Portable .zip</span><span class="sz">10 MB</span></a>
           </div>
           <p class="dlnote">
             The installer is unsigned, so SmartScreen will show a blue warning. Choose
@@ -700,7 +700,7 @@ cd vibez &amp;&amp; cargo run --release</code>
     <footer>
       <span>GPL-3.0-or-later</span>
       <a href="https://github.com/alexanderwanyoike/vibez">Source</a>
-      <a href="https://github.com/alexanderwanyoike/vibez/releases/tag/v0.1.1">Release notes</a>
+      <a href="https://github.com/alexanderwanyoike/vibez/releases/tag/__VERSION__">Release notes</a>
       <a href="https://github.com/alexanderwanyoike/vibez/blob/main/docs/ARCHITECTURE.md">Architecture</a>
     </footer>
   </div>
@@ -719,7 +719,7 @@ cd vibez &amp;&amp; cargo run --release</code>
   tick();
 
   /* the pad grid: same default mapping as the app */
-  /* Every image below is a crop from the running v0.1.1 build on the
+  /* Every image below is a crop from the running __VERSION__ build on the
      elise2 project, framed on the control the pad is about. */
   var PADS = [
     { k: '1', n: 'Sections',        m: 'Perform \u00b7 F1', s: 'images/sections.webp', c: 'Perform \u00b7 Sections mode \u00b7 bank 1',


### PR DESCRIPTION
The landing page hardcoded the version in **22 places**, including all seven direct asset links. Every release needed a matching site edit, and forgetting one either advertises the wrong version or links assets that do not exist. That is exactly the trap v0.1.1 walked into: the site had to be bumped in the release PR, which created a window where the links 404'd until the tag was pushed.

## Approach

`site/index.html` now carries `__VERSION__` and `__RELEASE_DATE__` placeholders, the same convention `packaging/macos/Info.plist` already uses. The Pages workflow resolves the newest published release, substitutes into a staged copy, and deploys that.

**Substitution happens at deploy time, not in the browser.** The served page stays fully static: no JavaScript, no `api.github.com` call from the visitor, nothing to rate limit, and it still works with JS disabled. The alternative, fetching releases client-side, would have made the download buttons depend on a third-party request completing.

A `release: [published]` trigger is added, so cutting a release redeploys the site on its own. The version follows the release rather than a commit.

## Guards

A silent failure here ships broken download links, so the run fails loudly rather than deploying something wrong:

- no published release found
- the release carries **zero assets** (every link would 404)
- any placeholder **survives substitution** — otherwise a rename could ship literal `__VERSION__` text to users

## Verification

Ran the workflow's exact pipeline locally against the real v0.1.1 release and diffed the output against the page currently on `dev`:

```
tag=v0.1.1  date=29 July 2026  assets=7
IDENTICAL: substitution reproduces the live page exactly
```

Byte for byte, so this changes the mechanism and not the rendered page. Workflow YAML parses, the embedded shell passes `bash -n`, and `jq` and GNU `date` are both preinstalled on `ubuntu-latest`.

## Note on ordering

Because the `release` event triggers a redeploy, the sequence for the next release becomes: merge the release PR, push the tag, and the site updates itself once the release publishes. No site edit in the release PR, and no 404 window.

Stacked on top of #123 conceptually but touches different lines, so they should merge in either order without conflict.