### PR TITLE
refactor: give RemoteUiState ownership of availability mutations

### DIFF
--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -44,23 +44,16 @@ pub(super) fn remote_catalog_startup_task(cache: DropboxCache) -> Task<Message> 
                 ),
             };
             let catalog_children = crate::remote_provider::build_remote_catalog_children(&catalog);
-            let cached_identities: std::collections::HashMap<String, Option<String>> =
-                cache.cached_identities().into_iter().collect();
-            let cached_provider_item_ids = catalog
-                .entries
-                .iter()
-                .filter(|entry| {
-                    cached_identities
-                        .get(&entry.provider_item_id)
-                        .is_some_and(|revision| revision.as_deref() == entry.revision.as_deref())
-                })
-                .map(|entry| entry.provider_item_id.clone())
-                .collect();
+            let availability = refreshed_remote_availability(
+                &cache,
+                &catalog,
+                std::collections::HashMap::new(),
+            );
             let cache_usage = cache.usage().unwrap_or_default();
             crate::message::RemoteCatalogStartupData {
                 catalog,
                 catalog_children,
-                cached_provider_item_ids,
+                availability,
                 cache_usage,
                 load_error,
             }
@@ -104,12 +97,12 @@ pub(super) fn seed_remote_availability(
     cache: &DropboxCache,
     remote: &mut crate::state::RemoteUiState,
 ) {
-    remote.availability = refreshed_remote_availability(
+    let refreshed = refreshed_remote_availability(
         cache,
         &remote.catalog,
         std::mem::take(&mut remote.availability),
     );
-    remote.mark_catalog_runtime_changed();
+    remote.replace_availability(refreshed);
 }
 
 fn refreshed_remote_availability(
@@ -365,7 +358,7 @@ impl App {
         self.remote_audition_cache_lease = None;
         let maintenance = self.media_cache_maintenance_task();
         let request_id = self.remote_import_request.begin();
-        self.state.browser.remote.availability.insert(
+        self.state.browser.remote.set_availability(
             entry.path_lower.clone(),
             if self
                 .dropbox_cache
@@ -376,7 +369,6 @@ impl App {
                 crate::state::RemoteAvailability::Fetching
             },
         );
-        self.state.browser.remote.mark_catalog_runtime_changed();
         self.state.status_text = format!("Importing Remote media: {}", entry.name);
         let client = self.dropbox_client.clone();
         let cache = self.dropbox_cache.clone();
@@ -465,11 +457,10 @@ impl App {
             .is_cached(&entry.path_lower, entry.rev.as_deref());
         if !cached && self.dropbox_client.is_none() {
             self.state.browser.remote.preview_in_progress = false;
-            self.state.browser.remote.availability.insert(
+            self.state.browser.remote.set_availability(
                 entry.path_lower,
                 crate::state::RemoteAvailability::ReconnectRequired,
             );
-            self.state.browser.remote.mark_catalog_runtime_changed();
             self.state.status_text =
                 "Reconnect Required · this Remote item is not in Media Cache".into();
             self.state
@@ -486,7 +477,7 @@ impl App {
             self.state.browser.audition_generation
         };
         self.state.browser.remote.preview_in_progress = !cached;
-        self.state.browser.remote.availability.insert(
+        self.state.browser.remote.set_availability(
             entry.path_lower.clone(),
             if cached {
                 crate::state::RemoteAvailability::Cached
@@ -494,7 +485,6 @@ impl App {
                 crate::state::RemoteAvailability::Fetching
             },
         );
-        self.state.browser.remote.mark_catalog_runtime_changed();
         self.state.status_text = if cached {
             format!("Preparing cached Audition: {}", entry.name)
         } else {

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -44,11 +44,8 @@ pub(super) fn remote_catalog_startup_task(cache: DropboxCache) -> Task<Message> 
                 ),
             };
             let catalog_children = crate::remote_provider::build_remote_catalog_children(&catalog);
-            let availability = refreshed_remote_availability(
-                &cache,
-                &catalog,
-                std::collections::HashMap::new(),
-            );
+            let availability =
+                refreshed_remote_availability(&cache, &catalog, std::collections::HashMap::new());
             let cache_usage = cache.usage().unwrap_or_default();
             crate::message::RemoteCatalogStartupData {
                 catalog,

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -26,15 +26,10 @@ impl App {
                 let item_count = data.catalog.entries.len();
                 self.state.browser.remote.catalog = Arc::new(data.catalog);
                 self.state.browser.remote.catalog_children = data.catalog_children;
-                self.state.browser.remote.availability.clear();
-                self.state.browser.remote.availability.extend(
-                    data.cached_provider_item_ids
-                        .into_iter()
-                        .map(|provider_item_id| {
-                            (provider_item_id, crate::state::RemoteAvailability::Cached)
-                        }),
-                );
-                self.state.browser.remote.mark_catalog_runtime_changed();
+                self.state
+                    .browser
+                    .remote
+                    .replace_availability(data.availability);
                 self.state.browser.remote.cache_usage_bytes = data.cache_usage.bytes;
                 self.state.browser.remote.cache_entries = data.cache_usage.entries;
                 self.state.browser.remote.refresh_items = item_count;
@@ -493,16 +488,11 @@ impl App {
                 self.state
                     .browser
                     .remote
-                    .availability
-                    .insert(path_lower.clone(), crate::state::RemoteAvailability::Cached);
-                if let Some(entry) = Arc::make_mut(&mut self.state.browser.remote.catalog)
-                    .entries
-                    .iter_mut()
-                    .find(|entry| entry.provider_item_id == path_lower)
-                {
-                    entry.derived_metadata = Some(materialized.metadata.clone());
-                }
-                self.state.browser.remote.mark_catalog_runtime_changed();
+                    .set_availability(path_lower.clone(), crate::state::RemoteAvailability::Cached);
+                self.state
+                    .browser
+                    .remote
+                    .set_entry_derived_metadata(&path_lower, materialized.metadata.clone());
                 let persist = self.remote_catalog_persist_task(None);
                 let maintenance = self.media_cache_maintenance_task();
                 self.remote_audition_cache_lease = Some(materialized.lease);
@@ -538,9 +528,7 @@ impl App {
                 self.state
                     .browser
                     .remote
-                    .availability
-                    .insert(path_lower, availability);
-                self.state.browser.remote.mark_catalog_runtime_changed();
+                    .set_availability(path_lower, availability);
                 self.state
                     .browser
                     .fail_waveform_load(&source, error.clone());

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -173,7 +173,7 @@ pub struct RemoteMaterializedSample {
 pub struct RemoteCatalogStartupData {
     pub catalog: crate::remote_provider::RemoteCatalogSnapshot,
     pub catalog_children: HashMap<String, Vec<usize>>,
-    pub cached_provider_item_ids: HashSet<String>,
+    pub availability: HashMap<String, crate::state::RemoteAvailability>,
     pub cache_usage: vibez_dropbox::CacheUsage,
     pub load_error: Option<String>,
 }

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -810,10 +810,16 @@ pub struct RemoteUiState {
     pub selected_path: Option<String>,
     /// A preview fetch / playback is in flight.
     pub preview_in_progress: bool,
+    /// UI-owned availability per provider item. Mutate ONLY through
+    /// [`Self::set_availability`] / [`Self::replace_availability`] so the
+    /// runtime revision below stays in sync; direct inserts reintroduce the
+    /// refresh-clobber race those methods exist to prevent.
     pub availability: HashMap<String, RemoteAvailability>,
     /// Changes made by materialization/import flows while a catalog refresh
     /// snapshot is being prepared. Prepared snapshots use this to detect and
-    /// rebase over newer UI-owned metadata instead of replacing it.
+    /// rebase over newer UI-owned metadata instead of replacing it. Bumped
+    /// internally by the mutation methods on this type; never write it
+    /// directly.
     pub catalog_runtime_revision: u64,
     pub cache_usage_bytes: u64,
     pub cache_entries: usize,
@@ -854,8 +860,47 @@ impl Default for RemoteUiState {
 }
 
 impl RemoteUiState {
-    pub(crate) fn mark_catalog_runtime_changed(&mut self) {
+    fn mark_catalog_runtime_changed(&mut self) {
         self.catalog_runtime_revision = self.catalog_runtime_revision.wrapping_add(1);
+    }
+
+    /// Record a UI-owned availability change and bump the runtime revision so
+    /// an in-flight refresh preparation rebases over it instead of clobbering
+    /// it.
+    pub(crate) fn set_availability(
+        &mut self,
+        provider_item_id: String,
+        availability: RemoteAvailability,
+    ) {
+        self.availability.insert(provider_item_id, availability);
+        self.mark_catalog_runtime_changed();
+    }
+
+    /// Replace the whole availability map (startup load, cache reseed) and
+    /// bump the runtime revision.
+    pub(crate) fn replace_availability(
+        &mut self,
+        availability: HashMap<String, RemoteAvailability>,
+    ) {
+        self.availability = availability;
+        self.mark_catalog_runtime_changed();
+    }
+
+    /// Write derived metadata for one catalog entry (post-materialization)
+    /// and bump the runtime revision.
+    pub(crate) fn set_entry_derived_metadata(
+        &mut self,
+        provider_item_id: &str,
+        metadata: vibez_dropbox::DerivedMetadata,
+    ) {
+        if let Some(entry) = Arc::make_mut(&mut self.catalog)
+            .entries
+            .iter_mut()
+            .find(|entry| entry.provider_item_id == provider_item_id)
+        {
+            entry.derived_metadata = Some(metadata);
+        }
+        self.mark_catalog_runtime_changed();
     }
 
     /// Rebuild the parent/children lookup after the catalog is loaded or


### PR DESCRIPTION
Addresses the availability-rule duplication from the v0.1.5 release review and hardens the revision counter introduced in #153.

**Problem.** `catalog_runtime_revision` relied on call-site discipline: seven places mutated `availability` or entry metadata and each had to remember `mark_catalog_runtime_changed()`. A future missed site would silently reintroduce the prepare-clobber race #153 fixed. Separately, the startup task carried its own inline copy of the cached-revision rule, and the copies had already diverged (the startup copy did not skip folders).

**Change.**
- `RemoteUiState::set_availability` / `replace_availability` / `set_entry_derived_metadata` are now the only mutation paths; each bumps the revision internally and `mark_catalog_runtime_changed` is private, so a new call site cannot forget the bump.
- All seven sites (import start, reconnect-required, audition prepare, materialized ready, audition fail, startup load, cache reseed) route through them.
- `remote_catalog_startup_task` now derives availability via `refreshed_remote_availability`, deleting the divergent inline rule; `RemoteCatalogStartupData` carries the finished map instead of a raw id set.

Behavior note: startup availability now skips folder entries, matching the refresh path (previously a folder id present in the cache index would briefly show a Cached badge until the first refresh removed it).

508 vibez-ui tests pass, clippy clean.