### PR TITLE
feat(app): title the window after the open project and confirm on close

### DIFF
--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -102,10 +102,13 @@ pub fn run() -> iced::Result {
         64,
     )
     .ok();
-    iced::application("vibez", App::update, App::view)
+    iced::application(App::title, App::update, App::view)
         .theme(App::theme)
         .antialiasing(true)
         .subscription(App::subscription)
+        // Unsaved edits get a confirmation instead of a silent exit, so the
+        // close request has to reach `update` rather than the window itself.
+        .exit_on_close_request(false)
         .window({
             #[allow(unused_mut)]
             let mut settings = iced::window::Settings {
@@ -169,6 +172,7 @@ mod views_browser_places;
 mod views_browser_remote;
 mod views_browser_style;
 mod views_clip_swing;
+mod views_close_confirm;
 mod views_detail;
 mod views_devices;
 mod views_mixer;
@@ -183,6 +187,7 @@ mod views_settings;
 mod views_settings_perform;
 mod views_shell;
 mod views_transport;
+mod window_policy;
 
 #[cfg(test)]
 mod project_format_v1_tests;
@@ -545,6 +550,15 @@ impl App {
         }
     }
 
+    /// Re-evaluated by iced after every update, so the title tracks the open
+    /// project and its dirty flag without anything having to push it.
+    fn title(&self) -> String {
+        window_policy::window_title(
+            self.state.project.current_path.as_deref(),
+            self.state.project.dirty,
+        )
+    }
+
     fn theme(&self) -> Theme {
         th::vibez_theme()
     }
@@ -566,6 +580,9 @@ impl App {
                 )),
                 iced::Event::Window(iced::window::Event::Unfocused) => {
                     Some(Message::Perform(PerformMsg::WindowUnfocused))
+                }
+                iced::Event::Window(iced::window::Event::CloseRequested) => {
+                    Some(Message::WindowCloseRequested)
                 }
                 _ => None,
             }),

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -371,14 +371,9 @@ impl App {
             .collect();
 
         Project {
-            name: self
-                .state
-                .project
-                .current_path
-                .as_ref()
-                .and_then(|path| path.file_stem())
-                .map(|name| name.to_string_lossy().to_string())
-                .unwrap_or_else(|| "Untitled".to_string()),
+            name: super::window_policy::project_display_name(
+                self.state.project.current_path.as_deref(),
+            ),
             bpm: self.state.transport.bpm,
             groove_profile: vibez_core::perform::GrooveProfile::default(),
             swing: self.state.perform.project_swing(),

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -287,6 +287,20 @@ impl App {
                 }
             }
 
+            // -- Window close protection --
+            Message::WindowCloseRequested => {
+                return self.route_window_close_requested();
+            }
+            Message::CloseConfirmSave => {
+                return self.route_close_confirm_save();
+            }
+            Message::CloseConfirmDiscard => {
+                return self.route_close_confirm_discard();
+            }
+            Message::CloseConfirmCancel => {
+                return self.route_close_confirm_cancel();
+            }
+
             // -- Settings --
             Message::OpenSettings => {
                 self.state.settings_open = true;

--- a/crates/vibez-ui/src/app/update_project.rs
+++ b/crates/vibez-ui/src/app/update_project.rs
@@ -2,7 +2,15 @@
 
 use crate::domains::project::{ProjectCtx, ProjectMsg};
 
+use super::window_policy::{close_request_decision, CloseRequest};
 use super::*;
+
+/// Quits the application. iced 0.13 has no "quit" task; the run loop ends when
+/// the last window closes, and the window has to be looked up because the
+/// close request carries no id through our message type.
+fn exit_application() -> Task<Message> {
+    iced::window::get_latest().and_then(iced::window::close)
+}
 
 impl App {
     pub(super) fn route_project_message(&mut self, msg: ProjectMsg) -> Task<Message> {
@@ -101,6 +109,8 @@ impl App {
                 |result| Message::ProjectSaved(Box::new(result)),
             );
         }
+        // Backing out of save-as also backs out of the quit that asked for it.
+        self.state.project.exit_after_save = false;
         Task::none()
     }
 
@@ -129,11 +139,44 @@ impl App {
                 self.state.project.current_path = Some(saved.path.clone());
                 self.state.project.dirty = false;
                 self.state.status_text = format!("Saved {}", saved.path.display());
+                if std::mem::take(&mut self.state.project.exit_after_save) {
+                    return exit_application();
+                }
             }
             Err(err) => {
                 self.state.status_text = format!("Project save error: {err}");
+                // A failed write must not take the project down with it; the
+                // error stays on screen with the edits intact.
+                self.state.project.exit_after_save = false;
             }
         }
+        Task::none()
+    }
+
+    pub(super) fn route_window_close_requested(&mut self) -> Task<Message> {
+        match close_request_decision(self.state.project.dirty) {
+            CloseRequest::Exit => exit_application(),
+            CloseRequest::Confirm => {
+                self.state.project.close_confirm_open = true;
+                Task::none()
+            }
+        }
+    }
+
+    pub(super) fn route_close_confirm_save(&mut self) -> Task<Message> {
+        self.state.project.close_confirm_open = false;
+        self.state.project.exit_after_save = true;
+        self.update(Message::SaveProject)
+    }
+
+    pub(super) fn route_close_confirm_discard(&mut self) -> Task<Message> {
+        self.state.project.close_confirm_open = false;
+        exit_application()
+    }
+
+    pub(super) fn route_close_confirm_cancel(&mut self) -> Task<Message> {
+        self.state.project.close_confirm_open = false;
+        self.state.project.exit_after_save = false;
         Task::none()
     }
 }

--- a/crates/vibez-ui/src/app/views_close_confirm.rs
+++ b/crates/vibez-ui/src/app/views_close_confirm.rs
@@ -1,0 +1,95 @@
+//! The save/discard/cancel dialog raised when the window is closed with
+//! unsaved edits. Its own file because `views_overlays.rs` is close to the
+//! 1,000-line ceiling.
+
+use iced::widget::{button, center, column, container, horizontal_space, row, text};
+use iced::{Element, Length, Theme};
+
+use crate::message::Message;
+use crate::theme as th;
+
+use super::window_policy::project_display_name;
+use super::*;
+
+impl App {
+    pub(super) fn view_close_confirm_overlay(&self) -> Element<'_, Message> {
+        let project_name = project_display_name(self.state.project.current_path.as_deref());
+        let destination = match self.state.project.current_path.as_deref() {
+            Some(path) => format!("Unsaved changes will be written to {}.", path.display()),
+            None => "This project has never been saved. Saving will ask for a file.".to_string(),
+        };
+
+        let cancel = button(text("Cancel").size(12).color(th::text()))
+            .on_press(Message::CloseConfirmCancel)
+            .padding([7, 14]);
+        // Discarding is the destructive path here, not closing, so it carries
+        // the danger styling that Delete carries elsewhere.
+        let discard = button(text("Discard").size(12).color(th::bg_dark()))
+            .on_press(Message::CloseConfirmDiscard)
+            .padding([7, 14])
+            .style(|_theme: &Theme, status| button::Style {
+                background: Some(
+                    if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                        th::blend(th::danger(), th::text(), 0.18)
+                    } else {
+                        th::danger()
+                    }
+                    .into(),
+                ),
+                text_color: th::bg_dark(),
+                border: iced::Border::default(),
+                ..Default::default()
+            });
+        let save = button(text("Save").size(12).color(th::bg_dark()))
+            .on_press(Message::CloseConfirmSave)
+            .padding([7, 14])
+            .style(|_theme: &Theme, status| button::Style {
+                background: Some(
+                    if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                        th::blend(th::accent(), th::text(), 0.18)
+                    } else {
+                        th::accent()
+                    }
+                    .into(),
+                ),
+                text_color: th::bg_dark(),
+                border: iced::Border::default(),
+                ..Default::default()
+            });
+
+        let card = container(
+            column![
+                text(format!("Save changes to {project_name}?"))
+                    .font(crate::typography::PERFORM_DISPLAY)
+                    .size(18)
+                    .color(th::text()),
+                text(destination).size(11).color(th::text_dim()),
+                text("Discarding closes vibez and loses every edit since the last save.")
+                    .size(10)
+                    .color(th::text_dim()),
+                row![horizontal_space(), cancel, discard, save].spacing(8),
+            ]
+            .spacing(12),
+        )
+        .padding(20)
+        .width(Length::Fixed(440.0))
+        .style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_surface().into()),
+            border: iced::Border {
+                color: th::border_light(),
+                width: 1.0,
+                radius: 4.0.into(),
+            },
+            ..Default::default()
+        });
+
+        container(center(card))
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.62).into()),
+                ..Default::default()
+            })
+            .into()
+    }
+}

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -158,7 +158,11 @@ impl App {
             base_layout
         };
 
-        if self
+        // Quitting outranks every other overlay: whatever menu was open, the
+        // answer to "are you about to lose work" has to be the visible one.
+        if self.state.project.close_confirm_open {
+            stack![base_layout, self.view_close_confirm_overlay()].into()
+        } else if self
             .state
             .arrangement
             .pending_project_track_deletion

--- a/crates/vibez-ui/src/app/window_policy.rs
+++ b/crates/vibez-ui/src/app/window_policy.rs
@@ -1,0 +1,112 @@
+//! Window title derivation and the close-request decision.
+//!
+//! Both rules are free functions over plain values rather than methods on
+//! [`super::App`], because `App` owns an audio engine and cannot be built in a
+//! test. Keeping the rules here is what makes the title format and the
+//! "does quitting need a prompt" policy directly assertable.
+
+use std::path::Path;
+
+/// Name used for a project that has never been written to disk. Shared with
+/// `project_from_state` so the title bar and the serialized project agree on
+/// what an unsaved project is called.
+pub(super) const UNTITLED_PROJECT_NAME: &str = "Untitled";
+
+/// Marker appended to the title while the project holds unsaved edits. A
+/// trailing glyph rather than a prefix so the project name stays the part of
+/// the title that window lists and taskbars truncate last.
+const DIRTY_MARKER: &str = " *";
+
+/// The project's display name: the file stem of its path, or
+/// [`UNTITLED_PROJECT_NAME`] before the first save. Deliberately the stem and
+/// not the full path, so the title stays readable for deeply nested files.
+pub(super) fn project_display_name(current_path: Option<&Path>) -> String {
+    current_path
+        .and_then(|path| path.file_stem())
+        .map(|stem| stem.to_string_lossy().to_string())
+        .unwrap_or_else(|| UNTITLED_PROJECT_NAME.to_string())
+}
+
+/// The full window title for the given project path and dirty flag.
+pub(super) fn window_title(current_path: Option<&Path>, dirty: bool) -> String {
+    let name = project_display_name(current_path);
+    let marker = if dirty { DIRTY_MARKER } else { "" };
+    format!("vibez - {name}{marker}")
+}
+
+/// What a window close request should do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CloseRequest {
+    /// Nothing would be lost; let the window go.
+    Exit,
+    /// Unsaved edits exist; put the save/discard/cancel dialog up instead.
+    Confirm,
+}
+
+/// Decides a close request purely from the dirty flag. A repeated request
+/// while the dialog is already up lands here again and re-affirms `Confirm`,
+/// so hammering the window button can never race past the prompt.
+pub(super) fn close_request_decision(dirty: bool) -> CloseRequest {
+    if dirty {
+        CloseRequest::Confirm
+    } else {
+        CloseRequest::Exit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{close_request_decision, project_display_name, window_title, CloseRequest};
+    use std::path::Path;
+
+    #[test]
+    fn a_saved_project_titles_with_its_file_stem_not_its_path() {
+        assert_eq!(
+            window_title(Some(Path::new("/home/alex/music/Night Drive.vzp")), false),
+            "vibez - Night Drive"
+        );
+        assert_eq!(
+            project_display_name(Some(Path::new("/home/alex/music/Night Drive.vzp"))),
+            "Night Drive"
+        );
+    }
+
+    #[test]
+    fn a_never_saved_project_titles_as_untitled() {
+        assert_eq!(window_title(None, false), "vibez - Untitled");
+    }
+
+    #[test]
+    fn unsaved_changes_append_the_dirty_marker_for_named_and_untitled_projects() {
+        assert_eq!(
+            window_title(Some(Path::new("/tmp/Night Drive.vzp")), true),
+            "vibez - Night Drive *"
+        );
+        assert_eq!(window_title(None, true), "vibez - Untitled *");
+    }
+
+    #[test]
+    fn the_dirty_marker_disappears_once_the_project_is_saved() {
+        let path = Path::new("/tmp/Night Drive.vzp");
+        assert_eq!(window_title(Some(path), true), "vibez - Night Drive *");
+        assert_eq!(window_title(Some(path), false), "vibez - Night Drive");
+    }
+
+    #[test]
+    fn a_path_without_an_extension_still_titles_with_its_name() {
+        assert_eq!(
+            window_title(Some(Path::new("/tmp/scratch")), false),
+            "vibez - scratch"
+        );
+    }
+
+    #[test]
+    fn a_clean_project_closes_without_a_prompt() {
+        assert_eq!(close_request_decision(false), CloseRequest::Exit);
+    }
+
+    #[test]
+    fn unsaved_changes_turn_a_close_request_into_a_confirmation() {
+        assert_eq!(close_request_decision(true), CloseRequest::Confirm);
+    }
+}

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -377,6 +377,18 @@ pub enum Message {
     ProjectSavePathSelected(Option<PathBuf>),
     ProjectLoaded(Box<Result<ProjectLoadResult, String>>),
     ProjectSaved(Box<Result<ProjectSaveResult, String>>),
+
+    // Window close protection. The window is configured not to exit on its
+    // own close request, so every one of these arrives here first.
+    /// The user asked to close the window (title bar button, Alt+F4, ...).
+    WindowCloseRequested,
+    /// Close dialog: save first, then quit. Falls through save-as when the
+    /// project has no path yet.
+    CloseConfirmSave,
+    /// Close dialog: quit and lose the unsaved edits.
+    CloseConfirmDiscard,
+    /// Close dialog: stay in the project.
+    CloseConfirmCancel,
     /// Settings: toggle auto-warp-on-import.
     ToggleAutoWarpOnImport,
     /// Settings: set warp detection confidence threshold.

--- a/crates/vibez-ui/src/state/snapshot.rs
+++ b/crates/vibez-ui/src/state/snapshot.rs
@@ -57,6 +57,14 @@ pub struct ProjectState {
     /// the arrangement, but serialized back into every save so unavailable
     /// media stays relinkable instead of silently vanishing.
     pub unresolved_clips: Vec<crate::message::UnresolvedTimelineClip>,
+    /// Whether the save/discard/cancel dialog raised by a close request with
+    /// unsaved edits is up.
+    pub close_confirm_open: bool,
+    /// Whether the in-flight save was started by that dialog's Save button.
+    /// A save has to complete asynchronously (and may still open a save-as
+    /// dialog first), so the intent to quit has to outlive the message that
+    /// expressed it.
+    pub exit_after_save: bool,
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
## Why

Two gaps that show up the moment you have more than one project on disk.

The window title was the literal string `"vibez"`. With several vibez windows open, or just one open next to everything else in a taskbar, nothing said which project you were looking at. The dirty flag already existed and was already surfaced, but only inside the File menu as a `Save*` label, which means you had to open a menu to learn you had unsaved work.

Closing the window exited immediately. `route_new_project` discards without asking too, but that at least keeps you in the app; the close button lost the session outright.

## Title

`iced::application(...)` now takes `App::title` instead of `"vibez"`. iced re-evaluates it after every update, so the title tracks state without anything having to push it.

The format is `vibez - {name}`, `" *"` appended while dirty, and `Untitled` for a project that has never been saved.

The name is the path's file stem, not the full path, so the project name stays the part of the title that taskbars truncate last. That derivation already existed inline in `project_from_state`, which is what writes `Project.name` into the saved file. Rather than write a second copy, both now call `window_policy::project_display_name`, so the title bar and the serialized project cannot disagree about what an unsaved project is called. This is the only change outside the feature and it makes `project_io.rs` shorter.

No new dirty tracking was introduced. `state.project.dirty` and `state.project.current_path` are read as they are.

## Confirm on close

`.exit_on_close_request(false)` on the builder, plus a `window::Event::CloseRequested` arm in the existing `listen_with` subscription, so every close request lands in `update` as `Message::WindowCloseRequested`.

A clean project closes with no dialog. A dirty one raises the overlay. The decision is a one-argument function over the dirty flag rather than a check spread through the handler, which also means a repeated close request while the dialog is already up re-affirms `Confirm` instead of racing past the prompt.

The Save path deliberately does not reimplement saving. It sets `exit_after_save` and dispatches the existing `Message::SaveProject`, which already falls through to save-as when there is no path yet. That intent has to be a state field rather than a local, because the save is asynchronous and may open a native file dialog first. Three ways out of it, all of which leave you in the app with your edits:

- the save-as dialog is cancelled (`route_project_save_path_selected(None)`),
- the write fails, in which case the error stays on screen,
- Cancel is pressed before any of it starts.

The overlay is inserted at the **top** of the overlay chain in `views_shell.rs`: whatever menu happened to be open, "are you about to lose work" has to be the visible question.

## Styling

Matches `view_track_deletion_overlay` exactly: 440px card, `PERFORM_DISPLAY` title at 18, body copy at 11 in `text_dim`, buttons right-aligned behind a `horizontal_space` with `padding([7, 14])`, backdrop at 62% black. Discard carries the `th::danger()` styling that Delete carries elsewhere, since discarding is the destructive action here, not closing. Save carries the accent.

It lives in its own `views_close_confirm.rs` rather than in `views_overlays.rs`, which was at 898 lines and had no room left under the 1,000-line ceiling.

## Tests

`crates/vibez-ui/src/app/window_policy.rs`, testing the pure rules directly since `App` owns an audio engine and cannot be constructed in a test:

- `a_saved_project_titles_with_its_file_stem_not_its_path`
- `a_never_saved_project_titles_as_untitled`
- `unsaved_changes_append_the_dirty_marker_for_named_and_untitled_projects`
- `the_dirty_marker_disappears_once_the_project_is_saved`
- `a_path_without_an_extension_still_titles_with_its_name`
- `a_clean_project_closes_without_a_prompt`
- `unsaved_changes_turn_a_close_request_into_a_confirmation`

## Verification

`cargo build --workspace`, `cargo clippy --workspace --all-targets`, `cargo test --workspace`, and `cargo fmt --check` all pass. Clippy under CI's `-D warnings` is clean; the only warnings anywhere are the two pre-existing raw-pointer casts in `vibez-plugin-host`, untouched here.

Every file touched stays under the 1,000-line ceiling. `project_io.rs` was already over at 1240 and this change takes it down to 1235; splitting it is out of scope for this one.
