### PR TITLE
feat(project): add recent projects submenu

### DIFF
--- a/crates/vibez-ui/src/app/menu_lifecycle.rs
+++ b/crates/vibez-ui/src/app/menu_lifecycle.rs
@@ -16,7 +16,10 @@ pub(super) fn dismiss(state: &mut AppState, overlay: MenuOverlay) -> bool {
 
     match overlay {
         MenuOverlay::ArrangementContext => state.view.context_menu = None,
-        MenuOverlay::File => state.project.file_menu_open = false,
+        MenuOverlay::File => {
+            state.project.file_menu_open = false;
+            state.project.recent_projects_open = false;
+        }
         MenuOverlay::Edit => state.view.edit_menu_open = false,
         MenuOverlay::About => state.about_open = false,
     }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -215,6 +215,8 @@ impl App {
         // here rather than at the render site so a hand-edited ui.json
         // cannot open the window at an unusable size.
         let interface_scale = ui_settings.clamped_interface_scale();
+        let recent_project_paths =
+            crate::ui_settings::normalize_recent_projects(ui_settings.recent_project_paths.clone());
 
         let (stream, sample_rate, audio_stream_health) =
             match AudioOutputStream::open(engine, Some(512)) {
@@ -296,6 +298,10 @@ impl App {
             update_check: crate::update_check::UpdateCheckState {
                 enabled: ui_settings.check_for_updates,
                 last_check_unix: ui_settings.last_update_check_unix,
+                ..Default::default()
+            },
+            project: crate::state::ProjectState {
+                recent_project_paths,
                 ..Default::default()
             },
             view: crate::state::ViewState {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -1,7 +1,7 @@
 //! Split out of app.rs; inherent methods on [`super::App`].
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use vibez_core::effect::EffectType;
 
@@ -293,6 +293,15 @@ impl App {
             path,
         );
         if self.state.project.recent_project_paths != before {
+            self.persist_ui_settings();
+        }
+    }
+
+    pub(super) fn forget_recent_project(&mut self, path: &Path) {
+        if crate::ui_settings::forget_recent_project(
+            &mut self.state.project.recent_project_paths,
+            path,
+        ) {
             self.persist_ui_settings();
         }
     }

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -117,6 +117,7 @@ impl App {
         self.state.view.context_menu = None;
         self.state.devices.context_menu = None;
         self.state.project.file_menu_open = false;
+        self.state.project.recent_projects_open = false;
         self.state.project.unresolved_clips.clear();
         self.state.view.editing_track_name = None;
         self.state.view.editing_clip_name = None;
@@ -256,6 +257,7 @@ impl App {
 
     pub(super) fn persist_ui_settings(&mut self) {
         let settings = UiSettings {
+            recent_project_paths: self.state.project.recent_project_paths.clone(),
             perform_input_mapping: self.state.perform.input_mapping.clone(),
             fixed_computer_velocity: self.state.perform.fixed_computer_velocity(),
             track_mute_quantization: self.state.perform.track_mute_quantization(),
@@ -281,6 +283,17 @@ impl App {
         };
         if let Err(err) = settings.save() {
             self.state.status_text = format!("UI settings save error: {err}");
+        }
+    }
+
+    pub(super) fn remember_recent_project(&mut self, path: PathBuf) {
+        let before = self.state.project.recent_project_paths.clone();
+        crate::ui_settings::remember_recent_project(
+            &mut self.state.project.recent_project_paths,
+            path,
+        );
+        if self.state.project.recent_project_paths != before {
+            self.persist_ui_settings();
         }
     }
 

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -267,8 +267,8 @@ impl App {
             Message::ProjectSavePathSelected(path) => {
                 return self.route_project_save_path_selected(path);
             }
-            Message::ProjectLoaded(result) => {
-                return self.route_project_loaded(*result);
+            Message::ProjectLoaded { path, result } => {
+                return self.route_project_loaded(path, *result);
             }
             Message::ProjectSaved(result) => {
                 return self.route_project_saved(*result);

--- a/crates/vibez-ui/src/app/update_project.rs
+++ b/crates/vibez-ui/src/app/update_project.rs
@@ -123,12 +123,16 @@ impl App {
     ) -> Task<Message> {
         if let Some(path) = path {
             self.state.status_text = format!("Opening {}...", path.display());
+            let completed_path = path.clone();
             let dropbox = self
                 .dropbox_client
                 .clone()
                 .map(|client| (client, self.dropbox_cache.clone()));
-            return Task::perform(load_project_async(path, dropbox), |result| {
-                Message::ProjectLoaded(Box::new(result))
+            return Task::perform(load_project_async(path, dropbox), move |result| {
+                Message::ProjectLoaded {
+                    path: completed_path.clone(),
+                    result: Box::new(result),
+                }
             });
         }
         Task::none()
@@ -160,6 +164,7 @@ impl App {
 
     pub(super) fn route_project_loaded(
         &mut self,
+        attempted_path: PathBuf,
         result: Result<ProjectLoadResult, String>,
     ) -> Task<Message> {
         match result {
@@ -169,6 +174,7 @@ impl App {
                 self.remember_recent_project(path);
             }
             Err(err) => {
+                self.forget_recent_project(&attempted_path);
                 self.state.status_text = format!("Project load error: {err}");
             }
         }

--- a/crates/vibez-ui/src/app/update_project.rs
+++ b/crates/vibez-ui/src/app/update_project.rs
@@ -53,6 +53,9 @@ impl App {
             self.apply_snapshot(snapshot);
             self.mark_project_dirty();
         }
+        if action.persist_ui_settings {
+            self.persist_ui_settings();
+        }
         Task::none()
     }
 
@@ -161,7 +164,9 @@ impl App {
     ) -> Task<Message> {
         match result {
             Ok(loaded) => {
+                let path = loaded.path.clone();
                 self.rebuild_from_loaded_project(loaded);
+                self.remember_recent_project(path);
             }
             Err(err) => {
                 self.state.status_text = format!("Project load error: {err}");
@@ -182,6 +187,7 @@ impl App {
             Ok(saved) => {
                 self.apply_saved_project_sources(&saved.project);
                 self.state.project.current_path = Some(saved.path.clone());
+                self.remember_recent_project(saved.path.clone());
                 self.state.project.dirty = !completion_is_current;
                 if !completion_is_current {
                     // An Untitled project can receive another edit while its

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -10,6 +10,7 @@ use iced::{Element, Length, Theme};
 
 use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::piano_roll::PianoRollMsg;
+use crate::domains::project::ProjectMsg;
 use crate::domains::view::ViewMsg;
 use vibez_core::effect::EffectType;
 use vibez_core::midi::InstrumentKind;
@@ -580,6 +581,34 @@ impl App {
         );
 
         let open_btn = make_menu_btn("Open...", icons::MUSIC, Message::OpenProject);
+        let recent_btn = button(
+            row![
+                icons::icon(icons::MUSIC).size(12).color(th::text()),
+                text("Recent Projects").size(12).color(th::text()),
+                horizontal_space(),
+                text("›")
+                    .size(16)
+                    .color(if self.state.project.recent_projects_open {
+                        th::accent()
+                    } else {
+                        th::text_dim()
+                    }),
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::Project(ProjectMsg::ToggleRecentProjects))
+        .padding([8, 16])
+        .width(Length::Fill)
+        .style(|_theme: &Theme, status| button::Style {
+            background: match status {
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
+                _ => None,
+            },
+            text_color: th::text(),
+            border: iced::Border::default(),
+            ..Default::default()
+        });
         let save_label = if self.state.project.dirty {
             "Save*"
         } else {
@@ -618,6 +647,7 @@ impl App {
         let menu_content = column![new_btn]
             .spacing(2)
             .push(open_btn)
+            .push(recent_btn)
             .push(save_btn)
             .push(save_as_btn)
             .push(export_btn)
@@ -636,10 +666,102 @@ impl App {
             ..Default::default()
         });
 
-        // Position below the header, near the File button
+        let recent_card = self.state.project.recent_projects_open.then(|| {
+            let mut items = column![text("RECENT PROJECTS").size(9).color(th::text_muted())]
+                .spacing(2)
+                .padding(4)
+                .width(Length::Fixed(320.0));
+            if self.state.project.recent_project_paths.is_empty() {
+                items = items.push(
+                    container(text("No recent projects").size(11).color(th::text_dim()))
+                        .padding([10, 12]),
+                );
+            } else {
+                for path in &self.state.project.recent_project_paths {
+                    let name = path
+                        .file_name()
+                        .unwrap_or(path.as_os_str())
+                        .to_string_lossy()
+                        .into_owned();
+                    let parent = path
+                        .parent()
+                        .map(|parent| parent.display().to_string())
+                        .unwrap_or_default();
+                    let open_path = path.clone();
+                    items = items.push(
+                        button(
+                            column![
+                                text(name).size(11).color(th::text()),
+                                text(parent).size(9).color(th::text_muted()),
+                            ]
+                            .spacing(1),
+                        )
+                        .on_press(Message::menu_item(
+                            MenuOverlay::File,
+                            Message::ProjectOpenPathSelected(Some(open_path)),
+                        ))
+                        .padding([6, 10])
+                        .width(Length::Fill)
+                        .style(|_theme: &Theme, status| button::Style {
+                            background: match status {
+                                button::Status::Hovered | button::Status::Pressed => {
+                                    Some(th::bg_hover().into())
+                                }
+                                _ => None,
+                            },
+                            text_color: th::text(),
+                            border: iced::Border::default(),
+                            ..Default::default()
+                        }),
+                    );
+                }
+                items = items.push(
+                    button(
+                        row![
+                            icons::icon(icons::TRASH_2).size(11).color(th::text_dim()),
+                            text("Clear Recent Projects").size(11).color(th::text_dim()),
+                        ]
+                        .spacing(6),
+                    )
+                    .on_press(Message::menu_item(
+                        MenuOverlay::File,
+                        Message::Project(ProjectMsg::ClearRecentProjects),
+                    ))
+                    .padding([8, 10])
+                    .width(Length::Fill)
+                    .style(|_theme: &Theme, status| button::Style {
+                        background: match status {
+                            button::Status::Hovered | button::Status::Pressed => {
+                                Some(th::bg_hover().into())
+                            }
+                            _ => None,
+                        },
+                        text_color: th::text_dim(),
+                        border: iced::Border::default(),
+                        ..Default::default()
+                    }),
+                );
+            }
+            container(items).style(|_theme: &Theme| container::Style {
+                background: Some(th::bg_surface().into()),
+                border: iced::Border {
+                    color: th::border(),
+                    width: 1.0,
+                    radius: 6.0.into(),
+                },
+                ..Default::default()
+            })
+        });
+
+        // Position below the header, near the File button.
+        let menus = if let Some(recent_card) = recent_card {
+            row![menu_card, recent_card].spacing(4)
+        } else {
+            row![menu_card]
+        };
         let padded = column![
             vertical_space().height(Length::Fixed(42.0)),
-            row![horizontal_space().width(Length::Fixed(60.0)), menu_card,]
+            row![horizontal_space().width(Length::Fixed(60.0)), menus,]
         ];
 
         mouse_area(container(padded).width(Length::Fill).height(Length::Fill))

--- a/crates/vibez-ui/src/domains/project.rs
+++ b/crates/vibez-ui/src/domains/project.rs
@@ -17,6 +17,8 @@ use crate::state::{ProjectSnapshot, ProjectState};
 #[derive(Debug, Clone)]
 pub enum ProjectMsg {
     ToggleFileMenu,
+    ToggleRecentProjects,
+    ClearRecentProjects,
     Undo,
     Redo,
 }
@@ -37,6 +39,8 @@ pub struct ProjectAction {
     pub status: Option<String>,
     /// Restore this snapshot (tears down and replays the engine).
     pub apply_snapshot: Option<ProjectSnapshot>,
+    /// Global recent-project history changed and must be saved to UI settings.
+    pub persist_ui_settings: bool,
 }
 
 impl ProjectState {
@@ -50,6 +54,20 @@ impl ProjectState {
         match msg {
             ProjectMsg::ToggleFileMenu => {
                 self.file_menu_open = !self.file_menu_open;
+                if !self.file_menu_open {
+                    self.recent_projects_open = false;
+                }
+            }
+            ProjectMsg::ToggleRecentProjects => {
+                if self.file_menu_open {
+                    self.recent_projects_open = !self.recent_projects_open;
+                }
+            }
+            ProjectMsg::ClearRecentProjects => {
+                self.recent_project_paths.clear();
+                self.recent_projects_open = false;
+                action.persist_ui_settings = true;
+                action.status = Some("Cleared recent projects".to_string());
             }
             ProjectMsg::Undo => {
                 let Some(snapshot) = self.history.pop_undo() else {
@@ -233,6 +251,28 @@ mod tests {
         assert_eq!(action.status.as_deref(), Some("Undo"));
         assert_eq!(p.history.undo.len(), 0);
         assert_eq!(p.history.redo.len(), 1);
+    }
+
+    #[test]
+    fn recent_projects_submenu_follows_the_file_menu_and_can_be_cleared() {
+        let mut project = ProjectState {
+            recent_project_paths: vec!["/projects/a.vzp".into()],
+            ..Default::default()
+        };
+
+        project.update(ProjectMsg::ToggleFileMenu, ctx());
+        project.update(ProjectMsg::ToggleRecentProjects, ctx());
+        assert!(project.file_menu_open);
+        assert!(project.recent_projects_open);
+
+        let action = project.update(ProjectMsg::ClearRecentProjects, ctx());
+        assert!(project.recent_project_paths.is_empty());
+        assert!(!project.recent_projects_open);
+        assert!(action.persist_ui_settings);
+
+        project.update(ProjectMsg::ToggleFileMenu, ctx());
+        assert!(!project.file_menu_open);
+        assert!(!project.recent_projects_open);
     }
 
     #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -390,7 +390,10 @@ pub enum Message {
     SaveProjectAs,
     ProjectOpenPathSelected(Option<PathBuf>),
     ProjectSavePathSelected(Option<PathBuf>),
-    ProjectLoaded(Box<Result<ProjectLoadResult, String>>),
+    ProjectLoaded {
+        path: PathBuf,
+        result: Box<Result<ProjectLoadResult, String>>,
+    },
     ProjectSaved(Box<ProjectSaveCompleted>),
 
     // Window close protection. The window is configured not to exit on its

--- a/crates/vibez-ui/src/state/snapshot.rs
+++ b/crates/vibez-ui/src/state/snapshot.rs
@@ -50,6 +50,8 @@ impl UndoGestureId {
 #[derive(Debug, Default)]
 pub struct ProjectState {
     pub file_menu_open: bool,
+    pub recent_projects_open: bool,
+    pub recent_project_paths: Vec<PathBuf>,
     pub current_path: Option<PathBuf>,
     pub dirty: bool,
     pub history: UndoHistory,

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -158,6 +158,12 @@ pub fn remember_recent_project(paths: &mut Vec<PathBuf>, path: PathBuf) {
     paths.truncate(RECENT_PROJECT_LIMIT);
 }
 
+pub fn forget_recent_project(paths: &mut Vec<PathBuf>, path: &Path) -> bool {
+    let previous_len = paths.len();
+    paths.retain(|existing| existing != path);
+    paths.len() != previous_len
+}
+
 impl UiSettings {
     pub fn settings_path() -> PathBuf {
         dirs::config_dir()
@@ -280,6 +286,31 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn failed_recent_project_is_pruned_without_touching_other_entries() {
+        let mut paths = vec![
+            PathBuf::from("/projects/a.vzp"),
+            PathBuf::from("/projects/missing.vzp"),
+            PathBuf::from("/projects/b.vzp"),
+        ];
+
+        assert!(forget_recent_project(
+            &mut paths,
+            Path::new("/projects/missing.vzp")
+        ));
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/projects/a.vzp"),
+                PathBuf::from("/projects/b.vzp")
+            ]
+        );
+        assert!(!forget_recent_project(
+            &mut paths,
+            Path::new("/projects/unknown.vzp")
+        ));
     }
 
     #[test]

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiSettings {
+    /// Most recently opened or successfully saved projects, newest first.
+    #[serde(default)]
+    pub recent_project_paths: Vec<PathBuf>,
     #[serde(default)]
     pub perform_input_mapping: crate::domains::perform::PerformInputMapping,
     #[serde(default = "default_fixed_computer_velocity")]
@@ -107,6 +110,7 @@ pub fn clamp_interface_scale(scale: f32) -> f32 {
 impl Default for UiSettings {
     fn default() -> Self {
         Self {
+            recent_project_paths: Vec::new(),
             perform_input_mapping: crate::domains::perform::PerformInputMapping::default(),
             fixed_computer_velocity: default_fixed_computer_velocity(),
             track_mute_quantization: vibez_core::perform::TrackMuteQuantization::default(),
@@ -131,6 +135,27 @@ impl Default for UiSettings {
             last_update_check_unix: None,
         }
     }
+}
+
+pub const RECENT_PROJECT_LIMIT: usize = 6;
+
+pub fn normalize_recent_projects(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut normalized = Vec::new();
+    for path in paths {
+        if !normalized.contains(&path) {
+            normalized.push(path);
+        }
+        if normalized.len() == RECENT_PROJECT_LIMIT {
+            break;
+        }
+    }
+    normalized
+}
+
+pub fn remember_recent_project(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    paths.retain(|existing| existing != &path);
+    paths.insert(0, path);
+    paths.truncate(RECENT_PROJECT_LIMIT);
 }
 
 impl UiSettings {
@@ -229,6 +254,39 @@ impl UiSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recent_projects_are_deduplicated_capped_and_promoted() {
+        let mut paths = normalize_recent_projects([
+            "/projects/a.vzp".into(),
+            "/projects/b.vzp".into(),
+            "/projects/a.vzp".into(),
+            "/projects/c.vzp".into(),
+            "/projects/d.vzp".into(),
+            "/projects/e.vzp".into(),
+            "/projects/f.vzp".into(),
+            "/projects/g.vzp".into(),
+        ]);
+        assert_eq!(paths.len(), RECENT_PROJECT_LIMIT);
+        assert_eq!(paths[0], PathBuf::from("/projects/a.vzp"));
+
+        remember_recent_project(&mut paths, "/projects/d.vzp".into());
+        assert_eq!(paths[0], PathBuf::from("/projects/d.vzp"));
+        assert_eq!(paths.len(), RECENT_PROJECT_LIMIT);
+        assert_eq!(
+            paths
+                .iter()
+                .filter(|path| path.as_path() == std::path::Path::new("/projects/d.vzp"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn old_settings_start_with_no_recent_projects() {
+        let loaded: UiSettings = serde_json::from_str("{}").unwrap();
+        assert!(loaded.recent_project_paths.is_empty());
+    }
 
     #[test]
     fn old_settings_receive_the_browser_width_default() {


### PR DESCRIPTION
## Summary
- add a Recent Projects submenu to File with filenames and parent paths
- keep the six most recent successful project opens/saves in global UI settings
- deduplicate and promote reopened projects to the top
- add Clear Recent Projects and preserve compatibility with existing settings files

## Verification
- `cargo test -p vibez-ui --lib` (492 passed)
- `cargo clippy -p vibez-ui --all-targets -- -D warnings`
- `cargo fmt --all -- --check`