### PR TITLE
fix: keep large Remote catalogs off the UI startup path

### DIFF
--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -12,6 +12,57 @@ pub(super) const REMOTE_SELECTION_DEBOUNCE: std::time::Duration =
     std::time::Duration::from_millis(200);
 pub(super) const REMOTE_CATALOG_SAVE_PAGE_INTERVAL: usize = 10;
 
+async fn run_remote_startup_loader<T, F>(loader: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    tokio::task::spawn_blocking(loader)
+        .await
+        .map_err(|error| format!("Remote catalog startup task failed: {error}"))
+}
+
+pub(super) fn remote_catalog_startup_task(cache: DropboxCache) -> Task<Message> {
+    Task::perform(
+        run_remote_startup_loader(move || {
+            let store = crate::remote_provider::RemoteCatalogStore::for_dropbox();
+            let (catalog, load_error) = match store.load() {
+                Ok(catalog) => (catalog, None),
+                Err(error) => (
+                    crate::remote_provider::RemoteCatalogSnapshot::default(),
+                    Some(error),
+                ),
+            };
+            let catalog_children = crate::remote_provider::build_remote_catalog_children(&catalog);
+            let cached_identities: std::collections::HashMap<String, Option<String>> =
+                cache.cached_identities().into_iter().collect();
+            let cached_provider_item_ids = catalog
+                .entries
+                .iter()
+                .filter(|entry| {
+                    cached_identities
+                        .get(&entry.provider_item_id)
+                        .is_some_and(|revision| revision.as_deref() == entry.revision.as_deref())
+                })
+                .map(|entry| entry.provider_item_id.clone())
+                .collect();
+            let cache_usage = cache.usage().unwrap_or_default();
+            crate::message::RemoteCatalogStartupData {
+                catalog,
+                catalog_children,
+                cached_provider_item_ids,
+                cache_usage,
+                load_error,
+            }
+        }),
+        |result| {
+            Message::RemoteCatalogStartupLoaded(crate::message::RemoteCatalogStartupResult::new(
+                result,
+            ))
+        },
+    )
+}
+
 fn queue_latest_remote_audition(slot: &mut Option<DropboxEntry>, entry: DropboxEntry) {
     *slot = Some(entry);
 }
@@ -212,7 +263,11 @@ impl App {
     }
 
     pub(super) fn handle_remote_catalog_refresh(&mut self) -> Task<Message> {
-        if self.state.browser.remote.catalog_state == crate::state::RemoteCatalogState::Refreshing {
+        if matches!(
+            self.state.browser.remote.catalog_state,
+            crate::state::RemoteCatalogState::Loading
+                | crate::state::RemoteCatalogState::Refreshing
+        ) {
             return Task::none();
         }
         let Some(client) = self.dropbox_client.clone() else {
@@ -334,6 +389,28 @@ impl App {
             return Task::none();
         };
         self.start_remote_import(entry, target, treatment)
+    }
+}
+
+#[cfg(test)]
+mod startup_tests {
+    use std::time::Duration;
+
+    use super::run_remote_startup_loader;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn remote_startup_loader_never_blocks_the_ui_executor() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let loader = tokio::spawn(run_remote_startup_loader(move || {
+            release_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("UI executor should release the background loader");
+            42
+        }));
+
+        tokio::task::yield_now().await;
+        assert!(release_tx.send(()).is_ok());
+        assert_eq!(loader.await.unwrap().unwrap(), 42);
     }
 }
 

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -243,7 +243,6 @@ impl App {
             budget_bytes: ui_settings.media_cache_budget_bytes,
             automatic_eviction: ui_settings.media_cache_automatic_eviction,
         });
-        let cache_usage = dropbox_cache.usage().unwrap_or_default();
         let resolved_key = load_app_key_with_env_override(&dropbox_settings);
         let dropbox_client = match (&resolved_key, &dropbox_settings.tokens) {
             (Some(key), Some(tokens)) => {
@@ -251,39 +250,16 @@ impl App {
             }
             _ => None,
         };
-        let catalog_store = crate::remote_provider::RemoteCatalogStore::for_dropbox();
-        let (remote_catalog, mut remote_catalog_state) = match catalog_store.load() {
-            Ok(catalog) => (catalog, crate::state::RemoteCatalogState::Ready),
-            Err(error) => (
-                crate::remote_provider::RemoteCatalogSnapshot::default(),
-                crate::state::RemoteCatalogState::Stale { error },
-            ),
-        };
-        if dropbox_client.is_none()
-            && matches!(
-                remote_catalog_state,
-                crate::state::RemoteCatalogState::Ready
-            )
-        {
-            remote_catalog_state = crate::state::RemoteCatalogState::AuthenticationRequired {
-                error: "Sign in to refresh; showing the last saved Remote catalog".into(),
-            };
-        }
-        let mut remote_ui_state = crate::state::RemoteUiState {
+        let remote_ui_state = crate::state::RemoteUiState {
             connected: dropbox_client.is_some(),
             account_email: dropbox_settings.account_email.clone(),
             app_key_input: dropbox_settings.app_key.clone().unwrap_or_default(),
             has_app_key: resolved_key.is_some(),
-            catalog: remote_catalog,
-            catalog_state: remote_catalog_state,
-            cache_usage_bytes: cache_usage.bytes,
-            cache_entries: cache_usage.entries,
+            catalog_state: crate::state::RemoteCatalogState::Loading,
             cache_budget_bytes: ui_settings.media_cache_budget_bytes,
             cache_automatic_eviction: ui_settings.media_cache_automatic_eviction,
             ..Default::default()
         };
-        remote_ui_state.rebuild_catalog_children();
-        dropbox_io::seed_remote_availability(&dropbox_cache, &mut remote_ui_state);
 
         let mut state = AppState {
             transport: crate::state::TransportState {
@@ -430,11 +406,8 @@ impl App {
                 })
             })
         }));
-        let remote_startup_task = if app.dropbox_client.is_some() {
-            Task::done(Message::RefreshRemoteConnection)
-        } else {
-            Task::none()
-        };
+        let remote_startup_task =
+            dropbox_io::remote_catalog_startup_task(app.dropbox_cache.clone());
         let plugin_catalog_startup_task = if app.state.plugin_settings.cache_needs_refresh() {
             Task::done(Message::ScanPlugins)
         } else {

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -862,6 +862,9 @@ impl App {
                 self.state.status_text = format!("Dropbox connect failed: {err}");
             }
             Message::DisconnectDropbox => return self.on_disconnect_dropbox(),
+            Message::RemoteCatalogStartupLoaded(result) => {
+                return self.on_remote_catalog_startup_loaded(result)
+            }
             Message::RefreshRemoteConnection => {
                 return self.handle_remote_catalog_refresh();
             }

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -14,6 +14,65 @@ use crate::message::Message;
 use super::*;
 
 impl App {
+    pub(super) fn on_remote_catalog_startup_loaded(
+        &mut self,
+        result: crate::message::RemoteCatalogStartupResult,
+    ) -> Task<Message> {
+        let Some(result) = result.take() else {
+            return Task::none();
+        };
+        match result {
+            Ok(data) => {
+                let item_count = data.catalog.entries.len();
+                self.state.browser.remote.catalog = data.catalog;
+                self.state.browser.remote.catalog_children = data.catalog_children;
+                self.state.browser.remote.availability.clear();
+                self.state.browser.remote.availability.extend(
+                    data.cached_provider_item_ids
+                        .into_iter()
+                        .map(|provider_item_id| {
+                            (provider_item_id, crate::state::RemoteAvailability::Cached)
+                        }),
+                );
+                self.state.browser.remote.cache_usage_bytes = data.cache_usage.bytes;
+                self.state.browser.remote.cache_entries = data.cache_usage.entries;
+                self.state.browser.remote.refresh_items = item_count;
+                if let Some(error) = data.load_error {
+                    self.state.browser.remote.catalog_state =
+                        crate::state::RemoteCatalogState::Stale {
+                            error: error.clone(),
+                        };
+                    self.state.status_text = format!("Remote catalog load failed: {error}");
+                } else if self.dropbox_client.is_none() {
+                    self.state.browser.remote.catalog_state =
+                        crate::state::RemoteCatalogState::AuthenticationRequired {
+                            error: "Sign in to refresh; showing the last saved Remote catalog"
+                                .into(),
+                        };
+                    self.state.status_text =
+                        format!("Loaded {item_count} saved Remote catalog items");
+                } else {
+                    self.state.browser.remote.catalog_state =
+                        crate::state::RemoteCatalogState::Ready;
+                    self.state.status_text =
+                        format!("Loaded {item_count} saved Remote catalog items");
+                }
+            }
+            Err(error) => {
+                self.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Stale {
+                    error: error.clone(),
+                };
+                self.state.status_text = error;
+            }
+        }
+
+        if self.dropbox_client.is_some() {
+            self.handle_remote_catalog_refresh()
+        } else {
+            Task::none()
+        }
+    }
+
     pub(super) fn on_save_dropbox_app_key(&mut self) -> Task<Message> {
         let value = self.state.browser.remote.app_key_input.trim().to_string();
         self.dropbox_settings.app_key = if value.is_empty() { None } else { Some(value) };

--- a/crates/vibez-ui/src/app/views_browser_remote.rs
+++ b/crates/vibez-ui/src/app/views_browser_remote.rs
@@ -141,6 +141,7 @@ impl App {
                 Some(format!("Partial refresh after {pages} page(s) · {error}"))
             }
             crate::state::RemoteCatalogState::Ready
+            | crate::state::RemoteCatalogState::Loading
             | crate::state::RemoteCatalogState::Refreshing => None,
         };
         if let Some(notice) = catalog_notice {
@@ -391,7 +392,9 @@ impl App {
                 .push(browser_row_divider());
         }
         if total_results == 0 {
-            let empty = if remote.catalog.entries.is_empty() {
+            let empty = if remote.catalog_state == crate::state::RemoteCatalogState::Loading {
+                "Loading saved Remote metadata…"
+            } else if remote.catalog.entries.is_empty() {
                 "No saved Remote metadata yet; connect and refresh when available"
             } else if searching {
                 "No media or folders match this scope"

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -166,6 +167,36 @@ pub struct RemoteMaterializedSample {
     pub source: MediaSourceRef,
     pub lease: vibez_dropbox::CacheLease,
     pub metadata: vibez_dropbox::DerivedMetadata,
+}
+
+#[derive(Debug)]
+pub struct RemoteCatalogStartupData {
+    pub catalog: crate::remote_provider::RemoteCatalogSnapshot,
+    pub catalog_children: HashMap<String, Vec<usize>>,
+    pub cached_provider_item_ids: HashSet<String>,
+    pub cache_usage: vibez_dropbox::CacheUsage,
+    pub load_error: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct RemoteCatalogStartupResult(
+    Arc<std::sync::Mutex<Option<Result<RemoteCatalogStartupData, String>>>>,
+);
+
+impl RemoteCatalogStartupResult {
+    pub fn new(result: Result<RemoteCatalogStartupData, String>) -> Self {
+        Self(Arc::new(std::sync::Mutex::new(Some(result))))
+    }
+
+    pub fn take(&self) -> Option<Result<RemoteCatalogStartupData, String>> {
+        self.0.lock().ok()?.take()
+    }
+}
+
+impl std::fmt::Debug for RemoteCatalogStartupResult {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RemoteCatalogStartupResult")
+    }
 }
 
 /// Successful background result from `quantize_audio_clip_async`.
@@ -619,6 +650,7 @@ pub enum Message {
     ConnectDropbox,
     DropboxConnected(Result<DropboxConnectOutcome, String>),
     DisconnectDropbox,
+    RemoteCatalogStartupLoaded(RemoteCatalogStartupResult),
     RefreshRemoteConnection,
     RemoteCatalogPageFetched {
         generation: u64,

--- a/crates/vibez-ui/src/remote_provider.rs
+++ b/crates/vibez-ui/src/remote_provider.rs
@@ -312,6 +312,35 @@ pub fn reconcile_remote_catalog(
     }
 }
 
+pub fn build_remote_catalog_children(
+    catalog: &RemoteCatalogSnapshot,
+) -> HashMap<String, Vec<usize>> {
+    let mut children: HashMap<String, Vec<usize>> = HashMap::new();
+    for (index, entry) in catalog.entries.iter().enumerate() {
+        children
+            .entry(entry.parent_path.clone())
+            .or_default()
+            .push(index);
+    }
+    for indexes in children.values_mut() {
+        indexes.sort_by(|left, right| {
+            let left = &catalog.entries[*left];
+            let right = &catalog.entries[*right];
+            (
+                !left.is_folder,
+                left.name.to_ascii_lowercase(),
+                &left.provider_item_id,
+            )
+                .cmp(&(
+                    !right.is_folder,
+                    right.name.to_ascii_lowercase(),
+                    &right.provider_item_id,
+                ))
+        });
+    }
+    children
+}
+
 #[derive(Debug, Clone)]
 pub struct RemoteCatalogStore {
     path: PathBuf,

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -696,6 +696,7 @@ impl BrowserState {
 pub enum RemoteCatalogState {
     #[default]
     Ready,
+    Loading,
     Refreshing,
     Stale {
         error: String,
@@ -734,6 +735,7 @@ impl RemoteCatalogState {
     pub fn label(&self) -> &'static str {
         match self {
             Self::Ready => "READY",
+            Self::Loading => "LOADING",
             Self::Refreshing => "REFRESHING",
             Self::Stale { .. } => "STALE",
             Self::Partial { .. } => "PARTIAL",
@@ -748,6 +750,7 @@ mod remote_catalog_state_tests {
 
     #[test]
     fn refresh_auth_stale_and_partial_states_have_distinct_labels() {
+        assert_eq!(RemoteCatalogState::Loading.label(), "LOADING");
         assert_eq!(RemoteCatalogState::Refreshing.label(), "REFRESHING");
         assert_eq!(
             RemoteCatalogState::AuthenticationRequired {
@@ -850,30 +853,8 @@ impl RemoteUiState {
     /// reconciled. UI redraws can then navigate one folder without rescanning
     /// the complete provider catalog.
     pub fn rebuild_catalog_children(&mut self) {
-        let mut children: HashMap<String, Vec<usize>> = HashMap::new();
-        for (index, entry) in self.catalog.entries.iter().enumerate() {
-            children
-                .entry(entry.parent_path.clone())
-                .or_default()
-                .push(index);
-        }
-        for indexes in children.values_mut() {
-            indexes.sort_by(|left, right| {
-                let left = &self.catalog.entries[*left];
-                let right = &self.catalog.entries[*right];
-                (
-                    !left.is_folder,
-                    left.name.to_ascii_lowercase(),
-                    &left.provider_item_id,
-                )
-                    .cmp(&(
-                        !right.is_folder,
-                        right.name.to_ascii_lowercase(),
-                        &right.provider_item_id,
-                    ))
-            });
-        }
-        self.catalog_children = children;
+        self.catalog_children =
+            crate::remote_provider::build_remote_catalog_children(&self.catalog);
     }
 
     pub fn catalog_child_indices(&self, parent: &str) -> &[usize] {


### PR DESCRIPTION
## Summary

- load and deserialize the persisted Dropbox catalog on a blocking worker instead of in App::new
- build the 383k-entry folder index and cache availability map before returning the catalog to UI state
- expose an honest LOADING browser state while saved Remote metadata is prepared
- start the existing asynchronous Dropbox refresh only after the saved catalog is installed
- add a synchronization-based regression proving the loader yields to a single-thread UI executor

## Reproduction and result

The local Megalodon catalog is 214 MB with 383,557 entries. Before this change, launch spent 2.87 seconds between audio initialization and the later startup marker. After the change, UI-side startup reaches that marker immediately while catalog preparation continues in the background.

## Verification

- cargo test -p vibez-ui (498 passed)
- cargo clippy -p vibez-ui --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check