### PR TITLE
fix(ci): generate release notes once, not per platform leg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Create the release, with its generated notes, exactly once. The build
+  # matrix must only attach assets: when a matrix leg passes
+  # generate_release_notes for an already-existing release, GitHub appends a
+  # fresh copy of the notes to the body, so four legs produced four copies.
+  create-release:
+    name: Create release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: softprops/action-gh-release@v2
+        with:
+          draft: false
+          generate_release_notes: true
+
   build:
     name: Build (${{ matrix.label }})
+    needs: [create-release]
+    # workflow_dispatch builds packages with no release to attach to, so
+    # create-release is skipped; needs would then skip this job too unless
+    # the gate readmits it explicitly.
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.create-release.result == 'success') }}
     strategy:
       fail-fast: false
       matrix:
@@ -156,6 +175,8 @@ jobs:
             vibez-*-setup.exe
           if-no-files-found: error
 
+      # Assets only. Notes are generated once by create-release; repeating
+      # generate_release_notes here is what duplicated the body per platform.
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
@@ -167,5 +188,3 @@ jobs:
             vibez-*.dmg
             vibez-*.zip
             vibez-*-setup.exe
-          draft: false
-          generate_release_notes: true


### PR DESCRIPTION
## The bug

Every release body carries its generated notes multiple times (v0.1.2 has four copies). Ugly, and it also bloats what update tooling and the site pull from the release body.

## Root cause

The `Attach to release` step runs inside the four-way platform build matrix, and every leg passes `generate_release_notes: true` to `softprops/action-gh-release`. The first leg to finish creates the release with notes; each later leg updates the existing release, and GitHub appends a freshly generated copy of the notes to the body it already has. Four matrix legs, up to four copies. Older releases had three legs, hence three copies.

## The fix

- A dedicated `create-release` job creates the release and its notes exactly once, before any build leg runs (`needs`).
- The matrix legs now only attach assets. With no body or notes inputs, the action leaves the existing body untouched.
- `workflow_dispatch` keeps its current behavior (package builds, no release): `create-release` is skipped and the build gate readmits the matrix explicitly, since `needs` on a skipped job would otherwise skip the builds too.

## Also

The existing releases' bodies are being deduplicated separately via `gh release edit`; this PR prevents recurrence from the next tag onward. Note the fix must be on `main` before the next tag is cut, which the normal main-from-dev release PR flow already guarantees.

## Verification

YAML validated. Not exercisable without cutting a tag; the behavior change is confined to job structure and the two `generate_release_notes` sites.