### PR TITLE
feat(perform): mute tracks at section end

### DIFF
--- a/crates/vibez-core/src/perform.rs
+++ b/crates/vibez-core/src/perform.rs
@@ -405,8 +405,48 @@ impl std::fmt::Display for SectionLaunchQuantization {
     }
 }
 
-/// Track Mutes accept every reusable grid boundary and no Section-only policy.
-pub type TrackMuteQuantization = MusicalBoundary;
+/// Musical boundary at which a queued Track Mute becomes effective.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackMuteQuantization {
+    #[default]
+    Immediate,
+    OneBeat,
+    OneBar,
+    EndOfSection,
+}
+
+impl TrackMuteQuantization {
+    pub const ALL: [Self; 4] = [
+        Self::Immediate,
+        Self::OneBeat,
+        Self::OneBar,
+        Self::EndOfSection,
+    ];
+
+    pub const fn label(self) -> &'static str {
+        if let Some(boundary) = self.musical_boundary() {
+            boundary.label()
+        } else {
+            "End of Section"
+        }
+    }
+
+    pub const fn musical_boundary(self) -> Option<MusicalBoundary> {
+        match self {
+            Self::Immediate => Some(MusicalBoundary::Immediate),
+            Self::OneBeat => Some(MusicalBoundary::OneBeat),
+            Self::OneBar => Some(MusicalBoundary::OneBar),
+            Self::EndOfSection => None,
+        }
+    }
+}
+
+impl std::fmt::Display for TrackMuteQuantization {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.label())
+    }
+}
 
 #[cfg(test)]
 mod track_mute_quantization_tests {
@@ -431,11 +471,15 @@ mod track_mute_quantization_tests {
         );
         assert_eq!(
             TrackMuteQuantization::ALL.map(TrackMuteQuantization::label),
-            ["Immediate", "1 Beat", "1 Bar"]
+            ["Immediate", "1 Beat", "1 Bar", "End of Section"]
         );
         assert_eq!(
             serde_json::to_string(&TrackMuteQuantization::OneBar).unwrap(),
             "\"one_bar\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TrackMuteQuantization::EndOfSection).unwrap(),
+            "\"end_of_section\""
         );
     }
 }

--- a/crates/vibez-engine/src/engine_automation_commands.rs
+++ b/crates/vibez-engine/src/engine_automation_commands.rs
@@ -136,6 +136,7 @@ impl AudioEngine {
         track.queued_mute = Some(QueuedTrackMute {
             muted,
             effective_at_samples,
+            end_of_section: quantization == TrackMuteQuantization::EndOfSection,
         });
         let _ = self.event_tx.push(EngineEvent::TrackMuteQueued {
             track_id,
@@ -159,6 +160,17 @@ impl AudioEngine {
                 .map(|queued| (track.id, queued))
         }) {
             self.apply_track_mute_at(track_id, queued.muted, queued.effective_at_samples);
+        }
+    }
+
+    pub(super) fn apply_end_of_section_track_mutes(&mut self, at_samples: u64) {
+        while let Some((track_id, muted)) = self.tracks.iter().find_map(|track| {
+            track
+                .queued_mute
+                .filter(|queued| queued.end_of_section)
+                .map(|queued| (track.id, queued.muted))
+        }) {
+            self.apply_track_mute_at(track_id, muted, at_samples);
         }
     }
 

--- a/crates/vibez-engine/src/engine_automation_commands.rs
+++ b/crates/vibez-engine/src/engine_automation_commands.rs
@@ -106,10 +106,21 @@ impl AudioEngine {
             return;
         }
 
-        let beats = quantization
-            .beats()
-            .expect("Immediate Track Mutes return before boundary resolution");
-        let effective_at_samples = self.next_grid_boundary(now, beats);
+        let effective_at_samples = if let Some(boundary) = quantization.musical_boundary() {
+            boundary
+                .beats()
+                .map_or(now, |beats| self.next_grid_boundary(now, beats))
+        } else {
+            self.active_section
+                .map(|active| {
+                    now.saturating_add(
+                        active
+                            .length_samples
+                            .saturating_sub(active.position_samples),
+                    )
+                })
+                .unwrap_or(now)
+        };
         if effective_at_samples <= now {
             let _ = self.event_tx.push(EngineEvent::TrackMuteQueued {
                 track_id,

--- a/crates/vibez-engine/src/engine_section_queue.rs
+++ b/crates/vibez-engine/src/engine_section_queue.rs
@@ -9,6 +9,7 @@ impl AudioEngine {
         mut prepared: Box<PreparedSectionPlaybackSource>,
         effective_at_samples: u64,
     ) {
+        self.apply_end_of_section_track_mutes(effective_at_samples);
         self.begin_performance_clock();
         let section_id = prepared.section_id;
         let length_samples = self.section_length_samples(prepared.length_beats);

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -293,6 +293,39 @@ fn end_of_section_track_mute_uses_the_active_section_wrap() {
 }
 
 #[test]
+fn end_of_section_track_mute_follows_an_earlier_section_transition() {
+    let (mut engine, mut commands, mut events, track_id) = playing_engine(0.6, 2.0);
+    while events.pop().is_ok() {}
+    commands
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::EndOfSection,
+        })
+        .unwrap();
+    commands
+        .push(EngineCommand::QueueSection {
+            prepared: source(SectionId::new(), track_id, 4.0, 0.8),
+            quantization: SectionLaunchQuantization::OneBeat,
+        })
+        .unwrap();
+
+    engine.process(&mut [0.0; 6], 1);
+
+    assert!(
+        std::iter::from_fn(|| events.pop().ok()).any(|event| matches!(
+            event,
+            EngineEvent::TrackMuteChanged {
+                track_id: event_track,
+                muted: true,
+                effective_at_samples: 4,
+            } if event_track == track_id
+        ))
+    );
+    assert!(engine.tracks()[0].mute);
+}
+
+#[test]
 fn requeue_returns_stale_residency_and_only_latest_section_transitions() {
     let (mut engine, mut commands, mut events, track_id) = playing_engine(0.1, 8.0);
     while events.pop().is_ok() {}

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -266,6 +266,33 @@ fn one_bar_and_end_of_section_use_their_exact_boundaries() {
 }
 
 #[test]
+fn end_of_section_track_mute_uses_the_active_section_wrap() {
+    let (mut engine, mut commands, mut events, track_id) = playing_engine(0.6, 2.0);
+    while events.pop().is_ok() {}
+    commands
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::EndOfSection,
+        })
+        .unwrap();
+
+    engine.process(&mut [0.0; 10], 1);
+
+    assert!(
+        std::iter::from_fn(|| events.pop().ok()).any(|event| matches!(
+            event,
+            EngineEvent::TrackMuteChanged {
+                track_id: event_track,
+                muted: true,
+                effective_at_samples: 8,
+            } if event_track == track_id
+        ))
+    );
+    assert!(engine.tracks()[0].mute);
+}
+
+#[test]
 fn requeue_returns_stale_residency_and_only_latest_section_transitions() {
     let (mut engine, mut commands, mut events, track_id) = playing_engine(0.1, 8.0);
     while events.pop().is_ok() {}

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -24,6 +24,7 @@ const MUTE_RAMP_FRAMES: u32 = 64;
 pub(crate) struct QueuedTrackMute {
     pub muted: bool,
     pub effective_at_samples: u64,
+    pub end_of_section: bool,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/vibez-ui/src/app/views_perform_pads.rs
+++ b/crates/vibez-ui/src/app/views_perform_pads.rs
@@ -173,7 +173,7 @@ impl App {
                     Some(self.state.perform.track_mute_quantization()),
                     |value| Message::Perform(PerformMsg::SetTrackMuteQuantization(value)),
                 )
-                .width(Length::Fixed(104.0))
+                .width(Length::Fixed(126.0))
                 .padding([4, 7])
                 .text_size(9);
                 row![


### PR DESCRIPTION
## Summary
- add End of Section to the Track Mute quantization picker
- resolve the mute against the active Section's next wrap/end boundary in the audio engine
- apply immediately when stopped or when no Section is active
- preserve existing serialized Immediate, 1 Beat, and 1 Bar settings

## Test plan
- `cargo fmt --check`
- `cargo test -p vibez-core track_mute_quantization_tests`
- `cargo test -p vibez-engine engine::mute_event_tests`
- `cargo test -p vibez-engine end_of_section_track_mute_uses_the_active_section_wrap`
- `cargo test -p vibez-ui track_mute_quantization`
- `cargo clippy -p vibez-core -p vibez-engine -p vibez-ui --all-targets -- -D warnings`