### PR TITLE
fix: retain recent projects after transient load errors

### DIFF
--- a/crates/vibez-ui/src/app/async_helpers.rs
+++ b/crates/vibez-ui/src/app/async_helpers.rs
@@ -571,33 +571,63 @@ pub(super) async fn finish_loaded_clip(
     }
 }
 
+fn classify_project_format_load_error(
+    error: vibez_project::project_format_v1::ProjectFormatError,
+) -> crate::message::ProjectLoadError {
+    let missing = matches!(
+        &error,
+        vibez_project::project_format_v1::ProjectFormatError::Io(io_error)
+            if io_error.kind() == std::io::ErrorKind::NotFound
+    );
+    if missing {
+        crate::message::ProjectLoadError::missing_project(error.to_string())
+    } else {
+        crate::message::ProjectLoadError::other(error.to_string())
+    }
+}
+
+fn classify_legacy_project_load_error(
+    error: vibez_project::ProjectError,
+) -> crate::message::ProjectLoadError {
+    let missing = matches!(
+        &error,
+        vibez_project::ProjectError::Io(io_error)
+            if io_error.kind() == std::io::ErrorKind::NotFound
+    );
+    if missing {
+        crate::message::ProjectLoadError::missing_project(error.to_string())
+    } else {
+        crate::message::ProjectLoadError::other(error.to_string())
+    }
+}
+
 pub(super) async fn load_project_async(
     path: PathBuf,
     dropbox: Option<(Arc<DropboxClient>, DropboxCache)>,
-) -> Result<ProjectLoadResult, String> {
+) -> Result<ProjectLoadResult, crate::message::ProjectLoadError> {
     let load_path = path.clone();
     let (project, container_path) = tokio::task::spawn_blocking(move || {
         match vibez_project::project_format_v1::detect_project_format(&load_path)
-            .map_err(|error| error.to_string())?
+            .map_err(classify_project_format_load_error)?
         {
             vibez_project::project_format_v1::ProjectFileFormat::V1 => {
                 let container =
                     vibez_project::project_format_v1::ProjectContainer::open(&load_path)
-                        .map_err(|error| error.to_string())?;
+                        .map_err(classify_project_format_load_error)?;
                 let document = container
                     .load_document()
-                    .map_err(|error| error.to_string())?;
+                    .map_err(classify_project_format_load_error)?;
                 Ok((document.project, Some(load_path)))
             }
             vibez_project::project_format_v1::ProjectFileFormat::LegacyJson => {
                 Project::load_from_file(&load_path)
                     .map(|project| (project, None))
-                    .map_err(|error| error.to_string())
+                    .map_err(classify_legacy_project_load_error)
             }
         }
     })
     .await
-    .map_err(|err| format!("load task failed: {err}"))??;
+    .map_err(|err| crate::message::ProjectLoadError::other(format!("load task failed: {err}")))??;
 
     let mut clips = Vec::new();
     let mut unresolved_clips = Vec::new();
@@ -880,5 +910,34 @@ mod export_tests {
             0,
             "failed export must clean up every temporary file"
         );
+    }
+}
+
+#[cfg(test)]
+mod project_load_error_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_missing_top_level_project_is_classified_for_recent_path_pruning() {
+        let directory = tempfile::tempdir().unwrap();
+        let missing = directory.path().join("removed.vzp");
+
+        let error = load_project_async(missing, None).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            crate::message::ProjectLoadError::MissingProject(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_existing_but_invalid_project_is_not_classified_as_missing() {
+        let directory = tempfile::tempdir().unwrap();
+        let invalid = directory.path().join("invalid.vzp");
+        std::fs::write(&invalid, "not a Vibez project").unwrap();
+
+        let error = load_project_async(invalid, None).await.unwrap_err();
+
+        assert!(matches!(error, crate::message::ProjectLoadError::Other(_)));
     }
 }

--- a/crates/vibez-ui/src/app/update_project.rs
+++ b/crates/vibez-ui/src/app/update_project.rs
@@ -165,7 +165,7 @@ impl App {
     pub(super) fn route_project_loaded(
         &mut self,
         attempted_path: PathBuf,
-        result: Result<ProjectLoadResult, String>,
+        result: Result<ProjectLoadResult, crate::message::ProjectLoadError>,
     ) -> Task<Message> {
         match result {
             Ok(loaded) => {
@@ -174,7 +174,9 @@ impl App {
                 self.remember_recent_project(path);
             }
             Err(err) => {
-                self.forget_recent_project(&attempted_path);
+                if err.is_missing_project() {
+                    self.forget_recent_project(&attempted_path);
+                }
                 self.state.status_text = format!("Project load error: {err}");
             }
         }
@@ -266,5 +268,23 @@ impl App {
         self.state.project.close_confirm_open = false;
         self.state.project.exit_after_save = false;
         Task::none()
+    }
+}
+
+#[cfg(test)]
+mod recent_project_load_error_tests {
+    #[test]
+    fn transient_load_errors_keep_the_recent_project_path() {
+        let error = crate::message::ProjectLoadError::other("permission temporarily denied");
+
+        assert!(!error.is_missing_project());
+    }
+
+    #[test]
+    fn a_confirmed_missing_project_prunes_the_recent_project_path() {
+        let error =
+            crate::message::ProjectLoadError::MissingProject("project file was not found".into());
+
+        assert!(error.is_missing_project());
     }
 }

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -338,6 +338,34 @@ pub struct ProjectLoadResult {
 }
 
 #[derive(Debug, Clone)]
+pub enum ProjectLoadError {
+    MissingProject(String),
+    Other(String),
+}
+
+impl ProjectLoadError {
+    pub fn missing_project(error: impl Into<String>) -> Self {
+        Self::MissingProject(error.into())
+    }
+
+    pub fn other(error: impl Into<String>) -> Self {
+        Self::Other(error.into())
+    }
+
+    pub fn is_missing_project(&self) -> bool {
+        matches!(self, Self::MissingProject(_))
+    }
+}
+
+impl std::fmt::Display for ProjectLoadError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingProject(error) | Self::Other(error) => formatter.write_str(error),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct ProjectSaveResult {
     pub path: PathBuf,
     pub project: Project,
@@ -472,7 +500,7 @@ pub enum Message {
     ProjectSavePathSelected(Option<PathBuf>),
     ProjectLoaded {
         path: PathBuf,
-        result: Box<Result<ProjectLoadResult, String>>,
+        result: Box<Result<ProjectLoadResult, ProjectLoadError>>,
     },
     ProjectSaved(Box<ProjectSaveCompleted>),
 


### PR DESCRIPTION
## Summary

- carry typed project-load failure intent through the async load message instead of flattening every error into a string
- remove a Recent Projects entry only when the top-level project file returns `NotFound`
- retain the entry for permission failures, worker failures, malformed/corrupt projects, SQLite errors, and other retryable or repairable failures
- preserve the existing visible load-error message

## Why

The Recent Projects router previously called `forget_recent_project` for every load failure. A transient filesystem or worker failure therefore permanently removed a valid project from the menu.

This is intentionally a post-v0.1.5 follow-up and does not need to join release PR #149.

## Regression coverage

- a missing top-level project is classified for pruning
- an existing but invalid project is not classified as missing
- transient errors retain the recent path
- confirmed missing paths remain prunable

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --exclude vibez-plugin-host -- -D warnings`
- `cargo clippy -p vibez-plugin-host -- -D warnings`
- `cargo fmt --all -- --check`

Follow-up to the review on #149.
