### PR TITLE
Open Vibez in Perform workspace by default

### DIFF
--- a/crates/vibez-ui/src/app/views_transport.rs
+++ b/crates/vibez-ui/src/app/views_transport.rs
@@ -421,6 +421,7 @@ mod tests {
     #[test]
     fn arrange_keeps_the_canonical_cursor_and_duration_readout() {
         let mut state = AppState::default();
+        state.view.workspace = Workspace::Arrange;
         state.transport.sample_rate = 48_000;
         state.transport.position_samples = 72_000;
 

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -97,7 +97,7 @@ pub struct ViewState {
 impl Default for ViewState {
     fn default() -> Self {
         Self {
-            workspace: Workspace::Arrange,
+            workspace: Workspace::Perform,
             detail_panel_tab: DetailPanelTab::Clip,
             detail_panel_height: DETAIL_PANEL_DEFAULT_HEIGHT,
             detail_panel_resize_active: false,
@@ -980,6 +980,12 @@ mod tests {
     fn app_state_default_settings_tab() {
         let state = AppState::default();
         assert_eq!(state.settings_tab, SettingsTab::Audio);
+    }
+
+    #[test]
+    fn app_state_opens_in_perform_workspace() {
+        let state = AppState::default();
+        assert_eq!(state.view.workspace, Workspace::Perform);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- open Vibez in the Perform workspace instead of Arrange
- add a regression test for the startup workspace
- make the Arrange transport-label test declare its workspace precondition explicitly

## Testing

- `cargo fmt --check`
- `cargo test -p vibez-ui` (482 passed)