### PR TITLE
feat(timeline): select all with Command+A

### DIFF
--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -438,6 +438,7 @@ pub(crate) fn global_key_handler(
             Some(Message::Arrangement(ArrangementMsg::MoveSelectedTrackDown))
         }
         iced::keyboard::Key::Character(ref c) => match c.as_str() {
+            "a" | "A" => Some(Message::SelectAllPressed),
             "c" | "C" => Some(Message::Arrangement(ArrangementMsg::CopySelectedClips)),
             "x" | "X" => Some(Message::Arrangement(ArrangementMsg::CutSelectedClips)),
             "v" | "V" => Some(Message::Arrangement(ArrangementMsg::PasteClips)),
@@ -490,6 +491,25 @@ mod tests {
         {
             iced::keyboard::Modifiers::CTRL
         }
+    }
+
+    #[test]
+    fn command_a_routes_centrally_instead_of_binding_a_canvas() {
+        use iced::keyboard::{Key, Modifiers};
+
+        // Context resolution happens in update(); the shortcut itself is
+        // surface-agnostic so the piano roll and the timeline canvases
+        // cannot race each other for it.
+        assert!(matches!(
+            global_key_handler(Key::Character("a".into()), command_modifier()),
+            Some(Message::SelectAllPressed)
+        ));
+        assert!(matches!(
+            global_key_handler(Key::Character("A".into()), command_modifier()),
+            Some(Message::SelectAllPressed)
+        ));
+        // Bare "a" is a Perform pad key, not select-all.
+        assert!(global_key_handler(Key::Character("a".into()), Modifiers::empty()).is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -604,6 +604,7 @@ impl App {
 
             // -- Multi-track messages --
             Message::DeleteKeyPressed => return self.on_delete_key_pressed(),
+            Message::SelectAllPressed => return self.on_select_all_pressed(),
             Message::AddClipToTrack(track_id) => {
                 return self.handle_add_clip_to_track(track_id);
             }

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -19,13 +19,16 @@ use crate::message::{BrowserImportTarget, Message};
 use super::*;
 
 impl App {
+    fn text_field_editing(&self) -> bool {
+        self.state.view.editing_track_name.is_some()
+            || self.state.view.editing_clip_name.is_some()
+            || self.state.perform.editing_section_name.is_some()
+    }
+
     pub(super) fn on_delete_key_pressed(&mut self) -> Task<Message> {
         // Never delete anything while a text field is being
         // edited; backspace belongs to the text there.
-        if self.state.view.editing_track_name.is_some()
-            || self.state.view.editing_clip_name.is_some()
-            || self.state.perform.editing_section_name.is_some()
-        {
+        if self.text_field_editing() {
             return Task::none();
         }
         // Priority 1: a selected automation point.
@@ -68,10 +71,7 @@ impl App {
     /// piano roll is on screen instead.
     pub(super) fn on_select_all_pressed(&mut self) -> Task<Message> {
         // A text field owns Command+A for its own contents.
-        if self.state.view.editing_track_name.is_some()
-            || self.state.view.editing_clip_name.is_some()
-            || self.state.perform.editing_section_name.is_some()
-        {
+        if self.text_field_editing() {
             return Task::none();
         }
 
@@ -83,24 +83,6 @@ impl App {
 
         self.update(Message::Arrangement(ArrangementMsg::SelectAllClips))
     }
-
-    /// The note clip the piano roll is currently editing, if it is the
-    /// visible detail-panel editor. Mirrors the condition `views_detail`
-    /// uses to decide whether to draw the piano roll at all.
-    fn open_piano_roll_clip(&self) -> Option<(TrackId, ClipId)> {
-        if self.state.view.detail_panel_tab != crate::state::DetailPanelTab::Clip {
-            return None;
-        }
-        let editor = self.state.active_timeline_editor();
-        let (track_id, clip_id) = editor.selected_note_clip?;
-        (editor.selected_track == Some(track_id)
-            && self
-                .state
-                .find_track(track_id)
-                .is_some_and(|track| track.kind.is_midi()))
-        .then_some((track_id, clip_id))
-    }
-
     pub(super) fn on_load_sampler_sample(&mut self, track_id: TrackId) -> Task<Message> {
         Task::perform(
             async {

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -59,6 +59,48 @@ impl App {
         Task::none()
     }
 
+    /// Command+A, resolved against whatever the user is actually editing.
+    ///
+    /// Mirrors [`Self::on_delete_key_pressed`]: the piano roll wins while
+    /// it is the visible editor, otherwise the active timeline's clips do.
+    /// Unlike Delete this cannot key off an existing selection, since the
+    /// point of the shortcut is to create one, so it asks whether the
+    /// piano roll is on screen instead.
+    pub(super) fn on_select_all_pressed(&mut self) -> Task<Message> {
+        // A text field owns Command+A for its own contents.
+        if self.state.view.editing_track_name.is_some()
+            || self.state.view.editing_clip_name.is_some()
+            || self.state.perform.editing_section_name.is_some()
+        {
+            return Task::none();
+        }
+
+        if let Some((track_id, clip_id)) = self.open_piano_roll_clip() {
+            return self.update(Message::PianoRoll(PianoRollMsg::SelectAllNotes(
+                track_id, clip_id,
+            )));
+        }
+
+        self.update(Message::Arrangement(ArrangementMsg::SelectAllClips))
+    }
+
+    /// The note clip the piano roll is currently editing, if it is the
+    /// visible detail-panel editor. Mirrors the condition `views_detail`
+    /// uses to decide whether to draw the piano roll at all.
+    fn open_piano_roll_clip(&self) -> Option<(TrackId, ClipId)> {
+        if self.state.view.detail_panel_tab != crate::state::DetailPanelTab::Clip {
+            return None;
+        }
+        let editor = self.state.active_timeline_editor();
+        let (track_id, clip_id) = editor.selected_note_clip?;
+        (editor.selected_track == Some(track_id)
+            && self
+                .state
+                .find_track(track_id)
+                .is_some_and(|track| track.kind.is_midi()))
+        .then_some((track_id, clip_id))
+    }
+
     pub(super) fn on_load_sampler_sample(&mut self, track_id: TrackId) -> Task<Message> {
         Task::perform(
             async {

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -75,7 +75,7 @@ impl App {
             return Task::none();
         }
 
-        if let Some((track_id, clip_id)) = self.open_piano_roll_clip() {
+        if let Some((track_id, clip_id)) = self.focused_piano_roll_clip() {
             return self.update(Message::PianoRoll(PianoRollMsg::SelectAllNotes(
                 track_id, clip_id,
             )));
@@ -83,6 +83,7 @@ impl App {
 
         self.update(Message::Arrangement(ArrangementMsg::SelectAllClips))
     }
+
     pub(super) fn on_load_sampler_sample(&mut self, track_id: TrackId) -> Task<Message> {
         Task::perform(
             async {

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -15,7 +15,7 @@ use vibez_core::perform::GrooveGrid;
 
 use crate::icons;
 use crate::message::Message;
-use crate::state::{ArrangementSelection, DetailPanelTab, UiClip};
+use crate::state::{ArrangementSelection, DetailPanelTab, TimelineEditorState, UiClip};
 use crate::theme as th;
 use crate::widgets::audio_clip_detail::AudioClipDetailWidget;
 use crate::widgets::piano_roll::PianoRollWidget;
@@ -46,11 +46,55 @@ fn effective_detail_panel_height(preferred_height: f32, window_height: f32) -> f
     preferred_height.clamp(DETAIL_PANEL_MIN_HEIGHT, maximum)
 }
 
+fn selected_note_clip_for_track(editor: &TimelineEditorState, track_id: TrackId) -> Option<ClipId> {
+    editor
+        .selected_note_clip
+        .filter(|(selected_track, _)| *selected_track == track_id)
+        .map(|(_, clip_id)| clip_id)
+        .or_else(|| {
+            editor.selected_clips.iter().find_map(|selection| {
+                if let ArrangementSelection::NoteClip {
+                    track_id: selected_track,
+                    clip_id,
+                } = selection
+                {
+                    (*selected_track == track_id).then_some(*clip_id)
+                } else {
+                    None
+                }
+            })
+        })
+}
+
 impl App {
     // ── Detail panel (Ableton-style device chain) ──
 
-    pub(super) fn view_detail_panel(&self) -> Element<'_, Message> {
+    /// The note clip owned by the visible piano-roll editor.
+    ///
+    /// Both rendering and global-shortcut routing use this resolver so
+    /// marquee selection cannot put the detail panel and Command+A in
+    /// different editing contexts.
+    pub(super) fn open_piano_roll_clip(&self) -> Option<(TrackId, ClipId)> {
+        if self.state.view.detail_panel_tab != DetailPanelTab::Clip {
+            return None;
+        }
+
         let editor = self.state.active_timeline_editor();
+        let track_id = editor.selected_track?;
+        if !self
+            .state
+            .find_track(track_id)
+            .is_some_and(|track| track.kind.is_midi())
+        {
+            return None;
+        }
+
+        let clip_id = selected_note_clip_for_track(editor, track_id)?;
+
+        Some((track_id, clip_id))
+    }
+
+    pub(super) fn view_detail_panel(&self) -> Element<'_, Message> {
         let detail_content: Element<'_, Message> = if let Some(track) = self
             .state
             .active_timeline_editor()
@@ -121,17 +165,8 @@ impl App {
             let tab_content: Element<'_, Message> = match self.state.view.detail_panel_tab {
                 DetailPanelTab::Clip => {
                     let is_midi = track.kind.is_midi();
-                    // Check for note clip selection on this MIDI track
-                    let has_note_clip = is_midi
-                        && (editor.selected_clips.iter().any(|s| {
-                            matches!(s, ArrangementSelection::NoteClip { track_id: tid, .. } if *tid == track_id)
-                        }) || self
-                            .state
-                            .active_timeline_editor()
-                            .selected_note_clip
-                            .is_some_and(|(tid, _)| tid == track_id));
 
-                    if has_note_clip {
+                    if self.open_piano_roll_clip().is_some() {
                         self.view_piano_roll_panel(track_id, track_color)
                     } else if is_midi {
                         self.view_midi_track_clip_placeholder(track_id, track_color)
@@ -236,29 +271,25 @@ impl App {
         .unwrap_or(-1.0);
 
         // Extract clip data as owned values (avoids lifetime conflicts with widget construction)
-        let clip_data: Option<(String, f64, f64, bool, GrooveGrid, TrackId, ClipId)> =
-            if let Some((tid, cid)) = self.state.active_timeline_editor().selected_note_clip {
-                if tid == track_id {
-                    self.state
-                        .active_timeline_content(track_id)
-                        .and_then(|content| content.note_clips.iter().find(|c| c.id == cid))
-                        .map(|c| {
-                            (
-                                c.name.clone(),
-                                c.position_beats,
-                                c.duration_beats,
-                                c.loop_enabled,
-                                c.groove_grid,
-                                tid,
-                                cid,
-                            )
-                        })
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
+        let clip_data: Option<(String, f64, f64, bool, GrooveGrid, TrackId, ClipId)> = self
+            .open_piano_roll_clip()
+            .filter(|(open_track_id, _)| *open_track_id == track_id)
+            .and_then(|(tid, cid)| {
+                self.state
+                    .active_timeline_content(track_id)
+                    .and_then(|content| content.note_clips.iter().find(|c| c.id == cid))
+                    .map(|c| {
+                        (
+                            c.name.clone(),
+                            c.position_beats,
+                            c.duration_beats,
+                            c.loop_enabled,
+                            c.groove_grid,
+                            tid,
+                            cid,
+                        )
+                    })
+            });
 
         let piano_widget = if let Some(ref cd) = clip_data {
             if let Some(content) = self.state.active_timeline_content(track_id) {
@@ -727,8 +758,12 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::{effective_detail_panel_height, resolved_detail_playhead_samples};
-    use vibez_core::id::SectionId;
+    use super::{
+        effective_detail_panel_height, resolved_detail_playhead_samples,
+        selected_note_clip_for_track,
+    };
+    use crate::state::{ArrangementSelection, TimelineEditorState};
+    use vibez_core::id::{ClipId, SectionId, TrackId};
 
     #[test]
     fn detail_panel_height_preserves_the_workspace_at_small_windows() {
@@ -754,6 +789,33 @@ mod tests {
         assert_eq!(
             resolved_detail_playhead_samples(true, Some(other), Some(playing), 96_000, 12_000,),
             None
+        );
+    }
+
+    #[test]
+    fn marquee_selected_note_clip_is_the_visible_piano_roll_clip() {
+        let track_id = TrackId::new();
+        let other_track = TrackId::new();
+        let marquee_clip = ClipId::new();
+        let explicit_clip = ClipId::new();
+        let mut editor = TimelineEditorState::default();
+        editor
+            .selected_clips
+            .insert(ArrangementSelection::NoteClip {
+                track_id,
+                clip_id: marquee_clip,
+            });
+
+        assert_eq!(
+            selected_note_clip_for_track(&editor, track_id),
+            Some(marquee_clip)
+        );
+        assert_eq!(selected_note_clip_for_track(&editor, other_track), None);
+
+        editor.selected_note_clip = Some((track_id, explicit_clip));
+        assert_eq!(
+            selected_note_clip_for_track(&editor, track_id),
+            Some(explicit_clip)
         );
     }
 }

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -46,7 +46,7 @@ fn effective_detail_panel_height(preferred_height: f32, window_height: f32) -> f
     preferred_height.clamp(DETAIL_PANEL_MIN_HEIGHT, maximum)
 }
 
-fn selected_note_clip_for_track(editor: &TimelineEditorState, track_id: TrackId) -> Option<ClipId> {
+fn visible_note_clip_for_track(editor: &TimelineEditorState, track_id: TrackId) -> Option<ClipId> {
     editor
         .selected_note_clip
         .filter(|(selected_track, _)| *selected_track == track_id)
@@ -66,31 +66,45 @@ fn selected_note_clip_for_track(editor: &TimelineEditorState, track_id: TrackId)
         })
 }
 
+fn focused_note_clip_for_track(editor: &TimelineEditorState, track_id: TrackId) -> Option<ClipId> {
+    editor
+        .selected_note_clip
+        .filter(|(selected_track, _)| *selected_track == track_id)
+        .map(|(_, clip_id)| clip_id)
+}
+
 impl App {
     // ── Detail panel (Ableton-style device chain) ──
 
-    /// The note clip owned by the visible piano-roll editor.
+    /// The selected MIDI track that can host the piano-roll detail view.
     ///
-    /// Both rendering and global-shortcut routing use this resolver so
-    /// marquee selection cannot put the detail panel and Command+A in
-    /// different editing contexts.
-    pub(super) fn open_piano_roll_clip(&self) -> Option<(TrackId, ClipId)> {
+    /// Visibility and keyboard focus intentionally share this structural
+    /// gate, then resolve their clip from different selection state.
+    fn piano_roll_track(&self) -> Option<TrackId> {
         if self.state.view.detail_panel_tab != DetailPanelTab::Clip {
             return None;
         }
 
         let editor = self.state.active_timeline_editor();
         let track_id = editor.selected_track?;
-        if !self
-            .state
+        self.state
             .find_track(track_id)
             .is_some_and(|track| track.kind.is_midi())
-        {
-            return None;
-        }
+            .then_some(track_id)
+    }
 
-        let clip_id = selected_note_clip_for_track(editor, track_id)?;
+    /// A note clip the piano roll can render. Arrangement selection may
+    /// supply the clip without transferring keyboard focus into the editor.
+    pub(super) fn visible_piano_roll_clip(&self) -> Option<(TrackId, ClipId)> {
+        let track_id = self.piano_roll_track()?;
+        let clip_id = visible_note_clip_for_track(self.state.active_timeline_editor(), track_id)?;
+        Some((track_id, clip_id))
+    }
 
+    /// The explicitly opened note clip that owns editor shortcuts.
+    pub(super) fn focused_piano_roll_clip(&self) -> Option<(TrackId, ClipId)> {
+        let track_id = self.piano_roll_track()?;
+        let clip_id = focused_note_clip_for_track(self.state.active_timeline_editor(), track_id)?;
         Some((track_id, clip_id))
     }
 
@@ -166,7 +180,7 @@ impl App {
                 DetailPanelTab::Clip => {
                     let is_midi = track.kind.is_midi();
 
-                    if self.open_piano_roll_clip().is_some() {
+                    if self.visible_piano_roll_clip().is_some() {
                         self.view_piano_roll_panel(track_id, track_color)
                     } else if is_midi {
                         self.view_midi_track_clip_placeholder(track_id, track_color)
@@ -272,7 +286,7 @@ impl App {
 
         // Extract clip data as owned values (avoids lifetime conflicts with widget construction)
         let clip_data: Option<(String, f64, f64, bool, GrooveGrid, TrackId, ClipId)> = self
-            .open_piano_roll_clip()
+            .visible_piano_roll_clip()
             .filter(|(open_track_id, _)| *open_track_id == track_id)
             .and_then(|(tid, cid)| {
                 self.state
@@ -759,8 +773,8 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::{
-        effective_detail_panel_height, resolved_detail_playhead_samples,
-        selected_note_clip_for_track,
+        effective_detail_panel_height, focused_note_clip_for_track,
+        resolved_detail_playhead_samples, visible_note_clip_for_track,
     };
     use crate::state::{ArrangementSelection, TimelineEditorState};
     use vibez_core::id::{ClipId, SectionId, TrackId};
@@ -807,15 +821,39 @@ mod tests {
             });
 
         assert_eq!(
-            selected_note_clip_for_track(&editor, track_id),
+            visible_note_clip_for_track(&editor, track_id),
             Some(marquee_clip)
         );
-        assert_eq!(selected_note_clip_for_track(&editor, other_track), None);
+        assert_eq!(visible_note_clip_for_track(&editor, other_track), None);
 
         editor.selected_note_clip = Some((track_id, explicit_clip));
         assert_eq!(
-            selected_note_clip_for_track(&editor, track_id),
+            visible_note_clip_for_track(&editor, track_id),
             Some(explicit_clip)
+        );
+    }
+
+    #[test]
+    fn arrangement_selection_does_not_focus_the_piano_roll_for_select_all() {
+        let track_id = TrackId::new();
+        let selected_clip = ClipId::new();
+        let explicitly_open_clip = ClipId::new();
+        let mut editor = TimelineEditorState::default();
+        editor
+            .selected_clips
+            .insert(ArrangementSelection::NoteClip {
+                track_id,
+                clip_id: selected_clip,
+            });
+
+        // This is the state after the first arrangement Command+A. A
+        // second press must remain arrangement select-all.
+        assert_eq!(focused_note_clip_for_track(&editor, track_id), None);
+
+        editor.selected_note_clip = Some((track_id, explicitly_open_clip));
+        assert_eq!(
+            focused_note_clip_for_track(&editor, track_id),
+            Some(explicitly_open_clip)
         );
     }
 }

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -80,6 +80,8 @@ pub enum ArrangementMsg {
         end_beats: f64,
         track_id: Option<TrackId>,
     },
+    /// Select every clip on every track of this timeline.
+    SelectAllClips,
     SetTimeSelectionActive(bool),
     /// Live rubber-band update. `track_ids` are the lanes the box spans,
     /// resolved by the widget from real row geometry. Carries the time
@@ -165,6 +167,7 @@ impl ArrangementMsg {
                 | Self::ToggleClipLoop(..)
                 | Self::SetClipLoopRegion { .. }
                 | Self::SetTimeSelection { .. }
+                | Self::SelectAllClips
                 | Self::SetTimeSelectionActive(_)
                 | Self::MarqueeSelect { .. }
                 | Self::EndMarqueeSelect
@@ -202,6 +205,7 @@ impl ArrangementMsg {
                 | ArrangementMsg::EngineTrackMeter { .. }
                 | ArrangementMsg::SelectArrangementClip { .. }
                 | ArrangementMsg::SetTimeSelection { .. }
+                | ArrangementMsg::SelectAllClips
                 | ArrangementMsg::SetTimeSelectionActive(_)
                 | ArrangementMsg::MarqueeSelect { .. }
                 | ArrangementMsg::EndMarqueeSelect

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -753,6 +753,29 @@ impl TimelineEditorState {
             ArrangementMsg::EndMarqueeSelect => {
                 self.marquee = None;
             }
+            ArrangementMsg::SelectAllClips => {
+                self.selected_clips = self
+                    .timeline
+                    .by_track
+                    .iter()
+                    .flat_map(|(track_id, content)| {
+                        let audio = content.clips.iter().map(|clip| {
+                            ArrangementSelection::AudioClip {
+                                track_id: *track_id,
+                                clip_id: clip.id,
+                            }
+                        });
+                        let notes = content.note_clips.iter().map(|clip| {
+                            ArrangementSelection::NoteClip {
+                                track_id: *track_id,
+                                clip_id: clip.id,
+                            }
+                        });
+                        audio.chain(notes)
+                    })
+                    .collect();
+                action.focus_clip_tab = !self.selected_clips.is_empty();
+            }
             ArrangementMsg::SetTimeSelectionActive(active) => {
                 self.time_selection_active = active;
                 if !active {

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -754,26 +754,28 @@ impl TimelineEditorState {
                 self.marquee = None;
             }
             ArrangementMsg::SelectAllClips => {
-                self.selected_clips = self
-                    .timeline
-                    .by_track
-                    .iter()
-                    .flat_map(|(track_id, content)| {
-                        let audio = content.clips.iter().map(|clip| {
-                            ArrangementSelection::AudioClip {
-                                track_id: *track_id,
-                                clip_id: clip.id,
-                            }
-                        });
-                        let notes = content.note_clips.iter().map(|clip| {
-                            ArrangementSelection::NoteClip {
-                                track_id: *track_id,
-                                clip_id: clip.id,
-                            }
-                        });
-                        audio.chain(notes)
-                    })
-                    .collect();
+                self.selected_clips =
+                    self.timeline
+                        .by_track
+                        .iter()
+                        .flat_map(|(track_id, content)| {
+                            let audio =
+                                content
+                                    .clips
+                                    .iter()
+                                    .map(|clip| ArrangementSelection::AudioClip {
+                                        track_id: *track_id,
+                                        clip_id: clip.id,
+                                    });
+                            let notes = content.note_clips.iter().map(|clip| {
+                                ArrangementSelection::NoteClip {
+                                    track_id: *track_id,
+                                    clip_id: clip.id,
+                                }
+                            });
+                            audio.chain(notes)
+                        })
+                        .collect();
                 action.focus_clip_tab = !self.selected_clips.is_empty();
             }
             ArrangementMsg::SetTimeSelectionActive(active) => {

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -1099,3 +1099,47 @@ fn ending_the_drag_drops_the_box_but_keeps_the_selection() {
         clip_id,
     }));
 }
+
+#[test]
+fn select_all_clips_takes_every_clip_on_every_track() {
+    let mut a = arrangement_with_tracks(2);
+    let (t0, first) = add_audio_clip(&mut a, 0, 0, 100);
+    let (_, second) = add_audio_clip(&mut a, 0, 400, 100);
+    let (t1, third) = add_audio_clip(&mut a, 1, 200, 100);
+    let mut engine = RecordingEngine::default();
+
+    a.update(
+        ArrangementMsg::SelectAllClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    assert_eq!(a.selected_clips.len(), 3);
+    for (track_id, clip_id) in [(t0, first), (t0, second), (t1, third)] {
+        assert!(a
+            .selected_clips
+            .contains(&ArrangementSelection::AudioClip { track_id, clip_id }));
+    }
+}
+
+#[test]
+fn select_all_clips_on_an_empty_timeline_selects_nothing() {
+    let mut a = arrangement_with_tracks(2);
+    let stale_track = a.tracks[0].id;
+    a.selected_clips.insert(ArrangementSelection::AudioClip {
+        track_id: stale_track,
+        clip_id: ClipId::new(),
+    });
+    let mut engine = RecordingEngine::default();
+
+    let action = a.update(
+        ArrangementMsg::SelectAllClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    // The stale selection is replaced, not extended, and an empty result
+    // must not pull focus to a clip tab with nothing to show.
+    assert!(a.selected_clips.is_empty());
+    assert!(!action.focus_clip_tab);
+}

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -361,6 +361,9 @@ pub enum Message {
 
     // Cursor tracking
     DeleteKeyPressed,
+    /// Command+A. Context-resolved in `update`, like [`Self::DeleteKeyPressed`]:
+    /// the open piano roll's notes first, then the active timeline's clips.
+    SelectAllPressed,
 
     // File menu
     NewProject,

--- a/crates/vibez-ui/src/widgets/piano_roll/mod.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/mod.rs
@@ -928,24 +928,10 @@ impl canvas::Program<Message> for PianoRollWidget {
                 }
             }
 
-            // ── Keyboard: Ctrl+A → select all notes ──
-            canvas::Event::Keyboard(iced::keyboard::Event::KeyPressed {
-                key: iced::keyboard::Key::Character(ref ch),
-                modifiers,
-                ..
-            }) if ch.as_str() == "a"
-                && crate::app::command_held(modifiers, crate::app::ON_MACOS) =>
-            {
-                if let Some(ref clip_data) = self.clip {
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(Message::PianoRoll(PianoRollMsg::SelectAllNotes(
-                            self.track_id,
-                            clip_data.clip_id,
-                        ))),
-                    );
-                }
-            }
+            // Command+A is handled centrally by the global
+            // SelectAllPressed shortcut, for the same reason Delete is:
+            // every canvas receives keyboard events, so two canvases
+            // binding one key race each other.
 
             _ => {}
         }

--- a/crates/vibez-ui/src/widgets/piano_roll/mod.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/mod.rs
@@ -932,7 +932,6 @@ impl canvas::Program<Message> for PianoRollWidget {
             // SelectAllPressed shortcut, for the same reason Delete is:
             // every canvas receives keyboard events, so two canvases
             // binding one key race each other.
-
             _ => {}
         }
 


### PR DESCRIPTION
Stack 3/3 — based on #127, **retarget to `dev` once the stack merges**.

Command+A selects every clip on the active timeline (Arrange and Section construction), or every note when the piano roll is the visible editor.

## Why it is routed centrally

Command+A had no global binding at all. The piano roll canvas bound it locally — which is the exact race the existing `DeleteKeyPressed` comments warn about:

> every canvas receives keyboard events, so two canvases binding the same key race each other

So this follows the precedent Delete already set: one `Message::SelectAllPressed` from `global_key_handler`, context-resolved in `update`. The local canvas binding is removed.

Because resolution goes through `active_timeline_editor()`, Arrange and Sections are both covered by the same handler.

## The one difference from Delete

`on_delete_key_pressed` decides between notes and clips by asking *what is already selected*. Select-all cannot do that — creating a selection is the whole point, so there is never one to inspect. Instead `open_piano_roll_clip()` asks whether the piano roll is actually on screen, mirroring the condition `views_detail` uses to decide whether to draw it (Clip tab + MIDI track + selected note clip on the selected track).

Text fields keep Command+A for their own contents, same guard as Delete.

## Tests

- `command_a_routes_centrally_instead_of_binding_a_canvas` — asserts the shortcut is surface-agnostic, and that bare `a` stays a Perform pad key
- `select_all_clips_takes_every_clip_on_every_track`
- `select_all_clips_on_an_empty_timeline_selects_nothing` — replaces rather than extends a stale selection, and does not pull focus to a clip tab with nothing in it

`cargo build --workspace`, all 24 suites and `cargo clippy --all-targets` clean.