### PR TITLE
feat(updates): notify passively when a newer release exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5196,6 +5196,7 @@ dependencies = [
  "dirs 5.0.1",
  "iced",
  "notify",
+ "reqwest",
  "rfd",
  "rtrb",
  "serde",

--- a/crates/vibez-ui/Cargo.toml
+++ b/crates/vibez-ui/Cargo.toml
@@ -20,6 +20,9 @@ base64 = { workspace = true }
 serde_json = { workspace = true }
 notify = { workspace = true }
 rfd = "0.15"
+# Same client and TLS backend the Dropbox integration already links, so
+# the release check adds no new transitive stack.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync"] }
 x11rb = "0.13"
 dirs = "5"

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -192,6 +192,7 @@ mod views_perform_record;
 mod views_perform_sections;
 mod views_settings;
 mod views_settings_appearance;
+mod views_settings_dropbox;
 mod views_settings_perform;
 mod views_shell;
 mod views_transport;

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -194,6 +194,7 @@ mod views_settings;
 mod views_settings_appearance;
 mod views_settings_dropbox;
 mod views_settings_perform;
+mod views_settings_updates;
 mod views_shell;
 mod views_transport;
 mod window_policy;
@@ -287,6 +288,11 @@ impl App {
             auto_warp_on_import: ui_settings.auto_warp_on_import,
             warp_confidence_threshold: ui_settings.warp_confidence_threshold,
             confirm_project_track_deletion: ui_settings.confirm_project_track_deletion,
+            update_check: crate::update_check::UpdateCheckState {
+                enabled: ui_settings.check_for_updates,
+                last_check_unix: ui_settings.last_update_check_unix,
+                ..Default::default()
+            },
             view: crate::state::ViewState {
                 perform_surface_width: ui_settings.perform_surface_width,
                 detail_panel_height: ui_settings.detail_panel_height,
@@ -436,6 +442,22 @@ impl App {
         // `vibez <project.vzp>` opens a project straight from the
         // command line (also how file-manager associations launch
         // us). Legacy `.vibez` files load the same way.
+        // Release check. Off the UI thread via Task::perform, at most
+        // once a day, and skipped entirely when the user opted out so
+        // that "off" means no traffic rather than a discarded result.
+        let update_check_task = if crate::update_check::should_check(
+            app.state.update_check.enabled,
+            app.state.update_check.last_check_unix,
+            crate::update_check::now_unix(),
+        ) {
+            Task::perform(
+                crate::update_check::fetch_latest_tag(),
+                Message::UpdateCheckCompleted,
+            )
+        } else {
+            Task::none()
+        };
+
         let open_task = std::env::args()
             .nth(1)
             .map(std::path::PathBuf::from)
@@ -449,6 +471,7 @@ impl App {
                 local_startup_task,
                 remote_startup_task,
                 plugin_catalog_startup_task,
+                update_check_task,
                 open_task,
             ]),
         )

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -274,6 +274,8 @@ impl App {
             media_cache_automatic_eviction: self.state.browser.remote.cache_automatic_eviction,
             confirm_project_track_deletion: self.state.confirm_project_track_deletion,
             interface_scale: self.interface_scale,
+            check_for_updates: self.state.update_check.enabled,
+            last_update_check_unix: self.state.update_check.last_check_unix,
         };
         if let Err(err) = settings.save() {
             self.state.status_text = format!("UI settings save error: {err}");

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -688,6 +688,28 @@ impl App {
                     !self.state.confirm_project_track_deletion;
                 self.persist_ui_settings();
             }
+            Message::ToggleCheckForUpdates => {
+                self.state.update_check.enabled = !self.state.update_check.enabled;
+                self.persist_ui_settings();
+            }
+            Message::UpdateCheckCompleted(tag) => {
+                self.state
+                    .update_check
+                    .record_result(tag, crate::update_check::now_unix());
+                // Persist so the throttle survives a restart, which is
+                // the whole point of recording failures too.
+                self.persist_ui_settings();
+            }
+            Message::DismissUpdateNotice => {
+                self.state.update_check.dismissed = true;
+            }
+            Message::OpenReleasesPage => {
+                // Retiring the notice once the URL has been handed off
+                // keeps a single mechanism for hiding it.
+                return Task::perform(crate::update_check::open_releases_page(), |()| {
+                    Message::DismissUpdateNotice
+                });
+            }
             Message::RescanMidiInputs => return self.on_rescan_midi_inputs(),
             Message::OpenMidiInput(name) => return self.on_open_midi_input(name),
             Message::CloseMidiInput => {

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -101,6 +101,11 @@ impl App {
                 SettingsTab::Appearance,
                 active == SettingsTab::Appearance
             ),
+            make_tab_btn(
+                "Updates",
+                SettingsTab::Updates,
+                active == SettingsTab::Updates
+            ),
         ]
         .spacing(0);
 
@@ -112,6 +117,7 @@ impl App {
             SettingsTab::Warping => self.view_settings_warping_tab(),
             SettingsTab::Perform => self.view_settings_perform_tab(),
             SettingsTab::Appearance => self.view_settings_appearance_tab(),
+            SettingsTab::Updates => self.view_settings_updates_tab(),
         };
 
         let content = column![

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -5,14 +5,11 @@ use iced::widget::{
 };
 use iced::{Color, Element, Length, Theme};
 
-use crate::domains::browser::BrowserMsg;
-
 use crate::icons;
 use crate::message::Message;
 use crate::state::SettingsTab;
 use crate::theme as th;
 
-use super::views_browser_style::browser_utility_action_style;
 use super::*;
 
 impl App {
@@ -498,201 +495,6 @@ impl App {
         .into()
     }
 
-    pub(super) fn view_settings_dropbox_tab(&self) -> Element<'_, Message> {
-        let title = text("Dropbox").size(14).color(th::text());
-        let hint = text(
-            "Register an app at https://www.dropbox.com/developers/apps \
-            (Scoped access, Full Dropbox). Paste the App key below.",
-        )
-        .size(11)
-        .color(th::text_dim());
-
-        let app_key_input = text_input("App key", &self.state.browser.remote.app_key_input)
-            .on_input(|s| Message::Browser(BrowserMsg::SetDropboxAppKey(s)))
-            .on_submit(Message::SaveDropboxAppKey)
-            .size(13)
-            .width(Length::Fill);
-        let save_key_btn = button(text("Save").size(12).color(th::text()))
-            .on_press(Message::SaveDropboxAppKey)
-            .padding([6, 12])
-            .style(|_theme: &Theme, status| {
-                let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::bg_hover().into())
-                    }
-                    _ => None,
-                };
-                button::Style {
-                    background: bg,
-                    text_color: th::text(),
-                    border: iced::Border {
-                        color: th::accent_dim(),
-                        width: 1.0,
-                        radius: 4.0.into(),
-                    },
-                    ..Default::default()
-                }
-            });
-
-        let key_row = row![app_key_input, save_key_btn]
-            .spacing(8)
-            .align_y(iced::Alignment::Center);
-
-        let account_line: Element<'_, Message> = if self.state.browser.remote.connected {
-            let email = self
-                .state
-                .browser
-                .remote
-                .account_email
-                .clone()
-                .unwrap_or_else(|| "connected".into());
-            text(format!("Connected: {email}"))
-                .size(12)
-                .color(th::accent())
-                .into()
-        } else if self.state.browser.remote.auth_in_progress {
-            text("Waiting for browser authorisation...")
-                .size(12)
-                .color(th::text_dim())
-                .into()
-        } else {
-            text("Not connected").size(12).color(th::text_dim()).into()
-        };
-
-        let can_connect =
-            self.state.browser.remote.has_app_key && !self.state.browser.remote.auth_in_progress;
-        let connect_label = if self.state.browser.remote.auth_in_progress {
-            "Connecting..."
-        } else if self.state.browser.remote.connected {
-            "Reconnect"
-        } else {
-            "Connect"
-        };
-        let connect_btn = {
-            let mut btn = button(text(connect_label).size(12).color(th::accent()));
-            if can_connect {
-                btn = btn.on_press(Message::ConnectDropbox);
-            }
-            btn.padding([6, 12]).style(|_theme: &Theme, status| {
-                let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::bg_hover().into())
-                    }
-                    _ => None,
-                };
-                button::Style {
-                    background: bg,
-                    text_color: th::accent(),
-                    border: iced::Border {
-                        color: th::accent_dim(),
-                        width: 1.0,
-                        radius: 4.0.into(),
-                    },
-                    ..Default::default()
-                }
-            })
-        };
-
-        let disconnect_btn: Element<'_, Message> = if self.state.browser.remote.connected {
-            button(text("Disconnect").size(12).color(th::text_dim()))
-                .on_press(Message::DisconnectDropbox)
-                .padding([6, 12])
-                .style(|_theme: &Theme, status| {
-                    let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => {
-                            Some(th::bg_hover().into())
-                        }
-                        _ => None,
-                    };
-                    button::Style {
-                        background: bg,
-                        text_color: th::text_dim(),
-                        border: iced::Border::default(),
-                        ..Default::default()
-                    }
-                })
-                .into()
-        } else {
-            horizontal_space().width(Length::Shrink).into()
-        };
-
-        let error_line: Element<'_, Message> =
-            if let Some(err) = self.state.browser.remote.last_error.clone() {
-                text(err).size(11).color(th::danger()).into()
-            } else {
-                horizontal_space().width(Length::Shrink).into()
-            };
-
-        let budget_gib =
-            self.state.browser.remote.cache_budget_bytes as f32 / (1024.0 * 1024.0 * 1024.0);
-        let cache_usage = text(format!(
-            "{} across {} item(s)",
-            format_settings_bytes(self.state.browser.remote.cache_usage_bytes),
-            self.state.browser.remote.cache_entries
-        ))
-        .size(11)
-        .color(th::text_dim());
-        let budget = slider(1.0..=500.0, budget_gib, Message::SetMediaCacheBudgetGiB)
-            .step(1.0_f32)
-            .width(Length::Fill);
-        let eviction_enabled = self.state.browser.remote.cache_automatic_eviction;
-        let eviction = button(
-            text(if eviction_enabled {
-                "LRU EVICTION ON"
-            } else {
-                "LRU EVICTION OFF"
-            })
-            .size(10)
-            .color(if eviction_enabled {
-                th::accent()
-            } else {
-                th::text_dim()
-            }),
-        )
-        .on_press(Message::ToggleMediaCacheAutomaticEviction)
-        .padding([5, 8])
-        .style(browser_utility_action_style);
-        let clear = button(text("CLEAR CACHE").size(10).color(th::text_dim()))
-            .on_press(Message::ClearMediaCache)
-            .padding([5, 8])
-            .style(browser_utility_action_style);
-        let cache_error: Element<'_, Message> = self
-            .state
-            .browser
-            .remote
-            .cache_error
-            .as_ref()
-            .map(|error| text(error).size(10).color(th::danger()).into())
-            .unwrap_or_else(|| horizontal_space().width(Length::Shrink).into());
-
-        column![
-            title,
-            hint,
-            key_row,
-            account_line,
-            row![connect_btn, disconnect_btn]
-                .spacing(8)
-                .align_y(iced::Alignment::Center),
-            error_line,
-            text("MEDIA CACHE").size(10).color(th::text_muted()),
-            row![
-                cache_usage,
-                horizontal_space(),
-                text(format!("{budget_gib:.0} GiB budget"))
-                    .size(11)
-                    .color(th::text_dim())
-            ]
-            .align_y(iced::Alignment::Center),
-            budget,
-            row![eviction, clear]
-                .spacing(8)
-                .align_y(iced::Alignment::Center),
-            cache_error,
-        ]
-        .spacing(10)
-        .into()
-    }
-
     pub(super) fn view_settings_warping_tab(&self) -> Element<'_, Message> {
         let title = text("Sample Warping").size(14).color(th::text());
         let hint = text(
@@ -793,7 +595,9 @@ impl App {
     }
 }
 
-fn format_settings_bytes(bytes: u64) -> String {
+/// Shared with the Dropbox tab, which reports Media Cache usage in the
+/// same units.
+pub(super) fn format_settings_bytes(bytes: u64) -> String {
     const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
     const MIB: f64 = 1024.0 * 1024.0;
     const KIB: f64 = 1024.0;

--- a/crates/vibez-ui/src/app/views_settings_dropbox.rs
+++ b/crates/vibez-ui/src/app/views_settings_dropbox.rs
@@ -1,0 +1,212 @@
+//! The Dropbox remote-storage settings tab.
+//!
+//! Lives apart from `views_settings.rs` only because that file sits at
+//! the repository's 1,000-line ceiling; the tab is otherwise an
+//! ordinary sibling of the other settings tabs.
+
+use iced::widget::{button, column, horizontal_space, row, slider, text, text_input};
+use iced::{Element, Length, Theme};
+
+use crate::message::Message;
+use crate::theme as th;
+
+use super::views_browser_style::browser_utility_action_style;
+use super::views_settings::format_settings_bytes;
+use super::*;
+
+impl App {
+    pub(super) fn view_settings_dropbox_tab(&self) -> Element<'_, Message> {
+        let title = text("Dropbox").size(14).color(th::text());
+        let hint = text(
+            "Register an app at https://www.dropbox.com/developers/apps \
+            (Scoped access, Full Dropbox). Paste the App key below.",
+        )
+        .size(11)
+        .color(th::text_dim());
+
+        let app_key_input = text_input("App key", &self.state.browser.remote.app_key_input)
+            .on_input(|s| Message::Browser(BrowserMsg::SetDropboxAppKey(s)))
+            .on_submit(Message::SaveDropboxAppKey)
+            .size(13)
+            .width(Length::Fill);
+        let save_key_btn = button(text("Save").size(12).color(th::text()))
+            .on_press(Message::SaveDropboxAppKey)
+            .padding([6, 12])
+            .style(|_theme: &Theme, status| {
+                let bg = match status {
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => None,
+                };
+                button::Style {
+                    background: bg,
+                    text_color: th::text(),
+                    border: iced::Border {
+                        color: th::accent_dim(),
+                        width: 1.0,
+                        radius: 4.0.into(),
+                    },
+                    ..Default::default()
+                }
+            });
+
+        let key_row = row![app_key_input, save_key_btn]
+            .spacing(8)
+            .align_y(iced::Alignment::Center);
+
+        let account_line: Element<'_, Message> = if self.state.browser.remote.connected {
+            let email = self
+                .state
+                .browser
+                .remote
+                .account_email
+                .clone()
+                .unwrap_or_else(|| "connected".into());
+            text(format!("Connected: {email}"))
+                .size(12)
+                .color(th::accent())
+                .into()
+        } else if self.state.browser.remote.auth_in_progress {
+            text("Waiting for browser authorisation...")
+                .size(12)
+                .color(th::text_dim())
+                .into()
+        } else {
+            text("Not connected").size(12).color(th::text_dim()).into()
+        };
+
+        let can_connect =
+            self.state.browser.remote.has_app_key && !self.state.browser.remote.auth_in_progress;
+        let connect_label = if self.state.browser.remote.auth_in_progress {
+            "Connecting..."
+        } else if self.state.browser.remote.connected {
+            "Reconnect"
+        } else {
+            "Connect"
+        };
+        let connect_btn = {
+            let mut btn = button(text(connect_label).size(12).color(th::accent()));
+            if can_connect {
+                btn = btn.on_press(Message::ConnectDropbox);
+            }
+            btn.padding([6, 12]).style(|_theme: &Theme, status| {
+                let bg = match status {
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => None,
+                };
+                button::Style {
+                    background: bg,
+                    text_color: th::accent(),
+                    border: iced::Border {
+                        color: th::accent_dim(),
+                        width: 1.0,
+                        radius: 4.0.into(),
+                    },
+                    ..Default::default()
+                }
+            })
+        };
+
+        let disconnect_btn: Element<'_, Message> = if self.state.browser.remote.connected {
+            button(text("Disconnect").size(12).color(th::text_dim()))
+                .on_press(Message::DisconnectDropbox)
+                .padding([6, 12])
+                .style(|_theme: &Theme, status| {
+                    let bg = match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::bg_hover().into())
+                        }
+                        _ => None,
+                    };
+                    button::Style {
+                        background: bg,
+                        text_color: th::text_dim(),
+                        border: iced::Border::default(),
+                        ..Default::default()
+                    }
+                })
+                .into()
+        } else {
+            horizontal_space().width(Length::Shrink).into()
+        };
+
+        let error_line: Element<'_, Message> =
+            if let Some(err) = self.state.browser.remote.last_error.clone() {
+                text(err).size(11).color(th::danger()).into()
+            } else {
+                horizontal_space().width(Length::Shrink).into()
+            };
+
+        let budget_gib =
+            self.state.browser.remote.cache_budget_bytes as f32 / (1024.0 * 1024.0 * 1024.0);
+        let cache_usage = text(format!(
+            "{} across {} item(s)",
+            format_settings_bytes(self.state.browser.remote.cache_usage_bytes),
+            self.state.browser.remote.cache_entries
+        ))
+        .size(11)
+        .color(th::text_dim());
+        let budget = slider(1.0..=500.0, budget_gib, Message::SetMediaCacheBudgetGiB)
+            .step(1.0_f32)
+            .width(Length::Fill);
+        let eviction_enabled = self.state.browser.remote.cache_automatic_eviction;
+        let eviction = button(
+            text(if eviction_enabled {
+                "LRU EVICTION ON"
+            } else {
+                "LRU EVICTION OFF"
+            })
+            .size(10)
+            .color(if eviction_enabled {
+                th::accent()
+            } else {
+                th::text_dim()
+            }),
+        )
+        .on_press(Message::ToggleMediaCacheAutomaticEviction)
+        .padding([5, 8])
+        .style(browser_utility_action_style);
+        let clear = button(text("CLEAR CACHE").size(10).color(th::text_dim()))
+            .on_press(Message::ClearMediaCache)
+            .padding([5, 8])
+            .style(browser_utility_action_style);
+        let cache_error: Element<'_, Message> = self
+            .state
+            .browser
+            .remote
+            .cache_error
+            .as_ref()
+            .map(|error| text(error).size(10).color(th::danger()).into())
+            .unwrap_or_else(|| horizontal_space().width(Length::Shrink).into());
+
+        column![
+            title,
+            hint,
+            key_row,
+            account_line,
+            row![connect_btn, disconnect_btn]
+                .spacing(8)
+                .align_y(iced::Alignment::Center),
+            error_line,
+            text("MEDIA CACHE").size(10).color(th::text_muted()),
+            row![
+                cache_usage,
+                horizontal_space(),
+                text(format!("{budget_gib:.0} GiB budget"))
+                    .size(11)
+                    .color(th::text_dim())
+            ]
+            .align_y(iced::Alignment::Center),
+            budget,
+            row![eviction, clear]
+                .spacing(8)
+                .align_y(iced::Alignment::Center),
+            cache_error,
+        ]
+        .spacing(10)
+        .into()
+    }
+}

--- a/crates/vibez-ui/src/app/views_settings_updates.rs
+++ b/crates/vibez-ui/src/app/views_settings_updates.rs
@@ -1,0 +1,109 @@
+//! The Updates settings tab: opt in or out of the startup release
+//! check, and see what the last one found.
+
+use iced::widget::{button, column, container, row, text};
+use iced::{Element, Length, Theme};
+
+use crate::icons;
+use crate::message::Message;
+use crate::theme as th;
+use crate::update_check;
+
+use super::*;
+
+impl App {
+    pub(super) fn view_settings_updates_tab(&self) -> Element<'_, Message> {
+        let state = &self.state.update_check;
+
+        let title = text("Updates").size(14).color(th::text());
+        let hint = text(
+            "Vibez can ask GitHub once a day whether a newer version has been \
+             released. It never downloads or installs anything: the notice is a \
+             dismissible chip in the status bar with a link to the releases page. \
+             Turn this off and no request is made at all.",
+        )
+        .size(11)
+        .color(th::text_dim());
+
+        let toggle_icon = if state.enabled {
+            icons::icon(icons::CIRCLE_DOT).size(12).color(th::accent())
+        } else {
+            icons::icon(icons::CIRCLE).size(12).color(th::text_dim())
+        };
+        let toggle_btn = button(
+            row![
+                toggle_icon,
+                text("Check for updates on startup")
+                    .size(12)
+                    .color(th::text())
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::ToggleCheckForUpdates)
+        .padding([4, 8])
+        .style(|_theme: &Theme, _status| button::Style {
+            background: None,
+            text_color: th::text(),
+            border: iced::Border::default(),
+            ..Default::default()
+        });
+
+        let current = text(format!(
+            "You are running version {}.",
+            update_check::current_version()
+        ))
+        .size(11)
+        .color(th::text_dim());
+
+        // Report only what the user can act on. A failed check is
+        // indistinguishable from "nothing new" by design, so the
+        // absence of a version here is never framed as an error.
+        let found: Element<'_, Message> = match &state.available {
+            Some(version) => row![
+                text(format!("Version {version} is available."))
+                    .size(11)
+                    .color(th::accent()),
+                button(text("View releases").size(11).color(th::accent()))
+                    .on_press(Message::OpenReleasesPage)
+                    .padding([3, 10])
+                    .style(|_theme: &Theme, status| {
+                        let bg = match status {
+                            button::Status::Hovered | button::Status::Pressed => {
+                                Some(th::bg_hover().into())
+                            }
+                            _ => None,
+                        };
+                        button::Style {
+                            background: bg,
+                            text_color: th::accent(),
+                            border: iced::Border {
+                                color: th::accent_dim(),
+                                width: 1.0,
+                                radius: 4.0.into(),
+                            },
+                            ..Default::default()
+                        }
+                    }),
+            ]
+            .spacing(8)
+            .align_y(iced::Alignment::Center)
+            .into(),
+            None => text("No newer version found.")
+                .size(11)
+                .color(th::text_muted())
+                .into(),
+        };
+
+        let divider = container(column![].height(Length::Fixed(1.0)).width(Length::Fill)).style(
+            |_theme: &Theme| container::Style {
+                background: Some(th::border().into()),
+                ..Default::default()
+            },
+        );
+
+        column![title, hint, toggle_btn, divider, current, found]
+            .spacing(10)
+            .into()
+    }
+}

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -409,6 +409,62 @@ impl App {
             .into()
     }
 
+    /// The release notice: a chip in the status bar rather than a
+    /// dialog, so learning about a new version never steals focus from
+    /// the arrangement or interrupts playback. Both halves are
+    /// one-click terminal: open the page, or dismiss.
+    fn view_update_notice(&self, version: &str) -> Element<'_, Message> {
+        let open = button(
+            row![
+                icons::icon(icons::CIRCLE_DOT).size(9).color(th::accent()),
+                text(format!("Version {version} available"))
+                    .size(11)
+                    .color(th::accent()),
+            ]
+            .spacing(5)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::OpenReleasesPage)
+        .padding([1, 8])
+        .style(|_theme: &Theme, status| {
+            let bg = match status {
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
+                _ => None,
+            };
+            button::Style {
+                background: bg,
+                text_color: th::accent(),
+                border: iced::Border {
+                    color: th::accent_dim(),
+                    width: 1.0,
+                    radius: 3.0.into(),
+                },
+                ..Default::default()
+            }
+        });
+
+        let dismiss = button(icons::icon(icons::X).size(10).color(th::text_dim()))
+            .on_press(Message::DismissUpdateNotice)
+            .padding([1, 4])
+            .style(|_theme: &Theme, status| {
+                let text_color = match status {
+                    button::Status::Hovered | button::Status::Pressed => th::text(),
+                    _ => th::text_dim(),
+                };
+                button::Style {
+                    background: None,
+                    text_color,
+                    border: iced::Border::default(),
+                    ..Default::default()
+                }
+            });
+
+        row![open, dismiss]
+            .spacing(2)
+            .align_y(iced::Alignment::Center)
+            .into()
+    }
+
     pub(super) fn view_status(&self) -> Element<'_, Message> {
         let status = text(&self.state.status_text).size(11).color(th::text_dim());
         let content: Element<'_, Message> = match self.state.export_progress {
@@ -423,7 +479,15 @@ impl App {
             .spacing(8)
             .align_y(iced::Alignment::Center)
             .into(),
-            None => status.into(),
+            // An export in flight owns the right-hand side of the bar;
+            // a release notice can wait for the next frame that has room.
+            None => match self.state.update_check.notice() {
+                Some(version) => row![status, horizontal_space(), self.view_update_notice(version)]
+                    .spacing(8)
+                    .align_y(iced::Alignment::Center)
+                    .into(),
+                None => status.into(),
+            },
         };
 
         container(content)

--- a/crates/vibez-ui/src/lib.rs
+++ b/crates/vibez-ui/src/lib.rs
@@ -13,6 +13,7 @@ mod themes;
 mod timeline_geometry;
 mod typography;
 mod ui_settings;
+mod update_check;
 mod warp;
 pub mod widgets;
 

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -398,6 +398,17 @@ pub enum Message {
     /// Settings: resize the whole interface. Distinct from timeline
     /// zoom, which changes visible musical time instead.
     SetInterfaceScale(f32),
+    /// Settings: opt in or out of the startup release check. Takes
+    /// effect at the next launch; it never triggers a check itself.
+    ToggleCheckForUpdates,
+    /// The startup release check finished. `Some` carries the newest
+    /// upstream tag; `None` means the request failed and is reported
+    /// only by advancing the throttle.
+    UpdateCheckCompleted(Option<String>),
+    /// Hide the update notice for the rest of this session.
+    DismissUpdateNotice,
+    /// Open the releases page in the system browser.
+    OpenReleasesPage,
     /// Settings: re-warp every warped clip to the current project
     /// tempo. Uses each clip's retained `original_audio` when
     /// available.

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -189,6 +189,7 @@ pub enum SettingsTab {
     Warping,
     Perform,
     Appearance,
+    Updates,
 }
 
 #[cfg(test)]
@@ -472,6 +473,8 @@ pub struct AppState {
     pub settings_tab: SettingsTab,
     pub settings_buffer_size: u32,
     pub confirm_project_track_deletion: bool,
+    /// Startup release check: preference, throttle, and pending notice.
+    pub update_check: crate::update_check::UpdateCheckState,
     // Project domain slice: file menu, path, dirty flag, undo.
     pub project: ProjectState,
     /// Automatically detect sample BPM and warp to project tempo on
@@ -524,6 +527,7 @@ impl Default for AppState {
             settings_tab: SettingsTab::default(),
             settings_buffer_size: 512,
             confirm_project_track_deletion: false,
+            update_check: crate::update_check::UpdateCheckState::default(),
             project: ProjectState::default(),
             auto_warp_on_import: false,
             warp_confidence_threshold: 0.6,

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -62,6 +62,15 @@ pub struct UiSettings {
     /// the app.
     #[serde(default = "default_interface_scale")]
     pub interface_scale: f32,
+    /// Ask GitHub at startup whether a newer release exists. On by
+    /// default: the check is one request a day and the result is a
+    /// dismissible chip, never a dialog. Off means no network call.
+    #[serde(default = "default_check_for_updates")]
+    pub check_for_updates: bool,
+    /// Unix seconds of the last release check, so the once-a-day
+    /// throttle survives a restart. `None` until the first attempt.
+    #[serde(default)]
+    pub last_update_check_unix: Option<u64>,
 }
 
 /// Smallest supported interface scale. Below this, hit targets in the
@@ -113,6 +122,8 @@ impl Default for UiSettings {
             media_cache_automatic_eviction: default_media_cache_automatic_eviction(),
             confirm_project_track_deletion: false,
             interface_scale: default_interface_scale(),
+            check_for_updates: default_check_for_updates(),
+            last_update_check_unix: None,
         }
     }
 }
@@ -190,6 +201,10 @@ fn default_warp_confidence_threshold() -> f32 {
 
 fn default_interface_scale() -> f32 {
     INTERFACE_SCALE_DEFAULT
+}
+
+const fn default_check_for_updates() -> bool {
+    true
 }
 
 #[cfg(test)]
@@ -349,6 +364,26 @@ mod tests {
             vibez_dropbox::DEFAULT_MEDIA_CACHE_BUDGET_BYTES
         );
         assert!(loaded.media_cache_automatic_eviction);
+    }
+
+    #[test]
+    fn settings_predating_the_release_check_opt_into_it_with_no_history() {
+        let old: UiSettings = serde_json::from_str("{}").unwrap();
+        assert!(old.check_for_updates);
+        assert_eq!(old.last_update_check_unix, None);
+    }
+
+    #[test]
+    fn release_check_preference_and_timestamp_roundtrip() {
+        let settings = UiSettings {
+            check_for_updates: false,
+            last_update_check_unix: Some(1_772_000_000),
+            ..Default::default()
+        };
+        let loaded: UiSettings =
+            serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
+        assert!(!loaded.check_for_updates);
+        assert_eq!(loaded.last_update_check_unix, Some(1_772_000_000));
     }
 
     #[test]

--- a/crates/vibez-ui/src/update_check.rs
+++ b/crates/vibez-ui/src/update_check.rs
@@ -1,0 +1,349 @@
+//! Passive release notification: once a day, ask GitHub whether a newer
+//! version has been published and, if so, offer a link to the releases
+//! page.
+//!
+//! Deliberately passive. Vibez never downloads or installs anything on
+//! the user's behalf, so the only action the notice offers is opening a
+//! browser. Every failure path here is silent: a DAW is routinely run on
+//! machines with no network (studios, stages), and a release check that
+//! could not complete is not a problem the user needs to hear about. An
+//! unreachable network therefore behaves exactly like the feature being
+//! switched off.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Where the notice's action sends the user. Human-facing page rather
+/// than a binary, because this feature never installs anything.
+pub const RELEASES_PAGE_URL: &str = "https://github.com/alexanderwanyoike/vibez/releases";
+
+/// Unauthenticated endpoint for the newest published, non-draft release.
+const LATEST_RELEASE_API_URL: &str =
+    "https://api.github.com/repos/alexanderwanyoike/vibez/releases/latest";
+
+/// Minimum spacing between two network checks. GitHub rate-limits
+/// unauthenticated callers by IP, and knowing about a release a few
+/// hours sooner is worth neither that budget nor the traffic.
+pub const CHECK_INTERVAL_SECS: u64 = 24 * 60 * 60;
+
+/// Ceiling on the whole request, so a connection that opens but never
+/// answers cannot park a runtime worker for the life of the session.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// GitHub rejects unauthenticated API requests that arrive without a
+/// User-Agent, so this is required rather than decorative.
+const USER_AGENT: &str = concat!("vibez/", env!("CARGO_PKG_VERSION"));
+
+/// A release version reduced to the three numbers that order it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ReleaseVersion {
+    major: u64,
+    minor: u64,
+    patch: u64,
+}
+
+impl ReleaseVersion {
+    /// Parse a release tag such as `0.2.0` or `v0.2.0`.
+    ///
+    /// Returns `None` for anything that is not exactly three numeric
+    /// components, pre-release suffixes included. Two reasons: a tag we
+    /// cannot parse is indistinguishable from a tagging scheme this
+    /// build predates, where the safe answer is to stay quiet; and a
+    /// passive notifier should never nudge a user on a stable build
+    /// towards `0.2.0-rc1`.
+    pub fn parse(tag: &str) -> Option<Self> {
+        let trimmed = tag.trim();
+        let digits = trimmed.strip_prefix('v').unwrap_or(trimmed);
+        let mut parts = digits.split('.');
+        let major = parts.next()?.parse::<u64>().ok()?;
+        let minor = parts.next()?.parse::<u64>().ok()?;
+        let patch = parts.next()?.parse::<u64>().ok()?;
+        if parts.next().is_some() {
+            return None;
+        }
+        Some(Self {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl std::fmt::Display for ReleaseVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// The version string to advertise, or `None` when `tag` is not strictly
+/// newer than `current`.
+///
+/// The returned string is re-rendered from the parsed numbers rather
+/// than echoed, so the notice reads the same whether or not upstream
+/// tagged with a `v` prefix.
+pub fn newer_release(tag: &str, current: &str) -> Option<String> {
+    let latest = ReleaseVersion::parse(tag)?;
+    let current = ReleaseVersion::parse(current)?;
+    (latest > current).then(|| latest.to_string())
+}
+
+/// The version this binary was built as, for comparison against a tag.
+pub fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Whether a startup check is due.
+///
+/// Split out as a pure function so the opt-out and the throttle can be
+/// tested without a clock or a network.
+pub fn should_check(enabled: bool, last_check_unix: Option<u64>, now_unix: u64) -> bool {
+    if !enabled {
+        return false;
+    }
+    match last_check_unix {
+        None => true,
+        // A timestamp in the future means the clock moved backwards
+        // (or the settings file was hand-edited). Treat that as due
+        // rather than locking the check out until real time catches up.
+        Some(last) => now_unix < last || now_unix.saturating_sub(last) >= CHECK_INTERVAL_SECS,
+    }
+}
+
+/// Wall-clock seconds since the Unix epoch, saturating at 0 for clocks
+/// set before 1970 so a nonsense clock cannot panic startup.
+pub fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0)
+}
+
+/// Runtime half of the feature: the persisted preference and timestamp,
+/// plus whatever the last check turned up.
+#[derive(Debug, Clone)]
+pub struct UpdateCheckState {
+    /// Persisted preference. When false no network call is made at all.
+    pub enabled: bool,
+    /// Persisted timestamp of the last completed attempt, recorded
+    /// whether or not it found anything, so a machine that is offline
+    /// every morning still backs off instead of retrying every launch.
+    pub last_check_unix: Option<u64>,
+    /// Version to advertise, once a check has found a newer one.
+    pub available: Option<String>,
+    /// Dismissed for this session only. Not persisted: the next launch
+    /// re-raises it, which is the gentlest way to keep a genuinely
+    /// stale install from going unnoticed forever.
+    pub dismissed: bool,
+}
+
+impl Default for UpdateCheckState {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            last_check_unix: None,
+            available: None,
+            dismissed: false,
+        }
+    }
+}
+
+impl UpdateCheckState {
+    /// Whether the status bar should currently show the notice.
+    pub fn notice(&self) -> Option<&str> {
+        if self.dismissed {
+            return None;
+        }
+        self.available.as_deref()
+    }
+
+    /// Fold the outcome of a check into the state. Called for both
+    /// outcomes so the throttle advances even when the request failed.
+    pub fn record_result(&mut self, tag: Option<String>, now_unix: u64) {
+        self.last_check_unix = Some(now_unix);
+        let Some(tag) = tag else {
+            return;
+        };
+        if let Some(version) = newer_release(&tag, current_version()) {
+            // A newer release than the one already showing re-raises a
+            // notice the user dismissed earlier this session.
+            if self.available.as_deref() != Some(version.as_str()) {
+                self.dismissed = false;
+            }
+            self.available = Some(version);
+        }
+    }
+}
+
+/// The one field of the GitHub release payload this feature reads.
+#[derive(serde::Deserialize)]
+struct LatestRelease {
+    tag_name: String,
+}
+
+/// Ask GitHub for the newest release tag, yielding `None` on any
+/// failure whatsoever: DNS, TLS, timeout, rate limit, malformed JSON.
+/// Callers cannot distinguish the failures because none of them should
+/// change what the user sees.
+pub async fn fetch_latest_tag() -> Option<String> {
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .ok()?;
+    let response = client
+        .get(LATEST_RELEASE_API_URL)
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let release: LatestRelease = response.json().await.ok()?;
+    Some(release.tag_name)
+}
+
+/// Hand the releases page to the platform's browser.
+///
+/// Reuses the Dropbox OAuth flow's opener rather than taking a second
+/// dependency on `open`. `open::that` blocks while it spawns the
+/// handler, so it runs on a blocking thread: the UI thread must never
+/// wait on a browser launch.
+pub async fn open_releases_page() {
+    let _ = tokio::task::spawn_blocking(|| {
+        use vibez_dropbox::BrowserOpener;
+        let _ = vibez_dropbox::SystemBrowserOpener.open(RELEASES_PAGE_URL);
+    })
+    .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DAY: u64 = CHECK_INTERVAL_SECS;
+
+    #[test]
+    fn an_identical_release_offers_no_update() {
+        assert_eq!(newer_release("0.1.2", "0.1.2"), None);
+    }
+
+    #[test]
+    fn a_newer_release_is_offered() {
+        assert_eq!(newer_release("0.2.0", "0.1.2"), Some("0.2.0".to_string()));
+    }
+
+    #[test]
+    fn an_older_release_is_not_offered() {
+        assert_eq!(newer_release("0.1.1", "0.1.2"), None);
+    }
+
+    #[test]
+    fn a_v_prefixed_tag_is_compared_and_shown_without_its_prefix() {
+        assert_eq!(newer_release("v0.2.0", "0.1.2"), Some("0.2.0".to_string()));
+        assert_eq!(newer_release("v0.1.2", "0.1.2"), None);
+    }
+
+    #[test]
+    fn version_components_are_compared_numerically_not_lexically() {
+        assert_eq!(newer_release("0.10.0", "0.9.9"), Some("0.10.0".to_string()));
+        assert_eq!(newer_release("1.0.0", "0.99.99"), Some("1.0.0".to_string()));
+        assert_eq!(newer_release("0.9.9", "0.10.0"), None);
+    }
+
+    #[test]
+    fn a_malformed_tag_offers_no_update() {
+        for tag in ["", "nightly", "0.2", "0.2.0.1", "v", "1.2.x", "0..1"] {
+            assert_eq!(newer_release(tag, "0.1.2"), None, "tag {tag:?}");
+        }
+    }
+
+    #[test]
+    fn a_prerelease_tag_offers_no_update() {
+        assert_eq!(newer_release("0.2.0-rc1", "0.1.2"), None);
+        assert_eq!(newer_release("v0.2.0-beta.1", "0.1.2"), None);
+    }
+
+    #[test]
+    fn the_shipped_package_version_is_a_comparable_tag() {
+        assert!(ReleaseVersion::parse(current_version()).is_some());
+    }
+
+    #[test]
+    fn a_first_run_checks_immediately() {
+        assert!(should_check(true, None, 1_000_000));
+    }
+
+    #[test]
+    fn a_check_within_the_last_day_is_skipped() {
+        assert!(!should_check(true, Some(1_000_000), 1_000_000 + DAY - 1));
+    }
+
+    #[test]
+    fn a_check_a_full_day_old_runs_again() {
+        assert!(should_check(true, Some(1_000_000), 1_000_000 + DAY));
+    }
+
+    #[test]
+    fn an_opted_out_user_never_checks() {
+        assert!(!should_check(false, None, 1_000_000));
+        assert!(!should_check(false, Some(0), 1_000_000 + DAY * 30));
+    }
+
+    #[test]
+    fn a_clock_moved_backwards_still_checks() {
+        assert!(should_check(true, Some(2_000_000), 1_000_000));
+    }
+
+    #[test]
+    fn a_failed_check_advances_the_throttle_without_raising_a_notice() {
+        let mut state = UpdateCheckState::default();
+        state.record_result(None, 1_000_000);
+        assert_eq!(state.last_check_unix, Some(1_000_000));
+        assert_eq!(state.notice(), None);
+        assert!(!should_check(
+            state.enabled,
+            state.last_check_unix,
+            1_000_100
+        ));
+    }
+
+    #[test]
+    fn an_older_upstream_tag_raises_no_notice() {
+        let mut state = UpdateCheckState::default();
+        state.record_result(Some("0.0.1".to_string()), 1_000_000);
+        assert_eq!(state.notice(), None);
+    }
+
+    #[test]
+    fn a_dismissed_notice_stays_hidden_for_the_session() {
+        let mut state = UpdateCheckState {
+            available: Some("9.9.9".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(state.notice(), Some("9.9.9"));
+        state.dismissed = true;
+        assert_eq!(state.notice(), None);
+    }
+
+    #[test]
+    fn a_release_newer_than_the_dismissed_one_raises_the_notice_again() {
+        let mut state = UpdateCheckState {
+            available: Some("9.9.9".to_string()),
+            dismissed: true,
+            ..Default::default()
+        };
+        state.record_result(Some("9.9.10".to_string()), 1_000_000);
+        assert_eq!(state.notice(), Some("9.9.10"));
+    }
+
+    #[test]
+    fn re_reporting_the_same_release_leaves_it_dismissed() {
+        let mut state = UpdateCheckState {
+            available: Some("9.9.9".to_string()),
+            dismissed: true,
+            ..Default::default()
+        };
+        state.record_result(Some("9.9.9".to_string()), 1_000_000);
+        assert_eq!(state.notice(), None);
+    }
+}


### PR DESCRIPTION
## What

Vibez now tells you when a newer version has been released. On startup it asks GitHub for the latest release tag and, if it is newer than the running build, raises a dismissible chip in the status bar with a link to the releases page.

Nothing is downloaded and nothing is installed. The only action offered is opening a browser.

## Why this shape

A DAW is routinely run on machines with no network, so a release check that could not complete is not a problem the user needs to hear about. Every failure path is silent: DNS, TLS, timeouts, rate limits and malformed payloads all collapse to "nothing to report". An offline machine behaves exactly like one that opted out.

The notice is a status-bar chip rather than a dialog, so learning about a new version never steals focus from the arrangement or interrupts playback.

## Decisions

- **HTTP client**: reuses the `reqwest` + `rustls-tls` client the Dropbox integration already links, so the release check adds no new transitive stack.
- **Browser opener**: reuses `vibez-dropbox`'s existing `SystemBrowserOpener` on `spawn_blocking`, so there is no second dependency on `open` and the UI thread never waits on a browser launch.
- **Threading**: the fetch runs through `Task::perform`, so neither the UI nor the audio thread ever blocks on it. A 10s request timeout keeps a half-open connection from parking a runtime worker for the session.
- **Version comparison**: numeric per component, tolerating a leading `v`. Anything else yields no notice, pre-release suffixes included: an unparseable tag is indistinguishable from a tagging scheme this build predates, and a passive notifier should not nudge stable users onto release candidates.
- **Throttle**: at most one check per 24 hours. The timestamp is recorded for failed attempts too, so a laptop that is offline every morning backs off instead of retrying on every launch.
- **Persistence**: `check_for_updates` (default on) and `last_update_check_unix` join `UiSettings` in `ui.json`, both with per-field serde defaults so existing settings files load unchanged.
- **Dismissal**: session-scoped. The next launch re-raises it, which keeps a genuinely stale install from going unnoticed forever, while a release newer than the dismissed one re-raises it immediately.

## Settings

A new Settings > Updates tab carries "Check for updates on startup", default on. When off, no request is made at all. It also reports the running version and whatever the last check found.

## File split

`views_settings.rs` sat at the repository's 1,000-line ceiling. The first commit moves `view_settings_dropbox_tab` verbatim into `views_settings_dropbox.rs`, mirroring the existing `views_settings_perform` split, to make room. No behaviour change.

## Tests

18 new tests, none touching the network or the filesystem:

- Version comparison: equal, newer, older, `v`-prefixed, malformed tags, pre-release tags, and numeric-not-lexical ordering (`0.10.0` > `0.9.9`).
- Throttle and opt-out gating: first run, within a day, a full day old, opted out, and a clock moved backwards.
- Notice state: a failed check advances the throttle without raising a notice, dismissal holds for the session, and a newer release re-raises it.
- Settings round-trip plus a legacy `{}` document receiving the defaults.

## Verification

- `cargo build --workspace`: clean
- `cargo clippy --workspace --all-targets`: no new warnings (2 pre-existing pointer-cast warnings in `vibez-plugin-host` remain untouched)
- `cargo test --workspace`: all pass
- `cargo fmt --check`: clean
