### PR TITLE
feat(ui): add an About dialog

### DIFF
--- a/crates/vibez-ui/build.rs
+++ b/crates/vibez-ui/build.rs
@@ -1,0 +1,57 @@
+//! Bakes the short commit of the build tree into the binary so the About
+//! dialog can name the exact source a build came from.
+//!
+//! Release tarballs, distro packages and crates.io builds ship without a
+//! `.git` directory, and some build machines have no `git` at all. Every
+//! failure path here therefore degrades to `UNKNOWN_COMMIT` instead of
+//! aborting the build: a missing commit is a cosmetic loss in one dialog,
+//! never a reason for vibez to fail to compile.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Must stay in step with `crate::about::UNKNOWN_COMMIT`; a build script
+/// cannot import from the crate it builds.
+const UNKNOWN_COMMIT: &str = "unknown";
+
+fn main() {
+    let commit = short_commit().unwrap_or_else(|| UNKNOWN_COMMIT.to_string());
+    println!("cargo:rustc-env=VIBEZ_GIT_HASH={commit}");
+
+    // Watch HEAD and the branch ref so the baked hash follows both a
+    // checkout and a fresh commit on the current branch. Paths that do not
+    // exist are skipped: naming a missing file makes cargo rebuild this
+    // crate on every single invocation.
+    for path in head_watch_paths() {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn short_commit() -> Option<String> {
+    let hash = git(&["rev-parse", "--short=7", "HEAD"])?;
+    (!hash.is_empty()).then_some(hash)
+}
+
+/// Files whose content changes whenever the checked-out commit changes.
+fn head_watch_paths() -> Vec<PathBuf> {
+    let mut refs = vec!["HEAD".to_string()];
+    if let Some(branch) = git(&["symbolic-ref", "--quiet", "HEAD"]) {
+        refs.push(branch);
+    }
+
+    refs.iter()
+        .filter_map(|reference| git(&["rev-parse", "--git-path", reference]))
+        .map(PathBuf::from)
+        .filter(|path| path.exists())
+        .collect()
+}
+
+/// Trimmed stdout of a successful `git` run, or `None` when git is absent,
+/// this is not a repository, or the command failed.
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8(output.stdout).ok()?.trim().to_string())
+}

--- a/crates/vibez-ui/src/about.rs
+++ b/crates/vibez-ui/src/about.rs
@@ -1,0 +1,65 @@
+//! What this build of vibez is, and where it came from.
+//!
+//! Both facts are fixed at compile time: the version by Cargo, the commit
+//! by `build.rs`. Nothing here consults the filesystem or the environment
+//! at runtime, so a binary that has been copied, packaged or renamed still
+//! reports the source tree it was actually built from.
+
+pub const APP_NAME: &str = "vibez";
+
+/// Matches the LICENSE file at the repository root and the `license` field
+/// in the workspace manifest; all three must be changed together.
+pub const LICENSE: &str = "GPL-3.0-or-later";
+
+/// What `build.rs` emits when `git` could not identify the build tree.
+pub const UNKNOWN_COMMIT: &str = "unknown";
+
+pub const REPOSITORY_URL: &str = "https://github.com/alexanderwanyoike/vibez";
+pub const WEBSITE_URL: &str = "https://alexanderwanyoike.github.io/vibez/";
+pub const RELEASES_URL: &str = "https://github.com/alexanderwanyoike/vibez/releases";
+
+/// The version string shown in the About dialog.
+///
+/// An unresolvable commit is dropped rather than printed: "0.1.2 (unknown)"
+/// reads to a user as something broken, while a bare "0.1.2" reads as a
+/// release build, which is precisely what a tarball or packaged build is.
+pub fn version_line(version: &str, commit: &str) -> String {
+    let commit = commit.trim();
+    if commit.is_empty() || commit == UNKNOWN_COMMIT {
+        version.to_string()
+    } else {
+        format!("{version} ({commit})")
+    }
+}
+
+/// The running build's version line.
+pub fn build_version_line() -> String {
+    version_line(env!("CARGO_PKG_VERSION"), env!("VIBEZ_GIT_HASH"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_version_line_names_the_commit_a_build_came_from() {
+        assert_eq!(version_line("0.1.2", "a1b2c3d"), "0.1.2 (a1b2c3d)");
+    }
+
+    #[test]
+    fn a_commit_no_build_script_could_resolve_is_dropped_not_shown() {
+        assert_eq!(version_line("0.1.2", UNKNOWN_COMMIT), "0.1.2");
+        assert_eq!(version_line("0.1.2", ""), "0.1.2");
+        assert_eq!(version_line("0.1.2", "   "), "0.1.2");
+    }
+
+    #[test]
+    fn the_version_line_survives_the_whitespace_git_output_carries() {
+        assert_eq!(version_line("0.1.2", " a1b2c3d\n"), "0.1.2 (a1b2c3d)");
+    }
+
+    #[test]
+    fn the_running_build_reports_its_own_cargo_version() {
+        assert!(build_version_line().starts_with(env!("CARGO_PKG_VERSION")));
+    }
+}

--- a/crates/vibez-ui/src/app/async_helpers.rs
+++ b/crates/vibez-ui/src/app/async_helpers.rs
@@ -283,6 +283,21 @@ pub(super) async fn connect_dropbox_async(
     Ok((info, tokens))
 }
 
+/// Hand a URL to the system browser on a blocking thread.
+///
+/// Reuses the opener vibez-dropbox already owns for its OAuth flow rather
+/// than taking a second browser dependency. `BrowserOpener::open` waits for
+/// the platform launcher to return, which must never happen on the update
+/// loop: on a cold browser start that stall would freeze the whole UI.
+pub(super) async fn open_url_async(url: &'static str) -> Result<(), String> {
+    let opener: Arc<dyn vibez_dropbox::BrowserOpener> =
+        Arc::new(vibez_dropbox::SystemBrowserOpener);
+    tokio::task::spawn_blocking(move || opener.open(url))
+        .await
+        .map_err(|error| format!("Browser task failed: {error}"))?
+        .map_err(|error| error.to_string())
+}
+
 /// Commit downloaded bytes to the Media Cache on a blocking thread; the
 /// write can be multi-MB and must not stall the async executor.
 pub(super) async fn write_cache_blocking(

--- a/crates/vibez-ui/src/app/menu_lifecycle.rs
+++ b/crates/vibez-ui/src/app/menu_lifecycle.rs
@@ -11,12 +11,14 @@ pub(super) fn dismiss(state: &mut AppState, overlay: MenuOverlay) -> bool {
         MenuOverlay::ArrangementContext => state.view.context_menu.is_some(),
         MenuOverlay::File => state.project.file_menu_open,
         MenuOverlay::Edit => state.view.edit_menu_open,
+        MenuOverlay::About => state.about_open,
     };
 
     match overlay {
         MenuOverlay::ArrangementContext => state.view.context_menu = None,
         MenuOverlay::File => state.project.file_menu_open = false,
         MenuOverlay::Edit => state.view.edit_menu_open = false,
+        MenuOverlay::About => state.about_open = false,
     }
 
     was_open
@@ -24,7 +26,9 @@ pub(super) fn dismiss(state: &mut AppState, overlay: MenuOverlay) -> bool {
 
 /// Return the topmost menu Escape should dismiss, matching shell overlay order.
 pub(super) fn visible(state: &AppState) -> Option<MenuOverlay> {
-    if state.project.file_menu_open {
+    if state.about_open {
+        Some(MenuOverlay::About)
+    } else if state.project.file_menu_open {
         Some(MenuOverlay::File)
     } else if state.view.edit_menu_open {
         Some(MenuOverlay::Edit)
@@ -140,6 +144,38 @@ mod tests {
 
         assert!(app.state.settings_open);
         assert!(!app.state.project.file_menu_open);
+    }
+
+    #[test]
+    fn the_about_dialog_outranks_the_menu_it_was_opened_from() {
+        let mut state = AppState::default();
+        state.project.file_menu_open = true;
+        state.about_open = true;
+
+        assert_eq!(visible(&state), Some(MenuOverlay::About));
+        dismiss(&mut state, MenuOverlay::About);
+        assert_eq!(visible(&state), Some(MenuOverlay::File));
+    }
+
+    #[test]
+    fn the_about_item_opens_the_dialog_and_closes_the_file_menu() {
+        let mut app = test_app();
+        app.state.project.file_menu_open = true;
+
+        let _ = app.update(Message::menu_item(MenuOverlay::File, Message::OpenAbout));
+
+        assert!(app.state.about_open);
+        assert!(!app.state.project.file_menu_open);
+    }
+
+    #[test]
+    fn escape_closes_the_about_dialog() {
+        let mut app = test_app();
+        app.state.about_open = true;
+
+        let _ = app.update(Message::EscapePressed);
+
+        assert!(!app.state.about_open);
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -160,6 +160,7 @@ mod update_project;
 mod update_remote;
 mod update_timeline;
 mod update_view;
+mod views_about;
 mod views_arrangement;
 mod views_automation;
 mod views_browser;

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -274,6 +274,19 @@ impl App {
                 return self.route_project_saved(*result);
             }
 
+            // -- About --
+            Message::OpenAbout => {
+                self.state.about_open = true;
+            }
+            Message::OpenUrl(url) => {
+                return Task::perform(open_url_async(url), Message::UrlOpened);
+            }
+            Message::UrlOpened(result) => {
+                if let Err(error) = result {
+                    self.state.status_text = format!("Could not open link: {error}");
+                }
+            }
+
             // -- Settings --
             Message::OpenSettings => {
                 self.state.settings_open = true;

--- a/crates/vibez-ui/src/app/views_about.rs
+++ b/crates/vibez-ui/src/app/views_about.rs
@@ -1,0 +1,128 @@
+//! The About dialog: what this build is, and where to find the project.
+//!
+//! Its own module rather than an addition to `views_settings.rs`, which sits
+//! at the crate's 1,000-line ceiling. Dismissal is not implemented here: the
+//! backdrop and close button both emit `MenuOverlay::About`, so a press, the
+//! Escape key and a menu selection all retire the dialog through the single
+//! path in `menu_lifecycle`.
+
+use iced::widget::{button, center, column, container, horizontal_space, mouse_area, row, text};
+use iced::{Element, Length, Theme};
+
+use crate::about;
+use crate::icons;
+use crate::message::{MenuOverlay, Message};
+use crate::theme as th;
+
+use super::*;
+
+impl App {
+    pub(super) fn view_about_modal(&self) -> Element<'_, Message> {
+        let close = Message::dismiss_menu(MenuOverlay::About);
+
+        let close_btn = button(icons::icon(icons::X).size(14).color(th::text_dim()))
+            .on_press(close)
+            .padding([4, 8])
+            .style(|_theme: &Theme, status| {
+                let bg = match status {
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => None,
+                };
+                button::Style {
+                    background: bg,
+                    text_color: th::text_dim(),
+                    border: iced::Border::default(),
+                    ..Default::default()
+                }
+            });
+
+        let header = row![
+            text(about::APP_NAME).size(22).color(th::accent()),
+            horizontal_space(),
+            close_btn
+        ]
+        .align_y(iced::Alignment::Center);
+
+        let version = text(about::build_version_line()).size(13).color(th::text());
+        let license = text(format!("Licensed under {}", about::LICENSE))
+            .size(12)
+            .color(th::text_dim());
+
+        // Rendered as label plus URL so the destination is visible before the
+        // click; a browser handoff cannot be previewed or undone.
+        let link_btn = |label: &'static str, url: &'static str| {
+            button(
+                row![
+                    text(label)
+                        .size(12)
+                        .color(th::text())
+                        .width(Length::Fixed(84.0)),
+                    text(url).size(11).color(th::accent()),
+                ]
+                .spacing(8)
+                .align_y(iced::Alignment::Center),
+            )
+            .on_press(Message::OpenUrl(url))
+            .padding([6, 8])
+            .width(Length::Fill)
+            .style(|_theme: &Theme, status| {
+                let bg = match status {
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => None,
+                };
+                button::Style {
+                    background: bg,
+                    text_color: th::text(),
+                    border: iced::Border::default(),
+                    ..Default::default()
+                }
+            })
+        };
+
+        let links = column![
+            link_btn("Repository", about::REPOSITORY_URL),
+            link_btn("Website", about::WEBSITE_URL),
+            link_btn("Releases", about::RELEASES_URL),
+        ]
+        .spacing(2);
+
+        let divider = container(horizontal_space())
+            .width(Length::Fill)
+            .height(Length::Fixed(1.0))
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::border().into()),
+                ..Default::default()
+            });
+
+        let content = column![header, version, license, divider, links]
+            .spacing(10)
+            .padding(20)
+            .width(Length::Fixed(460.0));
+
+        let dialog = container(content).style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_surface().into()),
+            border: iced::Border {
+                color: th::border(),
+                width: 1.0,
+                radius: 8.0.into(),
+            },
+            ..Default::default()
+        });
+
+        mouse_area(
+            container(center(dialog).width(Length::Fill).height(Length::Fill))
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.5).into()),
+                    ..Default::default()
+                }),
+        )
+        .on_press(Message::dismiss_menu(MenuOverlay::About))
+        .into()
+    }
+}

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -613,6 +613,8 @@ impl App {
             }
         });
 
+        let about_btn = make_menu_btn("About vibez", icons::CIRCLE_DOT, Message::OpenAbout);
+
         let menu_content = column![new_btn]
             .spacing(2)
             .push(open_btn)
@@ -620,6 +622,7 @@ impl App {
             .push(save_as_btn)
             .push(export_btn)
             .push(settings_btn)
+            .push(about_btn)
             .padding(4)
             .width(Length::Fixed(220.0));
 

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -167,6 +167,8 @@ impl App {
             stack![base_layout, self.view_track_deletion_overlay()].into()
         } else if self.state.settings_open {
             stack![base_layout, self.view_settings_modal()].into()
+        } else if self.state.about_open {
+            stack![base_layout, self.view_about_modal()].into()
         } else if self.state.project.file_menu_open {
             stack![base_layout, self.view_file_menu_overlay()].into()
         } else if self.state.view.edit_menu_open {

--- a/crates/vibez-ui/src/lib.rs
+++ b/crates/vibez-ui/src/lib.rs
@@ -1,3 +1,4 @@
+mod about;
 mod app;
 mod domains;
 pub mod icons;

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -56,13 +56,16 @@ pub enum DrumPadParam {
     FineTune,
 }
 
-/// Menus whose lifecycle is owned by their overlay rather than inferred from
-/// unrelated application messages.
+/// Menus and dialogs whose lifecycle is owned by their overlay rather than
+/// inferred from unrelated application messages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MenuOverlay {
     ArrangementContext,
     File,
     Edit,
+    /// The About dialog joins the menus rather than the Settings modal so
+    /// that Escape and a backdrop press close it, which Settings predates.
+    About,
 }
 
 #[derive(Debug, Clone)]
@@ -460,6 +463,13 @@ pub enum Message {
         payload: PreparedBrowserImport,
     },
     BrowserSampleDecodeError(String),
+
+    // About
+    OpenAbout,
+    /// Hand a link to the system browser. Every URL reaching this variant is
+    /// a compile-time constant, so there is nothing here to validate.
+    OpenUrl(&'static str),
+    UrlOpened(Result<(), String>),
 
     // Settings
     OpenSettings,

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -468,6 +468,7 @@ pub struct AppState {
 
     // File menu / Settings
     pub settings_open: bool,
+    pub about_open: bool,
     pub settings_tab: SettingsTab,
     pub settings_buffer_size: u32,
     pub confirm_project_track_deletion: bool,
@@ -519,6 +520,7 @@ impl Default for AppState {
             clip_clipboard: ClipClipboard::default(),
             devices: crate::domains::devices::DevicesState::default(),
             settings_open: false,
+            about_open: false,
             settings_tab: SettingsTab::default(),
             settings_buffer_size: 512,
             confirm_project_track_deletion: false,


### PR DESCRIPTION
## Why

vibez ships nightly-ish builds from several places (packages, tarballs, the releases page) and there was no way to answer "which build is this?" from inside the app. `--version` on the CLI exists, but a producer who launched from a desktop icon never sees it. Bug reports carry no provenance.

## What lands

`File > About vibez` opens a modal with:

- app name and the version line, e.g. `0.1.2 (1ed3e55)`
- the license, `GPL-3.0-or-later`, matching LICENSE and the workspace manifest
- Repository, Website and Releases links, each rendered as label plus its URL so the destination is visible before the click, since a browser handoff cannot be previewed or undone

## The commit hash

A new `crates/vibez-ui/build.rs` bakes `git rev-parse --short=7 HEAD` in as `VIBEZ_GIT_HASH`. It lives in vibez-ui rather than the root package because a build script's `rustc-env` only reaches the crate it belongs to, and the dialog is drawn there.

Every failure path degrades to `"unknown"` instead of aborting: no `.git` (release tarball, distro package, crates.io), no `git` binary, or a failed invocation. A missing commit is a cosmetic loss in one dialog, never a reason for vibez to fail to compile. `about::version_line` then drops an unknown commit entirely rather than printing `0.1.2 (unknown)`, which reads to a user as a defect where a bare `0.1.2` correctly reads as a release build.

Rerun tracking watches both `HEAD` and the current branch ref, resolved through `git rev-parse --git-path` so it is correct inside a linked worktree, so the baked hash follows a checkout *and* a fresh commit on the same branch. Paths that do not exist are skipped, because naming a missing file makes cargo rebuild vibez-ui on every invocation.

Verified by compiling the script standalone: inside the repo it emits `VIBEZ_GIT_HASH=1ed3e55` plus two rerun paths, and in a directory outside any repository it emits `VIBEZ_GIT_HASH=unknown` and no rerun paths.

## No new dependency

vibez-dropbox already owns `open = "5"` behind its `BrowserOpener` trait for the OAuth flow, and vibez-ui already constructs `SystemBrowserOpener` in `async_helpers.rs`. Link presses reuse it. `BrowserOpener::open` waits for the platform launcher to return, so it runs on `spawn_blocking`: on a cold browser start that stall would otherwise freeze the UI. A failure surfaces in the status bar rather than being swallowed.

## Dismissal

The dialog is registered as `MenuOverlay::About` rather than following the Settings modal. Settings can only be closed by its X or a backdrop press; Escape does not reach it. Going through `menu_lifecycle` means the close button, the backdrop and Escape all retire the About dialog through the one path that module exists to own, at no extra cost. It sits above the File menu in both `visible()` and the shell's overlay chain, matching the existing ordering rule.

Placement is the File menu, next to Settings, rather than a new Help menu: File is where this app already keeps application-level entries, and a menu holding a single item is not worth the header space.

## Tests

- `crates/vibez-ui/src/about.rs`: `the_version_line_names_the_commit_a_build_came_from`, `a_commit_no_build_script_could_resolve_is_dropped_not_shown`, `the_version_line_survives_the_whitespace_git_output_carries`, `the_running_build_reports_its_own_cargo_version`.
- `crates/vibez-ui/src/app/menu_lifecycle.rs`, in the existing style: `the_about_dialog_outranks_the_menu_it_was_opened_from`, `the_about_item_opens_the_dialog_and_closes_the_file_menu`, `escape_closes_the_about_dialog`.

The view itself is pure layout and is untested, matching the other `views_*` modules.

## Verification

`cargo build --workspace`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` (450 passing in vibez-ui) and `cargo fmt --check` all pass. Clippy reports only the two pre-existing raw-pointer-cast warnings in vibez-plugin-host, untouched here.

Every touched file stays under the 1,000-line ceiling. The dialog is a new `views_about.rs` (128) because `views_settings.rs` is already at exactly 1,000. Worth flagging: `state/mod.rs` is now 996 after one added field, so the next change there should split it.
