### PR TITLE
feat(arrange): trim clips by captured track mutes

### DIFF
--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -224,6 +224,12 @@ impl App {
                 "Ctrl+J",
                 Message::join_selected_clips(),
             ),
+            item(
+                icons::SCISSORS,
+                "Trim Track Mutes",
+                "",
+                Message::Arrangement(ArrangementMsg::TrimSelectedByTrackMutes),
+            ),
         ]
         .spacing(1)
         .padding(4)
@@ -758,6 +764,11 @@ impl App {
                     icons::COPY,
                     "Join Clips (Ctrl+J)".into(),
                     Message::join_selected_clips(),
+                ));
+                col = col.push(menu_btn(
+                    icons::SCISSORS,
+                    "Trim Track Mutes".into(),
+                    Message::Arrangement(ArrangementMsg::TrimSelectedByTrackMutes),
                 ));
 
                 // Rename clip

--- a/crates/vibez-ui/src/domains/arrangement/media_ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/media_ops.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use crate::message::{AudioQuantizeSuccess, AutoWarpOutcome, ClipWarpSuccess};
 use std::sync::Arc;
 
+use vibez_core::automation::{AutomationLane, AutomationTarget};
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::MidiNote;
 use vibez_engine::commands::EngineCommand;
@@ -61,7 +62,259 @@ fn visible_notes(clip: &UiNoteClip, local_start: f64, local_end: f64) -> Vec<Mid
     visible
 }
 
+/// Unmuted portions of `[start, end)` in project beats. Track Mute is a
+/// stepped lane and deliberately imposes no state before its first point, so
+/// uncaptured material before the first event is retained.
+fn unmuted_beat_ranges(lane: &AutomationLane, start: f64, end: f64) -> Vec<(f64, f64)> {
+    if end <= start {
+        return Vec::new();
+    }
+
+    let mut boundaries = vec![start];
+    boundaries.extend(
+        lane.points
+            .iter()
+            .map(|point| point.beat)
+            .filter(|beat| *beat > start && *beat < end),
+    );
+    boundaries.push(end);
+
+    boundaries
+        .windows(2)
+        .filter_map(|window| {
+            let range_start = window[0];
+            let range_end = window[1];
+            let muted = lane.value_at(range_start).is_some_and(|value| value >= 0.5);
+            (!muted && range_end > range_start).then_some((range_start, range_end))
+        })
+        .collect()
+}
+
 impl TimelineEditorState {
+    pub(super) fn op_trim_selected_by_track_mutes(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        ctx: ArrangementCtx,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        if self.selected_clips.is_empty() || ctx.samples_per_beat <= 0.0 {
+            action.status = Some("Select clips to trim by Track Mutes".to_string());
+            return action;
+        }
+
+        enum Replacement {
+            Audio {
+                track_id: TrackId,
+                original_id: ClipId,
+                clips: Vec<UiClip>,
+            },
+            Notes {
+                track_id: TrackId,
+                original_id: ClipId,
+                clips: Vec<UiNoteClip>,
+            },
+        }
+
+        let mut replacements = Vec::new();
+        for selection in self.selected_clips.iter().copied() {
+            let (track_id, clip_id) = match selection {
+                ArrangementSelection::AudioClip { track_id, clip_id }
+                | ArrangementSelection::NoteClip { track_id, clip_id } => (track_id, clip_id),
+            };
+            let Some(content) = self.find_content(track_id) else {
+                continue;
+            };
+            let Some(mute_lane) = content
+                .automation
+                .iter()
+                .find(|lane| lane.target == AutomationTarget::TrackMute)
+            else {
+                continue;
+            };
+
+            match selection {
+                ArrangementSelection::AudioClip { .. } => {
+                    let Some(clip) = content.clips.iter().find(|clip| clip.id == clip_id) else {
+                        continue;
+                    };
+                    let clip_start_beat = clip.position as f64 / ctx.samples_per_beat;
+                    let clip_end_sample = clip.position.saturating_add(clip.duration);
+                    let clip_end_beat = clip_end_sample as f64 / ctx.samples_per_beat;
+                    let ranges = unmuted_beat_ranges(mute_lane, clip_start_beat, clip_end_beat);
+                    let covers_original = ranges.as_slice() == [(clip_start_beat, clip_end_beat)];
+                    if covers_original {
+                        continue;
+                    }
+                    let clips = ranges
+                        .into_iter()
+                        .filter_map(|(start, end)| {
+                            let start_sample = ((start * ctx.samples_per_beat).round() as u64)
+                                .clamp(clip.position, clip_end_sample);
+                            let end_sample = ((end * ctx.samples_per_beat).round() as u64)
+                                .clamp(start_sample, clip_end_sample);
+                            (end_sample > start_sample).then(|| {
+                                let local_start = start_sample - clip.position;
+                                let mut fragment = clip.clone();
+                                fragment.id = ClipId::new();
+                                fragment.position = start_sample;
+                                fragment.source_offset =
+                                    audio_source_frame(clip, local_start) as u64;
+                                fragment.duration = end_sample - start_sample;
+                                fragment
+                            })
+                        })
+                        .collect();
+                    replacements.push(Replacement::Audio {
+                        track_id,
+                        original_id: clip_id,
+                        clips,
+                    });
+                }
+                ArrangementSelection::NoteClip { .. } => {
+                    let Some(clip) = content.note_clips.iter().find(|clip| clip.id == clip_id)
+                    else {
+                        continue;
+                    };
+                    let clip_end = clip.position_beats + clip.duration_beats;
+                    let ranges = unmuted_beat_ranges(mute_lane, clip.position_beats, clip_end);
+                    let covers_original = ranges.as_slice() == [(clip.position_beats, clip_end)];
+                    if covers_original {
+                        continue;
+                    }
+                    let clips = ranges
+                        .into_iter()
+                        .map(|(start, end)| {
+                            let local_start = start - clip.position_beats;
+                            let local_end = end - clip.position_beats;
+                            let mut fragment = clip.clone();
+                            fragment.id = ClipId::new();
+                            fragment.position_beats = start;
+                            fragment.duration_beats = end - start;
+                            fragment.notes = visible_notes(clip, local_start, local_end);
+                            fragment.selected_notes.clear();
+                            if fragment.loop_enabled {
+                                fragment.loop_start_beats = 0.0;
+                                fragment.loop_end_beats = fragment.duration_beats;
+                            }
+                            fragment
+                        })
+                        .collect();
+                    replacements.push(Replacement::Notes {
+                        track_id,
+                        original_id: clip_id,
+                        clips,
+                    });
+                }
+            }
+        }
+
+        if replacements.is_empty() {
+            action.status = Some("No selected clip material overlaps Track Mutes".to_string());
+            return action;
+        }
+
+        let trimmed_count = replacements.len();
+        let mut fragment_count = 0;
+        let mut new_selection = self.selected_clips.clone();
+        for replacement in replacements {
+            match replacement {
+                Replacement::Audio {
+                    track_id,
+                    original_id,
+                    clips,
+                } => {
+                    new_selection.remove(&ArrangementSelection::AudioClip {
+                        track_id,
+                        clip_id: original_id,
+                    });
+                    engine.send(EngineCommand::RemoveClip(track_id, original_id));
+                    if let Some(content) = self.find_content_mut(track_id) {
+                        content.clips.retain(|clip| clip.id != original_id);
+                    }
+                    for clip in &clips {
+                        engine.send(EngineCommand::AddClip {
+                            track_id,
+                            clip_id: clip.id,
+                            audio: Arc::clone(&clip.audio),
+                            position: clip.position,
+                            source_offset: clip.source_offset,
+                            duration: clip.duration,
+                            loop_enabled: clip.loop_enabled,
+                            loop_start: clip.loop_start,
+                            loop_end: clip.loop_end,
+                        });
+                        new_selection.insert(ArrangementSelection::AudioClip {
+                            track_id,
+                            clip_id: clip.id,
+                        });
+                    }
+                    fragment_count += clips.len();
+                    if let Some(content) = self.find_content_mut(track_id) {
+                        content.clips.extend(clips);
+                    }
+                }
+                Replacement::Notes {
+                    track_id,
+                    original_id,
+                    clips,
+                } => {
+                    new_selection.remove(&ArrangementSelection::NoteClip {
+                        track_id,
+                        clip_id: original_id,
+                    });
+                    engine.send(EngineCommand::RemoveNoteClip(track_id, original_id));
+                    if let Some(content) = self.find_content_mut(track_id) {
+                        content.note_clips.retain(|clip| clip.id != original_id);
+                    }
+                    for clip in &clips {
+                        engine.send(EngineCommand::AddNoteClip {
+                            track_id,
+                            clip_id: clip.id,
+                            position_beats: clip.position_beats,
+                            duration_beats: clip.duration_beats,
+                            loop_enabled: clip.loop_enabled,
+                            loop_start_beats: clip.loop_start_beats,
+                            loop_end_beats: clip.loop_end_beats,
+                            groove_grid: clip.groove_grid,
+                        });
+                        for note in &clip.notes {
+                            engine.send(EngineCommand::AddNote {
+                                track_id,
+                                clip_id: clip.id,
+                                note: *note,
+                            });
+                        }
+                        new_selection.insert(ArrangementSelection::NoteClip {
+                            track_id,
+                            clip_id: clip.id,
+                        });
+                    }
+                    fragment_count += clips.len();
+                    if let Some(content) = self.find_content_mut(track_id) {
+                        content.note_clips.extend(clips);
+                    }
+                }
+            }
+        }
+
+        self.selected_clips = new_selection;
+        self.selected_note_clip =
+            self.selected_clips
+                .iter()
+                .find_map(|selection| match selection {
+                    ArrangementSelection::NoteClip { track_id, clip_id } => {
+                        Some((*track_id, *clip_id))
+                    }
+                    ArrangementSelection::AudioClip { .. } => None,
+                });
+        action.status = Some(format!(
+            "Trimmed {trimmed_count} clip{} by Track Mutes · kept {fragment_count} fragment{}",
+            if trimmed_count == 1 { "" } else { "s" },
+            if fragment_count == 1 { "" } else { "s" },
+        ));
+        action
+    }
+
     pub(super) fn op_resize_audio_clip(
         &mut self,
         engine: &mut impl EngineHandle,

--- a/crates/vibez-ui/src/domains/arrangement/media_ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/media_ops.rs
@@ -79,15 +79,23 @@ fn unmuted_beat_ranges(lane: &AutomationLane, start: f64, end: f64) -> Vec<(f64,
     );
     boundaries.push(end);
 
-    boundaries
-        .windows(2)
-        .filter_map(|window| {
-            let range_start = window[0];
-            let range_end = window[1];
-            let muted = lane.value_at(range_start).is_some_and(|value| value >= 0.5);
-            (!muted && range_end > range_start).then_some((range_start, range_end))
-        })
-        .collect()
+    let mut ranges: Vec<(f64, f64)> = Vec::new();
+    for window in boundaries.windows(2) {
+        let range_start = window[0];
+        let range_end = window[1];
+        let muted = lane.value_at(range_start).is_some_and(|value| value >= 0.5);
+        if muted || range_end <= range_start {
+            continue;
+        }
+        if let Some((_, previous_end)) = ranges.last_mut() {
+            if *previous_end == range_start {
+                *previous_end = range_end;
+                continue;
+            }
+        }
+        ranges.push((range_start, range_end));
+    }
+    ranges
 }
 
 impl TimelineEditorState {

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -121,6 +121,9 @@ pub enum ArrangementMsg {
     },
     SplitSelectedAtPlayhead,
     JoinSelectedClips,
+    /// Replace selected clips with the portions where their track's captured
+    /// Track Mute automation is off.
+    TrimSelectedByTrackMutes,
     DeleteClipsInRegion {
         start_beats: f64,
         end_beats: f64,
@@ -184,6 +187,7 @@ impl ArrangementMsg {
                 | Self::SplitNoteClip { .. }
                 | Self::SplitSelectedAtPlayhead
                 | Self::JoinSelectedClips
+                | Self::TrimSelectedByTrackMutes
                 | Self::DeleteClipsInRegion { .. }
                 | Self::SplitClipsAtRegion { .. }
                 | Self::CreateClipFromSelection

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -913,6 +913,9 @@ impl TimelineEditorState {
             ArrangementMsg::JoinSelectedClips => {
                 return self.op_join_selected_clips(engine, ctx);
             }
+            ArrangementMsg::TrimSelectedByTrackMutes => {
+                return self.op_trim_selected_by_track_mutes(engine, ctx);
+            }
             ArrangementMsg::DeleteClipsInRegion {
                 start_beats,
                 end_beats,

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -983,6 +983,41 @@ fn trim_track_mutes_leaves_selected_clip_without_mute_automation_untouched() {
 }
 
 #[test]
+fn trim_track_mutes_ignores_redundant_unmuted_automation_points() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut a, 0, 0, 800);
+    let mut lane = AutomationLane::new(AutomationTarget::TrackMute);
+    for beat in [2.5, 6.0] {
+        lane.insert_point(AutomationPoint {
+            beat,
+            value: 0.0,
+            curve: 0.0,
+        });
+    }
+    a.tracks[0].automation.push(lane);
+    a.selected_clips
+        .insert(ArrangementSelection::AudioClip { track_id, clip_id });
+    let mut engine = RecordingEngine::default();
+
+    let action = a.update(
+        ArrangementMsg::TrimSelectedByTrackMutes,
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(a.tracks[0].clips.len(), 1);
+    assert_eq!(a.tracks[0].clips[0].id, clip_id);
+    assert!(engine.0.is_empty());
+    assert_eq!(
+        action.status.as_deref(),
+        Some("No selected clip material overlaps Track Mutes")
+    );
+}
+
+#[test]
 fn split_looped_midi_materializes_both_looped_halves() {
     let mut a = arrangement_with_tracks(1);
     let mut engine = RecordingEngine::default();

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -4,7 +4,7 @@ use super::test_support::*;
 use super::*;
 use crate::domains::test_support::RecordingEngine;
 use crate::state::UiClip;
-use vibez_core::automation::{AutomationLane, AutomationTarget};
+use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
 use vibez_core::midi::MidiNote;
 
 #[test]
@@ -818,6 +818,168 @@ fn split_looped_audio_preserves_source_phase() {
     assert!(halves.iter().all(|clip| clip.loop_enabled));
     assert_eq!(halves[1].source_offset, 50);
     assert_eq!((halves[1].loop_start, halves[1].loop_end), (0, 100));
+}
+
+#[test]
+fn trim_track_mutes_replaces_audio_with_unmuted_fragments_and_preserves_loop_phase() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut a, 0, 0, 800);
+    let clip = &mut a.tracks[0].clips[0];
+    clip.loop_enabled = true;
+    clip.loop_start = 0;
+    clip.loop_end = 100;
+    let mut lane = AutomationLane::new(AutomationTarget::TrackMute);
+    for (beat, value) in [(2.5, 1.0), (4.5, 0.0)] {
+        lane.insert_point(AutomationPoint {
+            beat,
+            value,
+            curve: 0.0,
+        });
+    }
+    a.tracks[0].automation.push(lane);
+    a.selected_clips
+        .insert(ArrangementSelection::AudioClip { track_id, clip_id });
+    let mut engine = RecordingEngine::default();
+
+    let action = a.update(
+        ArrangementMsg::TrimSelectedByTrackMutes,
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..Default::default()
+        },
+    );
+
+    let mut fragments: Vec<_> = a.tracks[0].clips.iter().collect();
+    fragments.sort_by_key(|clip| clip.position);
+    assert_eq!(fragments.len(), 2);
+    assert_eq!((fragments[0].position, fragments[0].duration), (0, 250));
+    assert_eq!((fragments[1].position, fragments[1].duration), (450, 350));
+    assert_eq!(fragments[1].source_offset, 50);
+    assert!(fragments.iter().all(|clip| clip.loop_enabled));
+    assert_eq!(a.selected_clips.len(), 2);
+    assert_eq!(
+        engine
+            .0
+            .iter()
+            .filter(|command| matches!(command, EngineCommand::RemoveClip(..)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        engine
+            .0
+            .iter()
+            .filter(|command| matches!(command, EngineCommand::AddClip { .. }))
+            .count(),
+        2
+    );
+    assert_eq!(
+        action.status.as_deref(),
+        Some("Trimmed 1 clip by Track Mutes · kept 2 fragments")
+    );
+}
+
+#[test]
+fn trim_track_mutes_materializes_midi_notes_across_unmuted_fragments() {
+    let mut a = arrangement_with_tracks(1);
+    let mut engine = RecordingEngine::default();
+    a.update(
+        ArrangementMsg::AddMidiTrack,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    engine.0.clear();
+    let track_id = a.tracks[1].id;
+    let clip_id = ClipId::new();
+    a.tracks[1].note_clips.push(UiNoteClip {
+        id: clip_id,
+        name: "Held note".to_string(),
+        position_beats: 0.0,
+        duration_beats: 8.0,
+        notes: vec![MidiNote {
+            pitch: 60,
+            velocity: 100,
+            start_beat: 1.0,
+            duration_beats: 5.0,
+        }],
+        selected_notes: HashSet::new(),
+        loop_enabled: false,
+        loop_start_beats: 0.0,
+        loop_end_beats: 0.0,
+        groove_grid: vibez_core::perform::GrooveGrid::Off,
+    });
+    let mut lane = AutomationLane::new(AutomationTarget::TrackMute);
+    for (beat, value) in [(2.0, 1.0), (4.0, 0.0)] {
+        lane.insert_point(AutomationPoint {
+            beat,
+            value,
+            curve: 0.0,
+        });
+    }
+    a.tracks[1].automation.push(lane);
+    a.selected_clips
+        .insert(ArrangementSelection::NoteClip { track_id, clip_id });
+
+    a.update(
+        ArrangementMsg::TrimSelectedByTrackMutes,
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..Default::default()
+        },
+    );
+
+    let mut fragments: Vec<_> = a.tracks[1].note_clips.iter().collect();
+    fragments.sort_by(|a, b| a.position_beats.partial_cmp(&b.position_beats).unwrap());
+    assert_eq!(fragments.len(), 2);
+    assert_eq!(
+        (fragments[0].position_beats, fragments[0].duration_beats),
+        (0.0, 2.0)
+    );
+    assert_eq!(
+        (fragments[1].position_beats, fragments[1].duration_beats),
+        (4.0, 4.0)
+    );
+    assert_eq!(
+        (
+            fragments[0].notes[0].start_beat,
+            fragments[0].notes[0].duration_beats
+        ),
+        (1.0, 1.0)
+    );
+    assert_eq!(
+        (
+            fragments[1].notes[0].start_beat,
+            fragments[1].notes[0].duration_beats
+        ),
+        (0.0, 2.0)
+    );
+}
+
+#[test]
+fn trim_track_mutes_leaves_selected_clip_without_mute_automation_untouched() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut a, 0, 0, 800);
+    a.selected_clips
+        .insert(ArrangementSelection::AudioClip { track_id, clip_id });
+    let mut engine = RecordingEngine::default();
+
+    let action = a.update(
+        ArrangementMsg::TrimSelectedByTrackMutes,
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(a.tracks[0].clips[0].id, clip_id);
+    assert!(engine.0.is_empty());
+    assert_eq!(
+        action.status.as_deref(),
+        Some("No selected clip material overlaps Track Mutes")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add **Trim Track Mutes** to the Edit menu and Arrange clip context menu
- replace selected audio and MIDI clips with only their unmuted captured spans
- preserve looped audio source phase and materialize/rebase looped MIDI fragments
- keep the resulting fragments selected so Ctrl+A supports whole-arrangement trimming

## Verification
- `cargo test -p vibez-ui --lib`
- `cargo clippy -p vibez-ui --all-targets -- -D warnings`
- `cargo fmt --all -- --check`