### PR TITLE
fix(perform): route select-all and delete by editor focus

### DIFF
--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -25,10 +25,20 @@ impl App {
             || self.state.perform.editing_section_name.is_some()
     }
 
+    /// Delete/Backspace, resolved against whatever the user is actually
+    /// editing.
+    ///
+    /// The priority ladder below reads the focused timeline, so the focus gate
+    /// has to come first: in Perform the Section lanes stay on screen next to
+    /// the pad surface, and a producer hitting Delete over the pads is not
+    /// asking to destroy the clips they can see beside them.
     pub(super) fn on_delete_key_pressed(&mut self) -> Task<Message> {
         // Never delete anything while a text field is being
         // edited; backspace belongs to the text there.
         if self.text_field_editing() {
+            return Task::none();
+        }
+        if !self.editor_shortcuts_have_focus() {
             return Task::none();
         }
         // Priority 1: a selected automation point.
@@ -64,14 +74,18 @@ impl App {
 
     /// Command+A, resolved against whatever the user is actually editing.
     ///
-    /// Mirrors [`Self::on_delete_key_pressed`]: the piano roll wins while
-    /// it is the visible editor, otherwise the active timeline's clips do.
-    /// Unlike Delete this cannot key off an existing selection, since the
-    /// point of the shortcut is to create one, so it asks whether the
-    /// piano roll is on screen instead.
+    /// Mirrors [`Self::on_delete_key_pressed`]: the focus gate first, then the
+    /// explicitly opened piano roll, then the focused timeline's clips. Unlike
+    /// Delete this cannot key off an existing selection, since the point of
+    /// the shortcut is to create one, so it asks which editor was last opened
+    /// rather than which one holds a selection. Selecting everything must not
+    /// escalate the target on a second press.
     pub(super) fn on_select_all_pressed(&mut self) -> Task<Message> {
         // A text field owns Command+A for its own contents.
         if self.text_field_editing() {
+            return Task::none();
+        }
+        if !self.editor_shortcuts_have_focus() {
             return Task::none();
         }
 

--- a/crates/vibez-ui/src/app/update_timeline.rs
+++ b/crates/vibez-ui/src/app/update_timeline.rs
@@ -25,6 +25,24 @@ pub(super) fn section_timeline_claims_focus(workspace: Workspace, selected_secti
     workspace == Workspace::Perform && selected_section
 }
 
+/// Whether a shortcut that edits a timeline without naming one has a focused
+/// timeline to act on.
+///
+/// Perform keeps the pad surface and the Section lanes on screen together, so
+/// unlike Arrange it cannot answer "which timeline" from visibility alone.
+/// While the pads own focus the producer is performing, not editing, and
+/// Arrange is off screen, so these shortcuts are dropped rather than aimed at
+/// a timeline nobody is looking at. Delete and Command+A deliberately share
+/// this gate with the clipboard, so one keystroke cannot destroy a Section
+/// selection that Copy would have left alone.
+fn editor_shortcuts_reach_a_focused_timeline(
+    workspace: Workspace,
+    selected_section: bool,
+    focus: PerformEditorFocus,
+) -> bool {
+    workspace != Workspace::Perform || clipboard_targets_section(workspace, selected_section, focus)
+}
+
 fn focused_timeline_playhead_beats(
     workspace: Workspace,
     selected_section: bool,
@@ -54,6 +72,15 @@ fn focused_section_seek_beat(
 impl App {
     pub(super) fn focused_editor_is_section(&self) -> bool {
         clipboard_targets_section(
+            self.state.view.workspace,
+            self.state.perform.selected_section.is_some(),
+            self.state.perform.editor_focus,
+        )
+    }
+
+    /// Gate for Delete and Command+A, which name no timeline of their own.
+    pub(super) fn editor_shortcuts_have_focus(&self) -> bool {
+        editor_shortcuts_reach_a_focused_timeline(
             self.state.view.workspace,
             self.state.perform.selected_section.is_some(),
             self.state.perform.editor_focus,
@@ -391,5 +418,84 @@ mod clipboard_focus_tests {
         assert!(section_timeline_claims_focus(Workspace::Perform, true));
         assert!(!section_timeline_claims_focus(Workspace::Arrange, true));
         assert!(!section_timeline_claims_focus(Workspace::Perform, false));
+    }
+}
+
+#[cfg(test)]
+mod editor_shortcut_focus_tests {
+    use super::*;
+
+    #[test]
+    fn select_all_and_delete_leave_the_section_lanes_alone_while_the_pads_own_focus() {
+        // The lanes stay on screen beside the pad surface, so a producer
+        // playing pads would otherwise lose their clip selection, or the
+        // clips themselves, to a key they never aimed at an editor.
+        assert!(!editor_shortcuts_reach_a_focused_timeline(
+            Workspace::Perform,
+            true,
+            PerformEditorFocus::PadSurface,
+        ));
+        assert!(editor_shortcuts_reach_a_focused_timeline(
+            Workspace::Perform,
+            true,
+            PerformEditorFocus::SectionConstruction,
+        ));
+    }
+
+    #[test]
+    fn perform_shortcuts_never_reach_the_off_screen_arrange_timeline() {
+        // Without a selected Section the lanes have nothing to edit. Arrange
+        // is not the fallback: it is not on screen, so Delete there would
+        // destroy clips the producer cannot see.
+        for focus in [
+            PerformEditorFocus::PadSurface,
+            PerformEditorFocus::SectionConstruction,
+        ] {
+            assert!(!editor_shortcuts_reach_a_focused_timeline(
+                Workspace::Perform,
+                false,
+                focus,
+            ));
+        }
+    }
+
+    #[test]
+    fn arrange_shortcuts_ignore_whatever_perform_focus_was_left_behind() {
+        // Perform focus is runtime state that outlives leaving the workspace,
+        // and Arrange owns the only timeline once it is the visible one.
+        for selected_section in [false, true] {
+            for focus in [
+                PerformEditorFocus::PadSurface,
+                PerformEditorFocus::SectionConstruction,
+            ] {
+                assert!(editor_shortcuts_reach_a_focused_timeline(
+                    Workspace::Arrange,
+                    selected_section,
+                    focus,
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn select_all_and_delete_target_exactly_what_the_clipboard_targets_in_perform() {
+        // One focus answer for every unnamed-target shortcut. Command+A also
+        // reads no selection state, so a second press cannot escalate to a
+        // wider target than the first press had.
+        for selected_section in [false, true] {
+            for focus in [
+                PerformEditorFocus::PadSurface,
+                PerformEditorFocus::SectionConstruction,
+            ] {
+                assert_eq!(
+                    editor_shortcuts_reach_a_focused_timeline(
+                        Workspace::Perform,
+                        selected_section,
+                        focus
+                    ),
+                    clipboard_targets_section(Workspace::Perform, selected_section, focus),
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why

Global shortcuts in this project route by **focus**: the editor the user last explicitly interacted with, never by what is visible and never by what a selection implies. Copy and Paste already obey that rule through `clipboard_targets_section`. Delete and Command+A did not: they resolved their target from `state::active_timeline_editor()`, which answers *visibility*.

That gap is not cosmetic in Perform, where the pad surface and the Section construction lanes are on screen at the same time:

- Playing pads and pressing Delete reached into the Section lanes beside them and deleted the selected clips, and Command+A silently replaced a lane selection the producer had built by hand.
- With no Section selected, `active_timeline_editor()` falls back to Arrange. So in Perform both shortcuts operated on the **off-screen** Arrange timeline: Command+A selected every Arrange clip invisibly, and the next Delete removed them. That is the data-loss end of the same bug.

## The fix

One gate, `editor_shortcuts_reach_a_focused_timeline`, placed next to the existing focus predicates in `update_timeline.rs` and consumed by both `on_delete_key_pressed` and `on_select_all_pressed`:

- Outside Perform, Arrange owns the only timeline and nothing changes.
- Inside Perform, the shortcuts act only when the Section lanes own focus and a Section is selected.
- Otherwise they are dropped. Arrange is deliberately **not** a fallback while Perform is visible, since editing a timeline nobody is looking at is the failure being fixed.

Inside Perform the gate resolves to exactly what `clipboard_targets_section` resolves to, which is asserted as an invariant rather than left as a coincidence: Command+A, Delete, Copy, and Paste cannot drift onto different targets. The gate also reads no selection state, so a second Command+A cannot escalate to a wider target than the first press had.

## On `active_timeline_editor()`

Audited every caller before touching it. All of them mean "the visible editor": `views_clip_swing`, `views_perform_instrument`, `views_detail` rendering, and the `app/mod.rs` shortcut context. Its meaning is therefore left alone, and no split into visible/focused accessors was needed, unlike `visible_piano_roll_clip` / `focused_piano_roll_clip` in #128 where both meanings genuinely had callers. Focus is resolved one level up, at the application boundary, which is where `clipboard_targets_section` already lives. Rendering continues to follow visibility.

## Tests

New `editor_shortcut_focus_tests` in `crates/vibez-ui/src/app/update_timeline.rs`, in the style of `clipboard_shortcuts_follow_editor_focus_not_perform_playback`:

- `select_all_and_delete_leave_the_section_lanes_alone_while_the_pads_own_focus` - pad focus is inert, Section focus acts.
- `perform_shortcuts_never_reach_the_off_screen_arrange_timeline` - no selected Section means no target, under either focus.
- `arrange_shortcuts_ignore_whatever_perform_focus_was_left_behind` - Perform focus is runtime state that outlives leaving the workspace.
- `select_all_and_delete_target_exactly_what_the_clipboard_targets_in_perform` - pins the shared answer, and pins that repeat presses cannot escalate.

## Known follow-up, not in this PR

Launching a Section from a pad, including a computer-keyboard pad gesture, goes through `PerformState::select_section`, which sets `editor_focus = SectionConstruction`. So performing on the pads currently hands editor focus to the lanes, which blunts this gate for keyboard performers. Whether a pad launch should claim editor focus at all is a focus-model decision worth its own change, so it is deliberately left out here.

## Verification

`cargo build --workspace`, `cargo clippy --workspace --all-targets`, `cargo test --workspace`, and `cargo fmt --check` all pass. Clippy reports only two pre-existing raw-pointer-cast warnings in `vibez-plugin-host`, untouched by this change. Both edited files stay under the 1,000-line ceiling (`update_timeline.rs` 501, `update_media.rs` 762).