### PR TITLE
fix(piano-roll): land new notes in the cell the cursor is over

### DIFF
--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -510,6 +510,16 @@ impl SnapGrid {
         let size = self.beat_size();
         (beat / size).round() * size
     }
+
+    /// Snap a beat value down to the start of the grid cell containing it.
+    ///
+    /// Creation gestures must land in the cell the pointer is actually
+    /// over. `snap_beat` rounds to the nearest line, so a click in the
+    /// right half of a cell would create the note one cell too far right.
+    pub fn snap_beat_floor(self, beat: f64) -> f64 {
+        let size = self.beat_size();
+        (beat / size).floor() * size
+    }
 }
 
 impl std::fmt::Display for SnapGrid {
@@ -557,6 +567,16 @@ impl GridConfig {
     pub fn snap_beat(self, beat: f64, pixels_per_beat: f32) -> f64 {
         if self.snap_enabled {
             self.effective_grid(pixels_per_beat).snap_beat(beat)
+        } else {
+            beat
+        }
+    }
+
+    /// Cell-containing snap for creation gestures. See
+    /// [`SnapGrid::snap_beat_floor`].
+    pub fn snap_beat_floor(self, beat: f64, pixels_per_beat: f32) -> f64 {
+        if self.snap_enabled {
+            self.effective_grid(pixels_per_beat).snap_beat_floor(beat)
         } else {
             beat
         }

--- a/crates/vibez-ui/src/widgets/piano_roll/mod.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/mod.rs
@@ -132,7 +132,8 @@ impl PianoRollWidget {
     /// pointer is over. Nearest-line snapping would drop a click in the
     /// right half of a cell into the following one.
     fn snapped_beat_floor(&self, beat: f64, bounds: &Rectangle) -> f64 {
-        self.grid.snap_beat_floor(beat, self.pixels_per_beat(bounds))
+        self.grid
+            .snap_beat_floor(beat, self.pixels_per_beat(bounds))
     }
 
     fn pitch_to_y(&self, pitch: u8) -> f32 {

--- a/crates/vibez-ui/src/widgets/piano_roll/mod.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/mod.rs
@@ -128,6 +128,13 @@ impl PianoRollWidget {
         self.grid.snap_beat(beat, self.pixels_per_beat(bounds))
     }
 
+    /// Snap for note *creation*: the new note starts in the grid cell the
+    /// pointer is over. Nearest-line snapping would drop a click in the
+    /// right half of a cell into the following one.
+    fn snapped_beat_floor(&self, beat: f64, bounds: &Rectangle) -> f64 {
+        self.grid.snap_beat_floor(beat, self.pixels_per_beat(bounds))
+    }
+
     fn pitch_to_y(&self, pitch: u8) -> f32 {
         let row = (HIGH_NOTE.saturating_sub(pitch).saturating_sub(1)) as f32;
         row * KEY_HEIGHT + RULER_HEIGHT - self.scroll_y
@@ -144,7 +151,9 @@ impl PianoRollWidget {
         let clip_data = self.clip.as_ref()?;
         let geometry = self.geometry(bounds);
 
-        for (idx, note) in clip_data.notes.iter().enumerate() {
+        // Reverse order: notes are drawn front-to-back, so the last one
+        // painted is the one visually on top and must win the hit.
+        for (idx, note) in clip_data.notes.iter().enumerate().rev() {
             if !(LOW_NOTE..HIGH_NOTE).contains(&note.pitch) {
                 continue;
             }
@@ -355,7 +364,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                             }
 
                             let note_duration = self.effective_grid(&bounds).beat_size();
-                            let snapped_beat = self.snapped_beat(beat, &bounds).max(0.0);
+                            let snapped_beat = self.snapped_beat_floor(beat, &bounds).max(0.0);
 
                             let max_start = self.total_beats - note_duration;
                             if max_start < 0.0 || snapped_beat > max_start {
@@ -489,7 +498,7 @@ impl canvas::Program<Message> for PianoRollWidget {
                             }
 
                             let note_duration = self.effective_grid(&bounds).beat_size();
-                            let snapped_beat = self.snapped_beat(beat, &bounds).max(0.0);
+                            let snapped_beat = self.snapped_beat_floor(beat, &bounds).max(0.0);
 
                             let max_start = self.total_beats - note_duration;
                             if max_start < 0.0 || snapped_beat > max_start {
@@ -864,6 +873,66 @@ mod tests {
 
         widget.grid = GridConfig::new(SnapGrid::SIXTEENTH, false, false, 0);
         assert_eq!(widget.snapped_beat(0.31, &bounds), 0.31);
+    }
+
+    #[test]
+    fn creating_a_note_keeps_it_in_the_cell_the_pointer_is_over() {
+        let bounds = Rectangle::new(Point::ORIGIN, iced::Size::new(852.0, 400.0));
+        let mut widget = PianoRollWidget::empty(TrackId::new(), 0.0, Color::WHITE);
+        widget.grid = GridConfig::new(SnapGrid::SIXTEENTH, true, false, 0);
+
+        // Right half of the cell starting at 0.25. Nearest-line snapping
+        // rounds up to 0.5, putting the note in the *next* cell, which is
+        // what made clicks feel offset from the cursor.
+        assert_eq!(widget.snapped_beat(0.4, &bounds), 0.5);
+        assert_eq!(widget.snapped_beat_floor(0.4, &bounds), 0.25);
+
+        // Left half still lands in the same cell either way.
+        assert_eq!(widget.snapped_beat_floor(0.3, &bounds), 0.25);
+        // Exactly on a line is unambiguous.
+        assert_eq!(widget.snapped_beat_floor(0.25, &bounds), 0.25);
+    }
+
+    #[test]
+    fn creation_snapping_is_free_when_snap_is_disabled() {
+        let bounds = Rectangle::new(Point::ORIGIN, iced::Size::new(852.0, 400.0));
+        let mut widget = PianoRollWidget::empty(TrackId::new(), 0.0, Color::WHITE);
+        widget.grid = GridConfig::new(SnapGrid::SIXTEENTH, false, false, 0);
+
+        assert_eq!(widget.snapped_beat_floor(0.4, &bounds), 0.4);
+    }
+
+    #[test]
+    fn overlapping_notes_hit_test_to_the_one_drawn_on_top() {
+        let bounds = Rectangle::new(Point::ORIGIN, iced::Size::new(852.0, 400.0));
+        let mut widget = PianoRollWidget::empty(TrackId::new(), 0.0, Color::WHITE);
+        widget.total_beats = 16.0;
+        widget.scroll_y = 0.0;
+
+        let note = |start: f64| MidiNote {
+            pitch: 60,
+            start_beat: start,
+            duration_beats: 2.0,
+            velocity: 100,
+        };
+        widget.clip = Some(PianoRollClipData {
+            clip_id: ClipId::new(),
+            // Same pitch, overlapping spans: the later note is painted last
+            // and so sits on top.
+            notes: vec![note(0.0), note(0.5)],
+            selected_notes: HashSet::new(),
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+        });
+
+        // A point inside the overlap must resolve to the top note (index 1).
+        let x = widget.beat_to_x(1.0, &bounds);
+        let y = widget.pitch_to_y(60) + 4.0;
+        assert_eq!(
+            widget.hit_test_note(Point::new(x, y), &bounds).map(|h| h.0),
+            Some(1)
+        );
     }
 }
 


### PR DESCRIPTION
Stack 1/3 — base `dev`. Independent of the other two.

## The bug

Clicking a cell in the piano roll sometimes created the note offset from where the cursor hit.

`SnapGrid::snap_beat` snaps to the **nearest** gridline, and note creation used it. So a click anywhere in the right half of a grid cell rounded *up* and created the note one cell further right than the pointer. At a 4-bar clip fitted to ~800px on a 1/16 grid the cells are ~12.5px, so anything within ~6px of a boundary landed in the wrong cell.

Nearest-line snapping is correct for *moving* and *resizing* an existing note. It is wrong for a creation gesture, which has to land where the user aimed. Every other DAW floors to the clicked cell.

## The fix

- Add `SnapGrid::snap_beat_floor` / `GridConfig::snap_beat_floor` for cell-containing snapping.
- Use it for the two creation paths only: draw-mode click and double-click add. Drag and resize keep round-to-nearest.

## Also

`hit_test_note` scanned notes forwards and returned the first match. Notes are painted in order, so the last one drawn sits on top — the hit test was returning the note *underneath* whenever two overlapped. Now scans back to front.

## Tests

Three new tests, all of which fail without this change:

- `creating_a_note_keeps_it_in_the_cell_the_pointer_is_over` — pins the round-vs-floor distinction directly (0.4 rounds to 0.5, floors to 0.25)
- `creation_snapping_is_free_when_snap_is_disabled`
- `overlapping_notes_hit_test_to_the_one_drawn_on_top`

`cargo build --workspace`, full test suite and `cargo clippy --all-targets` clean.