### PR TITLE
Release v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5085,7 +5085,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibez"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "iced",
  "libloading 0.8.9",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-audio-io"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "audio_thread_priority",
  "cpal",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-dropbox"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64",
  "dirs 5.0.1",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-dsp"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "signalsmith-stretch",
  "vibez-core",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-engine"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "rtrb",
  "vibez-core",
@@ -5154,14 +5154,14 @@ dependencies = [
 
 [[package]]
 name = "vibez-instruments"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "vibez-core",
 ]
 
 [[package]]
 name = "vibez-plugin-host"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap-sys",
  "dirs 5.0.1",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-project"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "rusqlite",
  "serde",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-ui"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/vibez-daw/vibez"

--- a/README.md
+++ b/README.md
@@ -142,3 +142,7 @@ where a redundant-looking cast can be load-bearing on another target.
 ## License
 
 GPL-3.0-or-later. See [LICENSE](LICENSE).
+
+---
+
+This one's for you Mum 🥲 I miss you

--- a/crates/vibez-audio-io/src/audio_stream.rs
+++ b/crates/vibez-audio-io/src/audio_stream.rs
@@ -5,10 +5,10 @@
 //! inside the real-time audio callback.
 
 use std::fmt;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{
@@ -40,6 +40,39 @@ impl StreamHealth {
             CallbackAction::Process
         }
     }
+}
+
+/// Smoothed fraction of each device buffer deadline spent in the audio
+/// callback. Stored as basis points so the real-time writer and UI reader do
+/// not need a lock.
+#[derive(Clone, Default)]
+struct StreamCpuLoad(Arc<AtomicU32>);
+
+impl StreamCpuLoad {
+    fn record(&self, elapsed: Duration, frames: usize, sample_rate: u32) {
+        let instantaneous = callback_load_basis_points(elapsed, frames, sample_rate);
+        let previous = self.0.load(Ordering::Relaxed);
+        let smoothed = if previous == 0 {
+            instantaneous
+        } else {
+            (previous.saturating_mul(4) + instantaneous) / 5
+        };
+        self.0.store(smoothed, Ordering::Relaxed);
+    }
+
+    fn percent(&self) -> f32 {
+        self.0.load(Ordering::Relaxed) as f32 / 100.0
+    }
+}
+
+fn callback_load_basis_points(elapsed: Duration, frames: usize, sample_rate: u32) -> u32 {
+    if frames == 0 || sample_rate == 0 {
+        return 0;
+    }
+    let deadline_seconds = frames as f64 / sample_rate as f64;
+    ((elapsed.as_secs_f64() / deadline_seconds) * 10_000.0)
+        .round()
+        .clamp(0.0, 99_900.0) as u32
 }
 
 /// A presentation-facing transition in the output stream lifecycle.
@@ -181,6 +214,7 @@ pub struct AudioOutputStream {
     engine_slot: Arc<Mutex<Option<AudioEngine>>>,
     event_reporter: StreamEventReporter,
     event_rx: Receiver<AudioStreamEvent>,
+    cpu_load: StreamCpuLoad,
 }
 
 impl AudioOutputStream {
@@ -210,11 +244,13 @@ impl AudioOutputStream {
     ) -> Result<Self, AudioStreamError> {
         let engine_slot = Arc::new(Mutex::new(Some(engine)));
         let (event_reporter, event_rx) = StreamEventReporter::channel();
+        let cpu_load = StreamCpuLoad::default();
         let (stream, params) = Self::build_stream(
             Arc::clone(&engine_slot),
             device,
             buffer_size,
             event_reporter.clone(),
+            cpu_load.clone(),
         )?;
         Ok(Self {
             stream,
@@ -222,6 +258,7 @@ impl AudioOutputStream {
             engine_slot,
             event_reporter,
             event_rx,
+            cpu_load,
         })
     }
 
@@ -252,6 +289,7 @@ impl AudioOutputStream {
                 &device,
                 buffer_size,
                 self.event_reporter.clone(),
+                self.cpu_load.clone(),
             )?;
 
             self.stream = stream;
@@ -279,6 +317,7 @@ impl AudioOutputStream {
         device: &cpal::Device,
         buffer_size: Option<u32>,
         event_reporter: StreamEventReporter,
+        cpu_load: StreamCpuLoad,
     ) -> Result<(cpal::Stream, StreamParams), AudioStreamError> {
         let supported_config = device.default_output_config()?;
 
@@ -327,6 +366,7 @@ impl AudioOutputStream {
         let health = StreamHealth::default();
         let callback_health = health.clone();
         let error_reporter = event_reporter;
+        let callback_cpu_load = cpu_load;
 
         let stream = device.build_output_stream(
             &config,
@@ -366,14 +406,19 @@ impl AudioOutputStream {
 
                 // try_lock: never blocks the audio thread.  If the UI thread
                 // holds the lock during reconfigure, output silence.
+                let started = Instant::now();
+                let mut processed = false;
                 if let Ok(mut guard) = slot.try_lock() {
                     if let Some(engine) = guard.as_mut() {
                         engine.process(data, ch);
-                        return;
+                        processed = true;
                     }
                 }
                 // Fallback: silence
-                data.fill(0.0);
+                if !processed {
+                    data.fill(0.0);
+                }
+                callback_cpu_load.record(started.elapsed(), data.len() / ch, rt_sample_rate);
             },
             move |err| {
                 health.mark_failed();
@@ -428,6 +473,12 @@ impl AudioOutputStream {
     /// Return the next lifecycle event without blocking the UI thread.
     pub fn try_next_event(&self) -> Option<AudioStreamEvent> {
         self.event_rx.try_recv().ok()
+    }
+
+    /// Smoothed audio callback load as a percentage of the current buffer
+    /// deadline. Values over 100% mean the callback missed its deadline.
+    pub fn cpu_load_percent(&self) -> f32 {
+        self.cpu_load.percent()
     }
 }
 
@@ -485,6 +536,31 @@ mod tests {
 
         assert_eq!(health.callback_action(), CallbackAction::SilenceAndYield);
         assert_eq!(health.callback_action(), CallbackAction::SilenceAndYield);
+    }
+
+    #[test]
+    fn callback_load_compares_processing_time_with_the_device_deadline() {
+        assert_eq!(
+            callback_load_basis_points(Duration::from_millis(5), 480, 48_000),
+            5_000
+        );
+        assert_eq!(
+            callback_load_basis_points(Duration::from_millis(12), 480, 48_000),
+            12_000
+        );
+        assert_eq!(
+            callback_load_basis_points(Duration::from_secs(1), 0, 48_000),
+            0
+        );
+    }
+
+    #[test]
+    fn callback_load_is_smoothed_without_locking_the_audio_thread() {
+        let load = StreamCpuLoad::default();
+        load.record(Duration::from_millis(5), 480, 48_000);
+        assert_eq!(load.percent(), 50.0);
+        load.record(Duration::from_millis(10), 480, 48_000);
+        assert_eq!(load.percent(), 60.0);
     }
 
     #[test]

--- a/crates/vibez-core/src/perform.rs
+++ b/crates/vibez-core/src/perform.rs
@@ -405,8 +405,48 @@ impl std::fmt::Display for SectionLaunchQuantization {
     }
 }
 
-/// Track Mutes accept every reusable grid boundary and no Section-only policy.
-pub type TrackMuteQuantization = MusicalBoundary;
+/// Musical boundary at which a queued Track Mute becomes effective.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackMuteQuantization {
+    #[default]
+    Immediate,
+    OneBeat,
+    OneBar,
+    EndOfSection,
+}
+
+impl TrackMuteQuantization {
+    pub const ALL: [Self; 4] = [
+        Self::Immediate,
+        Self::OneBeat,
+        Self::OneBar,
+        Self::EndOfSection,
+    ];
+
+    pub const fn label(self) -> &'static str {
+        if let Some(boundary) = self.musical_boundary() {
+            boundary.label()
+        } else {
+            "End of Section"
+        }
+    }
+
+    pub const fn musical_boundary(self) -> Option<MusicalBoundary> {
+        match self {
+            Self::Immediate => Some(MusicalBoundary::Immediate),
+            Self::OneBeat => Some(MusicalBoundary::OneBeat),
+            Self::OneBar => Some(MusicalBoundary::OneBar),
+            Self::EndOfSection => None,
+        }
+    }
+}
+
+impl std::fmt::Display for TrackMuteQuantization {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.label())
+    }
+}
 
 #[cfg(test)]
 mod track_mute_quantization_tests {
@@ -431,11 +471,15 @@ mod track_mute_quantization_tests {
         );
         assert_eq!(
             TrackMuteQuantization::ALL.map(TrackMuteQuantization::label),
-            ["Immediate", "1 Beat", "1 Bar"]
+            ["Immediate", "1 Beat", "1 Bar", "End of Section"]
         );
         assert_eq!(
             serde_json::to_string(&TrackMuteQuantization::OneBar).unwrap(),
             "\"one_bar\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TrackMuteQuantization::EndOfSection).unwrap(),
+            "\"end_of_section\""
         );
     }
 }

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -349,6 +349,7 @@ impl AudioEngine {
         }
         if section_ended {
             self.stop_section_record();
+            self.apply_end_of_section_track_mutes_at_queued_boundary();
             self.cancel_queued_track_mutes();
             let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
                 effective_at_samples: self.performance_position,

--- a/crates/vibez-engine/src/engine_automation_commands.rs
+++ b/crates/vibez-engine/src/engine_automation_commands.rs
@@ -136,6 +136,7 @@ impl AudioEngine {
         track.queued_mute = Some(QueuedTrackMute {
             muted,
             effective_at_samples,
+            end_of_section: quantization == TrackMuteQuantization::EndOfSection,
         });
         let _ = self.event_tx.push(EngineEvent::TrackMuteQueued {
             track_id,
@@ -159,6 +160,17 @@ impl AudioEngine {
                 .map(|queued| (track.id, queued))
         }) {
             self.apply_track_mute_at(track_id, queued.muted, queued.effective_at_samples);
+        }
+    }
+
+    pub(super) fn apply_end_of_section_track_mutes(&mut self, at_samples: u64) {
+        while let Some((track_id, muted)) = self.tracks.iter().find_map(|track| {
+            track
+                .queued_mute
+                .filter(|queued| queued.end_of_section)
+                .map(|queued| (track.id, queued.muted))
+        }) {
+            self.apply_track_mute_at(track_id, muted, at_samples);
         }
     }
 

--- a/crates/vibez-engine/src/engine_automation_commands.rs
+++ b/crates/vibez-engine/src/engine_automation_commands.rs
@@ -174,6 +174,17 @@ impl AudioEngine {
         }
     }
 
+    pub(super) fn apply_end_of_section_track_mutes_at_queued_boundary(&mut self) {
+        while let Some((track_id, queued)) = self.tracks.iter().find_map(|track| {
+            track
+                .queued_mute
+                .filter(|queued| queued.end_of_section)
+                .map(|queued| (track.id, queued))
+        }) {
+            self.apply_track_mute_at(track_id, queued.muted, queued.effective_at_samples);
+        }
+    }
+
     pub(super) fn cancel_queued_track_mutes(&mut self) {
         for track in &mut self.tracks {
             if track.queued_mute.take().is_some() {

--- a/crates/vibez-engine/src/engine_automation_commands.rs
+++ b/crates/vibez-engine/src/engine_automation_commands.rs
@@ -106,10 +106,21 @@ impl AudioEngine {
             return;
         }
 
-        let beats = quantization
-            .beats()
-            .expect("Immediate Track Mutes return before boundary resolution");
-        let effective_at_samples = self.next_grid_boundary(now, beats);
+        let effective_at_samples = if let Some(boundary) = quantization.musical_boundary() {
+            boundary
+                .beats()
+                .map_or(now, |beats| self.next_grid_boundary(now, beats))
+        } else {
+            self.active_section
+                .map(|active| {
+                    now.saturating_add(
+                        active
+                            .length_samples
+                            .saturating_sub(active.position_samples),
+                    )
+                })
+                .unwrap_or(now)
+        };
         if effective_at_samples <= now {
             let _ = self.event_tx.push(EngineEvent::TrackMuteQueued {
                 track_id,

--- a/crates/vibez-engine/src/engine_section_queue.rs
+++ b/crates/vibez-engine/src/engine_section_queue.rs
@@ -9,6 +9,7 @@ impl AudioEngine {
         mut prepared: Box<PreparedSectionPlaybackSource>,
         effective_at_samples: u64,
     ) {
+        self.apply_end_of_section_track_mutes(effective_at_samples);
         self.begin_performance_clock();
         let section_id = prepared.section_id;
         let length_samples = self.section_length_samples(prepared.length_beats);

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -293,6 +293,39 @@ fn end_of_section_track_mute_uses_the_active_section_wrap() {
 }
 
 #[test]
+fn end_of_section_track_mute_follows_an_earlier_section_transition() {
+    let (mut engine, mut commands, mut events, track_id) = playing_engine(0.6, 2.0);
+    while events.pop().is_ok() {}
+    commands
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::EndOfSection,
+        })
+        .unwrap();
+    commands
+        .push(EngineCommand::QueueSection {
+            prepared: source(SectionId::new(), track_id, 4.0, 0.8),
+            quantization: SectionLaunchQuantization::OneBeat,
+        })
+        .unwrap();
+
+    engine.process(&mut [0.0; 6], 1);
+
+    assert!(
+        std::iter::from_fn(|| events.pop().ok()).any(|event| matches!(
+            event,
+            EngineEvent::TrackMuteChanged {
+                track_id: event_track,
+                muted: true,
+                effective_at_samples: 4,
+            } if event_track == track_id
+        ))
+    );
+    assert!(engine.tracks()[0].mute);
+}
+
+#[test]
 fn requeue_returns_stale_residency_and_only_latest_section_transitions() {
     let (mut engine, mut commands, mut events, track_id) = playing_engine(0.1, 8.0);
     while events.pop().is_ok() {}

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -266,6 +266,33 @@ fn one_bar_and_end_of_section_use_their_exact_boundaries() {
 }
 
 #[test]
+fn end_of_section_track_mute_uses_the_active_section_wrap() {
+    let (mut engine, mut commands, mut events, track_id) = playing_engine(0.6, 2.0);
+    while events.pop().is_ok() {}
+    commands
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::EndOfSection,
+        })
+        .unwrap();
+
+    engine.process(&mut [0.0; 10], 1);
+
+    assert!(
+        std::iter::from_fn(|| events.pop().ok()).any(|event| matches!(
+            event,
+            EngineEvent::TrackMuteChanged {
+                track_id: event_track,
+                muted: true,
+                effective_at_samples: 8,
+            } if event_track == track_id
+        ))
+    );
+    assert!(engine.tracks()[0].mute);
+}
+
+#[test]
 fn requeue_returns_stale_residency_and_only_latest_section_transitions() {
     let (mut engine, mut commands, mut events, track_id) = playing_engine(0.1, 8.0);
     while events.pop().is_ok() {}

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -26,10 +26,20 @@ fn source(
     length_beats: f64,
     value: f32,
 ) -> Box<PreparedSectionPlaybackSource> {
+    source_with_looping(section_id, track_id, length_beats, value, true)
+}
+
+fn source_with_looping(
+    section_id: SectionId,
+    track_id: TrackId,
+    length_beats: f64,
+    value: f32,
+    looping: bool,
+) -> Box<PreparedSectionPlaybackSource> {
     Box::new(PreparedSectionPlaybackSource::new(
         section_id,
         length_beats,
-        true,
+        looping,
         vec![(
             track_id,
             PreparedPlaybackSource::new(
@@ -268,6 +278,49 @@ fn one_bar_and_end_of_section_use_their_exact_boundaries() {
 #[test]
 fn end_of_section_track_mute_uses_the_active_section_wrap() {
     let (mut engine, mut commands, mut events, track_id) = playing_engine(0.6, 2.0);
+    while events.pop().is_ok() {}
+    commands
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::EndOfSection,
+        })
+        .unwrap();
+
+    engine.process(&mut [0.0; 10], 1);
+
+    assert!(
+        std::iter::from_fn(|| events.pop().ok()).any(|event| matches!(
+            event,
+            EngineEvent::TrackMuteChanged {
+                track_id: event_track,
+                muted: true,
+                effective_at_samples: 8,
+            } if event_track == track_id
+        ))
+    );
+    assert!(engine.tracks()[0].mute);
+}
+
+#[test]
+fn end_of_section_track_mute_applies_when_a_one_shot_section_stops() {
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands.push(EngineCommand::SetBpm(120.0)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(source_with_looping(
+            SectionId::new(),
+            track_id,
+            2.0,
+            0.6,
+            false,
+        )))
+        .unwrap();
+    engine.process(&mut [0.0], 1);
     while events.pop().is_ok() {}
     commands
         .push(EngineCommand::QueueTrackMute {

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -24,6 +24,7 @@ const MUTE_RAMP_FRAMES: u32 = 64;
 pub(crate) struct QueuedTrackMute {
     pub muted: bool,
     pub effective_at_samples: u64,
+    pub end_of_section: bool,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -688,9 +688,12 @@ impl App {
     pub(super) fn poll_audio_stream_events(&mut self) {
         let mut events = Vec::new();
         if let Some(stream) = self._stream.as_ref() {
+            self.state.audio_cpu_load_percent = stream.cpu_load_percent();
             while let Some(event) = stream.try_next_event() {
                 events.push(event);
             }
+        } else {
+            self.state.audio_cpu_load_percent = 0.0;
         }
         for event in events {
             self.state.apply_audio_stream_event(event);

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -687,17 +687,18 @@ impl App {
 
     pub(super) fn poll_audio_stream_events(&mut self) {
         let mut events = Vec::new();
-        if let Some(stream) = self._stream.as_ref() {
-            self.state.audio_cpu_load_percent = stream.cpu_load_percent();
+        let measured_cpu_load = if let Some(stream) = self._stream.as_ref() {
             while let Some(event) = stream.try_next_event() {
                 events.push(event);
             }
+            Some(stream.cpu_load_percent())
         } else {
-            self.state.audio_cpu_load_percent = 0.0;
-        }
+            None
+        };
         for event in events {
             self.state.apply_audio_stream_event(event);
         }
+        self.state.update_audio_cpu_load(measured_cpu_load);
     }
 
     /// One frame of the 60fps subscription: drain engine events and

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -109,6 +109,7 @@ pub(super) fn seed_remote_availability(
         &remote.catalog,
         std::mem::take(&mut remote.availability),
     );
+    remote.mark_catalog_runtime_changed();
 }
 
 fn refreshed_remote_availability(
@@ -140,6 +141,71 @@ fn refreshed_remote_availability(
     availability
 }
 
+fn catalog_with_refresh_checkpoint(
+    previous_catalog: Arc<crate::remote_provider::RemoteCatalogSnapshot>,
+    checkpoint: Option<String>,
+) -> Arc<crate::remote_provider::RemoteCatalogSnapshot> {
+    let Some(checkpoint) = checkpoint else {
+        return previous_catalog;
+    };
+    if previous_catalog.checkpoint.as_deref() == Some(&checkpoint) {
+        return previous_catalog;
+    }
+    let mut catalog = (*previous_catalog).clone();
+    catalog.checkpoint = Some(checkpoint);
+    Arc::new(catalog)
+}
+
+fn rebase_remote_catalog_refresh(
+    mut data: crate::message::RemoteCatalogRefreshData,
+    live_catalog: Arc<crate::remote_provider::RemoteCatalogSnapshot>,
+    live_availability: std::collections::HashMap<String, crate::state::RemoteAvailability>,
+    live_runtime_revision: u64,
+) -> crate::message::RemoteCatalogRefreshData {
+    let base_by_id: std::collections::HashMap<_, _> = data
+        .base_catalog
+        .entries
+        .iter()
+        .map(|entry| (entry.provider_item_id.as_str(), entry))
+        .collect();
+    let live_by_id: std::collections::HashMap<_, _> = live_catalog
+        .entries
+        .iter()
+        .map(|entry| (entry.provider_item_id.as_str(), entry))
+        .collect();
+    for entry in &mut Arc::make_mut(&mut data.catalog).entries {
+        let Some(live_entry) = live_by_id.get(entry.provider_item_id.as_str()) else {
+            continue;
+        };
+        let base_metadata = base_by_id
+            .get(entry.provider_item_id.as_str())
+            .and_then(|base_entry| base_entry.derived_metadata.as_ref());
+        if live_entry.revision == entry.revision
+            && live_entry.derived_metadata.as_ref() != base_metadata
+        {
+            entry.derived_metadata = live_entry.derived_metadata.clone();
+        }
+    }
+
+    if let Some(availability) = data.availability.as_mut() {
+        for provider_item_id in data.base_availability.keys() {
+            if !live_availability.contains_key(provider_item_id) {
+                availability.remove(provider_item_id);
+            }
+        }
+        for (provider_item_id, live_state) in &live_availability {
+            if data.base_availability.get(provider_item_id) != Some(live_state) {
+                availability.insert(provider_item_id.clone(), live_state.clone());
+            }
+        }
+    }
+
+    data.base_catalog = live_catalog;
+    data.base_availability = live_availability;
+    data.base_runtime_revision = live_runtime_revision;
+    data
+}
+
 impl App {
     pub(super) fn prepare_remote_catalog_refresh(
         &mut self,
@@ -150,28 +216,29 @@ impl App {
         let generation = self.remote_catalog_request.current().unwrap_or(0);
         let previous_catalog = Arc::clone(&self.state.browser.remote.catalog);
         let previous_availability = self.state.browser.remote.availability.clone();
+        let base_runtime_revision = self.state.browser.remote.catalog_runtime_revision;
         let changes = std::mem::take(&mut self.remote_catalog_pending);
         let cache = self.dropbox_cache.clone();
         Task::perform(
             run_remote_refresh_preparer(move || {
                 if changes.is_empty() {
-                    let catalog = if previous_catalog.checkpoint == checkpoint {
-                        previous_catalog
-                    } else {
-                        let mut catalog = (*previous_catalog).clone();
-                        catalog.checkpoint = checkpoint;
-                        Arc::new(catalog)
-                    };
+                    let catalog =
+                        catalog_with_refresh_checkpoint(Arc::clone(&previous_catalog), checkpoint);
                     return crate::message::RemoteCatalogRefreshData {
                         generation,
                         pages,
                         catalog,
                         catalog_children: None,
                         availability: None,
+                        base_catalog: previous_catalog,
+                        base_availability: previous_availability,
+                        base_runtime_revision,
                         continuation,
                     };
                 }
 
+                let base_catalog = Arc::clone(&previous_catalog);
+                let base_availability = previous_availability.clone();
                 let mut catalog = (*previous_catalog).clone();
                 crate::remote_provider::reconcile_remote_catalog(
                     &mut catalog,
@@ -192,12 +259,40 @@ impl App {
                     catalog: Arc::new(catalog),
                     catalog_children: Some(catalog_children),
                     availability: Some(availability),
+                    base_catalog,
+                    base_availability,
+                    base_runtime_revision,
                     continuation,
                 }
             }),
-            |result| {
+            move |result| {
                 Message::RemoteCatalogRefreshPrepared(
-                    crate::message::RemoteCatalogRefreshResult::new(result),
+                    crate::message::RemoteCatalogRefreshResult::new(generation, result),
+                )
+            },
+        )
+    }
+
+    pub(super) fn rebase_remote_catalog_refresh(
+        &self,
+        data: crate::message::RemoteCatalogRefreshData,
+    ) -> Task<Message> {
+        let generation = data.generation;
+        let live_catalog = Arc::clone(&self.state.browser.remote.catalog);
+        let live_availability = self.state.browser.remote.availability.clone();
+        let live_runtime_revision = self.state.browser.remote.catalog_runtime_revision;
+        Task::perform(
+            run_remote_refresh_preparer(move || {
+                rebase_remote_catalog_refresh(
+                    data,
+                    live_catalog,
+                    live_availability,
+                    live_runtime_revision,
+                )
+            }),
+            move |result| {
+                Message::RemoteCatalogRefreshPrepared(
+                    crate::message::RemoteCatalogRefreshResult::new(generation, result),
                 )
             },
         )
@@ -281,6 +376,7 @@ impl App {
                 crate::state::RemoteAvailability::Fetching
             },
         );
+        self.state.browser.remote.mark_catalog_runtime_changed();
         self.state.status_text = format!("Importing Remote media: {}", entry.name);
         let client = self.dropbox_client.clone();
         let cache = self.dropbox_cache.clone();
@@ -373,6 +469,7 @@ impl App {
                 entry.path_lower,
                 crate::state::RemoteAvailability::ReconnectRequired,
             );
+            self.state.browser.remote.mark_catalog_runtime_changed();
             self.state.status_text =
                 "Reconnect Required · this Remote item is not in Media Cache".into();
             self.state
@@ -397,6 +494,7 @@ impl App {
                 crate::state::RemoteAvailability::Fetching
             },
         );
+        self.state.browser.remote.mark_catalog_runtime_changed();
         self.state.status_text = if cached {
             format!("Preparing cached Audition: {}", entry.name)
         } else {
@@ -519,5 +617,92 @@ mod tests {
             pending.as_ref().map(|entry| entry.path_lower.as_str()),
             Some("/winner.wav")
         );
+    }
+
+    #[test]
+    fn intermediate_refresh_without_a_checkpoint_preserves_the_saved_cursor() {
+        let previous = Arc::new(crate::remote_provider::RemoteCatalogSnapshot {
+            checkpoint: Some("saved-cursor".into()),
+            ..Default::default()
+        });
+
+        let refreshed = catalog_with_refresh_checkpoint(Arc::clone(&previous), None);
+
+        assert!(Arc::ptr_eq(&previous, &refreshed));
+        assert_eq!(refreshed.checkpoint.as_deref(), Some("saved-cursor"));
+    }
+
+    #[test]
+    fn prepared_refresh_rebases_materialized_metadata_and_availability() {
+        let base_catalog = Arc::new(crate::remote_provider::RemoteCatalogSnapshot {
+            entries: vec![crate::remote_provider::RemoteCatalogEntry {
+                provider_item_id: "/kick.wav".into(),
+                path: "/kick.wav".into(),
+                parent_path: String::new(),
+                name: "kick.wav".into(),
+                is_folder: false,
+                revision: Some("rev-1".into()),
+                size: Some(128),
+                derived_metadata: None,
+            }],
+            checkpoint: Some("old".into()),
+            ..Default::default()
+        });
+        let mut live_catalog = (*base_catalog).clone();
+        live_catalog.entries[0].derived_metadata = Some(vibez_dropbox::DerivedMetadata {
+            duration_seconds: 0.5,
+            channels: 1,
+            sample_rate: 44_100,
+            ..Default::default()
+        });
+        let live_catalog = Arc::new(live_catalog);
+        let base_availability = std::collections::HashMap::from([(
+            "/kick.wav".into(),
+            crate::state::RemoteAvailability::Fetching,
+        )]);
+        let live_availability = std::collections::HashMap::from([(
+            "/kick.wav".into(),
+            crate::state::RemoteAvailability::Cached,
+        )]);
+        let mut prepared_catalog = (*base_catalog).clone();
+        prepared_catalog.checkpoint = Some("new".into());
+        let data = crate::message::RemoteCatalogRefreshData {
+            generation: 4,
+            pages: 1,
+            catalog: Arc::new(prepared_catalog),
+            catalog_children: Some(Default::default()),
+            availability: Some(base_availability.clone()),
+            base_catalog,
+            base_availability,
+            base_runtime_revision: 7,
+            continuation: crate::message::RemoteCatalogRefreshContinuation::Complete,
+        };
+
+        let rebased =
+            rebase_remote_catalog_refresh(data, Arc::clone(&live_catalog), live_availability, 8);
+
+        assert_eq!(
+            rebased.catalog.entries[0]
+                .derived_metadata
+                .as_ref()
+                .unwrap()
+                .sample_rate,
+            44_100
+        );
+        assert_eq!(
+            rebased.availability.as_ref().unwrap().get("/kick.wav"),
+            Some(&crate::state::RemoteAvailability::Cached)
+        );
+        assert!(Arc::ptr_eq(&rebased.base_catalog, &live_catalog));
+        assert_eq!(rebased.base_runtime_revision, 8);
+    }
+
+    #[test]
+    fn refresh_errors_retain_their_generation_for_stale_result_rejection() {
+        let result =
+            crate::message::RemoteCatalogRefreshResult::new(23, Err("worker stopped".into()));
+
+        assert_eq!(result.generation(), 23);
+        assert!(matches!(result.take(), Some(Err(error)) if error == "worker stopped"));
     }
 }

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -12,6 +12,57 @@ pub(super) const REMOTE_SELECTION_DEBOUNCE: std::time::Duration =
     std::time::Duration::from_millis(200);
 pub(super) const REMOTE_CATALOG_SAVE_PAGE_INTERVAL: usize = 10;
 
+async fn run_remote_startup_loader<T, F>(loader: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    tokio::task::spawn_blocking(loader)
+        .await
+        .map_err(|error| format!("Remote catalog startup task failed: {error}"))
+}
+
+pub(super) fn remote_catalog_startup_task(cache: DropboxCache) -> Task<Message> {
+    Task::perform(
+        run_remote_startup_loader(move || {
+            let store = crate::remote_provider::RemoteCatalogStore::for_dropbox();
+            let (catalog, load_error) = match store.load() {
+                Ok(catalog) => (catalog, None),
+                Err(error) => (
+                    crate::remote_provider::RemoteCatalogSnapshot::default(),
+                    Some(error),
+                ),
+            };
+            let catalog_children = crate::remote_provider::build_remote_catalog_children(&catalog);
+            let cached_identities: std::collections::HashMap<String, Option<String>> =
+                cache.cached_identities().into_iter().collect();
+            let cached_provider_item_ids = catalog
+                .entries
+                .iter()
+                .filter(|entry| {
+                    cached_identities
+                        .get(&entry.provider_item_id)
+                        .is_some_and(|revision| revision.as_deref() == entry.revision.as_deref())
+                })
+                .map(|entry| entry.provider_item_id.clone())
+                .collect();
+            let cache_usage = cache.usage().unwrap_or_default();
+            crate::message::RemoteCatalogStartupData {
+                catalog,
+                catalog_children,
+                cached_provider_item_ids,
+                cache_usage,
+                load_error,
+            }
+        }),
+        |result| {
+            Message::RemoteCatalogStartupLoaded(crate::message::RemoteCatalogStartupResult::new(
+                result,
+            ))
+        },
+    )
+}
+
 fn queue_latest_remote_audition(slot: &mut Option<DropboxEntry>, entry: DropboxEntry) {
     *slot = Some(entry);
 }
@@ -212,7 +263,11 @@ impl App {
     }
 
     pub(super) fn handle_remote_catalog_refresh(&mut self) -> Task<Message> {
-        if self.state.browser.remote.catalog_state == crate::state::RemoteCatalogState::Refreshing {
+        if matches!(
+            self.state.browser.remote.catalog_state,
+            crate::state::RemoteCatalogState::Loading
+                | crate::state::RemoteCatalogState::Refreshing
+        ) {
             return Task::none();
         }
         let Some(client) = self.dropbox_client.clone() else {
@@ -334,6 +389,28 @@ impl App {
             return Task::none();
         };
         self.start_remote_import(entry, target, treatment)
+    }
+}
+
+#[cfg(test)]
+mod startup_tests {
+    use std::time::Duration;
+
+    use super::run_remote_startup_loader;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn remote_startup_loader_never_blocks_the_ui_executor() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let loader = tokio::spawn(run_remote_startup_loader(move || {
+            release_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("UI executor should release the background loader");
+            42
+        }));
+
+        tokio::task::yield_now().await;
+        assert!(release_tx.send(()).is_ok());
+        assert_eq!(loader.await.unwrap().unwrap(), 42);
     }
 }
 

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -22,6 +22,16 @@ where
         .map_err(|error| format!("Remote catalog startup task failed: {error}"))
 }
 
+async fn run_remote_refresh_preparer<T, F>(preparer: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    tokio::task::spawn_blocking(preparer)
+        .await
+        .map_err(|error| format!("Remote catalog refresh task failed: {error}"))
+}
+
 pub(super) fn remote_catalog_startup_task(cache: DropboxCache) -> Task<Message> {
     Task::perform(
         run_remote_startup_loader(move || {
@@ -94,32 +104,105 @@ pub(super) fn seed_remote_availability(
     cache: &DropboxCache,
     remote: &mut crate::state::RemoteUiState,
 ) {
+    remote.availability = refreshed_remote_availability(
+        cache,
+        &remote.catalog,
+        std::mem::take(&mut remote.availability),
+    );
+}
+
+fn refreshed_remote_availability(
+    cache: &DropboxCache,
+    catalog: &crate::remote_provider::RemoteCatalogSnapshot,
+    mut availability: std::collections::HashMap<String, crate::state::RemoteAvailability>,
+) -> std::collections::HashMap<String, crate::state::RemoteAvailability> {
     use crate::state::RemoteAvailability;
     let cached: std::collections::HashMap<String, Option<String>> =
         cache.cached_identities().into_iter().collect();
-    for entry in &remote.catalog.entries {
+    for entry in &catalog.entries {
         if entry.is_folder {
             continue;
         }
         let is_cached = cached
             .get(&entry.provider_item_id)
             .is_some_and(|revision| revision.as_deref() == entry.revision.as_deref());
-        match remote.availability.get(&entry.provider_item_id) {
+        match availability.get(&entry.provider_item_id) {
             Some(RemoteAvailability::Fetching) => {}
             Some(RemoteAvailability::Cached) if !is_cached => {
-                remote.availability.remove(&entry.provider_item_id);
+                availability.remove(&entry.provider_item_id);
             }
             _ if is_cached => {
-                remote
-                    .availability
-                    .insert(entry.provider_item_id.clone(), RemoteAvailability::Cached);
+                availability.insert(entry.provider_item_id.clone(), RemoteAvailability::Cached);
             }
             _ => {}
         }
     }
+    availability
 }
 
 impl App {
+    pub(super) fn prepare_remote_catalog_refresh(
+        &mut self,
+        pages: usize,
+        checkpoint: Option<String>,
+        continuation: crate::message::RemoteCatalogRefreshContinuation,
+    ) -> Task<Message> {
+        let generation = self.remote_catalog_request.current().unwrap_or(0);
+        let previous_catalog = Arc::clone(&self.state.browser.remote.catalog);
+        let previous_availability = self.state.browser.remote.availability.clone();
+        let changes = std::mem::take(&mut self.remote_catalog_pending);
+        let cache = self.dropbox_cache.clone();
+        Task::perform(
+            run_remote_refresh_preparer(move || {
+                if changes.is_empty() {
+                    let catalog = if previous_catalog.checkpoint == checkpoint {
+                        previous_catalog
+                    } else {
+                        let mut catalog = (*previous_catalog).clone();
+                        catalog.checkpoint = checkpoint;
+                        Arc::new(catalog)
+                    };
+                    return crate::message::RemoteCatalogRefreshData {
+                        generation,
+                        pages,
+                        catalog,
+                        catalog_children: None,
+                        availability: None,
+                        continuation,
+                    };
+                }
+
+                let mut catalog = (*previous_catalog).clone();
+                crate::remote_provider::reconcile_remote_catalog(
+                    &mut catalog,
+                    &crate::remote_provider::RemoteRefreshResult {
+                        pages: pages.max(1),
+                        changes,
+                        checkpoint,
+                        error: None,
+                    },
+                );
+                let catalog_children =
+                    crate::remote_provider::build_remote_catalog_children(&catalog);
+                let availability =
+                    refreshed_remote_availability(&cache, &catalog, previous_availability);
+                crate::message::RemoteCatalogRefreshData {
+                    generation,
+                    pages,
+                    catalog: Arc::new(catalog),
+                    catalog_children: Some(catalog_children),
+                    availability: Some(availability),
+                    continuation,
+                }
+            }),
+            |result| {
+                Message::RemoteCatalogRefreshPrepared(
+                    crate::message::RemoteCatalogRefreshResult::new(result),
+                )
+            },
+        )
+    }
+
     pub(super) fn remote_import_active(&self) -> bool {
         self.remote_import_request.is_active()
     }
@@ -175,32 +258,6 @@ impl App {
                 result,
             },
         )
-    }
-
-    /// Reconcile the pages accumulated since the last flush into the catalog
-    /// and rebuild the derived lookups. Returns whether anything changed.
-    pub(super) fn flush_remote_catalog_pages(
-        &mut self,
-        pages: usize,
-        checkpoint: Option<String>,
-    ) -> bool {
-        if self.remote_catalog_pending.is_empty() && checkpoint.is_none() {
-            return false;
-        }
-        let changes = std::mem::take(&mut self.remote_catalog_pending);
-        crate::remote_provider::reconcile_remote_catalog(
-            &mut self.state.browser.remote.catalog,
-            &crate::remote_provider::RemoteRefreshResult {
-                pages: pages.max(1),
-                changes,
-                checkpoint,
-                error: None,
-            },
-        );
-        self.state.browser.remote.rebuild_catalog_children();
-        self.state.browser.remote.refresh_items = self.state.browser.remote.catalog.entries.len();
-        self.reseed_remote_availability();
-        true
     }
 
     pub(super) fn start_remote_import(
@@ -396,7 +453,7 @@ impl App {
 mod startup_tests {
     use std::time::Duration;
 
-    use super::run_remote_startup_loader;
+    use super::{run_remote_refresh_preparer, run_remote_startup_loader};
 
     #[tokio::test(flavor = "current_thread")]
     async fn remote_startup_loader_never_blocks_the_ui_executor() {
@@ -411,6 +468,21 @@ mod startup_tests {
         tokio::task::yield_now().await;
         assert!(release_tx.send(()).is_ok());
         assert_eq!(loader.await.unwrap().unwrap(), 42);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn remote_refresh_preparation_never_blocks_the_ui_executor() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let preparation = tokio::spawn(run_remote_refresh_preparer(move || {
+            release_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("UI executor should release Remote refresh preparation");
+            42
+        }));
+
+        tokio::task::yield_now().await;
+        assert!(release_tx.send(()).is_ok());
+        assert_eq!(preparation.await.unwrap().unwrap(), 42);
     }
 }
 

--- a/crates/vibez-ui/src/app/menu_lifecycle.rs
+++ b/crates/vibez-ui/src/app/menu_lifecycle.rs
@@ -16,7 +16,10 @@ pub(super) fn dismiss(state: &mut AppState, overlay: MenuOverlay) -> bool {
 
     match overlay {
         MenuOverlay::ArrangementContext => state.view.context_menu = None,
-        MenuOverlay::File => state.project.file_menu_open = false,
+        MenuOverlay::File => {
+            state.project.file_menu_open = false;
+            state.project.recent_projects_open = false;
+        }
         MenuOverlay::Edit => state.view.edit_menu_open = false,
         MenuOverlay::About => state.about_open = false,
     }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -243,7 +243,6 @@ impl App {
             budget_bytes: ui_settings.media_cache_budget_bytes,
             automatic_eviction: ui_settings.media_cache_automatic_eviction,
         });
-        let cache_usage = dropbox_cache.usage().unwrap_or_default();
         let resolved_key = load_app_key_with_env_override(&dropbox_settings);
         let dropbox_client = match (&resolved_key, &dropbox_settings.tokens) {
             (Some(key), Some(tokens)) => {
@@ -251,39 +250,16 @@ impl App {
             }
             _ => None,
         };
-        let catalog_store = crate::remote_provider::RemoteCatalogStore::for_dropbox();
-        let (remote_catalog, mut remote_catalog_state) = match catalog_store.load() {
-            Ok(catalog) => (catalog, crate::state::RemoteCatalogState::Ready),
-            Err(error) => (
-                crate::remote_provider::RemoteCatalogSnapshot::default(),
-                crate::state::RemoteCatalogState::Stale { error },
-            ),
-        };
-        if dropbox_client.is_none()
-            && matches!(
-                remote_catalog_state,
-                crate::state::RemoteCatalogState::Ready
-            )
-        {
-            remote_catalog_state = crate::state::RemoteCatalogState::AuthenticationRequired {
-                error: "Sign in to refresh; showing the last saved Remote catalog".into(),
-            };
-        }
-        let mut remote_ui_state = crate::state::RemoteUiState {
+        let remote_ui_state = crate::state::RemoteUiState {
             connected: dropbox_client.is_some(),
             account_email: dropbox_settings.account_email.clone(),
             app_key_input: dropbox_settings.app_key.clone().unwrap_or_default(),
             has_app_key: resolved_key.is_some(),
-            catalog: remote_catalog,
-            catalog_state: remote_catalog_state,
-            cache_usage_bytes: cache_usage.bytes,
-            cache_entries: cache_usage.entries,
+            catalog_state: crate::state::RemoteCatalogState::Loading,
             cache_budget_bytes: ui_settings.media_cache_budget_bytes,
             cache_automatic_eviction: ui_settings.media_cache_automatic_eviction,
             ..Default::default()
         };
-        remote_ui_state.rebuild_catalog_children();
-        dropbox_io::seed_remote_availability(&dropbox_cache, &mut remote_ui_state);
 
         let mut state = AppState {
             transport: crate::state::TransportState {
@@ -430,11 +406,8 @@ impl App {
                 })
             })
         }));
-        let remote_startup_task = if app.dropbox_client.is_some() {
-            Task::done(Message::RefreshRemoteConnection)
-        } else {
-            Task::none()
-        };
+        let remote_startup_task =
+            dropbox_io::remote_catalog_startup_task(app.dropbox_cache.clone());
         let plugin_catalog_startup_task = if app.state.plugin_settings.cache_needs_refresh() {
             Task::done(Message::ScanPlugins)
         } else {

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -215,6 +215,8 @@ impl App {
         // here rather than at the render site so a hand-edited ui.json
         // cannot open the window at an unusable size.
         let interface_scale = ui_settings.clamped_interface_scale();
+        let recent_project_paths =
+            crate::ui_settings::normalize_recent_projects(ui_settings.recent_project_paths.clone());
 
         let (stream, sample_rate, audio_stream_health) =
             match AudioOutputStream::open(engine, Some(512)) {
@@ -296,6 +298,10 @@ impl App {
             update_check: crate::update_check::UpdateCheckState {
                 enabled: ui_settings.check_for_updates,
                 last_check_unix: ui_settings.last_update_check_unix,
+                ..Default::default()
+            },
+            project: crate::state::ProjectState {
+                recent_project_paths,
                 ..Default::default()
             },
             view: crate::state::ViewState {

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -1,7 +1,7 @@
 //! Split out of app.rs; inherent methods on [`super::App`].
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use vibez_core::effect::EffectType;
 
@@ -293,6 +293,15 @@ impl App {
             path,
         );
         if self.state.project.recent_project_paths != before {
+            self.persist_ui_settings();
+        }
+    }
+
+    pub(super) fn forget_recent_project(&mut self, path: &Path) {
+        if crate::ui_settings::forget_recent_project(
+            &mut self.state.project.recent_project_paths,
+            path,
+        ) {
             self.persist_ui_settings();
         }
     }

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -117,6 +117,7 @@ impl App {
         self.state.view.context_menu = None;
         self.state.devices.context_menu = None;
         self.state.project.file_menu_open = false;
+        self.state.project.recent_projects_open = false;
         self.state.project.unresolved_clips.clear();
         self.state.view.editing_track_name = None;
         self.state.view.editing_clip_name = None;
@@ -256,6 +257,7 @@ impl App {
 
     pub(super) fn persist_ui_settings(&mut self) {
         let settings = UiSettings {
+            recent_project_paths: self.state.project.recent_project_paths.clone(),
             perform_input_mapping: self.state.perform.input_mapping.clone(),
             fixed_computer_velocity: self.state.perform.fixed_computer_velocity(),
             track_mute_quantization: self.state.perform.track_mute_quantization(),
@@ -281,6 +283,17 @@ impl App {
         };
         if let Err(err) = settings.save() {
             self.state.status_text = format!("UI settings save error: {err}");
+        }
+    }
+
+    pub(super) fn remember_recent_project(&mut self, path: PathBuf) {
+        let before = self.state.project.recent_project_paths.clone();
+        crate::ui_settings::remember_recent_project(
+            &mut self.state.project.recent_project_paths,
+            path,
+        );
+        if self.state.project.recent_project_paths != before {
+            self.persist_ui_settings();
         }
     }
 

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -873,6 +873,9 @@ impl App {
                 completed_pages,
                 result,
             } => return self.on_remote_catalog_page_fetched(generation, completed_pages, result),
+            Message::RemoteCatalogRefreshPrepared(result) => {
+                return self.on_remote_catalog_refresh_prepared(result)
+            }
             Message::RemoteCatalogSaved {
                 generation,
                 next_checkpoint,

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -862,6 +862,9 @@ impl App {
                 self.state.status_text = format!("Dropbox connect failed: {err}");
             }
             Message::DisconnectDropbox => return self.on_disconnect_dropbox(),
+            Message::RemoteCatalogStartupLoaded(result) => {
+                return self.on_remote_catalog_startup_loaded(result)
+            }
             Message::RefreshRemoteConnection => {
                 return self.handle_remote_catalog_refresh();
             }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -267,8 +267,8 @@ impl App {
             Message::ProjectSavePathSelected(path) => {
                 return self.route_project_save_path_selected(path);
             }
-            Message::ProjectLoaded(result) => {
-                return self.route_project_loaded(*result);
+            Message::ProjectLoaded { path, result } => {
+                return self.route_project_loaded(path, *result);
             }
             Message::ProjectSaved(result) => {
                 return self.route_project_saved(*result);

--- a/crates/vibez-ui/src/app/update_project.rs
+++ b/crates/vibez-ui/src/app/update_project.rs
@@ -123,12 +123,16 @@ impl App {
     ) -> Task<Message> {
         if let Some(path) = path {
             self.state.status_text = format!("Opening {}...", path.display());
+            let completed_path = path.clone();
             let dropbox = self
                 .dropbox_client
                 .clone()
                 .map(|client| (client, self.dropbox_cache.clone()));
-            return Task::perform(load_project_async(path, dropbox), |result| {
-                Message::ProjectLoaded(Box::new(result))
+            return Task::perform(load_project_async(path, dropbox), move |result| {
+                Message::ProjectLoaded {
+                    path: completed_path.clone(),
+                    result: Box::new(result),
+                }
             });
         }
         Task::none()
@@ -160,6 +164,7 @@ impl App {
 
     pub(super) fn route_project_loaded(
         &mut self,
+        attempted_path: PathBuf,
         result: Result<ProjectLoadResult, String>,
     ) -> Task<Message> {
         match result {
@@ -169,6 +174,7 @@ impl App {
                 self.remember_recent_project(path);
             }
             Err(err) => {
+                self.forget_recent_project(&attempted_path);
                 self.state.status_text = format!("Project load error: {err}");
             }
         }

--- a/crates/vibez-ui/src/app/update_project.rs
+++ b/crates/vibez-ui/src/app/update_project.rs
@@ -53,6 +53,9 @@ impl App {
             self.apply_snapshot(snapshot);
             self.mark_project_dirty();
         }
+        if action.persist_ui_settings {
+            self.persist_ui_settings();
+        }
         Task::none()
     }
 
@@ -161,7 +164,9 @@ impl App {
     ) -> Task<Message> {
         match result {
             Ok(loaded) => {
+                let path = loaded.path.clone();
                 self.rebuild_from_loaded_project(loaded);
+                self.remember_recent_project(path);
             }
             Err(err) => {
                 self.state.status_text = format!("Project load error: {err}");
@@ -182,6 +187,7 @@ impl App {
             Ok(saved) => {
                 self.apply_saved_project_sources(&saved.project);
                 self.state.project.current_path = Some(saved.path.clone());
+                self.remember_recent_project(saved.path.clone());
                 self.state.project.dirty = !completion_is_current;
                 if !completion_is_current {
                     // An Untitled project can receive another edit while its

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -14,6 +14,65 @@ use crate::message::Message;
 use super::*;
 
 impl App {
+    pub(super) fn on_remote_catalog_startup_loaded(
+        &mut self,
+        result: crate::message::RemoteCatalogStartupResult,
+    ) -> Task<Message> {
+        let Some(result) = result.take() else {
+            return Task::none();
+        };
+        match result {
+            Ok(data) => {
+                let item_count = data.catalog.entries.len();
+                self.state.browser.remote.catalog = data.catalog;
+                self.state.browser.remote.catalog_children = data.catalog_children;
+                self.state.browser.remote.availability.clear();
+                self.state.browser.remote.availability.extend(
+                    data.cached_provider_item_ids
+                        .into_iter()
+                        .map(|provider_item_id| {
+                            (provider_item_id, crate::state::RemoteAvailability::Cached)
+                        }),
+                );
+                self.state.browser.remote.cache_usage_bytes = data.cache_usage.bytes;
+                self.state.browser.remote.cache_entries = data.cache_usage.entries;
+                self.state.browser.remote.refresh_items = item_count;
+                if let Some(error) = data.load_error {
+                    self.state.browser.remote.catalog_state =
+                        crate::state::RemoteCatalogState::Stale {
+                            error: error.clone(),
+                        };
+                    self.state.status_text = format!("Remote catalog load failed: {error}");
+                } else if self.dropbox_client.is_none() {
+                    self.state.browser.remote.catalog_state =
+                        crate::state::RemoteCatalogState::AuthenticationRequired {
+                            error: "Sign in to refresh; showing the last saved Remote catalog"
+                                .into(),
+                        };
+                    self.state.status_text =
+                        format!("Loaded {item_count} saved Remote catalog items");
+                } else {
+                    self.state.browser.remote.catalog_state =
+                        crate::state::RemoteCatalogState::Ready;
+                    self.state.status_text =
+                        format!("Loaded {item_count} saved Remote catalog items");
+                }
+            }
+            Err(error) => {
+                self.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Stale {
+                    error: error.clone(),
+                };
+                self.state.status_text = error;
+            }
+        }
+
+        if self.dropbox_client.is_some() {
+            self.handle_remote_catalog_refresh()
+        } else {
+            Task::none()
+        }
+    }
+
     pub(super) fn on_save_dropbox_app_key(&mut self) -> Task<Message> {
         let value = self.state.browser.remote.app_key_input.trim().to_string();
         self.dropbox_settings.app_key = if value.is_empty() { None } else { Some(value) };

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -34,6 +34,7 @@ impl App {
                             (provider_item_id, crate::state::RemoteAvailability::Cached)
                         }),
                 );
+                self.state.browser.remote.mark_catalog_runtime_changed();
                 self.state.browser.remote.cache_usage_bytes = data.cache_usage.bytes;
                 self.state.browser.remote.cache_entries = data.cache_usage.entries;
                 self.state.browser.remote.refresh_items = item_count;
@@ -212,6 +213,10 @@ impl App {
         &mut self,
         result: crate::message::RemoteCatalogRefreshResult,
     ) -> Task<Message> {
+        if !self.remote_catalog_request.is_current(result.generation()) {
+            std::thread::spawn(move || drop(result));
+            return Task::none();
+        }
         let Some(result) = result.take() else {
             return Task::none();
         };
@@ -225,9 +230,8 @@ impl App {
                 return Task::none();
             }
         };
-        if !self.remote_catalog_request.is_current(data.generation) {
-            std::thread::spawn(move || drop(data));
-            return Task::none();
+        if data.base_runtime_revision != self.state.browser.remote.catalog_runtime_revision {
+            return self.rebase_remote_catalog_refresh(data);
         }
 
         let retired_catalog =
@@ -498,6 +502,7 @@ impl App {
                 {
                     entry.derived_metadata = Some(materialized.metadata.clone());
                 }
+                self.state.browser.remote.mark_catalog_runtime_changed();
                 let persist = self.remote_catalog_persist_task(None);
                 let maintenance = self.media_cache_maintenance_task();
                 self.remote_audition_cache_lease = Some(materialized.lease);
@@ -535,6 +540,7 @@ impl App {
                     .remote
                     .availability
                     .insert(path_lower, availability);
+                self.state.browser.remote.mark_catalog_runtime_changed();
                 self.state
                     .browser
                     .fail_waveform_load(&source, error.clone());

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -24,7 +24,7 @@ impl App {
         match result {
             Ok(data) => {
                 let item_count = data.catalog.entries.len();
-                self.state.browser.remote.catalog = data.catalog;
+                self.state.browser.remote.catalog = Arc::new(data.catalog);
                 self.state.browser.remote.catalog_children = data.catalog_children;
                 self.state.browser.remote.availability.clear();
                 self.state.browser.remote.availability.extend(
@@ -146,14 +146,10 @@ impl App {
                 let next_checkpoint = page.checkpoint.clone();
                 self.remote_catalog_pending.extend(page.changes);
                 self.state.browser.remote.refresh_pages = pages;
-                // Reconciling re-sorts the catalog and rebuilds the
-                // child index, so batch it to save intervals and the
-                // final page instead of every page.
+                // Reconciliation is prepared off the UI thread at save
+                // intervals and at the final page.
                 let save_due = !has_more
                     || pages.is_multiple_of(super::dropbox_io::REMOTE_CATALOG_SAVE_PAGE_INTERVAL);
-                if save_due {
-                    self.flush_remote_catalog_pages(pages, (!has_more).then_some(page.checkpoint));
-                }
                 if has_more {
                     self.state.status_text = format!(
                         "Remote catalog: {} items available · fetching page {}…",
@@ -169,10 +165,13 @@ impl App {
                         return Task::none();
                     }
                     if save_due {
-                        // The next page is chained behind the save so
-                        // a persistence failure still stops the
-                        // refresh and only one save runs at a time.
-                        return self.remote_catalog_persist_task(Some(next_checkpoint));
+                        return self.prepare_remote_catalog_refresh(
+                            pages,
+                            None,
+                            crate::message::RemoteCatalogRefreshContinuation::FetchNext {
+                                checkpoint: next_checkpoint,
+                            },
+                        );
                     }
                     if let Some(client) = self.dropbox_client.clone() {
                         return super::dropbox_io::remote_catalog_page_task(
@@ -183,66 +182,137 @@ impl App {
                         );
                     }
                 } else {
-                    self.state.browser.remote.catalog_state =
-                        crate::state::RemoteCatalogState::Ready;
-                    self.state.status_text = format!(
-                        "Remote catalog refreshed: {} items across {pages} page(s)",
-                        self.state.browser.remote.refresh_items
+                    return self.prepare_remote_catalog_refresh(
+                        pages,
+                        Some(page.checkpoint),
+                        crate::message::RemoteCatalogRefreshContinuation::Complete,
                     );
-                    return self.remote_catalog_persist_task(None);
                 }
             }
             Err(error) => {
-                // Keep the pages that did arrive: reconcile them now
-                // and persist below so a mid-refresh failure cannot
-                // silently drop reconciled progress.
-                let flushed = self.flush_remote_catalog_pages(completed_pages, None);
-                if error.kind == crate::remote_provider::RemoteProviderErrorKind::CheckpointExpired
-                {
-                    // The provider invalidated our delta cursor; keep
-                    // the browsable catalog but restart the refresh
-                    // as a full listing from scratch.
-                    self.state.browser.remote.catalog.checkpoint = None;
-                    if let Some(client) = self.dropbox_client.clone() {
-                        self.state.browser.remote.refresh_pages = 0;
-                        self.state.status_text = "Remote checkpoint expired; rebuilding \
-                            the catalog from a full listing…"
-                            .into();
-                        return Task::batch([
-                            self.remote_catalog_persist_task(None),
-                            super::dropbox_io::remote_catalog_page_task(
-                                client, None, 0, generation,
-                            ),
-                        ]);
-                    }
+                if !self.remote_catalog_pending.is_empty() {
+                    return self.prepare_remote_catalog_refresh(
+                        completed_pages,
+                        None,
+                        crate::message::RemoteCatalogRefreshContinuation::Failed(error),
+                    );
                 }
-                self.state.browser.remote.catalog_state = if error.kind
-                    == crate::remote_provider::RemoteProviderErrorKind::Authentication
-                {
-                    crate::state::RemoteCatalogState::AuthenticationRequired {
-                        error: error.message.clone(),
-                    }
-                } else if completed_pages > 0 {
-                    crate::state::RemoteCatalogState::Partial {
-                        pages: completed_pages,
-                        error: error.message.clone(),
-                    }
-                } else {
-                    crate::state::RemoteCatalogState::Stale {
-                        error: error.message.clone(),
-                    }
-                };
-                self.state.status_text = format!(
-                    "Remote catalog kept {} available items after refresh error: {}",
-                    self.state.browser.remote.catalog.entries.len(),
-                    error.message
+                return self.finish_remote_catalog_refresh_error(
+                    generation,
+                    completed_pages,
+                    error,
+                    false,
                 );
-                if flushed {
-                    return self.remote_catalog_persist_task(None);
-                }
             }
         }
         Task::none()
+    }
+
+    pub(super) fn on_remote_catalog_refresh_prepared(
+        &mut self,
+        result: crate::message::RemoteCatalogRefreshResult,
+    ) -> Task<Message> {
+        let Some(result) = result.take() else {
+            return Task::none();
+        };
+        let data = match result {
+            Ok(data) => data,
+            Err(error) => {
+                self.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Stale {
+                    error: error.clone(),
+                };
+                self.state.status_text = error;
+                return Task::none();
+            }
+        };
+        if !self.remote_catalog_request.is_current(data.generation) {
+            std::thread::spawn(move || drop(data));
+            return Task::none();
+        }
+
+        let retired_catalog =
+            std::mem::replace(&mut self.state.browser.remote.catalog, data.catalog);
+        let retired_children = data.catalog_children.map(|children| {
+            std::mem::replace(&mut self.state.browser.remote.catalog_children, children)
+        });
+        let retired_availability = data.availability.map(|availability| {
+            std::mem::replace(&mut self.state.browser.remote.availability, availability)
+        });
+        // Large snapshots and their derived maps are destructed on a worker,
+        // too; replacing them must remain constant-time on the UI thread.
+        std::thread::spawn(move || {
+            drop((retired_catalog, retired_children, retired_availability));
+        });
+
+        self.state.browser.remote.refresh_items = self.state.browser.remote.catalog.entries.len();
+        match data.continuation {
+            crate::message::RemoteCatalogRefreshContinuation::FetchNext { checkpoint } => {
+                self.state.status_text = format!(
+                    "Remote catalog: {} items available · saving page {}…",
+                    self.state.browser.remote.refresh_items, data.pages
+                );
+                self.remote_catalog_persist_task(Some(checkpoint))
+            }
+            crate::message::RemoteCatalogRefreshContinuation::Complete => {
+                self.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Ready;
+                self.state.status_text = format!(
+                    "Remote catalog refreshed: {} items across {} page(s)",
+                    self.state.browser.remote.refresh_items, data.pages
+                );
+                self.remote_catalog_persist_task(None)
+            }
+            crate::message::RemoteCatalogRefreshContinuation::Failed(error) => {
+                self.finish_remote_catalog_refresh_error(data.generation, data.pages, error, true)
+            }
+        }
+    }
+
+    fn finish_remote_catalog_refresh_error(
+        &mut self,
+        generation: u64,
+        completed_pages: usize,
+        error: crate::remote_provider::RemoteProviderError,
+        reconciled_pages: bool,
+    ) -> Task<Message> {
+        if error.kind == crate::remote_provider::RemoteProviderErrorKind::CheckpointExpired {
+            // The provider invalidated our delta cursor; keep the browsable
+            // catalog but restart the refresh as a full listing from scratch.
+            Arc::make_mut(&mut self.state.browser.remote.catalog).checkpoint = None;
+            if let Some(client) = self.dropbox_client.clone() {
+                self.state.browser.remote.refresh_pages = 0;
+                self.state.status_text =
+                    "Remote checkpoint expired; rebuilding the catalog from a full listing…".into();
+                return Task::batch([
+                    self.remote_catalog_persist_task(None),
+                    super::dropbox_io::remote_catalog_page_task(client, None, 0, generation),
+                ]);
+            }
+        }
+        self.state.browser.remote.catalog_state =
+            if error.kind == crate::remote_provider::RemoteProviderErrorKind::Authentication {
+                crate::state::RemoteCatalogState::AuthenticationRequired {
+                    error: error.message.clone(),
+                }
+            } else if completed_pages > 0 {
+                crate::state::RemoteCatalogState::Partial {
+                    pages: completed_pages,
+                    error: error.message.clone(),
+                }
+            } else {
+                crate::state::RemoteCatalogState::Stale {
+                    error: error.message.clone(),
+                }
+            };
+        self.state.status_text = format!(
+            "Remote catalog kept {} available items after refresh error: {}",
+            self.state.browser.remote.catalog.entries.len(),
+            error.message
+        );
+        if reconciled_pages {
+            self.remote_catalog_persist_task(None)
+        } else {
+            Task::none()
+        }
     }
 
     pub(super) fn on_remote_catalog_saved(
@@ -421,11 +491,7 @@ impl App {
                     .remote
                     .availability
                     .insert(path_lower.clone(), crate::state::RemoteAvailability::Cached);
-                if let Some(entry) = self
-                    .state
-                    .browser
-                    .remote
-                    .catalog
+                if let Some(entry) = Arc::make_mut(&mut self.state.browser.remote.catalog)
                     .entries
                     .iter_mut()
                     .find(|entry| entry.provider_item_id == path_lower)

--- a/crates/vibez-ui/src/app/views_browser_remote.rs
+++ b/crates/vibez-ui/src/app/views_browser_remote.rs
@@ -141,6 +141,7 @@ impl App {
                 Some(format!("Partial refresh after {pages} page(s) · {error}"))
             }
             crate::state::RemoteCatalogState::Ready
+            | crate::state::RemoteCatalogState::Loading
             | crate::state::RemoteCatalogState::Refreshing => None,
         };
         if let Some(notice) = catalog_notice {
@@ -391,7 +392,9 @@ impl App {
                 .push(browser_row_divider());
         }
         if total_results == 0 {
-            let empty = if remote.catalog.entries.is_empty() {
+            let empty = if remote.catalog_state == crate::state::RemoteCatalogState::Loading {
+                "Loading saved Remote metadata…"
+            } else if remote.catalog.entries.is_empty() {
                 "No saved Remote metadata yet; connect and refresh when available"
             } else if searching {
                 "No media or folders match this scope"

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -10,6 +10,7 @@ use iced::{Element, Length, Theme};
 
 use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::piano_roll::PianoRollMsg;
+use crate::domains::project::ProjectMsg;
 use crate::domains::view::ViewMsg;
 use vibez_core::effect::EffectType;
 use vibez_core::midi::InstrumentKind;
@@ -580,6 +581,34 @@ impl App {
         );
 
         let open_btn = make_menu_btn("Open...", icons::MUSIC, Message::OpenProject);
+        let recent_btn = button(
+            row![
+                icons::icon(icons::MUSIC).size(12).color(th::text()),
+                text("Recent Projects").size(12).color(th::text()),
+                horizontal_space(),
+                text("›")
+                    .size(16)
+                    .color(if self.state.project.recent_projects_open {
+                        th::accent()
+                    } else {
+                        th::text_dim()
+                    }),
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::Project(ProjectMsg::ToggleRecentProjects))
+        .padding([8, 16])
+        .width(Length::Fill)
+        .style(|_theme: &Theme, status| button::Style {
+            background: match status {
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
+                _ => None,
+            },
+            text_color: th::text(),
+            border: iced::Border::default(),
+            ..Default::default()
+        });
         let save_label = if self.state.project.dirty {
             "Save*"
         } else {
@@ -618,6 +647,7 @@ impl App {
         let menu_content = column![new_btn]
             .spacing(2)
             .push(open_btn)
+            .push(recent_btn)
             .push(save_btn)
             .push(save_as_btn)
             .push(export_btn)
@@ -636,10 +666,102 @@ impl App {
             ..Default::default()
         });
 
-        // Position below the header, near the File button
+        let recent_card = self.state.project.recent_projects_open.then(|| {
+            let mut items = column![text("RECENT PROJECTS").size(9).color(th::text_muted())]
+                .spacing(2)
+                .padding(4)
+                .width(Length::Fixed(320.0));
+            if self.state.project.recent_project_paths.is_empty() {
+                items = items.push(
+                    container(text("No recent projects").size(11).color(th::text_dim()))
+                        .padding([10, 12]),
+                );
+            } else {
+                for path in &self.state.project.recent_project_paths {
+                    let name = path
+                        .file_name()
+                        .unwrap_or(path.as_os_str())
+                        .to_string_lossy()
+                        .into_owned();
+                    let parent = path
+                        .parent()
+                        .map(|parent| parent.display().to_string())
+                        .unwrap_or_default();
+                    let open_path = path.clone();
+                    items = items.push(
+                        button(
+                            column![
+                                text(name).size(11).color(th::text()),
+                                text(parent).size(9).color(th::text_muted()),
+                            ]
+                            .spacing(1),
+                        )
+                        .on_press(Message::menu_item(
+                            MenuOverlay::File,
+                            Message::ProjectOpenPathSelected(Some(open_path)),
+                        ))
+                        .padding([6, 10])
+                        .width(Length::Fill)
+                        .style(|_theme: &Theme, status| button::Style {
+                            background: match status {
+                                button::Status::Hovered | button::Status::Pressed => {
+                                    Some(th::bg_hover().into())
+                                }
+                                _ => None,
+                            },
+                            text_color: th::text(),
+                            border: iced::Border::default(),
+                            ..Default::default()
+                        }),
+                    );
+                }
+                items = items.push(
+                    button(
+                        row![
+                            icons::icon(icons::TRASH_2).size(11).color(th::text_dim()),
+                            text("Clear Recent Projects").size(11).color(th::text_dim()),
+                        ]
+                        .spacing(6),
+                    )
+                    .on_press(Message::menu_item(
+                        MenuOverlay::File,
+                        Message::Project(ProjectMsg::ClearRecentProjects),
+                    ))
+                    .padding([8, 10])
+                    .width(Length::Fill)
+                    .style(|_theme: &Theme, status| button::Style {
+                        background: match status {
+                            button::Status::Hovered | button::Status::Pressed => {
+                                Some(th::bg_hover().into())
+                            }
+                            _ => None,
+                        },
+                        text_color: th::text_dim(),
+                        border: iced::Border::default(),
+                        ..Default::default()
+                    }),
+                );
+            }
+            container(items).style(|_theme: &Theme| container::Style {
+                background: Some(th::bg_surface().into()),
+                border: iced::Border {
+                    color: th::border(),
+                    width: 1.0,
+                    radius: 6.0.into(),
+                },
+                ..Default::default()
+            })
+        });
+
+        // Position below the header, near the File button.
+        let menus = if let Some(recent_card) = recent_card {
+            row![menu_card, recent_card].spacing(4)
+        } else {
+            row![menu_card]
+        };
         let padded = column![
             vertical_space().height(Length::Fixed(42.0)),
-            row![horizontal_space().width(Length::Fixed(60.0)), menu_card,]
+            row![horizontal_space().width(Length::Fixed(60.0)), menus,]
         ];
 
         mouse_area(container(padded).width(Length::Fill).height(Length::Fill))

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -30,6 +30,15 @@ fn project_track_deletion_list_height(location_count: usize) -> f32 {
     }
 }
 
+const FILE_MENU_ITEM_HEIGHT: f32 = 32.0;
+const FILE_MENU_ITEM_SPACING: f32 = 2.0;
+const FILE_MENU_CONTENT_PADDING: f32 = 4.0;
+const RECENT_PROJECTS_MENU_ITEM_INDEX: usize = 2;
+
+fn file_menu_item_top(item_index: usize) -> f32 {
+    FILE_MENU_CONTENT_PADDING + item_index as f32 * (FILE_MENU_ITEM_HEIGHT + FILE_MENU_ITEM_SPACING)
+}
+
 impl App {
     pub(super) fn view_track_deletion_overlay(&self) -> Element<'_, Message> {
         let track_id = self
@@ -562,6 +571,7 @@ impl App {
             )
             .on_press(Message::menu_item(MenuOverlay::File, msg))
             .padding([8, 16])
+            .height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))
             .width(Length::Fill)
             .style(|_theme: &Theme, status| {
                 let bg = match status {
@@ -651,7 +661,7 @@ impl App {
         let about_btn = make_menu_btn("About vibez", icons::CIRCLE_DOT, Message::OpenAbout);
 
         let menu_content = column![new_btn]
-            .spacing(2)
+            .spacing(FILE_MENU_ITEM_SPACING)
             .push(open_btn)
             .push(recent_btn)
             .push(save_btn)
@@ -659,7 +669,7 @@ impl App {
             .push(export_btn)
             .push(settings_btn)
             .push(about_btn)
-            .padding(4)
+            .padding(FILE_MENU_CONTENT_PADDING)
             .width(Length::Fixed(220.0));
 
         let menu_card = container(menu_content).style(|_theme: &Theme| container::Style {
@@ -761,7 +771,13 @@ impl App {
 
         // Position below the header, near the File button.
         let menus = if let Some(recent_card) = recent_card {
-            row![menu_card, recent_card].spacing(4)
+            let aligned_recent_card = column![
+                vertical_space().height(Length::Fixed(file_menu_item_top(
+                    RECENT_PROJECTS_MENU_ITEM_INDEX
+                ))),
+                recent_card
+            ];
+            row![menu_card, aligned_recent_card].spacing(4)
         } else {
             row![menu_card]
         };
@@ -1022,7 +1038,7 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::project_track_deletion_list_height;
+    use super::{file_menu_item_top, project_track_deletion_list_height};
 
     #[test]
     fn deletion_location_list_grows_with_content_then_caps() {
@@ -1030,5 +1046,11 @@ mod tests {
         assert_eq!(project_track_deletion_list_height(1), 28.0);
         assert_eq!(project_track_deletion_list_height(2), 60.0);
         assert_eq!(project_track_deletion_list_height(8), 120.0);
+    }
+
+    #[test]
+    fn file_submenu_starts_at_its_parent_row() {
+        assert_eq!(file_menu_item_top(0), 4.0);
+        assert_eq!(file_menu_item_top(2), 72.0);
     }
 }

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -224,6 +224,12 @@ impl App {
                 "Ctrl+J",
                 Message::join_selected_clips(),
             ),
+            item(
+                icons::SCISSORS,
+                "Trim Track Mutes",
+                "",
+                Message::Arrangement(ArrangementMsg::TrimSelectedByTrackMutes),
+            ),
         ]
         .spacing(1)
         .padding(4)
@@ -758,6 +764,11 @@ impl App {
                     icons::COPY,
                     "Join Clips (Ctrl+J)".into(),
                     Message::join_selected_clips(),
+                ));
+                col = col.push(menu_btn(
+                    icons::SCISSORS,
+                    "Trim Track Mutes".into(),
+                    Message::Arrangement(ArrangementMsg::TrimSelectedByTrackMutes),
                 ));
 
                 // Rename clip

--- a/crates/vibez-ui/src/app/views_perform_pads.rs
+++ b/crates/vibez-ui/src/app/views_perform_pads.rs
@@ -173,7 +173,7 @@ impl App {
                     Some(self.state.perform.track_mute_quantization()),
                     |value| Message::Perform(PerformMsg::SetTrackMuteQuantization(value)),
                 )
-                .width(Length::Fixed(104.0))
+                .width(Length::Fixed(126.0))
                 .padding([4, 7])
                 .text_size(9);
                 row![

--- a/crates/vibez-ui/src/app/views_transport.rs
+++ b/crates/vibez-ui/src/app/views_transport.rs
@@ -60,6 +60,54 @@ fn audio_stream_indicator(health: &AudioStreamHealth) -> Element<'_, Message> {
         .into()
 }
 
+fn audio_cpu_indicator(load_percent: f32) -> Element<'static, Message> {
+    let color = if load_percent >= 85.0 {
+        th::danger()
+    } else if load_percent >= 60.0 {
+        th::meter_yellow()
+    } else {
+        th::success()
+    };
+    let displayed = load_percent.round().clamp(0.0, 999.0) as u32;
+    let control = container(
+        row![
+            text("CPU").size(9).color(th::text_dim()),
+            text(format!("{displayed}%")).size(10).color(color),
+        ]
+        .spacing(4)
+        .align_y(iced::Alignment::Center),
+    )
+    .padding([4, 6])
+    .style(move |_theme: &Theme| container::Style {
+        background: Some(th::bg_elevated().into()),
+        border: iced::Border {
+            color,
+            width: 1.0,
+            radius: 3.0.into(),
+        },
+        ..Default::default()
+    });
+    let hint = container(
+        text("Audio processing time used per buffer. Red means the audio deadline is at risk.")
+            .size(10)
+            .color(th::text()),
+    )
+    .padding([5, 7])
+    .style(|_theme: &Theme| container::Style {
+        background: Some(th::bg_elevated().into()),
+        border: iced::Border {
+            color: th::border_light(),
+            width: 1.0,
+            radius: 3.0.into(),
+        },
+        ..Default::default()
+    });
+    tooltip(control, hint, tooltip::Position::Bottom)
+        .gap(6)
+        .padding(0)
+        .into()
+}
+
 impl App {
     pub(super) fn view_transport(&self) -> Element<'_, Message> {
         // Skip back button
@@ -349,6 +397,7 @@ impl App {
 
         let volume_icon = icons::icon(icons::VOLUME_2).size(14).color(th::text_dim());
         let stream_health = audio_stream_indicator(&self.state.audio_stream_health);
+        let cpu_load = audio_cpu_indicator(self.state.audio_cpu_load_percent);
 
         let transport = row![
             transport_buttons,
@@ -358,6 +407,7 @@ impl App {
             stream_health,
             volume_icon,
             master_meter_canvas,
+            cpu_load,
             row![bpm_input, bpm_spinner]
                 .spacing(2)
                 .align_y(iced::Alignment::Center),

--- a/crates/vibez-ui/src/domains/arrangement/media_ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/media_ops.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use crate::message::{AudioQuantizeSuccess, AutoWarpOutcome, ClipWarpSuccess};
 use std::sync::Arc;
 
+use vibez_core::automation::{AutomationLane, AutomationTarget};
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::MidiNote;
 use vibez_engine::commands::EngineCommand;
@@ -61,7 +62,259 @@ fn visible_notes(clip: &UiNoteClip, local_start: f64, local_end: f64) -> Vec<Mid
     visible
 }
 
+/// Unmuted portions of `[start, end)` in project beats. Track Mute is a
+/// stepped lane and deliberately imposes no state before its first point, so
+/// uncaptured material before the first event is retained.
+fn unmuted_beat_ranges(lane: &AutomationLane, start: f64, end: f64) -> Vec<(f64, f64)> {
+    if end <= start {
+        return Vec::new();
+    }
+
+    let mut boundaries = vec![start];
+    boundaries.extend(
+        lane.points
+            .iter()
+            .map(|point| point.beat)
+            .filter(|beat| *beat > start && *beat < end),
+    );
+    boundaries.push(end);
+
+    boundaries
+        .windows(2)
+        .filter_map(|window| {
+            let range_start = window[0];
+            let range_end = window[1];
+            let muted = lane.value_at(range_start).is_some_and(|value| value >= 0.5);
+            (!muted && range_end > range_start).then_some((range_start, range_end))
+        })
+        .collect()
+}
+
 impl TimelineEditorState {
+    pub(super) fn op_trim_selected_by_track_mutes(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        ctx: ArrangementCtx,
+    ) -> ArrangementAction {
+        let mut action = ArrangementAction::default();
+        if self.selected_clips.is_empty() || ctx.samples_per_beat <= 0.0 {
+            action.status = Some("Select clips to trim by Track Mutes".to_string());
+            return action;
+        }
+
+        enum Replacement {
+            Audio {
+                track_id: TrackId,
+                original_id: ClipId,
+                clips: Vec<UiClip>,
+            },
+            Notes {
+                track_id: TrackId,
+                original_id: ClipId,
+                clips: Vec<UiNoteClip>,
+            },
+        }
+
+        let mut replacements = Vec::new();
+        for selection in self.selected_clips.iter().copied() {
+            let (track_id, clip_id) = match selection {
+                ArrangementSelection::AudioClip { track_id, clip_id }
+                | ArrangementSelection::NoteClip { track_id, clip_id } => (track_id, clip_id),
+            };
+            let Some(content) = self.find_content(track_id) else {
+                continue;
+            };
+            let Some(mute_lane) = content
+                .automation
+                .iter()
+                .find(|lane| lane.target == AutomationTarget::TrackMute)
+            else {
+                continue;
+            };
+
+            match selection {
+                ArrangementSelection::AudioClip { .. } => {
+                    let Some(clip) = content.clips.iter().find(|clip| clip.id == clip_id) else {
+                        continue;
+                    };
+                    let clip_start_beat = clip.position as f64 / ctx.samples_per_beat;
+                    let clip_end_sample = clip.position.saturating_add(clip.duration);
+                    let clip_end_beat = clip_end_sample as f64 / ctx.samples_per_beat;
+                    let ranges = unmuted_beat_ranges(mute_lane, clip_start_beat, clip_end_beat);
+                    let covers_original = ranges.as_slice() == [(clip_start_beat, clip_end_beat)];
+                    if covers_original {
+                        continue;
+                    }
+                    let clips = ranges
+                        .into_iter()
+                        .filter_map(|(start, end)| {
+                            let start_sample = ((start * ctx.samples_per_beat).round() as u64)
+                                .clamp(clip.position, clip_end_sample);
+                            let end_sample = ((end * ctx.samples_per_beat).round() as u64)
+                                .clamp(start_sample, clip_end_sample);
+                            (end_sample > start_sample).then(|| {
+                                let local_start = start_sample - clip.position;
+                                let mut fragment = clip.clone();
+                                fragment.id = ClipId::new();
+                                fragment.position = start_sample;
+                                fragment.source_offset =
+                                    audio_source_frame(clip, local_start) as u64;
+                                fragment.duration = end_sample - start_sample;
+                                fragment
+                            })
+                        })
+                        .collect();
+                    replacements.push(Replacement::Audio {
+                        track_id,
+                        original_id: clip_id,
+                        clips,
+                    });
+                }
+                ArrangementSelection::NoteClip { .. } => {
+                    let Some(clip) = content.note_clips.iter().find(|clip| clip.id == clip_id)
+                    else {
+                        continue;
+                    };
+                    let clip_end = clip.position_beats + clip.duration_beats;
+                    let ranges = unmuted_beat_ranges(mute_lane, clip.position_beats, clip_end);
+                    let covers_original = ranges.as_slice() == [(clip.position_beats, clip_end)];
+                    if covers_original {
+                        continue;
+                    }
+                    let clips = ranges
+                        .into_iter()
+                        .map(|(start, end)| {
+                            let local_start = start - clip.position_beats;
+                            let local_end = end - clip.position_beats;
+                            let mut fragment = clip.clone();
+                            fragment.id = ClipId::new();
+                            fragment.position_beats = start;
+                            fragment.duration_beats = end - start;
+                            fragment.notes = visible_notes(clip, local_start, local_end);
+                            fragment.selected_notes.clear();
+                            if fragment.loop_enabled {
+                                fragment.loop_start_beats = 0.0;
+                                fragment.loop_end_beats = fragment.duration_beats;
+                            }
+                            fragment
+                        })
+                        .collect();
+                    replacements.push(Replacement::Notes {
+                        track_id,
+                        original_id: clip_id,
+                        clips,
+                    });
+                }
+            }
+        }
+
+        if replacements.is_empty() {
+            action.status = Some("No selected clip material overlaps Track Mutes".to_string());
+            return action;
+        }
+
+        let trimmed_count = replacements.len();
+        let mut fragment_count = 0;
+        let mut new_selection = self.selected_clips.clone();
+        for replacement in replacements {
+            match replacement {
+                Replacement::Audio {
+                    track_id,
+                    original_id,
+                    clips,
+                } => {
+                    new_selection.remove(&ArrangementSelection::AudioClip {
+                        track_id,
+                        clip_id: original_id,
+                    });
+                    engine.send(EngineCommand::RemoveClip(track_id, original_id));
+                    if let Some(content) = self.find_content_mut(track_id) {
+                        content.clips.retain(|clip| clip.id != original_id);
+                    }
+                    for clip in &clips {
+                        engine.send(EngineCommand::AddClip {
+                            track_id,
+                            clip_id: clip.id,
+                            audio: Arc::clone(&clip.audio),
+                            position: clip.position,
+                            source_offset: clip.source_offset,
+                            duration: clip.duration,
+                            loop_enabled: clip.loop_enabled,
+                            loop_start: clip.loop_start,
+                            loop_end: clip.loop_end,
+                        });
+                        new_selection.insert(ArrangementSelection::AudioClip {
+                            track_id,
+                            clip_id: clip.id,
+                        });
+                    }
+                    fragment_count += clips.len();
+                    if let Some(content) = self.find_content_mut(track_id) {
+                        content.clips.extend(clips);
+                    }
+                }
+                Replacement::Notes {
+                    track_id,
+                    original_id,
+                    clips,
+                } => {
+                    new_selection.remove(&ArrangementSelection::NoteClip {
+                        track_id,
+                        clip_id: original_id,
+                    });
+                    engine.send(EngineCommand::RemoveNoteClip(track_id, original_id));
+                    if let Some(content) = self.find_content_mut(track_id) {
+                        content.note_clips.retain(|clip| clip.id != original_id);
+                    }
+                    for clip in &clips {
+                        engine.send(EngineCommand::AddNoteClip {
+                            track_id,
+                            clip_id: clip.id,
+                            position_beats: clip.position_beats,
+                            duration_beats: clip.duration_beats,
+                            loop_enabled: clip.loop_enabled,
+                            loop_start_beats: clip.loop_start_beats,
+                            loop_end_beats: clip.loop_end_beats,
+                            groove_grid: clip.groove_grid,
+                        });
+                        for note in &clip.notes {
+                            engine.send(EngineCommand::AddNote {
+                                track_id,
+                                clip_id: clip.id,
+                                note: *note,
+                            });
+                        }
+                        new_selection.insert(ArrangementSelection::NoteClip {
+                            track_id,
+                            clip_id: clip.id,
+                        });
+                    }
+                    fragment_count += clips.len();
+                    if let Some(content) = self.find_content_mut(track_id) {
+                        content.note_clips.extend(clips);
+                    }
+                }
+            }
+        }
+
+        self.selected_clips = new_selection;
+        self.selected_note_clip =
+            self.selected_clips
+                .iter()
+                .find_map(|selection| match selection {
+                    ArrangementSelection::NoteClip { track_id, clip_id } => {
+                        Some((*track_id, *clip_id))
+                    }
+                    ArrangementSelection::AudioClip { .. } => None,
+                });
+        action.status = Some(format!(
+            "Trimmed {trimmed_count} clip{} by Track Mutes · kept {fragment_count} fragment{}",
+            if trimmed_count == 1 { "" } else { "s" },
+            if fragment_count == 1 { "" } else { "s" },
+        ));
+        action
+    }
+
     pub(super) fn op_resize_audio_clip(
         &mut self,
         engine: &mut impl EngineHandle,

--- a/crates/vibez-ui/src/domains/arrangement/media_ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/media_ops.rs
@@ -79,15 +79,23 @@ fn unmuted_beat_ranges(lane: &AutomationLane, start: f64, end: f64) -> Vec<(f64,
     );
     boundaries.push(end);
 
-    boundaries
-        .windows(2)
-        .filter_map(|window| {
-            let range_start = window[0];
-            let range_end = window[1];
-            let muted = lane.value_at(range_start).is_some_and(|value| value >= 0.5);
-            (!muted && range_end > range_start).then_some((range_start, range_end))
-        })
-        .collect()
+    let mut ranges: Vec<(f64, f64)> = Vec::new();
+    for window in boundaries.windows(2) {
+        let range_start = window[0];
+        let range_end = window[1];
+        let muted = lane.value_at(range_start).is_some_and(|value| value >= 0.5);
+        if muted || range_end <= range_start {
+            continue;
+        }
+        if let Some((_, previous_end)) = ranges.last_mut() {
+            if *previous_end == range_start {
+                *previous_end = range_end;
+                continue;
+            }
+        }
+        ranges.push((range_start, range_end));
+    }
+    ranges
 }
 
 impl TimelineEditorState {

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -121,6 +121,9 @@ pub enum ArrangementMsg {
     },
     SplitSelectedAtPlayhead,
     JoinSelectedClips,
+    /// Replace selected clips with the portions where their track's captured
+    /// Track Mute automation is off.
+    TrimSelectedByTrackMutes,
     DeleteClipsInRegion {
         start_beats: f64,
         end_beats: f64,
@@ -184,6 +187,7 @@ impl ArrangementMsg {
                 | Self::SplitNoteClip { .. }
                 | Self::SplitSelectedAtPlayhead
                 | Self::JoinSelectedClips
+                | Self::TrimSelectedByTrackMutes
                 | Self::DeleteClipsInRegion { .. }
                 | Self::SplitClipsAtRegion { .. }
                 | Self::CreateClipFromSelection

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -913,6 +913,9 @@ impl TimelineEditorState {
             ArrangementMsg::JoinSelectedClips => {
                 return self.op_join_selected_clips(engine, ctx);
             }
+            ArrangementMsg::TrimSelectedByTrackMutes => {
+                return self.op_trim_selected_by_track_mutes(engine, ctx);
+            }
             ArrangementMsg::DeleteClipsInRegion {
                 start_beats,
                 end_beats,

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -983,6 +983,41 @@ fn trim_track_mutes_leaves_selected_clip_without_mute_automation_untouched() {
 }
 
 #[test]
+fn trim_track_mutes_ignores_redundant_unmuted_automation_points() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut a, 0, 0, 800);
+    let mut lane = AutomationLane::new(AutomationTarget::TrackMute);
+    for beat in [2.5, 6.0] {
+        lane.insert_point(AutomationPoint {
+            beat,
+            value: 0.0,
+            curve: 0.0,
+        });
+    }
+    a.tracks[0].automation.push(lane);
+    a.selected_clips
+        .insert(ArrangementSelection::AudioClip { track_id, clip_id });
+    let mut engine = RecordingEngine::default();
+
+    let action = a.update(
+        ArrangementMsg::TrimSelectedByTrackMutes,
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(a.tracks[0].clips.len(), 1);
+    assert_eq!(a.tracks[0].clips[0].id, clip_id);
+    assert!(engine.0.is_empty());
+    assert_eq!(
+        action.status.as_deref(),
+        Some("No selected clip material overlaps Track Mutes")
+    );
+}
+
+#[test]
 fn split_looped_midi_materializes_both_looped_halves() {
     let mut a = arrangement_with_tracks(1);
     let mut engine = RecordingEngine::default();

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -4,7 +4,7 @@ use super::test_support::*;
 use super::*;
 use crate::domains::test_support::RecordingEngine;
 use crate::state::UiClip;
-use vibez_core::automation::{AutomationLane, AutomationTarget};
+use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
 use vibez_core::midi::MidiNote;
 
 #[test]
@@ -818,6 +818,168 @@ fn split_looped_audio_preserves_source_phase() {
     assert!(halves.iter().all(|clip| clip.loop_enabled));
     assert_eq!(halves[1].source_offset, 50);
     assert_eq!((halves[1].loop_start, halves[1].loop_end), (0, 100));
+}
+
+#[test]
+fn trim_track_mutes_replaces_audio_with_unmuted_fragments_and_preserves_loop_phase() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut a, 0, 0, 800);
+    let clip = &mut a.tracks[0].clips[0];
+    clip.loop_enabled = true;
+    clip.loop_start = 0;
+    clip.loop_end = 100;
+    let mut lane = AutomationLane::new(AutomationTarget::TrackMute);
+    for (beat, value) in [(2.5, 1.0), (4.5, 0.0)] {
+        lane.insert_point(AutomationPoint {
+            beat,
+            value,
+            curve: 0.0,
+        });
+    }
+    a.tracks[0].automation.push(lane);
+    a.selected_clips
+        .insert(ArrangementSelection::AudioClip { track_id, clip_id });
+    let mut engine = RecordingEngine::default();
+
+    let action = a.update(
+        ArrangementMsg::TrimSelectedByTrackMutes,
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..Default::default()
+        },
+    );
+
+    let mut fragments: Vec<_> = a.tracks[0].clips.iter().collect();
+    fragments.sort_by_key(|clip| clip.position);
+    assert_eq!(fragments.len(), 2);
+    assert_eq!((fragments[0].position, fragments[0].duration), (0, 250));
+    assert_eq!((fragments[1].position, fragments[1].duration), (450, 350));
+    assert_eq!(fragments[1].source_offset, 50);
+    assert!(fragments.iter().all(|clip| clip.loop_enabled));
+    assert_eq!(a.selected_clips.len(), 2);
+    assert_eq!(
+        engine
+            .0
+            .iter()
+            .filter(|command| matches!(command, EngineCommand::RemoveClip(..)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        engine
+            .0
+            .iter()
+            .filter(|command| matches!(command, EngineCommand::AddClip { .. }))
+            .count(),
+        2
+    );
+    assert_eq!(
+        action.status.as_deref(),
+        Some("Trimmed 1 clip by Track Mutes · kept 2 fragments")
+    );
+}
+
+#[test]
+fn trim_track_mutes_materializes_midi_notes_across_unmuted_fragments() {
+    let mut a = arrangement_with_tracks(1);
+    let mut engine = RecordingEngine::default();
+    a.update(
+        ArrangementMsg::AddMidiTrack,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    engine.0.clear();
+    let track_id = a.tracks[1].id;
+    let clip_id = ClipId::new();
+    a.tracks[1].note_clips.push(UiNoteClip {
+        id: clip_id,
+        name: "Held note".to_string(),
+        position_beats: 0.0,
+        duration_beats: 8.0,
+        notes: vec![MidiNote {
+            pitch: 60,
+            velocity: 100,
+            start_beat: 1.0,
+            duration_beats: 5.0,
+        }],
+        selected_notes: HashSet::new(),
+        loop_enabled: false,
+        loop_start_beats: 0.0,
+        loop_end_beats: 0.0,
+        groove_grid: vibez_core::perform::GrooveGrid::Off,
+    });
+    let mut lane = AutomationLane::new(AutomationTarget::TrackMute);
+    for (beat, value) in [(2.0, 1.0), (4.0, 0.0)] {
+        lane.insert_point(AutomationPoint {
+            beat,
+            value,
+            curve: 0.0,
+        });
+    }
+    a.tracks[1].automation.push(lane);
+    a.selected_clips
+        .insert(ArrangementSelection::NoteClip { track_id, clip_id });
+
+    a.update(
+        ArrangementMsg::TrimSelectedByTrackMutes,
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..Default::default()
+        },
+    );
+
+    let mut fragments: Vec<_> = a.tracks[1].note_clips.iter().collect();
+    fragments.sort_by(|a, b| a.position_beats.partial_cmp(&b.position_beats).unwrap());
+    assert_eq!(fragments.len(), 2);
+    assert_eq!(
+        (fragments[0].position_beats, fragments[0].duration_beats),
+        (0.0, 2.0)
+    );
+    assert_eq!(
+        (fragments[1].position_beats, fragments[1].duration_beats),
+        (4.0, 4.0)
+    );
+    assert_eq!(
+        (
+            fragments[0].notes[0].start_beat,
+            fragments[0].notes[0].duration_beats
+        ),
+        (1.0, 1.0)
+    );
+    assert_eq!(
+        (
+            fragments[1].notes[0].start_beat,
+            fragments[1].notes[0].duration_beats
+        ),
+        (0.0, 2.0)
+    );
+}
+
+#[test]
+fn trim_track_mutes_leaves_selected_clip_without_mute_automation_untouched() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut a, 0, 0, 800);
+    a.selected_clips
+        .insert(ArrangementSelection::AudioClip { track_id, clip_id });
+    let mut engine = RecordingEngine::default();
+
+    let action = a.update(
+        ArrangementMsg::TrimSelectedByTrackMutes,
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(a.tracks[0].clips[0].id, clip_id);
+    assert!(engine.0.is_empty());
+    assert_eq!(
+        action.status.as_deref(),
+        Some("No selected clip material overlaps Track Mutes")
+    );
 }
 
 #[test]

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -1,5 +1,7 @@
 //! Browser-domain update tests. Split from domains/browser.rs.
 
+use std::sync::Arc;
+
 use super::*;
 
 #[test]
@@ -390,7 +392,7 @@ fn selecting_visible_remote_folder_from_local_activates_that_folder_in_one_click
         }),
         ..BrowserState::default()
     };
-    browser.remote.catalog.entries = vec![
+    Arc::make_mut(&mut browser.remote.catalog).entries = vec![
         RemoteCatalogEntry {
             provider_item_id: "/megalodon".into(),
             path: "/Megalodon".into(),
@@ -511,7 +513,7 @@ fn remote_catalog_children_are_indexed_folder_first_per_parent() {
         derived_metadata: None,
     };
     let mut browser = BrowserState::default();
-    browser.remote.catalog.entries = vec![
+    Arc::make_mut(&mut browser.remote.catalog).entries = vec![
         entry("/z.wav", "", "z.wav", false),
         entry("/beats", "", "Beats", true),
         entry("/a.wav", "", "a.wav", false),

--- a/crates/vibez-ui/src/domains/project.rs
+++ b/crates/vibez-ui/src/domains/project.rs
@@ -17,6 +17,8 @@ use crate::state::{ProjectSnapshot, ProjectState};
 #[derive(Debug, Clone)]
 pub enum ProjectMsg {
     ToggleFileMenu,
+    ToggleRecentProjects,
+    ClearRecentProjects,
     Undo,
     Redo,
 }
@@ -37,6 +39,8 @@ pub struct ProjectAction {
     pub status: Option<String>,
     /// Restore this snapshot (tears down and replays the engine).
     pub apply_snapshot: Option<ProjectSnapshot>,
+    /// Global recent-project history changed and must be saved to UI settings.
+    pub persist_ui_settings: bool,
 }
 
 impl ProjectState {
@@ -50,6 +54,20 @@ impl ProjectState {
         match msg {
             ProjectMsg::ToggleFileMenu => {
                 self.file_menu_open = !self.file_menu_open;
+                if !self.file_menu_open {
+                    self.recent_projects_open = false;
+                }
+            }
+            ProjectMsg::ToggleRecentProjects => {
+                if self.file_menu_open {
+                    self.recent_projects_open = !self.recent_projects_open;
+                }
+            }
+            ProjectMsg::ClearRecentProjects => {
+                self.recent_project_paths.clear();
+                self.recent_projects_open = false;
+                action.persist_ui_settings = true;
+                action.status = Some("Cleared recent projects".to_string());
             }
             ProjectMsg::Undo => {
                 let Some(snapshot) = self.history.pop_undo() else {
@@ -233,6 +251,28 @@ mod tests {
         assert_eq!(action.status.as_deref(), Some("Undo"));
         assert_eq!(p.history.undo.len(), 0);
         assert_eq!(p.history.redo.len(), 1);
+    }
+
+    #[test]
+    fn recent_projects_submenu_follows_the_file_menu_and_can_be_cleared() {
+        let mut project = ProjectState {
+            recent_project_paths: vec!["/projects/a.vzp".into()],
+            ..Default::default()
+        };
+
+        project.update(ProjectMsg::ToggleFileMenu, ctx());
+        project.update(ProjectMsg::ToggleRecentProjects, ctx());
+        assert!(project.file_menu_open);
+        assert!(project.recent_projects_open);
+
+        let action = project.update(ProjectMsg::ClearRecentProjects, ctx());
+        assert!(project.recent_project_paths.is_empty());
+        assert!(!project.recent_projects_open);
+        assert!(action.persist_ui_settings);
+
+        project.update(ProjectMsg::ToggleFileMenu, ctx());
+        assert!(!project.file_menu_open);
+        assert!(!project.recent_projects_open);
     }
 
     #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -192,21 +192,32 @@ pub struct RemoteCatalogRefreshData {
     pub catalog: Arc<crate::remote_provider::RemoteCatalogSnapshot>,
     pub catalog_children: Option<HashMap<String, Vec<usize>>>,
     pub availability: Option<HashMap<String, crate::state::RemoteAvailability>>,
+    pub base_catalog: Arc<crate::remote_provider::RemoteCatalogSnapshot>,
+    pub base_availability: HashMap<String, crate::state::RemoteAvailability>,
+    pub base_runtime_revision: u64,
     pub continuation: RemoteCatalogRefreshContinuation,
 }
 
 #[derive(Clone)]
-pub struct RemoteCatalogRefreshResult(
-    Arc<std::sync::Mutex<Option<Result<RemoteCatalogRefreshData, String>>>>,
-);
+pub struct RemoteCatalogRefreshResult {
+    generation: u64,
+    result: Arc<std::sync::Mutex<Option<Result<RemoteCatalogRefreshData, String>>>>,
+}
 
 impl RemoteCatalogRefreshResult {
-    pub fn new(result: Result<RemoteCatalogRefreshData, String>) -> Self {
-        Self(Arc::new(std::sync::Mutex::new(Some(result))))
+    pub fn new(generation: u64, result: Result<RemoteCatalogRefreshData, String>) -> Self {
+        Self {
+            generation,
+            result: Arc::new(std::sync::Mutex::new(Some(result))),
+        }
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
     }
 
     pub fn take(&self) -> Option<Result<RemoteCatalogRefreshData, String>> {
-        self.0.lock().ok()?.take()
+        self.result.lock().ok()?.take()
     }
 }
 

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -178,6 +178,44 @@ pub struct RemoteCatalogStartupData {
     pub load_error: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub enum RemoteCatalogRefreshContinuation {
+    FetchNext { checkpoint: String },
+    Complete,
+    Failed(crate::remote_provider::RemoteProviderError),
+}
+
+#[derive(Debug)]
+pub struct RemoteCatalogRefreshData {
+    pub generation: u64,
+    pub pages: usize,
+    pub catalog: Arc<crate::remote_provider::RemoteCatalogSnapshot>,
+    pub catalog_children: Option<HashMap<String, Vec<usize>>>,
+    pub availability: Option<HashMap<String, crate::state::RemoteAvailability>>,
+    pub continuation: RemoteCatalogRefreshContinuation,
+}
+
+#[derive(Clone)]
+pub struct RemoteCatalogRefreshResult(
+    Arc<std::sync::Mutex<Option<Result<RemoteCatalogRefreshData, String>>>>,
+);
+
+impl RemoteCatalogRefreshResult {
+    pub fn new(result: Result<RemoteCatalogRefreshData, String>) -> Self {
+        Self(Arc::new(std::sync::Mutex::new(Some(result))))
+    }
+
+    pub fn take(&self) -> Option<Result<RemoteCatalogRefreshData, String>> {
+        self.0.lock().ok()?.take()
+    }
+}
+
+impl std::fmt::Debug for RemoteCatalogRefreshResult {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RemoteCatalogRefreshResult")
+    }
+}
+
 #[derive(Clone)]
 pub struct RemoteCatalogStartupResult(
     Arc<std::sync::Mutex<Option<Result<RemoteCatalogStartupData, String>>>>,
@@ -658,6 +696,7 @@ pub enum Message {
         result:
             Result<crate::remote_provider::RemotePage, crate::remote_provider::RemoteProviderError>,
     },
+    RemoteCatalogRefreshPrepared(RemoteCatalogRefreshResult),
     RemoteCatalogSaved {
         generation: u64,
         /// `Some` continues pagination from this checkpoint after a

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -390,7 +390,10 @@ pub enum Message {
     SaveProjectAs,
     ProjectOpenPathSelected(Option<PathBuf>),
     ProjectSavePathSelected(Option<PathBuf>),
-    ProjectLoaded(Box<Result<ProjectLoadResult, String>>),
+    ProjectLoaded {
+        path: PathBuf,
+        result: Box<Result<ProjectLoadResult, String>>,
+    },
     ProjectSaved(Box<ProjectSaveCompleted>),
 
     // Window close protection. The window is configured not to exit on its

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -166,6 +167,36 @@ pub struct RemoteMaterializedSample {
     pub source: MediaSourceRef,
     pub lease: vibez_dropbox::CacheLease,
     pub metadata: vibez_dropbox::DerivedMetadata,
+}
+
+#[derive(Debug)]
+pub struct RemoteCatalogStartupData {
+    pub catalog: crate::remote_provider::RemoteCatalogSnapshot,
+    pub catalog_children: HashMap<String, Vec<usize>>,
+    pub cached_provider_item_ids: HashSet<String>,
+    pub cache_usage: vibez_dropbox::CacheUsage,
+    pub load_error: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct RemoteCatalogStartupResult(
+    Arc<std::sync::Mutex<Option<Result<RemoteCatalogStartupData, String>>>>,
+);
+
+impl RemoteCatalogStartupResult {
+    pub fn new(result: Result<RemoteCatalogStartupData, String>) -> Self {
+        Self(Arc::new(std::sync::Mutex::new(Some(result))))
+    }
+
+    pub fn take(&self) -> Option<Result<RemoteCatalogStartupData, String>> {
+        self.0.lock().ok()?.take()
+    }
+}
+
+impl std::fmt::Debug for RemoteCatalogStartupResult {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RemoteCatalogStartupResult")
+    }
 }
 
 /// Successful background result from `quantize_audio_clip_async`.
@@ -619,6 +650,7 @@ pub enum Message {
     ConnectDropbox,
     DropboxConnected(Result<DropboxConnectOutcome, String>),
     DisconnectDropbox,
+    RemoteCatalogStartupLoaded(RemoteCatalogStartupResult),
     RefreshRemoteConnection,
     RemoteCatalogPageFetched {
         generation: u64,

--- a/crates/vibez-ui/src/remote_provider.rs
+++ b/crates/vibez-ui/src/remote_provider.rs
@@ -280,6 +280,12 @@ pub fn reconcile_remote_catalog(
 ) {
     debug_assert!(result.pages > 0 || result.changes.is_empty());
     debug_assert!(result.error.is_none() || result.checkpoint.is_none());
+    if result.changes.is_empty() {
+        if let Some(checkpoint) = &result.checkpoint {
+            snapshot.checkpoint = Some(checkpoint.clone());
+        }
+        return;
+    }
     let mut entries: HashMap<String, RemoteCatalogEntry> = snapshot
         .entries
         .drain(..)
@@ -598,6 +604,30 @@ mod tests {
         reconcile_remote_catalog(&mut snapshot, &result);
         assert_eq!(snapshot.entries, vec![entry("/new.wav")]);
         assert_eq!(snapshot.checkpoint.as_deref(), Some("next"));
+    }
+
+    #[test]
+    fn an_empty_delta_advances_only_the_checkpoint() {
+        let mut snapshot = RemoteCatalogSnapshot {
+            checkpoint: Some("old".into()),
+            entries: vec![entry("/Megalodon/Kick.wav")],
+            ..RemoteCatalogSnapshot::default()
+        };
+        let entries_allocation = snapshot.entries.as_ptr();
+
+        reconcile_remote_catalog(
+            &mut snapshot,
+            &RemoteRefreshResult {
+                pages: 1,
+                changes: Vec::new(),
+                checkpoint: Some("next".into()),
+                error: None,
+            },
+        );
+
+        assert_eq!(snapshot.checkpoint.as_deref(), Some("next"));
+        assert_eq!(snapshot.entries.as_ptr(), entries_allocation);
+        assert_eq!(snapshot.entries, vec![entry("/Megalodon/Kick.wav")]);
     }
 
     #[test]

--- a/crates/vibez-ui/src/remote_provider.rs
+++ b/crates/vibez-ui/src/remote_provider.rs
@@ -312,6 +312,35 @@ pub fn reconcile_remote_catalog(
     }
 }
 
+pub fn build_remote_catalog_children(
+    catalog: &RemoteCatalogSnapshot,
+) -> HashMap<String, Vec<usize>> {
+    let mut children: HashMap<String, Vec<usize>> = HashMap::new();
+    for (index, entry) in catalog.entries.iter().enumerate() {
+        children
+            .entry(entry.parent_path.clone())
+            .or_default()
+            .push(index);
+    }
+    for indexes in children.values_mut() {
+        indexes.sort_by(|left, right| {
+            let left = &catalog.entries[*left];
+            let right = &catalog.entries[*right];
+            (
+                !left.is_folder,
+                left.name.to_ascii_lowercase(),
+                &left.provider_item_id,
+            )
+                .cmp(&(
+                    !right.is_folder,
+                    right.name.to_ascii_lowercase(),
+                    &right.provider_item_id,
+                ))
+        });
+    }
+    children
+}
+
 #[derive(Debug, Clone)]
 pub struct RemoteCatalogStore {
     path: PathBuf,

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -696,6 +696,7 @@ impl BrowserState {
 pub enum RemoteCatalogState {
     #[default]
     Ready,
+    Loading,
     Refreshing,
     Stale {
         error: String,
@@ -734,6 +735,7 @@ impl RemoteCatalogState {
     pub fn label(&self) -> &'static str {
         match self {
             Self::Ready => "READY",
+            Self::Loading => "LOADING",
             Self::Refreshing => "REFRESHING",
             Self::Stale { .. } => "STALE",
             Self::Partial { .. } => "PARTIAL",
@@ -748,6 +750,7 @@ mod remote_catalog_state_tests {
 
     #[test]
     fn refresh_auth_stale_and_partial_states_have_distinct_labels() {
+        assert_eq!(RemoteCatalogState::Loading.label(), "LOADING");
         assert_eq!(RemoteCatalogState::Refreshing.label(), "REFRESHING");
         assert_eq!(
             RemoteCatalogState::AuthenticationRequired {
@@ -850,30 +853,8 @@ impl RemoteUiState {
     /// reconciled. UI redraws can then navigate one folder without rescanning
     /// the complete provider catalog.
     pub fn rebuild_catalog_children(&mut self) {
-        let mut children: HashMap<String, Vec<usize>> = HashMap::new();
-        for (index, entry) in self.catalog.entries.iter().enumerate() {
-            children
-                .entry(entry.parent_path.clone())
-                .or_default()
-                .push(index);
-        }
-        for indexes in children.values_mut() {
-            indexes.sort_by(|left, right| {
-                let left = &self.catalog.entries[*left];
-                let right = &self.catalog.entries[*right];
-                (
-                    !left.is_folder,
-                    left.name.to_ascii_lowercase(),
-                    &left.provider_item_id,
-                )
-                    .cmp(&(
-                        !right.is_folder,
-                        right.name.to_ascii_lowercase(),
-                        &right.provider_item_id,
-                    ))
-            });
-        }
-        self.catalog_children = children;
+        self.catalog_children =
+            crate::remote_provider::build_remote_catalog_children(&self.catalog);
     }
 
     pub fn catalog_child_indices(&self, parent: &str) -> &[usize] {

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -811,6 +811,10 @@ pub struct RemoteUiState {
     /// A preview fetch / playback is in flight.
     pub preview_in_progress: bool,
     pub availability: HashMap<String, RemoteAvailability>,
+    /// Changes made by materialization/import flows while a catalog refresh
+    /// snapshot is being prepared. Prepared snapshots use this to detect and
+    /// rebase over newer UI-owned metadata instead of replacing it.
+    pub catalog_runtime_revision: u64,
     pub cache_usage_bytes: u64,
     pub cache_entries: usize,
     pub cache_budget_bytes: u64,
@@ -839,6 +843,7 @@ impl Default for RemoteUiState {
             selected_path: None,
             preview_in_progress: false,
             availability: HashMap::new(),
+            catalog_runtime_revision: 0,
             cache_usage_bytes: 0,
             cache_entries: 0,
             cache_budget_bytes: vibez_dropbox::DEFAULT_MEDIA_CACHE_BUDGET_BYTES,
@@ -849,6 +854,10 @@ impl Default for RemoteUiState {
 }
 
 impl RemoteUiState {
+    pub(crate) fn mark_catalog_runtime_changed(&mut self) {
+        self.catalog_runtime_revision = self.catalog_runtime_revision.wrapping_add(1);
+    }
+
     /// Rebuild the parent/children lookup after the catalog is loaded or
     /// reconciled. UI redraws can then navigate one folder without rescanning
     /// the complete provider catalog.

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -790,7 +790,7 @@ pub struct RemoteUiState {
     /// An OAuth flow is in progress; Connect button is disabled.
     pub auth_in_progress: bool,
     pub last_error: Option<String>,
-    pub catalog: RemoteCatalogSnapshot,
+    pub catalog: Arc<RemoteCatalogSnapshot>,
     pub catalog_state: RemoteCatalogState,
     /// Pages and entries applied during the current progressive Catalog Refresh.
     pub refresh_pages: usize,
@@ -827,7 +827,7 @@ impl Default for RemoteUiState {
             has_app_key: false,
             auth_in_progress: false,
             last_error: None,
-            catalog: RemoteCatalogSnapshot::default(),
+            catalog: Arc::new(RemoteCatalogSnapshot::default()),
             catalog_state: RemoteCatalogState::default(),
             refresh_pages: 0,
             refresh_items: 0,
@@ -852,6 +852,7 @@ impl RemoteUiState {
     /// Rebuild the parent/children lookup after the catalog is loaded or
     /// reconciled. UI redraws can then navigate one folder without rescanning
     /// the complete provider catalog.
+    #[cfg(test)]
     pub fn rebuild_catalog_children(&mut self) {
         self.catalog_children =
             crate::remote_provider::build_remote_catalog_children(&self.catalog);

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -583,6 +583,7 @@ impl AppState {
             AudioStreamEvent::Error(cause) => {
                 self.status_text = format!("Audio stream error: {cause}");
                 self.audio_stream_health = AudioStreamHealth::Error(cause);
+                self.audio_cpu_load_percent = 0.0;
             }
             AudioStreamEvent::Rebuilding => {
                 self.status_text = "Rebuilding audio stream…".into();
@@ -593,6 +594,15 @@ impl AppState {
                 self.audio_stream_health = AudioStreamHealth::Running;
             }
         }
+    }
+
+    pub fn update_audio_cpu_load(&mut self, measured_percent: Option<f32>) {
+        self.audio_cpu_load_percent =
+            if matches!(self.audio_stream_health, AudioStreamHealth::Running) {
+                measured_percent.unwrap_or(0.0)
+            } else {
+                0.0
+            };
     }
 
     pub fn position_seconds(&self) -> f64 {
@@ -784,7 +794,10 @@ mod audio_stream_health_tests {
 
     #[test]
     fn stream_error_and_recovery_update_persistent_health_and_status() {
-        let mut state = AppState::default();
+        let mut state = AppState {
+            audio_cpu_load_percent: 45.0,
+            ..AppState::default()
+        };
 
         state.apply_audio_stream_event(AudioStreamEvent::Error(
             "device disconnected mid-session".into(),
@@ -797,6 +810,7 @@ mod audio_stream_health_tests {
             state.status_text,
             "Audio stream error: device disconnected mid-session"
         );
+        assert_eq!(state.audio_cpu_load_percent, 0.0);
 
         state.apply_audio_stream_event(AudioStreamEvent::Rebuilding);
         assert_eq!(state.audio_stream_health, AudioStreamHealth::Rebuilding);

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -439,6 +439,8 @@ pub struct AppState {
     // Metering (master)
     pub peak_l: f32,
     pub peak_r: f32,
+    /// Smoothed audio callback work as a percentage of its buffer deadline.
+    pub audio_cpu_load_percent: f32,
     /// Spectrum analyser fed by the engine's per-track tap (follows
     /// the selected track); drawn behind the channel EQ curve.
     pub spectrum: crate::spectrum::SpectrumState,
@@ -511,6 +513,7 @@ impl Default for AppState {
             },
             peak_l: 0.0,
             peak_r: 0.0,
+            audio_cpu_load_percent: 0.0,
             spectrum: crate::spectrum::SpectrumState::default(),
             status_text: "Ready — Add a track to get started".to_string(),
             export_progress: None,

--- a/crates/vibez-ui/src/state/snapshot.rs
+++ b/crates/vibez-ui/src/state/snapshot.rs
@@ -50,6 +50,8 @@ impl UndoGestureId {
 #[derive(Debug, Default)]
 pub struct ProjectState {
     pub file_menu_open: bool,
+    pub recent_projects_open: bool,
+    pub recent_project_paths: Vec<PathBuf>,
     pub current_path: Option<PathBuf>,
     pub dirty: bool,
     pub history: UndoHistory,

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -158,6 +158,12 @@ pub fn remember_recent_project(paths: &mut Vec<PathBuf>, path: PathBuf) {
     paths.truncate(RECENT_PROJECT_LIMIT);
 }
 
+pub fn forget_recent_project(paths: &mut Vec<PathBuf>, path: &Path) -> bool {
+    let previous_len = paths.len();
+    paths.retain(|existing| existing != path);
+    paths.len() != previous_len
+}
+
 impl UiSettings {
     pub fn settings_path() -> PathBuf {
         dirs::config_dir()
@@ -280,6 +286,31 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn failed_recent_project_is_pruned_without_touching_other_entries() {
+        let mut paths = vec![
+            PathBuf::from("/projects/a.vzp"),
+            PathBuf::from("/projects/missing.vzp"),
+            PathBuf::from("/projects/b.vzp"),
+        ];
+
+        assert!(forget_recent_project(
+            &mut paths,
+            Path::new("/projects/missing.vzp")
+        ));
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/projects/a.vzp"),
+                PathBuf::from("/projects/b.vzp")
+            ]
+        );
+        assert!(!forget_recent_project(
+            &mut paths,
+            Path::new("/projects/unknown.vzp")
+        ));
     }
 
     #[test]

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiSettings {
+    /// Most recently opened or successfully saved projects, newest first.
+    #[serde(default)]
+    pub recent_project_paths: Vec<PathBuf>,
     #[serde(default)]
     pub perform_input_mapping: crate::domains::perform::PerformInputMapping,
     #[serde(default = "default_fixed_computer_velocity")]
@@ -107,6 +110,7 @@ pub fn clamp_interface_scale(scale: f32) -> f32 {
 impl Default for UiSettings {
     fn default() -> Self {
         Self {
+            recent_project_paths: Vec::new(),
             perform_input_mapping: crate::domains::perform::PerformInputMapping::default(),
             fixed_computer_velocity: default_fixed_computer_velocity(),
             track_mute_quantization: vibez_core::perform::TrackMuteQuantization::default(),
@@ -131,6 +135,27 @@ impl Default for UiSettings {
             last_update_check_unix: None,
         }
     }
+}
+
+pub const RECENT_PROJECT_LIMIT: usize = 6;
+
+pub fn normalize_recent_projects(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut normalized = Vec::new();
+    for path in paths {
+        if !normalized.contains(&path) {
+            normalized.push(path);
+        }
+        if normalized.len() == RECENT_PROJECT_LIMIT {
+            break;
+        }
+    }
+    normalized
+}
+
+pub fn remember_recent_project(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    paths.retain(|existing| existing != &path);
+    paths.insert(0, path);
+    paths.truncate(RECENT_PROJECT_LIMIT);
 }
 
 impl UiSettings {
@@ -229,6 +254,39 @@ impl UiSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recent_projects_are_deduplicated_capped_and_promoted() {
+        let mut paths = normalize_recent_projects([
+            "/projects/a.vzp".into(),
+            "/projects/b.vzp".into(),
+            "/projects/a.vzp".into(),
+            "/projects/c.vzp".into(),
+            "/projects/d.vzp".into(),
+            "/projects/e.vzp".into(),
+            "/projects/f.vzp".into(),
+            "/projects/g.vzp".into(),
+        ]);
+        assert_eq!(paths.len(), RECENT_PROJECT_LIMIT);
+        assert_eq!(paths[0], PathBuf::from("/projects/a.vzp"));
+
+        remember_recent_project(&mut paths, "/projects/d.vzp".into());
+        assert_eq!(paths[0], PathBuf::from("/projects/d.vzp"));
+        assert_eq!(paths.len(), RECENT_PROJECT_LIMIT);
+        assert_eq!(
+            paths
+                .iter()
+                .filter(|path| path.as_path() == std::path::Path::new("/projects/d.vzp"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn old_settings_start_with_no_recent_projects() {
+        let loaded: UiSettings = serde_json::from_str("{}").unwrap();
+        assert!(loaded.recent_project_paths.is_empty());
+    }
 
     #[test]
     fn old_settings_receive_the_browser_width_default() {

--- a/site/index.html
+++ b/site/index.html
@@ -125,6 +125,42 @@ h1 b { color: var(--blue); font-weight: 400; font-size: .58em; padding-bottom: 1
 .btn-2:hover { border-color: var(--line-2); background: var(--panel); }
 .plat { font-family: var(--mono); font-size: 12px; color: var(--dimmer); }
 
+/* ---------- promotional film ---------- */
+.showreel { padding: 34px 0 52px; }
+.showreel-head {
+  display: grid; gap: 10px; align-items: end; margin-bottom: 18px;
+}
+@media (min-width: 780px) {
+  .showreel-head { grid-template-columns: minmax(0, .78fr) minmax(320px, 1fr); gap: 36px; }
+}
+.showreel-head h2 { max-width: 14ch; }
+.showreel-head .lede { margin: 0; }
+.monitor {
+  border: 1px solid var(--line-2); border-radius: 6px; overflow: hidden;
+  background: var(--panel); box-shadow: 0 24px 70px rgba(0,0,0,.28);
+}
+.monitor-bar {
+  min-height: 38px; padding: 8px 13px; border-bottom: 1px solid var(--line);
+  display: flex; align-items: center; gap: 9px;
+  font-family: var(--mono); font-size: 10px; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--dimmer);
+}
+.monitor-light {
+  width: 7px; height: 7px; border-radius: 50%; flex: none;
+  background: var(--blue); box-shadow: 0 0 10px rgba(61,130,216,.75);
+}
+.monitor-bar span:last-child { margin-left: auto; color: var(--dim); }
+.video-frame { position: relative; aspect-ratio: 16 / 9; background: #050608; }
+.video-frame iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
+.monitor-foot {
+  padding: 9px 13px; border-top: 1px solid var(--line);
+  display: flex; justify-content: space-between; gap: 14px; flex-wrap: wrap;
+  font-family: var(--mono); font-size: 10px; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--dimmer);
+}
+.monitor-foot a { color: var(--dim); text-underline-offset: 3px; }
+.monitor-foot a:hover { color: var(--text); }
+
 /* ---------- pad hero ---------- */
 .padhero { padding: 44px 0 76px; }
 .padhero-in { display: grid; gap: 30px; align-items: start; }
@@ -335,6 +371,7 @@ footer a:hover { color: var(--text); }
     <span class="wordmark">vibez</span>
     <span class="ver">__VERSION__</span>
     <nav>
+      <a href="#watch">Watch</a>
       <a href="#perform">Perform</a>
       <a href="#arrange">Arrange</a>
       <a href="#mix">Mix</a>
@@ -364,8 +401,43 @@ footer a:hover { color: var(--text); }
       </p>
       <div class="cta">
         <a class="btn" href="#download">Download __VERSION__</a>
+        <a class="btn-2" href="#watch">Watch the film</a>
         <a class="btn-2" href="https://github.com/alexanderwanyoike/vibez">Source on GitHub</a>
         <span class="plat">Linux &middot; macOS &middot; Windows &middot; GPL-3.0</span>
+      </div>
+    </section>
+
+    <section class="showreel" id="watch" aria-labelledby="showreel-title">
+      <div class="showreel-head">
+        <div>
+          <p class="hint"><i></i> Live techno workflow</p>
+          <h2 id="showreel-title">See the whole signal path in motion.</h2>
+        </div>
+        <p class="lede">
+          From launching Sections and shaping a live performance to Capture, Arrange and the final
+          mix: this is vibez used as one continuous instrument.
+        </p>
+      </div>
+      <div class="monitor">
+        <div class="monitor-bar">
+          <span class="monitor-light" aria-hidden="true"></span>
+          <span>Now playing</span>
+          <span>Perform &rarr; Arrange &rarr; Mix</span>
+        </div>
+        <div class="video-frame">
+          <iframe
+            src="https://www.youtube-nocookie.com/embed/pdNbG7v-OKk"
+            title="Vibez: Perform, Arrange, Mix | Live Techno Workflow"
+            loading="lazy"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen>
+          </iframe>
+        </div>
+        <div class="monitor-foot">
+          <a href="https://www.youtube.com/watch?v=pdNbG7v-OKk">A film by Osmosis &middot; Watch on YouTube &nearr;</a>
+          <span>Live performance &middot; capture &middot; arrangement &middot; mix</span>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
Patch release for deeper Perform capture editing, project recall, responsive Remote browsing, audio visibility, and the Vibez site.

## Summary

- Add End of Section Track Mute quantization, including correct behavior when another Section transitions before the natural wrap and when a one-shot Section reaches its terminal boundary.
- Add Trim Track Mutes for selected Arrange audio and MIDI clips, preserving loop phase and avoiding fragmentation at redundant automation points.
- Show real-time audio callback CPU load beside the master meter and tempo controls, with truthful reset behavior after stream failure.
- Add a six-entry Recent Projects submenu with promotion, deduplication, clearing, automatic pruning of failed paths, and correct alignment with its parent menu item.
- Keep large saved Remote catalogs off the UI startup path while showing an honest loading state.
- Keep Dropbox refresh reconciliation, sorting, folder indexing, cache matching, persistence snapshots, and retired catalog disposal off the UI thread.
- Preserve the committed Dropbox cursor across intermediate refresh batches, rebase prepared snapshots over newer materialization/cache state, and reject stale worker failures before they can alter the active refresh.
- Feature the Vibez promotional workflow video on the GitHub Pages site using its existing visual language and responsive layout.
- Update the README and bump the Cargo workspace and lockfile from 0.1.4 to 0.1.5.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --exclude vibez-plugin-host -- -D warnings`
- [x] `cargo clippy -p vibez-plugin-host -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Feature and fix PRs #144 through #153 passed CI across Linux, macOS, and Windows
- [x] Manual QA: Recent Projects submenu alignment
- [x] Manual QA: 383,557-entry Megalodon Dropbox catalog remains responsive during startup and refresh
- [ ] Final release QA

## After merging

Tag and push `v0.1.5` to trigger the release-artifact workflow:

```sh
git tag v0.1.5
git push origin v0.1.5
```

Prepared with Codex.
