### PR TITLE
Deploy site updates to main (no version bump)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,12 @@
 name: Deploy site to GitHub Pages
 
-# The landing page is plain HTML in site/, so there is nothing to build:
-# the job uploads that directory and Pages serves it.
+# The landing page is plain HTML in site/. There is no build step and no
+# dependencies: the only processing is substituting the current release
+# version into the page, so the download links never have to be edited by
+# hand when a release goes out.
+#
+# site/index.html carries __VERSION__ and __RELEASE_DATE__ placeholders,
+# the same convention packaging/macos/Info.plist already uses.
 
 on:
   push:
@@ -9,6 +14,10 @@ on:
     paths:
       - 'site/**'
       - '.github/workflows/pages.yml'
+  # Redeploy when a release is published so the page follows the newest
+  # version without a commit.
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -33,9 +42,47 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
+      - name: Stage the site with the current release version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # The newest published, non-draft release. Release assets are named
+          # from the tag, so this is what the download links must point at.
+          release=$(gh release view --repo "$GITHUB_REPOSITORY" \
+            --json tagName,publishedAt,assets)
+
+          tag=$(jq -r '.tagName' <<<"$release")
+          published=$(jq -r '.publishedAt' <<<"$release")
+          assets=$(jq -r '.assets | length' <<<"$release")
+
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "::error::No published release found; refusing to deploy a page with placeholder links."
+            exit 1
+          fi
+          if [ "$assets" -eq 0 ]; then
+            echo "::error::Release $tag has no assets; every download link would 404."
+            exit 1
+          fi
+
+          date_human=$(date -u -d "$published" '+%-d %B %Y')
+          echo "Publishing site for $tag ($date_human, $assets assets)"
+
+          mkdir -p _site
+          cp -R site/. _site/
+          sed -i "s|__VERSION__|${tag}|g; s|__RELEASE_DATE__|${date_human}|g" _site/index.html
+
+          # A surviving placeholder means a rename broke the substitution and
+          # would ship literal __VERSION__ text to users.
+          if grep -q '__VERSION__\|__RELEASE_DATE__' _site/index.html; then
+            echo "::error::Placeholder left unsubstituted in _site/index.html"
+            exit 1
+          fi
+
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: site
+          path: _site
 
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/site/index.html
+++ b/site/index.html
@@ -326,7 +326,7 @@ footer a:hover { color: var(--text); }
 <header class="rail">
   <div class="rail-in">
     <span class="wordmark">vibez</span>
-    <span class="ver">v0.1.1</span>
+    <span class="ver">__VERSION__</span>
     <nav>
       <a href="#perform">Perform</a>
       <a href="#arrange">Arrange</a>
@@ -356,7 +356,7 @@ footer a:hover { color: var(--text); }
         turns a live performance into editable arrangement.
       </p>
       <div class="cta">
-        <a class="btn" href="#download">Download v0.1.1</a>
+        <a class="btn" href="#download">Download __VERSION__</a>
         <a class="btn-2" href="https://github.com/alexanderwanyoike/vibez">Source on GitHub</a>
         <span class="plat">Linux &middot; macOS &middot; Windows &middot; GPL-3.0</span>
       </div>
@@ -591,7 +591,7 @@ footer a:hover { color: var(--text); }
       <div class="band-head">
         <span class="stripe" style="background: var(--chords)"></span>
         <h2>What it does not do yet</h2>
-        <span class="role">v0.1.1</span>
+        <span class="role">__VERSION__</span>
       </div>
       <p class="lede">
         It is an alpha and worth saying so plainly. Linux is the primary development platform;
@@ -618,8 +618,8 @@ footer a:hover { color: var(--text); }
     <section class="dl" id="download">
       <div class="band-head">
         <span class="stripe" style="background: var(--blue)"></span>
-        <h2>Download v0.1.1</h2>
-        <span class="role">Released 29 July 2026</span>
+        <h2>Download __VERSION__</h2>
+        <span class="role">Released __RELEASE_DATE__</span>
       </div>
       <p class="lede">
         Direct downloads. Nothing is code signed yet, so macOS and Windows will both want a word
@@ -634,14 +634,14 @@ footer a:hover { color: var(--text); }
           </header>
           <p class="arch">x86_64</p>
           <div class="dllinks">
-            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-linux-x86_64.AppImage"><span>AppImage</span><span class="sz">13 MB</span></a>
-            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-linux-x86_64.deb"><span>.deb</span><span class="sz">8 MB</span></a>
-            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-linux-x86_64.tar.gz"><span>.tar.gz</span><span class="sz">13 MB</span></a>
+            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-linux-x86_64.AppImage"><span>AppImage</span><span class="sz">13 MB</span></a>
+            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-linux-x86_64.deb"><span>.deb</span><span class="sz">8 MB</span></a>
+            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-linux-x86_64.tar.gz"><span>.tar.gz</span><span class="sz">13 MB</span></a>
           </div>
           <p class="dlnote">
             Make the AppImage executable first:
-            <code class="cmdblock">chmod +x vibez-v0.1.1-linux-x86_64.AppImage
-./vibez-v0.1.1-linux-x86_64.AppImage</code>
+            <code class="cmdblock">chmod +x vibez-__VERSION__-linux-x86_64.AppImage
+./vibez-__VERSION__-linux-x86_64.AppImage</code>
           </p>
         </div>
 
@@ -652,8 +652,8 @@ footer a:hover { color: var(--text); }
           </header>
           <p class="arch">Apple silicon and Intel</p>
           <div class="dllinks">
-            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-macos-arm64.dmg"><span>Apple silicon</span><span class="sz">10 MB</span></a>
-            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-macos-x86_64.dmg"><span>Intel</span><span class="sz">11 MB</span></a>
+            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-macos-arm64.dmg"><span>Apple silicon</span><span class="sz">10 MB</span></a>
+            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-macos-x86_64.dmg"><span>Intel</span><span class="sz">11 MB</span></a>
           </div>
           <p class="dlnote">
             vibez is not notarised with Apple, so macOS will refuse to open it. After dragging it
@@ -671,8 +671,8 @@ footer a:hover { color: var(--text); }
           </header>
           <p class="arch">x86_64</p>
           <div class="dllinks">
-            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-windows-x86_64-setup.exe"><span>Installer</span><span class="sz">9 MB</span></a>
-            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/v0.1.1/vibez-v0.1.1-windows-x86_64.zip"><span>Portable .zip</span><span class="sz">10 MB</span></a>
+            <a class="dllink primary" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-windows-x86_64-setup.exe"><span>Installer</span><span class="sz">9 MB</span></a>
+            <a class="dllink" href="https://github.com/alexanderwanyoike/vibez/releases/download/__VERSION__/vibez-__VERSION__-windows-x86_64.zip"><span>Portable .zip</span><span class="sz">10 MB</span></a>
           </div>
           <p class="dlnote">
             The installer is unsigned, so SmartScreen will show a blue warning. Choose
@@ -700,7 +700,7 @@ cd vibez &amp;&amp; cargo run --release</code>
     <footer>
       <span>GPL-3.0-or-later</span>
       <a href="https://github.com/alexanderwanyoike/vibez">Source</a>
-      <a href="https://github.com/alexanderwanyoike/vibez/releases/tag/v0.1.1">Release notes</a>
+      <a href="https://github.com/alexanderwanyoike/vibez/releases/tag/__VERSION__">Release notes</a>
       <a href="https://github.com/alexanderwanyoike/vibez/blob/main/docs/ARCHITECTURE.md">Architecture</a>
     </footer>
   </div>
@@ -719,7 +719,7 @@ cd vibez &amp;&amp; cargo run --release</code>
   tick();
 
   /* the pad grid: same default mapping as the app */
-  /* Every image below is a crop from the running v0.1.1 build on the
+  /* Every image below is a crop from the running __VERSION__ build on the
      elise2 project, framed on the control the pad is about. */
   var PADS = [
     { k: '1', n: 'Sections',        m: 'Perform \u00b7 F1', s: 'images/sections.webp', c: 'Perform \u00b7 Sections mode \u00b7 bank 1',

--- a/site/index.html
+++ b/site/index.html
@@ -128,6 +128,10 @@ h1 b { color: var(--blue); font-weight: 400; font-size: .58em; padding-bottom: 1
 /* ---------- pad hero ---------- */
 .padhero { padding: 44px 0 76px; }
 .padhero-in { display: grid; gap: 30px; align-items: start; }
+/* Grid items default to min-width:auto and so refuse to shrink below their
+   content. On a phone that widened the whole document instead of letting
+   the pad labels wrap. */
+.padhero-in > * { min-width: 0; }
 @media (min-width: 1000px) { .padhero-in { grid-template-columns: minmax(0,1fr) minmax(0,1.02fr); gap: 40px; } }
 
 .hint {
@@ -138,7 +142,7 @@ h1 b { color: var(--blue); font-weight: 400; font-size: .58em; padding-bottom: 1
 .hint i { width: 6px; height: 6px; border-radius: 50%; background: var(--blue); flex: none; }
 .padgrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 9px; }
 .pad {
-  position: relative; aspect-ratio: 1.34 / 1;
+  position: relative; aspect-ratio: 1.34 / 1; min-width: 0;
   background: var(--panel); border: 1px solid var(--line); border-radius: 4px;
   cursor: pointer; text-align: left; padding: 10px 11px;
   display: flex; flex-direction: column; justify-content: space-between;
@@ -147,7 +151,8 @@ h1 b { color: var(--blue); font-weight: 400; font-size: .58em; padding-bottom: 1
 .pad:hover { border-color: var(--line-2); background: var(--panel-2); }
 .pad.lit { transform: translateY(1px); }
 .pad .k { font-family: var(--mono); font-size: 11px; color: var(--dimmer); letter-spacing: .06em; }
-.pad .n { font-size: 13px; font-weight: 600; line-height: 1.25; letter-spacing: -.01em; }
+.pad .n { font-size: 13px; font-weight: 600; line-height: 1.25; letter-spacing: -.01em;
+  overflow-wrap: anywhere; }
 @media (prefers-reduced-motion: reduce) { .pad { transition: none; } }
 .padlegend { font-family: var(--mono); font-size: 11px; color: var(--dimmer); margin-top: 14px; letter-spacing: .04em; }
 
@@ -284,7 +289,9 @@ kbd {
 .dl { border-top: 1px solid var(--line); padding: 74px 0; }
 .dlgrid { display: grid; gap: 16px; margin-top: 30px; }
 @media (min-width: 840px) { .dlgrid { grid-template-columns: repeat(3, 1fr); } }
-.dlcard { border: 1px solid var(--line); border-radius: 6px; background: var(--panel); padding: 22px; display: flex; flex-direction: column; }
+/* min-width:0 lets the card shrink so .cmdblock's own overflow-x:auto can
+   scroll the long xattr/chmod commands rather than widening the page. */
+.dlcard { border: 1px solid var(--line); border-radius: 6px; background: var(--panel); padding: 22px; display: flex; flex-direction: column; min-width: 0; }
 .dlcard header { display: flex; align-items: center; gap: 12px; margin-bottom: 6px; }
 .dlcard svg { width: 26px; height: 26px; fill: var(--text); flex: none; }
 .dlcard h3 { margin: 0; font-size: 20px; letter-spacing: -.02em; }


### PR DESCRIPTION
Promotes the two merged site PRs to `main` so they deploy. **Deliberately not a versioned release** — see below.

## What's in it

**#123 — horizontal overflow on phones.** The page scrolled sideways on mobile: at a 375px viewport the document was 511px wide. Two instances of one CSS trap, grid items defaulting to `min-width: auto` and refusing to shrink below their content. The download cards could not shrink around the `xattr`/`chmod` command block (435px min-content width, `white-space: pre`), and the pad hero column could not shrink below four pads sized to labels like "Quantized launch". Four declarations, no restructuring. Verified at 320/360/375/414/768/1024: document scroll width now equals the viewport exactly at every width.

**#124 — the site tracks the latest release.** The version was hardcoded in 22 places including all seven asset links, so every release needed a matching site edit. It now carries `__VERSION__` / `__RELEASE_DATE__` placeholders substituted at deploy time by the Pages workflow, with a `release: [published]` trigger so publishing a release redeploys the site by itself.

## Why there is no version bump or tag

`git diff --stat main...dev` touches exactly two files: `site/index.html` and `.github/workflows/pages.yml`. **Zero changes under `crates/`, `src/`, `Cargo.toml` or `Cargo.lock`.**

Tagging v0.1.2 would build and publish a full set of installers byte-identical to v0.1.1, put a release in the list that changes nothing for anyone who downloads it, and make the release history misleading about what shipped. The application is unchanged.

This is also exactly the case #124 exists to handle: the site follows the newest release rather than needing a bump. On merge, Pages redeploys and `__VERSION__` resolves to **v0.1.1**, which stays correct because that is still the current release.

Say the word if you'd rather cut v0.1.2 anyway and I'll add the bump.

## After merging

The Pages deploy triggers automatically (both changed paths are in the workflow's `paths` filter). Worth confirming once it lands:

- the seven download links still resolve, i.e. substitution produced `v0.1.1` and not literal `__VERSION__` (the workflow fails loudly if a placeholder survives, so a green run is the signal)
- no horizontal scroll on a phone

Nothing under `crates/`, so the Rust CI jobs have nothing to say about this one.