### PR TITLE
Release v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5085,7 +5085,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibez"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "iced",
  "libloading 0.8.9",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-audio-io"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "audio_thread_priority",
  "cpal",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-dropbox"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64",
  "dirs 5.0.1",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-dsp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "signalsmith-stretch",
  "vibez-core",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-engine"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "rtrb",
  "vibez-core",
@@ -5154,14 +5154,14 @@ dependencies = [
 
 [[package]]
 name = "vibez-instruments"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "vibez-core",
 ]
 
 [[package]]
 name = "vibez-plugin-host"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap-sys",
  "dirs 5.0.1",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-project"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "rusqlite",
  "serde",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-ui"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/vibez-daw/vibez"

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -254,7 +254,7 @@ impl App {
             self.state.status_text = status;
         }
         if action.mark_dirty {
-            self.state.project.dirty = true;
+            self.mark_project_dirty();
         }
         Task::none()
     }
@@ -769,7 +769,12 @@ impl App {
                 self.state.view.scroll_offset_beats = viewport.scroll_offset_beats;
             }
         }
-        export_task
+        let auto_save_task = if self.save_runtime.auto_save_due(std::time::Instant::now()) {
+            self.route_auto_save_project()
+        } else {
+            Task::none()
+        };
+        Task::batch([export_task, auto_save_task])
     }
 }
 

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -106,7 +106,13 @@ impl App {
                             muted,
                             effective_at_samples,
                         );
-                        apply_track_mute_event(&mut self.state, track_id, muted);
+                        if apply_track_mute_event(&mut self.state, track_id, muted) {
+                            self.save_runtime.project_changed(
+                                self.state.auto_save_enabled,
+                                self.state.project.current_path.is_some(),
+                                std::time::Instant::now(),
+                            );
+                        }
                     }
                     EngineEvent::TrackMuteQueued {
                         track_id,

--- a/crates/vibez-ui/src/app/keyboard.rs
+++ b/crates/vibez-ui/src/app/keyboard.rs
@@ -440,6 +440,7 @@ pub(crate) fn global_key_handler(
         iced::keyboard::Key::Character(ref c) => match c.as_str() {
             "a" | "A" => Some(Message::SelectAllPressed),
             "c" | "C" => Some(Message::Arrangement(ArrangementMsg::CopySelectedClips)),
+            "s" | "S" => Some(Message::SaveProject),
             "x" | "X" => Some(Message::Arrangement(ArrangementMsg::CutSelectedClips)),
             "v" | "V" => Some(Message::Arrangement(ArrangementMsg::PasteClips)),
             "t" | "T" => {
@@ -534,6 +535,19 @@ mod tests {
             global_key_handler(Key::Character("c".into()), command_modifier()),
             Some(Message::Arrangement(ArrangementMsg::CopySelectedClips))
         ));
+    }
+
+    #[test]
+    fn save_shortcut_answers_the_platform_command_modifier() {
+        use iced::keyboard::{Key, Modifiers};
+
+        for key in ["s", "S"] {
+            assert!(matches!(
+                global_key_handler(Key::Character(key.into()), command_modifier()),
+                Some(Message::SaveProject)
+            ));
+        }
+        assert!(global_key_handler(Key::Character("s".into()), Modifiers::empty()).is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/menu_lifecycle.rs
+++ b/crates/vibez-ui/src/app/menu_lifecycle.rs
@@ -82,6 +82,7 @@ mod tests {
             midi_input: None,
             midi_input_ports: Vec::new(),
             interface_scale: crate::ui_settings::INTERFACE_SCALE_DEFAULT,
+            save_runtime: Default::default(),
         }
     }
 

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -95,6 +95,8 @@ struct App {
     /// describes the window the project is viewed through, not the
     /// project or the view layout, and nothing about it is undoable.
     interface_scale: f32,
+    /// Debounce, revision, and in-flight coordination for project saves.
+    save_runtime: save_runtime::SaveRuntime,
     // Undo / redo
 }
 
@@ -162,6 +164,7 @@ mod plugins;
 mod project_io;
 mod project_replay;
 mod project_sections;
+mod save_runtime;
 mod section_record;
 mod update;
 mod update_media;
@@ -194,6 +197,7 @@ mod views_settings;
 mod views_settings_appearance;
 mod views_settings_dropbox;
 mod views_settings_perform;
+mod views_settings_project;
 mod views_settings_updates;
 mod views_shell;
 mod views_transport;
@@ -288,6 +292,7 @@ impl App {
             auto_warp_on_import: ui_settings.auto_warp_on_import,
             warp_confidence_threshold: ui_settings.warp_confidence_threshold,
             confirm_project_track_deletion: ui_settings.confirm_project_track_deletion,
+            auto_save_enabled: ui_settings.auto_save_enabled,
             update_check: crate::update_check::UpdateCheckState {
                 enabled: ui_settings.check_for_updates,
                 last_check_unix: ui_settings.last_update_check_unix,
@@ -392,6 +397,7 @@ impl App {
             midi_input,
             midi_input_ports: Vec::new(),
             interface_scale,
+            save_runtime: save_runtime::SaveRuntime::default(),
         };
 
         // Inform the engine of the actual sample rate
@@ -495,6 +501,11 @@ impl App {
 
     fn mark_project_dirty(&mut self) {
         self.state.project.dirty = true;
+        self.save_runtime.project_changed(
+            self.state.auto_save_enabled,
+            self.state.project.current_path.is_some(),
+            std::time::Instant::now(),
+        );
     }
 
     pub(super) fn active_editor_pixels_per_beat(&self) -> f32 {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -229,6 +229,7 @@ impl App {
     }
 
     pub(super) fn reset_to_new_project(&mut self) {
+        self.save_runtime.reset_document();
         self.remote_import_request.cancel();
         self.remote_materialization_request.cancel();
         self.remote_audition_cache_lease = None;
@@ -273,6 +274,7 @@ impl App {
             media_cache_budget_bytes: self.state.browser.remote.cache_budget_bytes,
             media_cache_automatic_eviction: self.state.browser.remote.cache_automatic_eviction,
             confirm_project_track_deletion: self.state.confirm_project_track_deletion,
+            auto_save_enabled: self.state.auto_save_enabled,
             interface_scale: self.interface_scale,
             check_for_updates: self.state.update_check.enabled,
             last_update_check_unix: self.state.update_check.last_check_unix,
@@ -854,6 +856,7 @@ impl App {
             .sync_project_tracks(&self.state.project_tracks.tracks);
         self.state.project.current_path = Some(loaded.path.clone());
         self.state.project.dirty = false;
+        self.save_runtime.reset_document();
         let provenance_suffix = remote_provenance
             .map(|label| format!(" · Remote source {label}"))
             .unwrap_or_default();

--- a/crates/vibez-ui/src/app/save_runtime.rs
+++ b/crates/vibez-ui/src/app/save_runtime.rs
@@ -1,0 +1,156 @@
+//! Runtime coordination for manual saves and debounced autosave.
+
+use std::time::{Duration, Instant};
+
+use crate::message::ProjectSaveToken;
+
+pub(super) const AUTO_SAVE_DEBOUNCE: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Default)]
+pub(super) struct SaveRuntime {
+    document_id: u64,
+    revision: u64,
+    auto_save_deadline: Option<Instant>,
+    in_flight: Option<ProjectSaveToken>,
+    manual_save_queued: bool,
+}
+
+impl SaveRuntime {
+    pub(super) fn project_changed(
+        &mut self,
+        auto_save_enabled: bool,
+        has_project_path: bool,
+        now: Instant,
+    ) {
+        self.revision = self.revision.wrapping_add(1);
+        if auto_save_enabled && has_project_path {
+            self.auto_save_deadline = Some(now + AUTO_SAVE_DEBOUNCE);
+        }
+    }
+
+    pub(super) fn set_auto_save_enabled(&mut self, enabled: bool, eligible: bool, now: Instant) {
+        self.auto_save_deadline = (enabled && eligible).then_some(now + AUTO_SAVE_DEBOUNCE);
+    }
+
+    pub(super) fn auto_save_due(&self, now: Instant) -> bool {
+        self.in_flight.is_none() && self.auto_save_deadline.is_some_and(|due| now >= due)
+    }
+
+    pub(super) fn cancel_pending_auto_save(&mut self) {
+        self.auto_save_deadline = None;
+    }
+
+    pub(super) fn begin_save(&mut self, automatic: bool) -> Option<ProjectSaveToken> {
+        if self.in_flight.is_some() {
+            if !automatic {
+                self.manual_save_queued = true;
+            }
+            return None;
+        }
+        let token = ProjectSaveToken {
+            document_id: self.document_id,
+            revision: self.revision,
+            automatic,
+        };
+        self.in_flight = Some(token);
+        self.auto_save_deadline = None;
+        Some(token)
+    }
+
+    /// Returns whether the completion belongs to the currently tracked save.
+    pub(super) fn finish_save(&mut self, token: ProjectSaveToken) -> bool {
+        if self.in_flight != Some(token) {
+            return false;
+        }
+        self.in_flight = None;
+        true
+    }
+
+    pub(super) fn completion_is_current(&self, token: ProjectSaveToken) -> bool {
+        token.document_id == self.document_id && token.revision == self.revision
+    }
+
+    pub(super) fn take_manual_save_queued(&mut self) -> bool {
+        std::mem::take(&mut self.manual_save_queued)
+    }
+
+    pub(super) fn is_saving(&self) -> bool {
+        self.in_flight.is_some()
+    }
+
+    pub(super) fn reset_document(&mut self) {
+        self.document_id = self.document_id.wrapping_add(1);
+        self.revision = 0;
+        self.auto_save_deadline = None;
+        self.in_flight = None;
+        self.manual_save_queued = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn autosave_is_debounced_and_only_scheduled_for_named_projects() {
+        let started = Instant::now();
+        let mut runtime = SaveRuntime::default();
+
+        runtime.project_changed(true, false, started);
+        assert!(!runtime.auto_save_due(started + AUTO_SAVE_DEBOUNCE));
+
+        runtime.project_changed(true, true, started);
+        assert!(!runtime.auto_save_due(started + AUTO_SAVE_DEBOUNCE / 2));
+        runtime.project_changed(true, true, started + AUTO_SAVE_DEBOUNCE / 2);
+        assert!(!runtime.auto_save_due(started + AUTO_SAVE_DEBOUNCE));
+        assert!(runtime.auto_save_due(started + AUTO_SAVE_DEBOUNCE * 2));
+    }
+
+    #[test]
+    fn a_save_completion_cannot_clean_a_newer_revision() {
+        let started = Instant::now();
+        let mut runtime = SaveRuntime::default();
+        runtime.project_changed(true, true, started);
+        let token = runtime.begin_save(true).unwrap();
+        runtime.project_changed(true, true, started + Duration::from_millis(10));
+
+        assert!(runtime.finish_save(token));
+        assert!(!runtime.completion_is_current(token));
+        assert!(runtime.auto_save_due(started + AUTO_SAVE_DEBOUNCE * 2));
+    }
+
+    #[test]
+    fn manual_save_waits_behind_an_in_flight_autosave() {
+        let mut runtime = SaveRuntime::default();
+        let automatic = runtime.begin_save(true).unwrap();
+
+        assert!(runtime.begin_save(false).is_none());
+        assert!(runtime.finish_save(automatic));
+        assert!(runtime.take_manual_save_queued());
+        assert!(!runtime.take_manual_save_queued());
+    }
+
+    #[test]
+    fn first_save_makes_newer_untitled_edits_eligible_for_autosave() {
+        let started = Instant::now();
+        let mut runtime = SaveRuntime::default();
+        runtime.project_changed(true, false, started);
+        let first_save = runtime.begin_save(false).unwrap();
+        runtime.project_changed(true, false, started + Duration::from_millis(10));
+        assert!(runtime.finish_save(first_save));
+        assert!(!runtime.completion_is_current(first_save));
+
+        runtime.set_auto_save_enabled(true, true, started + Duration::from_millis(20));
+        assert!(runtime.auto_save_due(started + AUTO_SAVE_DEBOUNCE * 2));
+    }
+
+    #[test]
+    fn old_document_completions_are_ignored_after_reset() {
+        let mut runtime = SaveRuntime::default();
+        let token = runtime.begin_save(false).unwrap();
+        runtime.reset_document();
+
+        assert!(!runtime.finish_save(token));
+        assert!(!runtime.completion_is_current(token));
+    }
+}

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -688,6 +688,15 @@ impl App {
                     !self.state.confirm_project_track_deletion;
                 self.persist_ui_settings();
             }
+            Message::ToggleAutoSave => {
+                self.state.auto_save_enabled = !self.state.auto_save_enabled;
+                self.save_runtime.set_auto_save_enabled(
+                    self.state.auto_save_enabled,
+                    self.state.project.dirty && self.state.project.current_path.is_some(),
+                    std::time::Instant::now(),
+                );
+                self.persist_ui_settings();
+            }
             Message::ToggleCheckForUpdates => {
                 self.state.update_check.enabled = !self.state.update_check.enabled;
                 self.persist_ui_settings();

--- a/crates/vibez-ui/src/app/update_project.rs
+++ b/crates/vibez-ui/src/app/update_project.rs
@@ -1,6 +1,7 @@
 //! Routes Project state and project-file messages.
 
 use crate::domains::project::{ProjectCtx, ProjectMsg};
+use crate::message::ProjectSaveCompleted;
 
 use super::window_policy::{close_request_decision, CloseRequest};
 use super::*;
@@ -13,6 +14,30 @@ fn exit_application() -> Task<Message> {
 }
 
 impl App {
+    fn start_project_save(
+        &mut self,
+        path: PathBuf,
+        source_path: Option<PathBuf>,
+        project: vibez_project::Project,
+        automatic: bool,
+    ) -> Task<Message> {
+        let Some(token) = self.save_runtime.begin_save(automatic) else {
+            if !automatic {
+                self.state.status_text = "Save queued behind the current save".into();
+            }
+            return Task::none();
+        };
+        self.state.status_text = if automatic {
+            "Auto-saving project...".into()
+        } else {
+            "Saving project...".into()
+        };
+        Task::perform(
+            save_project_async(path, source_path, project),
+            move |result| Message::ProjectSaved(Box::new(ProjectSaveCompleted { token, result })),
+        )
+    }
+
     pub(super) fn route_project_message(&mut self, msg: ProjectMsg) -> Task<Message> {
         if matches!(&msg, ProjectMsg::ToggleFileMenu) {
             self.state.view.edit_menu_open = false;
@@ -26,6 +51,7 @@ impl App {
         }
         if let Some(snapshot) = action.apply_snapshot {
             self.apply_snapshot(snapshot);
+            self.mark_project_dirty();
         }
         Task::none()
     }
@@ -52,15 +78,28 @@ impl App {
     pub(super) fn route_save_project(&mut self) -> Task<Message> {
         let project = self.project_for_save();
         if let Some(path) = self.state.project.current_path.clone() {
-            return Task::perform(
-                save_project_async(path.clone(), Some(path), project),
-                |result| Message::ProjectSaved(Box::new(result)),
-            );
+            return self.start_project_save(path.clone(), Some(path), project, false);
         }
         self.update(Message::SaveProjectAs)
     }
 
+    pub(super) fn route_auto_save_project(&mut self) -> Task<Message> {
+        if !self.state.auto_save_enabled || !self.state.project.dirty {
+            self.save_runtime.cancel_pending_auto_save();
+            return Task::none();
+        }
+        let Some(path) = self.state.project.current_path.clone() else {
+            return Task::none();
+        };
+        let project = self.project_for_save();
+        self.start_project_save(path.clone(), Some(path), project, true)
+    }
+
     pub(super) fn route_save_project_as(&mut self) -> Task<Message> {
+        if self.save_runtime.is_saving() {
+            self.state.status_text = "Wait for the current save before using Save As".into();
+            return Task::none();
+        }
         Task::perform(
             async {
                 let handle = rfd::AsyncFileDialog::new()
@@ -104,9 +143,11 @@ impl App {
                 path.set_extension("vzp");
             }
             let project = self.project_for_save();
-            return Task::perform(
-                save_project_async(path, self.state.project.current_path.clone(), project),
-                |result| Message::ProjectSaved(Box::new(result)),
+            return self.start_project_save(
+                path,
+                self.state.project.current_path.clone(),
+                project,
+                false,
             );
         }
         // Backing out of save-as also backs out of the quit that asked for it.
@@ -129,17 +170,48 @@ impl App {
         Task::none()
     }
 
-    pub(super) fn route_project_saved(
-        &mut self,
-        result: Result<ProjectSaveResult, String>,
-    ) -> Task<Message> {
+    pub(super) fn route_project_saved(&mut self, completed: ProjectSaveCompleted) -> Task<Message> {
+        let ProjectSaveCompleted { token, result } = completed;
+        if !self.save_runtime.finish_save(token) {
+            return Task::none();
+        }
+        let completion_is_current = self.save_runtime.completion_is_current(token);
+        let manual_save_queued = self.save_runtime.take_manual_save_queued();
+
         match result {
             Ok(saved) => {
                 self.apply_saved_project_sources(&saved.project);
                 self.state.project.current_path = Some(saved.path.clone());
-                self.state.project.dirty = false;
-                self.state.status_text = format!("Saved {}", saved.path.display());
-                if std::mem::take(&mut self.state.project.exit_after_save) {
+                self.state.project.dirty = !completion_is_current;
+                if !completion_is_current {
+                    // An Untitled project can receive another edit while its
+                    // first Save As is writing. It has a path now, so make
+                    // that newer revision eligible for the normal debounce.
+                    self.save_runtime.set_auto_save_enabled(
+                        self.state.auto_save_enabled,
+                        true,
+                        std::time::Instant::now(),
+                    );
+                }
+                let saved_status = if token.automatic {
+                    format!(
+                        "Auto-saved {}",
+                        saved
+                            .path
+                            .file_name()
+                            .unwrap_or(saved.path.as_os_str())
+                            .to_string_lossy()
+                    )
+                } else {
+                    format!("Saved {}", saved.path.display())
+                };
+                self.state.status_text = if completion_is_current {
+                    saved_status
+                } else {
+                    format!("{saved_status}; newer edits are still unsaved")
+                };
+                if completion_is_current && std::mem::take(&mut self.state.project.exit_after_save)
+                {
                     return exit_application();
                 }
             }
@@ -149,6 +221,10 @@ impl App {
                 // error stays on screen with the edits intact.
                 self.state.project.exit_after_save = false;
             }
+        }
+
+        if manual_save_queued {
+            return self.route_save_project();
         }
         Task::none()
     }

--- a/crates/vibez-ui/src/app/views_settings.rs
+++ b/crates/vibez-ui/src/app/views_settings.rs
@@ -52,7 +52,7 @@ impl App {
                     .wrapping(iced::widget::text::Wrapping::None),
             )
             .on_press(Message::SelectSettingsTab(tab))
-            .padding([6, 10])
+            .padding([6, 8])
             .style(move |_theme: &Theme, status| {
                 let bg = if is_active {
                     None
@@ -84,6 +84,11 @@ impl App {
         let active = self.state.settings_tab;
         let tab_bar = row![
             make_tab_btn("Audio", SettingsTab::Audio, active == SettingsTab::Audio),
+            make_tab_btn(
+                "Project",
+                SettingsTab::Project,
+                active == SettingsTab::Project
+            ),
             make_tab_btn(
                 "Plugins",
                 SettingsTab::Plugins,
@@ -120,6 +125,7 @@ impl App {
         // -- Tab body --
         let tab_body: Element<'_, Message> = match self.state.settings_tab {
             SettingsTab::Audio => self.view_settings_audio_tab(),
+            SettingsTab::Project => self.view_settings_project_tab(),
             SettingsTab::Plugins => self.view_settings_plugins_tab(),
             SettingsTab::Dropbox => self.view_settings_dropbox_tab(),
             SettingsTab::Warping => self.view_settings_warping_tab(),
@@ -147,10 +153,10 @@ impl App {
         ]
         .spacing(8)
         .padding(20)
-        // Wide enough for all seven tab labels on one line with ~30px to
+        // Wide enough for all eight tab labels on one line with room to
         // spare; still comfortably inside the 900px minimum window. Grow
-        // this before adding an eighth tab.
-        .width(Length::Fixed(560.0));
+        // this before adding a ninth tab.
+        .width(Length::Fixed(600.0));
 
         let dialog = container(content).style(|_theme: &Theme| container::Style {
             background: Some(th::bg_surface().into()),

--- a/crates/vibez-ui/src/app/views_settings_project.rs
+++ b/crates/vibez-ui/src/app/views_settings_project.rs
@@ -1,0 +1,59 @@
+//! Project persistence preferences.
+
+use iced::widget::{button, column, row, text};
+use iced::{Element, Length, Theme};
+
+use crate::message::Message;
+use crate::theme as th;
+
+use super::*;
+
+impl App {
+    pub(super) fn view_settings_project_tab(&self) -> Element<'_, Message> {
+        let enabled = self.state.auto_save_enabled;
+        let auto_save = button(
+            row![
+                crate::icons::icon(if enabled {
+                    crate::icons::CIRCLE_DOT
+                } else {
+                    crate::icons::CIRCLE
+                })
+                .size(12)
+                .color(if enabled { th::accent() } else { th::text_dim() }),
+                column![
+                    text("Auto save named projects").size(12).color(th::text()),
+                    text("On by default. Saves two seconds after editing stops; Untitled projects wait for Save As.")
+                        .size(10)
+                        .color(th::text_dim())
+                ]
+                .spacing(2)
+            ]
+            .spacing(8)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::ToggleAutoSave)
+        .padding([8, 9])
+        .width(Length::Fill)
+        .style(|_theme: &Theme, status| button::Style {
+            background: matches!(status, button::Status::Hovered | button::Status::Pressed)
+                .then(|| th::bg_hover().into()),
+            text_color: th::text(),
+            border: iced::Border {
+                color: th::border(),
+                width: 1.0,
+                radius: 4.0.into(),
+            },
+            ..Default::default()
+        });
+
+        column![
+            text("Saving").size(14).color(th::text()),
+            text("Autosave uses the current project file and never chooses a location for you.")
+                .size(11)
+                .color(th::text_dim()),
+            auto_save,
+        ]
+        .spacing(9)
+        .into()
+    }
+}

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -465,6 +465,40 @@ impl App {
             .into()
     }
 
+    /// Persistent project-save state at the far right of the bottom bar.
+    /// Unlike transient status text, this remains visible after another
+    /// operation reports its own result.
+    fn view_project_save_status(&self) -> Element<'_, Message> {
+        let (icon, label, color) = if self.save_runtime.is_saving() {
+            (icons::CIRCLE_DOT, "Saving...", th::accent())
+        } else if self.state.project.dirty {
+            (icons::CIRCLE, "Unsaved", th::text_dim())
+        } else if self.state.project.current_path.is_some() {
+            (icons::CIRCLE_DOT, "Saved", th::accent())
+        } else {
+            (icons::CIRCLE, "Not saved", th::text_dim())
+        };
+
+        container(
+            row![
+                icons::icon(icon).size(9).color(color),
+                text(label).size(11).color(color)
+            ]
+            .spacing(5)
+            .align_y(iced::Alignment::Center),
+        )
+        .padding([1, 7])
+        .style(move |_theme: &Theme| container::Style {
+            border: iced::Border {
+                color,
+                width: 1.0,
+                radius: 3.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
+    }
+
     pub(super) fn view_status(&self) -> Element<'_, Message> {
         let status = text(&self.state.status_text).size(11).color(th::text_dim());
         let content: Element<'_, Message> = match self.state.export_progress {
@@ -475,6 +509,7 @@ impl App {
                     .width(180)
                     .height(5),
                 text(format!("{percent}%")).size(11).color(th::text()),
+                self.view_project_save_status(),
             ]
             .spacing(8)
             .align_y(iced::Alignment::Center)
@@ -482,11 +517,19 @@ impl App {
             // An export in flight owns the right-hand side of the bar;
             // a release notice can wait for the next frame that has room.
             None => match self.state.update_check.notice() {
-                Some(version) => row![status, horizontal_space(), self.view_update_notice(version)]
+                Some(version) => row![
+                    status,
+                    horizontal_space(),
+                    self.view_update_notice(version),
+                    self.view_project_save_status()
+                ]
+                .spacing(8)
+                .align_y(iced::Alignment::Center)
+                .into(),
+                None => row![status, horizontal_space(), self.view_project_save_status()]
                     .spacing(8)
                     .align_y(iced::Alignment::Center)
                     .into(),
-                None => status.into(),
             },
         };
 

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -264,6 +264,21 @@ pub struct ProjectSaveResult {
     pub observation: Option<SaveObservation>,
 }
 
+/// Identity of the document revision captured by an asynchronous save.
+/// The completion uses this to avoid marking newer edits as saved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProjectSaveToken {
+    pub document_id: u64,
+    pub revision: u64,
+    pub automatic: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectSaveCompleted {
+    pub token: ProjectSaveToken,
+    pub result: Result<ProjectSaveResult, String>,
+}
+
 #[derive(Debug, Clone)]
 pub enum Message {
     /// A message emitted by one of the selected Section timeline canvases.
@@ -376,7 +391,7 @@ pub enum Message {
     ProjectOpenPathSelected(Option<PathBuf>),
     ProjectSavePathSelected(Option<PathBuf>),
     ProjectLoaded(Box<Result<ProjectLoadResult, String>>),
-    ProjectSaved(Box<Result<ProjectSaveResult, String>>),
+    ProjectSaved(Box<ProjectSaveCompleted>),
 
     // Window close protection. The window is configured not to exit on its
     // own close request, so every one of these arrives here first.
@@ -395,6 +410,8 @@ pub enum Message {
     SetWarpConfidenceThreshold(f32),
     /// Settings: ask before deleting a Project Track everywhere.
     ToggleProjectTrackDeleteConfirmation,
+    /// Settings: save named projects shortly after editing stops.
+    ToggleAutoSave,
     /// Settings: resize the whole interface. Distinct from timeline
     /// zoom, which changes visible musical time instead.
     SetInterfaceScale(f32),

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -184,6 +184,7 @@ impl Default for PianoRollState {
 pub enum SettingsTab {
     #[default]
     Audio,
+    Project,
     Plugins,
     Dropbox,
     Warping,
@@ -473,6 +474,8 @@ pub struct AppState {
     pub settings_tab: SettingsTab,
     pub settings_buffer_size: u32,
     pub confirm_project_track_deletion: bool,
+    /// Global autosave preference mirrored from [`crate::ui_settings::UiSettings`].
+    pub auto_save_enabled: bool,
     /// Startup release check: preference, throttle, and pending notice.
     pub update_check: crate::update_check::UpdateCheckState,
     // Project domain slice: file menu, path, dirty flag, undo.
@@ -527,6 +530,7 @@ impl Default for AppState {
             settings_tab: SettingsTab::default(),
             settings_buffer_size: 512,
             confirm_project_track_deletion: false,
+            auto_save_enabled: true,
             update_check: crate::update_check::UpdateCheckState::default(),
             project: ProjectState::default(),
             auto_warp_on_import: false,

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -53,6 +53,10 @@ pub struct UiSettings {
     /// Section content. Off by default because deletion is undoable.
     #[serde(default)]
     pub confirm_project_track_deletion: bool,
+    /// Save named projects shortly after editing stops. Untitled projects
+    /// still wait for an explicit save so autosave never opens a file picker.
+    #[serde(default = "default_auto_save_enabled")]
+    pub auto_save_enabled: bool,
     /// Multiplier applied to the whole logical coordinate space, so
     /// every panel, control and font grows or shrinks together. This is
     /// not timeline zoom: it changes how big the interface is drawn,
@@ -121,6 +125,7 @@ impl Default for UiSettings {
             media_cache_budget_bytes: default_media_cache_budget_bytes(),
             media_cache_automatic_eviction: default_media_cache_automatic_eviction(),
             confirm_project_track_deletion: false,
+            auto_save_enabled: default_auto_save_enabled(),
             interface_scale: default_interface_scale(),
             check_for_updates: default_check_for_updates(),
             last_update_check_unix: None,
@@ -172,6 +177,10 @@ fn default_media_cache_budget_bytes() -> u64 {
 }
 
 fn default_media_cache_automatic_eviction() -> bool {
+    true
+}
+
+const fn default_auto_save_enabled() -> bool {
     true
 }
 
@@ -313,6 +322,20 @@ mod tests {
         let loaded: UiSettings =
             serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
         assert!(loaded.confirm_project_track_deletion);
+    }
+
+    #[test]
+    fn auto_save_defaults_on_and_roundtrips() {
+        let old: UiSettings = serde_json::from_str("{}").unwrap();
+        assert!(old.auto_save_enabled);
+
+        let settings = UiSettings {
+            auto_save_enabled: false,
+            ..UiSettings::default()
+        };
+        let loaded: UiSettings =
+            serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
+        assert!(!loaded.auto_save_enabled);
     }
 
     #[test]


### PR DESCRIPTION
Patch release for safer, faster project saving.

## Summary

- Add the platform save shortcut: Ctrl+S on Windows/Linux and Cmd+S on macOS.
- Enable configurable autosave by default for named projects, debounced until two seconds after editing stops.
- Keep Untitled projects on the explicit Save As flow so autosave never chooses a destination or opens a file picker.
- Serialize manual and automatic saves and track document revisions so stale background completions cannot mark newer edits as saved.
- Show persistent Not saved, Unsaved, Saving, and Saved state in the bottom status bar.
- Bump the Cargo workspace and lockfile from 0.1.3 to 0.1.4.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --exclude vibez-plugin-host -- -D warnings`
- [x] `cargo clippy -p vibez-plugin-host -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Feature PRs #141 and #142 passed CI across Linux, macOS, and Windows
- [ ] Release PR CI

## After merging

Tag and push `v0.1.4` to trigger the release-artifact workflow:

```sh
git tag v0.1.4
git push origin v0.1.4
```

Prepared with Codex.