### PR TITLE
feat(audio): show callback CPU load in toolbar

### DIFF
--- a/crates/vibez-audio-io/src/audio_stream.rs
+++ b/crates/vibez-audio-io/src/audio_stream.rs
@@ -5,10 +5,10 @@
 //! inside the real-time audio callback.
 
 use std::fmt;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{
@@ -40,6 +40,39 @@ impl StreamHealth {
             CallbackAction::Process
         }
     }
+}
+
+/// Smoothed fraction of each device buffer deadline spent in the audio
+/// callback. Stored as basis points so the real-time writer and UI reader do
+/// not need a lock.
+#[derive(Clone, Default)]
+struct StreamCpuLoad(Arc<AtomicU32>);
+
+impl StreamCpuLoad {
+    fn record(&self, elapsed: Duration, frames: usize, sample_rate: u32) {
+        let instantaneous = callback_load_basis_points(elapsed, frames, sample_rate);
+        let previous = self.0.load(Ordering::Relaxed);
+        let smoothed = if previous == 0 {
+            instantaneous
+        } else {
+            (previous.saturating_mul(4) + instantaneous) / 5
+        };
+        self.0.store(smoothed, Ordering::Relaxed);
+    }
+
+    fn percent(&self) -> f32 {
+        self.0.load(Ordering::Relaxed) as f32 / 100.0
+    }
+}
+
+fn callback_load_basis_points(elapsed: Duration, frames: usize, sample_rate: u32) -> u32 {
+    if frames == 0 || sample_rate == 0 {
+        return 0;
+    }
+    let deadline_seconds = frames as f64 / sample_rate as f64;
+    ((elapsed.as_secs_f64() / deadline_seconds) * 10_000.0)
+        .round()
+        .clamp(0.0, 99_900.0) as u32
 }
 
 /// A presentation-facing transition in the output stream lifecycle.
@@ -181,6 +214,7 @@ pub struct AudioOutputStream {
     engine_slot: Arc<Mutex<Option<AudioEngine>>>,
     event_reporter: StreamEventReporter,
     event_rx: Receiver<AudioStreamEvent>,
+    cpu_load: StreamCpuLoad,
 }
 
 impl AudioOutputStream {
@@ -210,11 +244,13 @@ impl AudioOutputStream {
     ) -> Result<Self, AudioStreamError> {
         let engine_slot = Arc::new(Mutex::new(Some(engine)));
         let (event_reporter, event_rx) = StreamEventReporter::channel();
+        let cpu_load = StreamCpuLoad::default();
         let (stream, params) = Self::build_stream(
             Arc::clone(&engine_slot),
             device,
             buffer_size,
             event_reporter.clone(),
+            cpu_load.clone(),
         )?;
         Ok(Self {
             stream,
@@ -222,6 +258,7 @@ impl AudioOutputStream {
             engine_slot,
             event_reporter,
             event_rx,
+            cpu_load,
         })
     }
 
@@ -252,6 +289,7 @@ impl AudioOutputStream {
                 &device,
                 buffer_size,
                 self.event_reporter.clone(),
+                self.cpu_load.clone(),
             )?;
 
             self.stream = stream;
@@ -279,6 +317,7 @@ impl AudioOutputStream {
         device: &cpal::Device,
         buffer_size: Option<u32>,
         event_reporter: StreamEventReporter,
+        cpu_load: StreamCpuLoad,
     ) -> Result<(cpal::Stream, StreamParams), AudioStreamError> {
         let supported_config = device.default_output_config()?;
 
@@ -327,6 +366,7 @@ impl AudioOutputStream {
         let health = StreamHealth::default();
         let callback_health = health.clone();
         let error_reporter = event_reporter;
+        let callback_cpu_load = cpu_load;
 
         let stream = device.build_output_stream(
             &config,
@@ -366,14 +406,19 @@ impl AudioOutputStream {
 
                 // try_lock: never blocks the audio thread.  If the UI thread
                 // holds the lock during reconfigure, output silence.
+                let started = Instant::now();
+                let mut processed = false;
                 if let Ok(mut guard) = slot.try_lock() {
                     if let Some(engine) = guard.as_mut() {
                         engine.process(data, ch);
-                        return;
+                        processed = true;
                     }
                 }
                 // Fallback: silence
-                data.fill(0.0);
+                if !processed {
+                    data.fill(0.0);
+                }
+                callback_cpu_load.record(started.elapsed(), data.len() / ch, rt_sample_rate);
             },
             move |err| {
                 health.mark_failed();
@@ -428,6 +473,12 @@ impl AudioOutputStream {
     /// Return the next lifecycle event without blocking the UI thread.
     pub fn try_next_event(&self) -> Option<AudioStreamEvent> {
         self.event_rx.try_recv().ok()
+    }
+
+    /// Smoothed audio callback load as a percentage of the current buffer
+    /// deadline. Values over 100% mean the callback missed its deadline.
+    pub fn cpu_load_percent(&self) -> f32 {
+        self.cpu_load.percent()
     }
 }
 
@@ -485,6 +536,31 @@ mod tests {
 
         assert_eq!(health.callback_action(), CallbackAction::SilenceAndYield);
         assert_eq!(health.callback_action(), CallbackAction::SilenceAndYield);
+    }
+
+    #[test]
+    fn callback_load_compares_processing_time_with_the_device_deadline() {
+        assert_eq!(
+            callback_load_basis_points(Duration::from_millis(5), 480, 48_000),
+            5_000
+        );
+        assert_eq!(
+            callback_load_basis_points(Duration::from_millis(12), 480, 48_000),
+            12_000
+        );
+        assert_eq!(
+            callback_load_basis_points(Duration::from_secs(1), 0, 48_000),
+            0
+        );
+    }
+
+    #[test]
+    fn callback_load_is_smoothed_without_locking_the_audio_thread() {
+        let load = StreamCpuLoad::default();
+        load.record(Duration::from_millis(5), 480, 48_000);
+        assert_eq!(load.percent(), 50.0);
+        load.record(Duration::from_millis(10), 480, 48_000);
+        assert_eq!(load.percent(), 60.0);
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -688,9 +688,12 @@ impl App {
     pub(super) fn poll_audio_stream_events(&mut self) {
         let mut events = Vec::new();
         if let Some(stream) = self._stream.as_ref() {
+            self.state.audio_cpu_load_percent = stream.cpu_load_percent();
             while let Some(event) = stream.try_next_event() {
                 events.push(event);
             }
+        } else {
+            self.state.audio_cpu_load_percent = 0.0;
         }
         for event in events {
             self.state.apply_audio_stream_event(event);

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -687,17 +687,18 @@ impl App {
 
     pub(super) fn poll_audio_stream_events(&mut self) {
         let mut events = Vec::new();
-        if let Some(stream) = self._stream.as_ref() {
-            self.state.audio_cpu_load_percent = stream.cpu_load_percent();
+        let measured_cpu_load = if let Some(stream) = self._stream.as_ref() {
             while let Some(event) = stream.try_next_event() {
                 events.push(event);
             }
+            Some(stream.cpu_load_percent())
         } else {
-            self.state.audio_cpu_load_percent = 0.0;
-        }
+            None
+        };
         for event in events {
             self.state.apply_audio_stream_event(event);
         }
+        self.state.update_audio_cpu_load(measured_cpu_load);
     }
 
     /// One frame of the 60fps subscription: drain engine events and

--- a/crates/vibez-ui/src/app/views_transport.rs
+++ b/crates/vibez-ui/src/app/views_transport.rs
@@ -60,6 +60,54 @@ fn audio_stream_indicator(health: &AudioStreamHealth) -> Element<'_, Message> {
         .into()
 }
 
+fn audio_cpu_indicator(load_percent: f32) -> Element<'static, Message> {
+    let color = if load_percent >= 85.0 {
+        th::danger()
+    } else if load_percent >= 60.0 {
+        th::meter_yellow()
+    } else {
+        th::success()
+    };
+    let displayed = load_percent.round().clamp(0.0, 999.0) as u32;
+    let control = container(
+        row![
+            text("CPU").size(9).color(th::text_dim()),
+            text(format!("{displayed}%")).size(10).color(color),
+        ]
+        .spacing(4)
+        .align_y(iced::Alignment::Center),
+    )
+    .padding([4, 6])
+    .style(move |_theme: &Theme| container::Style {
+        background: Some(th::bg_elevated().into()),
+        border: iced::Border {
+            color,
+            width: 1.0,
+            radius: 3.0.into(),
+        },
+        ..Default::default()
+    });
+    let hint = container(
+        text("Audio processing time used per buffer. Red means the audio deadline is at risk.")
+            .size(10)
+            .color(th::text()),
+    )
+    .padding([5, 7])
+    .style(|_theme: &Theme| container::Style {
+        background: Some(th::bg_elevated().into()),
+        border: iced::Border {
+            color: th::border_light(),
+            width: 1.0,
+            radius: 3.0.into(),
+        },
+        ..Default::default()
+    });
+    tooltip(control, hint, tooltip::Position::Bottom)
+        .gap(6)
+        .padding(0)
+        .into()
+}
+
 impl App {
     pub(super) fn view_transport(&self) -> Element<'_, Message> {
         // Skip back button
@@ -349,6 +397,7 @@ impl App {
 
         let volume_icon = icons::icon(icons::VOLUME_2).size(14).color(th::text_dim());
         let stream_health = audio_stream_indicator(&self.state.audio_stream_health);
+        let cpu_load = audio_cpu_indicator(self.state.audio_cpu_load_percent);
 
         let transport = row![
             transport_buttons,
@@ -358,6 +407,7 @@ impl App {
             stream_health,
             volume_icon,
             master_meter_canvas,
+            cpu_load,
             row![bpm_input, bpm_spinner]
                 .spacing(2)
                 .align_y(iced::Alignment::Center),

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -583,6 +583,7 @@ impl AppState {
             AudioStreamEvent::Error(cause) => {
                 self.status_text = format!("Audio stream error: {cause}");
                 self.audio_stream_health = AudioStreamHealth::Error(cause);
+                self.audio_cpu_load_percent = 0.0;
             }
             AudioStreamEvent::Rebuilding => {
                 self.status_text = "Rebuilding audio stream…".into();
@@ -593,6 +594,15 @@ impl AppState {
                 self.audio_stream_health = AudioStreamHealth::Running;
             }
         }
+    }
+
+    pub fn update_audio_cpu_load(&mut self, measured_percent: Option<f32>) {
+        self.audio_cpu_load_percent =
+            if matches!(self.audio_stream_health, AudioStreamHealth::Running) {
+                measured_percent.unwrap_or(0.0)
+            } else {
+                0.0
+            };
     }
 
     pub fn position_seconds(&self) -> f64 {
@@ -784,7 +794,10 @@ mod audio_stream_health_tests {
 
     #[test]
     fn stream_error_and_recovery_update_persistent_health_and_status() {
-        let mut state = AppState::default();
+        let mut state = AppState {
+            audio_cpu_load_percent: 45.0,
+            ..AppState::default()
+        };
 
         state.apply_audio_stream_event(AudioStreamEvent::Error(
             "device disconnected mid-session".into(),
@@ -797,6 +810,7 @@ mod audio_stream_health_tests {
             state.status_text,
             "Audio stream error: device disconnected mid-session"
         );
+        assert_eq!(state.audio_cpu_load_percent, 0.0);
 
         state.apply_audio_stream_event(AudioStreamEvent::Rebuilding);
         assert_eq!(state.audio_stream_health, AudioStreamHealth::Rebuilding);

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -439,6 +439,8 @@ pub struct AppState {
     // Metering (master)
     pub peak_l: f32,
     pub peak_r: f32,
+    /// Smoothed audio callback work as a percentage of its buffer deadline.
+    pub audio_cpu_load_percent: f32,
     /// Spectrum analyser fed by the engine's per-track tap (follows
     /// the selected track); drawn behind the channel EQ curve.
     pub spectrum: crate::spectrum::SpectrumState,
@@ -511,6 +513,7 @@ impl Default for AppState {
             },
             peak_l: 0.0,
             peak_r: 0.0,
+            audio_cpu_load_percent: 0.0,
             spectrum: crate::spectrum::SpectrumState::default(),
             status_text: "Ready — Add a track to get started".to_string(),
             export_progress: None,


### PR DESCRIPTION
## Summary
- measure audio processing time against each device buffer deadline in the real-time callback
- publish a smoothed, lock-free CPU load value to the UI
- show a compact CPU percentage between the master level meter and tempo controls
- use success/warning/danger states to make deadline pressure visible

## Verification
- `cargo test -p vibez-audio-io audio_stream --lib`
- `cargo test -p vibez-ui views_transport --lib`
- `cargo clippy -p vibez-audio-io -p vibez-ui --all-targets -- -D warnings`
- `cargo fmt --all -- --check`