### PR TITLE
fix: keep Remote catalog refreshes off the UI thread

### DIFF
--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -22,6 +22,16 @@ where
         .map_err(|error| format!("Remote catalog startup task failed: {error}"))
 }
 
+async fn run_remote_refresh_preparer<T, F>(preparer: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    tokio::task::spawn_blocking(preparer)
+        .await
+        .map_err(|error| format!("Remote catalog refresh task failed: {error}"))
+}
+
 pub(super) fn remote_catalog_startup_task(cache: DropboxCache) -> Task<Message> {
     Task::perform(
         run_remote_startup_loader(move || {
@@ -94,32 +104,105 @@ pub(super) fn seed_remote_availability(
     cache: &DropboxCache,
     remote: &mut crate::state::RemoteUiState,
 ) {
+    remote.availability = refreshed_remote_availability(
+        cache,
+        &remote.catalog,
+        std::mem::take(&mut remote.availability),
+    );
+}
+
+fn refreshed_remote_availability(
+    cache: &DropboxCache,
+    catalog: &crate::remote_provider::RemoteCatalogSnapshot,
+    mut availability: std::collections::HashMap<String, crate::state::RemoteAvailability>,
+) -> std::collections::HashMap<String, crate::state::RemoteAvailability> {
     use crate::state::RemoteAvailability;
     let cached: std::collections::HashMap<String, Option<String>> =
         cache.cached_identities().into_iter().collect();
-    for entry in &remote.catalog.entries {
+    for entry in &catalog.entries {
         if entry.is_folder {
             continue;
         }
         let is_cached = cached
             .get(&entry.provider_item_id)
             .is_some_and(|revision| revision.as_deref() == entry.revision.as_deref());
-        match remote.availability.get(&entry.provider_item_id) {
+        match availability.get(&entry.provider_item_id) {
             Some(RemoteAvailability::Fetching) => {}
             Some(RemoteAvailability::Cached) if !is_cached => {
-                remote.availability.remove(&entry.provider_item_id);
+                availability.remove(&entry.provider_item_id);
             }
             _ if is_cached => {
-                remote
-                    .availability
-                    .insert(entry.provider_item_id.clone(), RemoteAvailability::Cached);
+                availability.insert(entry.provider_item_id.clone(), RemoteAvailability::Cached);
             }
             _ => {}
         }
     }
+    availability
 }
 
 impl App {
+    pub(super) fn prepare_remote_catalog_refresh(
+        &mut self,
+        pages: usize,
+        checkpoint: Option<String>,
+        continuation: crate::message::RemoteCatalogRefreshContinuation,
+    ) -> Task<Message> {
+        let generation = self.remote_catalog_request.current().unwrap_or(0);
+        let previous_catalog = Arc::clone(&self.state.browser.remote.catalog);
+        let previous_availability = self.state.browser.remote.availability.clone();
+        let changes = std::mem::take(&mut self.remote_catalog_pending);
+        let cache = self.dropbox_cache.clone();
+        Task::perform(
+            run_remote_refresh_preparer(move || {
+                if changes.is_empty() {
+                    let catalog = if previous_catalog.checkpoint == checkpoint {
+                        previous_catalog
+                    } else {
+                        let mut catalog = (*previous_catalog).clone();
+                        catalog.checkpoint = checkpoint;
+                        Arc::new(catalog)
+                    };
+                    return crate::message::RemoteCatalogRefreshData {
+                        generation,
+                        pages,
+                        catalog,
+                        catalog_children: None,
+                        availability: None,
+                        continuation,
+                    };
+                }
+
+                let mut catalog = (*previous_catalog).clone();
+                crate::remote_provider::reconcile_remote_catalog(
+                    &mut catalog,
+                    &crate::remote_provider::RemoteRefreshResult {
+                        pages: pages.max(1),
+                        changes,
+                        checkpoint,
+                        error: None,
+                    },
+                );
+                let catalog_children =
+                    crate::remote_provider::build_remote_catalog_children(&catalog);
+                let availability =
+                    refreshed_remote_availability(&cache, &catalog, previous_availability);
+                crate::message::RemoteCatalogRefreshData {
+                    generation,
+                    pages,
+                    catalog: Arc::new(catalog),
+                    catalog_children: Some(catalog_children),
+                    availability: Some(availability),
+                    continuation,
+                }
+            }),
+            |result| {
+                Message::RemoteCatalogRefreshPrepared(
+                    crate::message::RemoteCatalogRefreshResult::new(result),
+                )
+            },
+        )
+    }
+
     pub(super) fn remote_import_active(&self) -> bool {
         self.remote_import_request.is_active()
     }
@@ -175,32 +258,6 @@ impl App {
                 result,
             },
         )
-    }
-
-    /// Reconcile the pages accumulated since the last flush into the catalog
-    /// and rebuild the derived lookups. Returns whether anything changed.
-    pub(super) fn flush_remote_catalog_pages(
-        &mut self,
-        pages: usize,
-        checkpoint: Option<String>,
-    ) -> bool {
-        if self.remote_catalog_pending.is_empty() && checkpoint.is_none() {
-            return false;
-        }
-        let changes = std::mem::take(&mut self.remote_catalog_pending);
-        crate::remote_provider::reconcile_remote_catalog(
-            &mut self.state.browser.remote.catalog,
-            &crate::remote_provider::RemoteRefreshResult {
-                pages: pages.max(1),
-                changes,
-                checkpoint,
-                error: None,
-            },
-        );
-        self.state.browser.remote.rebuild_catalog_children();
-        self.state.browser.remote.refresh_items = self.state.browser.remote.catalog.entries.len();
-        self.reseed_remote_availability();
-        true
     }
 
     pub(super) fn start_remote_import(
@@ -396,7 +453,7 @@ impl App {
 mod startup_tests {
     use std::time::Duration;
 
-    use super::run_remote_startup_loader;
+    use super::{run_remote_refresh_preparer, run_remote_startup_loader};
 
     #[tokio::test(flavor = "current_thread")]
     async fn remote_startup_loader_never_blocks_the_ui_executor() {
@@ -411,6 +468,21 @@ mod startup_tests {
         tokio::task::yield_now().await;
         assert!(release_tx.send(()).is_ok());
         assert_eq!(loader.await.unwrap().unwrap(), 42);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn remote_refresh_preparation_never_blocks_the_ui_executor() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let preparation = tokio::spawn(run_remote_refresh_preparer(move || {
+            release_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("UI executor should release Remote refresh preparation");
+            42
+        }));
+
+        tokio::task::yield_now().await;
+        assert!(release_tx.send(()).is_ok());
+        assert_eq!(preparation.await.unwrap().unwrap(), 42);
     }
 }
 

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -873,6 +873,9 @@ impl App {
                 completed_pages,
                 result,
             } => return self.on_remote_catalog_page_fetched(generation, completed_pages, result),
+            Message::RemoteCatalogRefreshPrepared(result) => {
+                return self.on_remote_catalog_refresh_prepared(result)
+            }
             Message::RemoteCatalogSaved {
                 generation,
                 next_checkpoint,

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -24,7 +24,7 @@ impl App {
         match result {
             Ok(data) => {
                 let item_count = data.catalog.entries.len();
-                self.state.browser.remote.catalog = data.catalog;
+                self.state.browser.remote.catalog = Arc::new(data.catalog);
                 self.state.browser.remote.catalog_children = data.catalog_children;
                 self.state.browser.remote.availability.clear();
                 self.state.browser.remote.availability.extend(
@@ -146,14 +146,10 @@ impl App {
                 let next_checkpoint = page.checkpoint.clone();
                 self.remote_catalog_pending.extend(page.changes);
                 self.state.browser.remote.refresh_pages = pages;
-                // Reconciling re-sorts the catalog and rebuilds the
-                // child index, so batch it to save intervals and the
-                // final page instead of every page.
+                // Reconciliation is prepared off the UI thread at save
+                // intervals and at the final page.
                 let save_due = !has_more
                     || pages.is_multiple_of(super::dropbox_io::REMOTE_CATALOG_SAVE_PAGE_INTERVAL);
-                if save_due {
-                    self.flush_remote_catalog_pages(pages, (!has_more).then_some(page.checkpoint));
-                }
                 if has_more {
                     self.state.status_text = format!(
                         "Remote catalog: {} items available · fetching page {}…",
@@ -169,10 +165,13 @@ impl App {
                         return Task::none();
                     }
                     if save_due {
-                        // The next page is chained behind the save so
-                        // a persistence failure still stops the
-                        // refresh and only one save runs at a time.
-                        return self.remote_catalog_persist_task(Some(next_checkpoint));
+                        return self.prepare_remote_catalog_refresh(
+                            pages,
+                            None,
+                            crate::message::RemoteCatalogRefreshContinuation::FetchNext {
+                                checkpoint: next_checkpoint,
+                            },
+                        );
                     }
                     if let Some(client) = self.dropbox_client.clone() {
                         return super::dropbox_io::remote_catalog_page_task(
@@ -183,66 +182,137 @@ impl App {
                         );
                     }
                 } else {
-                    self.state.browser.remote.catalog_state =
-                        crate::state::RemoteCatalogState::Ready;
-                    self.state.status_text = format!(
-                        "Remote catalog refreshed: {} items across {pages} page(s)",
-                        self.state.browser.remote.refresh_items
+                    return self.prepare_remote_catalog_refresh(
+                        pages,
+                        Some(page.checkpoint),
+                        crate::message::RemoteCatalogRefreshContinuation::Complete,
                     );
-                    return self.remote_catalog_persist_task(None);
                 }
             }
             Err(error) => {
-                // Keep the pages that did arrive: reconcile them now
-                // and persist below so a mid-refresh failure cannot
-                // silently drop reconciled progress.
-                let flushed = self.flush_remote_catalog_pages(completed_pages, None);
-                if error.kind == crate::remote_provider::RemoteProviderErrorKind::CheckpointExpired
-                {
-                    // The provider invalidated our delta cursor; keep
-                    // the browsable catalog but restart the refresh
-                    // as a full listing from scratch.
-                    self.state.browser.remote.catalog.checkpoint = None;
-                    if let Some(client) = self.dropbox_client.clone() {
-                        self.state.browser.remote.refresh_pages = 0;
-                        self.state.status_text = "Remote checkpoint expired; rebuilding \
-                            the catalog from a full listing…"
-                            .into();
-                        return Task::batch([
-                            self.remote_catalog_persist_task(None),
-                            super::dropbox_io::remote_catalog_page_task(
-                                client, None, 0, generation,
-                            ),
-                        ]);
-                    }
+                if !self.remote_catalog_pending.is_empty() {
+                    return self.prepare_remote_catalog_refresh(
+                        completed_pages,
+                        None,
+                        crate::message::RemoteCatalogRefreshContinuation::Failed(error),
+                    );
                 }
-                self.state.browser.remote.catalog_state = if error.kind
-                    == crate::remote_provider::RemoteProviderErrorKind::Authentication
-                {
-                    crate::state::RemoteCatalogState::AuthenticationRequired {
-                        error: error.message.clone(),
-                    }
-                } else if completed_pages > 0 {
-                    crate::state::RemoteCatalogState::Partial {
-                        pages: completed_pages,
-                        error: error.message.clone(),
-                    }
-                } else {
-                    crate::state::RemoteCatalogState::Stale {
-                        error: error.message.clone(),
-                    }
-                };
-                self.state.status_text = format!(
-                    "Remote catalog kept {} available items after refresh error: {}",
-                    self.state.browser.remote.catalog.entries.len(),
-                    error.message
+                return self.finish_remote_catalog_refresh_error(
+                    generation,
+                    completed_pages,
+                    error,
+                    false,
                 );
-                if flushed {
-                    return self.remote_catalog_persist_task(None);
-                }
             }
         }
         Task::none()
+    }
+
+    pub(super) fn on_remote_catalog_refresh_prepared(
+        &mut self,
+        result: crate::message::RemoteCatalogRefreshResult,
+    ) -> Task<Message> {
+        let Some(result) = result.take() else {
+            return Task::none();
+        };
+        let data = match result {
+            Ok(data) => data,
+            Err(error) => {
+                self.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Stale {
+                    error: error.clone(),
+                };
+                self.state.status_text = error;
+                return Task::none();
+            }
+        };
+        if !self.remote_catalog_request.is_current(data.generation) {
+            std::thread::spawn(move || drop(data));
+            return Task::none();
+        }
+
+        let retired_catalog =
+            std::mem::replace(&mut self.state.browser.remote.catalog, data.catalog);
+        let retired_children = data.catalog_children.map(|children| {
+            std::mem::replace(&mut self.state.browser.remote.catalog_children, children)
+        });
+        let retired_availability = data.availability.map(|availability| {
+            std::mem::replace(&mut self.state.browser.remote.availability, availability)
+        });
+        // Large snapshots and their derived maps are destructed on a worker,
+        // too; replacing them must remain constant-time on the UI thread.
+        std::thread::spawn(move || {
+            drop((retired_catalog, retired_children, retired_availability));
+        });
+
+        self.state.browser.remote.refresh_items = self.state.browser.remote.catalog.entries.len();
+        match data.continuation {
+            crate::message::RemoteCatalogRefreshContinuation::FetchNext { checkpoint } => {
+                self.state.status_text = format!(
+                    "Remote catalog: {} items available · saving page {}…",
+                    self.state.browser.remote.refresh_items, data.pages
+                );
+                self.remote_catalog_persist_task(Some(checkpoint))
+            }
+            crate::message::RemoteCatalogRefreshContinuation::Complete => {
+                self.state.browser.remote.catalog_state = crate::state::RemoteCatalogState::Ready;
+                self.state.status_text = format!(
+                    "Remote catalog refreshed: {} items across {} page(s)",
+                    self.state.browser.remote.refresh_items, data.pages
+                );
+                self.remote_catalog_persist_task(None)
+            }
+            crate::message::RemoteCatalogRefreshContinuation::Failed(error) => {
+                self.finish_remote_catalog_refresh_error(data.generation, data.pages, error, true)
+            }
+        }
+    }
+
+    fn finish_remote_catalog_refresh_error(
+        &mut self,
+        generation: u64,
+        completed_pages: usize,
+        error: crate::remote_provider::RemoteProviderError,
+        reconciled_pages: bool,
+    ) -> Task<Message> {
+        if error.kind == crate::remote_provider::RemoteProviderErrorKind::CheckpointExpired {
+            // The provider invalidated our delta cursor; keep the browsable
+            // catalog but restart the refresh as a full listing from scratch.
+            Arc::make_mut(&mut self.state.browser.remote.catalog).checkpoint = None;
+            if let Some(client) = self.dropbox_client.clone() {
+                self.state.browser.remote.refresh_pages = 0;
+                self.state.status_text =
+                    "Remote checkpoint expired; rebuilding the catalog from a full listing…".into();
+                return Task::batch([
+                    self.remote_catalog_persist_task(None),
+                    super::dropbox_io::remote_catalog_page_task(client, None, 0, generation),
+                ]);
+            }
+        }
+        self.state.browser.remote.catalog_state =
+            if error.kind == crate::remote_provider::RemoteProviderErrorKind::Authentication {
+                crate::state::RemoteCatalogState::AuthenticationRequired {
+                    error: error.message.clone(),
+                }
+            } else if completed_pages > 0 {
+                crate::state::RemoteCatalogState::Partial {
+                    pages: completed_pages,
+                    error: error.message.clone(),
+                }
+            } else {
+                crate::state::RemoteCatalogState::Stale {
+                    error: error.message.clone(),
+                }
+            };
+        self.state.status_text = format!(
+            "Remote catalog kept {} available items after refresh error: {}",
+            self.state.browser.remote.catalog.entries.len(),
+            error.message
+        );
+        if reconciled_pages {
+            self.remote_catalog_persist_task(None)
+        } else {
+            Task::none()
+        }
     }
 
     pub(super) fn on_remote_catalog_saved(
@@ -421,11 +491,7 @@ impl App {
                     .remote
                     .availability
                     .insert(path_lower.clone(), crate::state::RemoteAvailability::Cached);
-                if let Some(entry) = self
-                    .state
-                    .browser
-                    .remote
-                    .catalog
+                if let Some(entry) = Arc::make_mut(&mut self.state.browser.remote.catalog)
                     .entries
                     .iter_mut()
                     .find(|entry| entry.provider_item_id == path_lower)

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -1,5 +1,7 @@
 //! Browser-domain update tests. Split from domains/browser.rs.
 
+use std::sync::Arc;
+
 use super::*;
 
 #[test]
@@ -390,7 +392,7 @@ fn selecting_visible_remote_folder_from_local_activates_that_folder_in_one_click
         }),
         ..BrowserState::default()
     };
-    browser.remote.catalog.entries = vec![
+    Arc::make_mut(&mut browser.remote.catalog).entries = vec![
         RemoteCatalogEntry {
             provider_item_id: "/megalodon".into(),
             path: "/Megalodon".into(),
@@ -511,7 +513,7 @@ fn remote_catalog_children_are_indexed_folder_first_per_parent() {
         derived_metadata: None,
     };
     let mut browser = BrowserState::default();
-    browser.remote.catalog.entries = vec![
+    Arc::make_mut(&mut browser.remote.catalog).entries = vec![
         entry("/z.wav", "", "z.wav", false),
         entry("/beats", "", "Beats", true),
         entry("/a.wav", "", "a.wav", false),

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -178,6 +178,44 @@ pub struct RemoteCatalogStartupData {
     pub load_error: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub enum RemoteCatalogRefreshContinuation {
+    FetchNext { checkpoint: String },
+    Complete,
+    Failed(crate::remote_provider::RemoteProviderError),
+}
+
+#[derive(Debug)]
+pub struct RemoteCatalogRefreshData {
+    pub generation: u64,
+    pub pages: usize,
+    pub catalog: Arc<crate::remote_provider::RemoteCatalogSnapshot>,
+    pub catalog_children: Option<HashMap<String, Vec<usize>>>,
+    pub availability: Option<HashMap<String, crate::state::RemoteAvailability>>,
+    pub continuation: RemoteCatalogRefreshContinuation,
+}
+
+#[derive(Clone)]
+pub struct RemoteCatalogRefreshResult(
+    Arc<std::sync::Mutex<Option<Result<RemoteCatalogRefreshData, String>>>>,
+);
+
+impl RemoteCatalogRefreshResult {
+    pub fn new(result: Result<RemoteCatalogRefreshData, String>) -> Self {
+        Self(Arc::new(std::sync::Mutex::new(Some(result))))
+    }
+
+    pub fn take(&self) -> Option<Result<RemoteCatalogRefreshData, String>> {
+        self.0.lock().ok()?.take()
+    }
+}
+
+impl std::fmt::Debug for RemoteCatalogRefreshResult {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RemoteCatalogRefreshResult")
+    }
+}
+
 #[derive(Clone)]
 pub struct RemoteCatalogStartupResult(
     Arc<std::sync::Mutex<Option<Result<RemoteCatalogStartupData, String>>>>,
@@ -658,6 +696,7 @@ pub enum Message {
         result:
             Result<crate::remote_provider::RemotePage, crate::remote_provider::RemoteProviderError>,
     },
+    RemoteCatalogRefreshPrepared(RemoteCatalogRefreshResult),
     RemoteCatalogSaved {
         generation: u64,
         /// `Some` continues pagination from this checkpoint after a

--- a/crates/vibez-ui/src/remote_provider.rs
+++ b/crates/vibez-ui/src/remote_provider.rs
@@ -280,6 +280,12 @@ pub fn reconcile_remote_catalog(
 ) {
     debug_assert!(result.pages > 0 || result.changes.is_empty());
     debug_assert!(result.error.is_none() || result.checkpoint.is_none());
+    if result.changes.is_empty() {
+        if let Some(checkpoint) = &result.checkpoint {
+            snapshot.checkpoint = Some(checkpoint.clone());
+        }
+        return;
+    }
     let mut entries: HashMap<String, RemoteCatalogEntry> = snapshot
         .entries
         .drain(..)
@@ -598,6 +604,30 @@ mod tests {
         reconcile_remote_catalog(&mut snapshot, &result);
         assert_eq!(snapshot.entries, vec![entry("/new.wav")]);
         assert_eq!(snapshot.checkpoint.as_deref(), Some("next"));
+    }
+
+    #[test]
+    fn an_empty_delta_advances_only_the_checkpoint() {
+        let mut snapshot = RemoteCatalogSnapshot {
+            checkpoint: Some("old".into()),
+            entries: vec![entry("/Megalodon/Kick.wav")],
+            ..RemoteCatalogSnapshot::default()
+        };
+        let entries_allocation = snapshot.entries.as_ptr();
+
+        reconcile_remote_catalog(
+            &mut snapshot,
+            &RemoteRefreshResult {
+                pages: 1,
+                changes: Vec::new(),
+                checkpoint: Some("next".into()),
+                error: None,
+            },
+        );
+
+        assert_eq!(snapshot.checkpoint.as_deref(), Some("next"));
+        assert_eq!(snapshot.entries.as_ptr(), entries_allocation);
+        assert_eq!(snapshot.entries, vec![entry("/Megalodon/Kick.wav")]);
     }
 
     #[test]

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -790,7 +790,7 @@ pub struct RemoteUiState {
     /// An OAuth flow is in progress; Connect button is disabled.
     pub auth_in_progress: bool,
     pub last_error: Option<String>,
-    pub catalog: RemoteCatalogSnapshot,
+    pub catalog: Arc<RemoteCatalogSnapshot>,
     pub catalog_state: RemoteCatalogState,
     /// Pages and entries applied during the current progressive Catalog Refresh.
     pub refresh_pages: usize,
@@ -827,7 +827,7 @@ impl Default for RemoteUiState {
             has_app_key: false,
             auth_in_progress: false,
             last_error: None,
-            catalog: RemoteCatalogSnapshot::default(),
+            catalog: Arc::new(RemoteCatalogSnapshot::default()),
             catalog_state: RemoteCatalogState::default(),
             refresh_pages: 0,
             refresh_items: 0,
@@ -852,6 +852,7 @@ impl RemoteUiState {
     /// Rebuild the parent/children lookup after the catalog is loaded or
     /// reconciled. UI redraws can then navigate one folder without rescanning
     /// the complete provider catalog.
+    #[cfg(test)]
     pub fn rebuild_catalog_children(&mut self) {
         self.catalog_children =
             crate::remote_provider::build_remote_catalog_children(&self.catalog);


### PR DESCRIPTION
## Summary

- prepare Dropbox refresh reconciliation, sorting, folder indexes, and cache availability on a blocking worker
- share catalog snapshots so persistence no longer clones hundreds of thousands of entries in update()
- make an empty Dropbox delta advance only its checkpoint instead of rebuilding the entire catalog
- retire replaced large catalog state away from the UI thread
- preserve progressive saves, failure recovery, cancellation generations, and checkpoint-expiry rebuilds
- add executor and empty-delta regressions

## Diagnosis

Measured against the saved Megalodon catalog (383,557 entries):

- catalog clone: 211 ms
- reconcile and sort: 7.13 s
- rebuild folder index: 366 ms
- cache availability pass: 408 ms

All four operations ran synchronously after a Remote page arrived, explaining the freeze while the status bar showed “Refreshing Remote catalog…”. They are now removed from the UI update path.

## Verification

- cargo test -p vibez-ui (501 passed)
- cargo clippy -p vibez-ui --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo check -p vibez-ui --all-targets
- git diff --check