### PR TITLE
Fix Pages deployment after automated releases

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,12 @@ on:
   # version without a commit.
   release:
     types: [published]
+  # Releases created with GITHUB_TOKEN cannot trigger another workflow from
+  # their release event. Wait for the complete release workflow instead so
+  # every platform asset exists before the download page is deployed.
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -33,6 +39,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

- trigger the Pages workflow after the full Release workflow completes
- deploy only when the Release workflow succeeds
- retain the published-release trigger for releases created outside GitHub Actions

GitHub suppresses downstream workflow events produced by `GITHUB_TOKEN`, so the previous `release.published` trigger did not run for automated releases.

## Test plan

- [x] `actionlint .github/workflows/pages.yml`
- [x] Manual Pages dispatch for `v0.1.2`
- [ ] Confirm the next tagged release automatically starts the Pages workflow

Prepared with Codex.