### PR TITLE
fix: close v0.1.5 refresh and section-boundary races

### DIFF
--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -349,6 +349,7 @@ impl AudioEngine {
         }
         if section_ended {
             self.stop_section_record();
+            self.apply_end_of_section_track_mutes_at_queued_boundary();
             self.cancel_queued_track_mutes();
             let _ = self.event_tx.push(EngineEvent::PerformanceCaptureStopped {
                 effective_at_samples: self.performance_position,

--- a/crates/vibez-engine/src/engine_automation_commands.rs
+++ b/crates/vibez-engine/src/engine_automation_commands.rs
@@ -174,6 +174,17 @@ impl AudioEngine {
         }
     }
 
+    pub(super) fn apply_end_of_section_track_mutes_at_queued_boundary(&mut self) {
+        while let Some((track_id, queued)) = self.tracks.iter().find_map(|track| {
+            track
+                .queued_mute
+                .filter(|queued| queued.end_of_section)
+                .map(|queued| (track.id, queued))
+        }) {
+            self.apply_track_mute_at(track_id, queued.muted, queued.effective_at_samples);
+        }
+    }
+
     pub(super) fn cancel_queued_track_mutes(&mut self) {
         for track in &mut self.tracks {
             if track.queued_mute.take().is_some() {

--- a/crates/vibez-engine/src/engine_section_queue_tests.rs
+++ b/crates/vibez-engine/src/engine_section_queue_tests.rs
@@ -26,10 +26,20 @@ fn source(
     length_beats: f64,
     value: f32,
 ) -> Box<PreparedSectionPlaybackSource> {
+    source_with_looping(section_id, track_id, length_beats, value, true)
+}
+
+fn source_with_looping(
+    section_id: SectionId,
+    track_id: TrackId,
+    length_beats: f64,
+    value: f32,
+    looping: bool,
+) -> Box<PreparedSectionPlaybackSource> {
     Box::new(PreparedSectionPlaybackSource::new(
         section_id,
         length_beats,
-        true,
+        looping,
         vec![(
             track_id,
             PreparedPlaybackSource::new(
@@ -268,6 +278,49 @@ fn one_bar_and_end_of_section_use_their_exact_boundaries() {
 #[test]
 fn end_of_section_track_mute_uses_the_active_section_wrap() {
     let (mut engine, mut commands, mut events, track_id) = playing_engine(0.6, 2.0);
+    while events.pop().is_ok() {}
+    commands
+        .push(EngineCommand::QueueTrackMute {
+            track_id,
+            muted: true,
+            quantization: TrackMuteQuantization::EndOfSection,
+        })
+        .unwrap();
+
+    engine.process(&mut [0.0; 10], 1);
+
+    assert!(
+        std::iter::from_fn(|| events.pop().ok()).any(|event| matches!(
+            event,
+            EngineEvent::TrackMuteChanged {
+                track_id: event_track,
+                muted: true,
+                effective_at_samples: 8,
+            } if event_track == track_id
+        ))
+    );
+    assert!(engine.tracks()[0].mute);
+}
+
+#[test]
+fn end_of_section_track_mute_applies_when_a_one_shot_section_stops() {
+    let (mut engine, mut commands, mut events) = AudioEngine::new();
+    let track_id = TrackId::new();
+    commands.push(EngineCommand::SetSampleRate(8)).unwrap();
+    commands.push(EngineCommand::SetBpm(120.0)).unwrap();
+    commands
+        .push(EngineCommand::AddTrack(track_id, "Audio".into()))
+        .unwrap();
+    commands
+        .push(EngineCommand::LaunchSection(source_with_looping(
+            SectionId::new(),
+            track_id,
+            2.0,
+            0.6,
+            false,
+        )))
+        .unwrap();
+    engine.process(&mut [0.0], 1);
     while events.pop().is_ok() {}
     commands
         .push(EngineCommand::QueueTrackMute {

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -109,6 +109,7 @@ pub(super) fn seed_remote_availability(
         &remote.catalog,
         std::mem::take(&mut remote.availability),
     );
+    remote.mark_catalog_runtime_changed();
 }
 
 fn refreshed_remote_availability(
@@ -140,6 +141,71 @@ fn refreshed_remote_availability(
     availability
 }
 
+fn catalog_with_refresh_checkpoint(
+    previous_catalog: Arc<crate::remote_provider::RemoteCatalogSnapshot>,
+    checkpoint: Option<String>,
+) -> Arc<crate::remote_provider::RemoteCatalogSnapshot> {
+    let Some(checkpoint) = checkpoint else {
+        return previous_catalog;
+    };
+    if previous_catalog.checkpoint.as_deref() == Some(&checkpoint) {
+        return previous_catalog;
+    }
+    let mut catalog = (*previous_catalog).clone();
+    catalog.checkpoint = Some(checkpoint);
+    Arc::new(catalog)
+}
+
+fn rebase_remote_catalog_refresh(
+    mut data: crate::message::RemoteCatalogRefreshData,
+    live_catalog: Arc<crate::remote_provider::RemoteCatalogSnapshot>,
+    live_availability: std::collections::HashMap<String, crate::state::RemoteAvailability>,
+    live_runtime_revision: u64,
+) -> crate::message::RemoteCatalogRefreshData {
+    let base_by_id: std::collections::HashMap<_, _> = data
+        .base_catalog
+        .entries
+        .iter()
+        .map(|entry| (entry.provider_item_id.as_str(), entry))
+        .collect();
+    let live_by_id: std::collections::HashMap<_, _> = live_catalog
+        .entries
+        .iter()
+        .map(|entry| (entry.provider_item_id.as_str(), entry))
+        .collect();
+    for entry in &mut Arc::make_mut(&mut data.catalog).entries {
+        let Some(live_entry) = live_by_id.get(entry.provider_item_id.as_str()) else {
+            continue;
+        };
+        let base_metadata = base_by_id
+            .get(entry.provider_item_id.as_str())
+            .and_then(|base_entry| base_entry.derived_metadata.as_ref());
+        if live_entry.revision == entry.revision
+            && live_entry.derived_metadata.as_ref() != base_metadata
+        {
+            entry.derived_metadata = live_entry.derived_metadata.clone();
+        }
+    }
+
+    if let Some(availability) = data.availability.as_mut() {
+        for provider_item_id in data.base_availability.keys() {
+            if !live_availability.contains_key(provider_item_id) {
+                availability.remove(provider_item_id);
+            }
+        }
+        for (provider_item_id, live_state) in &live_availability {
+            if data.base_availability.get(provider_item_id) != Some(live_state) {
+                availability.insert(provider_item_id.clone(), live_state.clone());
+            }
+        }
+    }
+
+    data.base_catalog = live_catalog;
+    data.base_availability = live_availability;
+    data.base_runtime_revision = live_runtime_revision;
+    data
+}
+
 impl App {
     pub(super) fn prepare_remote_catalog_refresh(
         &mut self,
@@ -150,28 +216,29 @@ impl App {
         let generation = self.remote_catalog_request.current().unwrap_or(0);
         let previous_catalog = Arc::clone(&self.state.browser.remote.catalog);
         let previous_availability = self.state.browser.remote.availability.clone();
+        let base_runtime_revision = self.state.browser.remote.catalog_runtime_revision;
         let changes = std::mem::take(&mut self.remote_catalog_pending);
         let cache = self.dropbox_cache.clone();
         Task::perform(
             run_remote_refresh_preparer(move || {
                 if changes.is_empty() {
-                    let catalog = if previous_catalog.checkpoint == checkpoint {
-                        previous_catalog
-                    } else {
-                        let mut catalog = (*previous_catalog).clone();
-                        catalog.checkpoint = checkpoint;
-                        Arc::new(catalog)
-                    };
+                    let catalog =
+                        catalog_with_refresh_checkpoint(Arc::clone(&previous_catalog), checkpoint);
                     return crate::message::RemoteCatalogRefreshData {
                         generation,
                         pages,
                         catalog,
                         catalog_children: None,
                         availability: None,
+                        base_catalog: previous_catalog,
+                        base_availability: previous_availability,
+                        base_runtime_revision,
                         continuation,
                     };
                 }
 
+                let base_catalog = Arc::clone(&previous_catalog);
+                let base_availability = previous_availability.clone();
                 let mut catalog = (*previous_catalog).clone();
                 crate::remote_provider::reconcile_remote_catalog(
                     &mut catalog,
@@ -192,12 +259,40 @@ impl App {
                     catalog: Arc::new(catalog),
                     catalog_children: Some(catalog_children),
                     availability: Some(availability),
+                    base_catalog,
+                    base_availability,
+                    base_runtime_revision,
                     continuation,
                 }
             }),
-            |result| {
+            move |result| {
                 Message::RemoteCatalogRefreshPrepared(
-                    crate::message::RemoteCatalogRefreshResult::new(result),
+                    crate::message::RemoteCatalogRefreshResult::new(generation, result),
+                )
+            },
+        )
+    }
+
+    pub(super) fn rebase_remote_catalog_refresh(
+        &self,
+        data: crate::message::RemoteCatalogRefreshData,
+    ) -> Task<Message> {
+        let generation = data.generation;
+        let live_catalog = Arc::clone(&self.state.browser.remote.catalog);
+        let live_availability = self.state.browser.remote.availability.clone();
+        let live_runtime_revision = self.state.browser.remote.catalog_runtime_revision;
+        Task::perform(
+            run_remote_refresh_preparer(move || {
+                rebase_remote_catalog_refresh(
+                    data,
+                    live_catalog,
+                    live_availability,
+                    live_runtime_revision,
+                )
+            }),
+            move |result| {
+                Message::RemoteCatalogRefreshPrepared(
+                    crate::message::RemoteCatalogRefreshResult::new(generation, result),
                 )
             },
         )
@@ -281,6 +376,7 @@ impl App {
                 crate::state::RemoteAvailability::Fetching
             },
         );
+        self.state.browser.remote.mark_catalog_runtime_changed();
         self.state.status_text = format!("Importing Remote media: {}", entry.name);
         let client = self.dropbox_client.clone();
         let cache = self.dropbox_cache.clone();
@@ -373,6 +469,7 @@ impl App {
                 entry.path_lower,
                 crate::state::RemoteAvailability::ReconnectRequired,
             );
+            self.state.browser.remote.mark_catalog_runtime_changed();
             self.state.status_text =
                 "Reconnect Required · this Remote item is not in Media Cache".into();
             self.state
@@ -397,6 +494,7 @@ impl App {
                 crate::state::RemoteAvailability::Fetching
             },
         );
+        self.state.browser.remote.mark_catalog_runtime_changed();
         self.state.status_text = if cached {
             format!("Preparing cached Audition: {}", entry.name)
         } else {
@@ -519,5 +617,92 @@ mod tests {
             pending.as_ref().map(|entry| entry.path_lower.as_str()),
             Some("/winner.wav")
         );
+    }
+
+    #[test]
+    fn intermediate_refresh_without_a_checkpoint_preserves_the_saved_cursor() {
+        let previous = Arc::new(crate::remote_provider::RemoteCatalogSnapshot {
+            checkpoint: Some("saved-cursor".into()),
+            ..Default::default()
+        });
+
+        let refreshed = catalog_with_refresh_checkpoint(Arc::clone(&previous), None);
+
+        assert!(Arc::ptr_eq(&previous, &refreshed));
+        assert_eq!(refreshed.checkpoint.as_deref(), Some("saved-cursor"));
+    }
+
+    #[test]
+    fn prepared_refresh_rebases_materialized_metadata_and_availability() {
+        let base_catalog = Arc::new(crate::remote_provider::RemoteCatalogSnapshot {
+            entries: vec![crate::remote_provider::RemoteCatalogEntry {
+                provider_item_id: "/kick.wav".into(),
+                path: "/kick.wav".into(),
+                parent_path: String::new(),
+                name: "kick.wav".into(),
+                is_folder: false,
+                revision: Some("rev-1".into()),
+                size: Some(128),
+                derived_metadata: None,
+            }],
+            checkpoint: Some("old".into()),
+            ..Default::default()
+        });
+        let mut live_catalog = (*base_catalog).clone();
+        live_catalog.entries[0].derived_metadata = Some(vibez_dropbox::DerivedMetadata {
+            duration_seconds: 0.5,
+            channels: 1,
+            sample_rate: 44_100,
+            ..Default::default()
+        });
+        let live_catalog = Arc::new(live_catalog);
+        let base_availability = std::collections::HashMap::from([(
+            "/kick.wav".into(),
+            crate::state::RemoteAvailability::Fetching,
+        )]);
+        let live_availability = std::collections::HashMap::from([(
+            "/kick.wav".into(),
+            crate::state::RemoteAvailability::Cached,
+        )]);
+        let mut prepared_catalog = (*base_catalog).clone();
+        prepared_catalog.checkpoint = Some("new".into());
+        let data = crate::message::RemoteCatalogRefreshData {
+            generation: 4,
+            pages: 1,
+            catalog: Arc::new(prepared_catalog),
+            catalog_children: Some(Default::default()),
+            availability: Some(base_availability.clone()),
+            base_catalog,
+            base_availability,
+            base_runtime_revision: 7,
+            continuation: crate::message::RemoteCatalogRefreshContinuation::Complete,
+        };
+
+        let rebased =
+            rebase_remote_catalog_refresh(data, Arc::clone(&live_catalog), live_availability, 8);
+
+        assert_eq!(
+            rebased.catalog.entries[0]
+                .derived_metadata
+                .as_ref()
+                .unwrap()
+                .sample_rate,
+            44_100
+        );
+        assert_eq!(
+            rebased.availability.as_ref().unwrap().get("/kick.wav"),
+            Some(&crate::state::RemoteAvailability::Cached)
+        );
+        assert!(Arc::ptr_eq(&rebased.base_catalog, &live_catalog));
+        assert_eq!(rebased.base_runtime_revision, 8);
+    }
+
+    #[test]
+    fn refresh_errors_retain_their_generation_for_stale_result_rejection() {
+        let result =
+            crate::message::RemoteCatalogRefreshResult::new(23, Err("worker stopped".into()));
+
+        assert_eq!(result.generation(), 23);
+        assert!(matches!(result.take(), Some(Err(error)) if error == "worker stopped"));
     }
 }

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -34,6 +34,7 @@ impl App {
                             (provider_item_id, crate::state::RemoteAvailability::Cached)
                         }),
                 );
+                self.state.browser.remote.mark_catalog_runtime_changed();
                 self.state.browser.remote.cache_usage_bytes = data.cache_usage.bytes;
                 self.state.browser.remote.cache_entries = data.cache_usage.entries;
                 self.state.browser.remote.refresh_items = item_count;
@@ -212,6 +213,10 @@ impl App {
         &mut self,
         result: crate::message::RemoteCatalogRefreshResult,
     ) -> Task<Message> {
+        if !self.remote_catalog_request.is_current(result.generation()) {
+            std::thread::spawn(move || drop(result));
+            return Task::none();
+        }
         let Some(result) = result.take() else {
             return Task::none();
         };
@@ -225,9 +230,8 @@ impl App {
                 return Task::none();
             }
         };
-        if !self.remote_catalog_request.is_current(data.generation) {
-            std::thread::spawn(move || drop(data));
-            return Task::none();
+        if data.base_runtime_revision != self.state.browser.remote.catalog_runtime_revision {
+            return self.rebase_remote_catalog_refresh(data);
         }
 
         let retired_catalog =
@@ -498,6 +502,7 @@ impl App {
                 {
                     entry.derived_metadata = Some(materialized.metadata.clone());
                 }
+                self.state.browser.remote.mark_catalog_runtime_changed();
                 let persist = self.remote_catalog_persist_task(None);
                 let maintenance = self.media_cache_maintenance_task();
                 self.remote_audition_cache_lease = Some(materialized.lease);
@@ -535,6 +540,7 @@ impl App {
                     .remote
                     .availability
                     .insert(path_lower, availability);
+                self.state.browser.remote.mark_catalog_runtime_changed();
                 self.state
                     .browser
                     .fail_waveform_load(&source, error.clone());

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -192,21 +192,32 @@ pub struct RemoteCatalogRefreshData {
     pub catalog: Arc<crate::remote_provider::RemoteCatalogSnapshot>,
     pub catalog_children: Option<HashMap<String, Vec<usize>>>,
     pub availability: Option<HashMap<String, crate::state::RemoteAvailability>>,
+    pub base_catalog: Arc<crate::remote_provider::RemoteCatalogSnapshot>,
+    pub base_availability: HashMap<String, crate::state::RemoteAvailability>,
+    pub base_runtime_revision: u64,
     pub continuation: RemoteCatalogRefreshContinuation,
 }
 
 #[derive(Clone)]
-pub struct RemoteCatalogRefreshResult(
-    Arc<std::sync::Mutex<Option<Result<RemoteCatalogRefreshData, String>>>>,
-);
+pub struct RemoteCatalogRefreshResult {
+    generation: u64,
+    result: Arc<std::sync::Mutex<Option<Result<RemoteCatalogRefreshData, String>>>>,
+}
 
 impl RemoteCatalogRefreshResult {
-    pub fn new(result: Result<RemoteCatalogRefreshData, String>) -> Self {
-        Self(Arc::new(std::sync::Mutex::new(Some(result))))
+    pub fn new(generation: u64, result: Result<RemoteCatalogRefreshData, String>) -> Self {
+        Self {
+            generation,
+            result: Arc::new(std::sync::Mutex::new(Some(result))),
+        }
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
     }
 
     pub fn take(&self) -> Option<Result<RemoteCatalogRefreshData, String>> {
-        self.0.lock().ok()?.take()
+        self.result.lock().ok()?.take()
     }
 }
 

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -811,6 +811,10 @@ pub struct RemoteUiState {
     /// A preview fetch / playback is in flight.
     pub preview_in_progress: bool,
     pub availability: HashMap<String, RemoteAvailability>,
+    /// Changes made by materialization/import flows while a catalog refresh
+    /// snapshot is being prepared. Prepared snapshots use this to detect and
+    /// rebase over newer UI-owned metadata instead of replacing it.
+    pub catalog_runtime_revision: u64,
     pub cache_usage_bytes: u64,
     pub cache_entries: usize,
     pub cache_budget_bytes: u64,
@@ -839,6 +843,7 @@ impl Default for RemoteUiState {
             selected_path: None,
             preview_in_progress: false,
             availability: HashMap::new(),
+            catalog_runtime_revision: 0,
             cache_usage_bytes: 0,
             cache_entries: 0,
             cache_budget_bytes: vibez_dropbox::DEFAULT_MEDIA_CACHE_BUDGET_BYTES,
@@ -849,6 +854,10 @@ impl Default for RemoteUiState {
 }
 
 impl RemoteUiState {
+    pub(crate) fn mark_catalog_runtime_changed(&mut self) {
+        self.catalog_runtime_revision = self.catalog_runtime_revision.wrapping_add(1);
+    }
+
     /// Rebuild the parent/children lookup after the catalog is loaded or
     /// reconciled. UI redraws can then navigate one folder without rescanning
     /// the complete provider catalog.


### PR DESCRIPTION
## Summary
- preserve the last committed Dropbox cursor during intermediate empty refresh batches
- rebase prepared Remote catalog snapshots over materialization/cache changes made while the worker runs
- reject stale refresh worker failures before they can alter current UI state
- apply End of Section track mutes when a non-looping Section reaches its terminal boundary

## Why
This addresses the release-correctness findings in the review on #149. Prepared refreshes previously replaced newer UI-owned metadata and availability with their captured baseline, and error completions did not carry enough identity to reject stale workers. A one-shot Section also stopped and cancelled its queued End of Section mute before the command became effective.

## Regression coverage
- intermediate `None` checkpoints preserve the saved Dropbox cursor
- a prepared refresh rebases newly materialized metadata and Cached availability
- refresh failures retain their generation for stale-result rejection
- a one-shot Section applies its queued track mute at the exact end boundary

## Verification
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --exclude vibez-plugin-host -- -D warnings`
- `cargo clippy -p vibez-plugin-host -- -D warnings`
- `cargo fmt --all -- --check`

## Deferred review notes
- Recent Projects pruning on transient load errors should follow typed project-load error classification, rather than guessing from the current string error.
- The broader Remote catalog orchestration/DRY suggestions are valuable follow-ups but are not required for this correctness patch.

Refs #149
