### PR TITLE
refactor: share one quantization enum for launches and track mutes

### DIFF
--- a/crates/vibez-core/src/perform.rs
+++ b/crates/vibez-core/src/perform.rs
@@ -405,48 +405,12 @@ impl std::fmt::Display for SectionLaunchQuantization {
     }
 }
 
-/// Musical boundary at which a queued Track Mute becomes effective.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TrackMuteQuantization {
-    #[default]
-    Immediate,
-    OneBeat,
-    OneBar,
-    EndOfSection,
-}
-
-impl TrackMuteQuantization {
-    pub const ALL: [Self; 4] = [
-        Self::Immediate,
-        Self::OneBeat,
-        Self::OneBar,
-        Self::EndOfSection,
-    ];
-
-    pub const fn label(self) -> &'static str {
-        if let Some(boundary) = self.musical_boundary() {
-            boundary.label()
-        } else {
-            "End of Section"
-        }
-    }
-
-    pub const fn musical_boundary(self) -> Option<MusicalBoundary> {
-        match self {
-            Self::Immediate => Some(MusicalBoundary::Immediate),
-            Self::OneBeat => Some(MusicalBoundary::OneBeat),
-            Self::OneBar => Some(MusicalBoundary::OneBar),
-            Self::EndOfSection => None,
-        }
-    }
-}
-
-impl std::fmt::Display for TrackMuteQuantization {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(self.label())
-    }
-}
+/// Musical boundary at which a queued Track Mute becomes effective. Shares
+/// [`SectionLaunchQuantization`]'s definition (and serde representation); the
+/// Track Mute compatibility default of `Immediate` is expressed where the
+/// setting is stored (`UiSettings` in vibez-ui), NOT by this type's
+/// `Default`, which is the Section launch default of `OneBar`.
+pub type TrackMuteQuantization = SectionLaunchQuantization;
 
 #[cfg(test)]
 mod track_mute_quantization_tests {
@@ -464,11 +428,7 @@ mod track_mute_quantization_tests {
     }
 
     #[test]
-    fn immediate_is_the_stable_compatibility_default() {
-        assert_eq!(
-            TrackMuteQuantization::default(),
-            TrackMuteQuantization::Immediate
-        );
+    fn track_mute_quantization_shares_the_section_launch_definition() {
         assert_eq!(
             TrackMuteQuantization::ALL.map(TrackMuteQuantization::label),
             ["Immediate", "1 Beat", "1 Bar", "End of Section"]
@@ -480,6 +440,13 @@ mod track_mute_quantization_tests {
         assert_eq!(
             serde_json::to_string(&TrackMuteQuantization::EndOfSection).unwrap(),
             "\"end_of_section\""
+        );
+        // The Track Mute compatibility default (Immediate) lives on the
+        // UiSettings field, not here: this shared type defaults to the
+        // Section launch default.
+        assert_eq!(
+            TrackMuteQuantization::default(),
+            SectionLaunchQuantization::OneBar
         );
     }
 }

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -186,7 +186,7 @@ pub struct PerformState {
     note_repeat_momentary: bool,
     note_repeat_momentary_key_id: Option<String>,
     note_repeat_latched: bool,
-    track_mute_quantization: TrackMuteQuantization,
+    track_mute_quantization: track_mutes::TrackMuteQuantizationSetting,
     pending_track_mutes: HashMap<TrackId, PendingTrackMute>,
     pub capture: CaptureState,
     pub section_record: section_record::SectionRecordState,
@@ -376,7 +376,7 @@ impl PerformState {
         Some(TrackMuteRequest {
             track_id,
             muted: !track.mute,
-            quantization: self.track_mute_quantization,
+            quantization: self.track_mute_quantization.0,
         })
     }
 
@@ -654,7 +654,7 @@ impl PerformState {
                 }
             }
             PerformMsg::SetTrackMuteQuantization(quantization) => {
-                self.track_mute_quantization = quantization;
+                self.track_mute_quantization.0 = quantization;
                 return PerformAction {
                     persist_settings: true,
                     ..PerformAction::default()

--- a/crates/vibez-ui/src/domains/perform/track_mutes.rs
+++ b/crates/vibez-ui/src/domains/perform/track_mutes.rs
@@ -17,13 +17,26 @@ pub struct PendingTrackMute {
     pub effective_at_samples: u64,
 }
 
+/// Private storage for the Perform-owned quantization setting. Exists so a
+/// fresh [`PerformState`] defaults to `Immediate` (the Track Mute
+/// compatibility default) while the shared quantization enum's own `Default`
+/// is the Section launch value (`OneBar`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct TrackMuteQuantizationSetting(pub(super) TrackMuteQuantization);
+
+impl Default for TrackMuteQuantizationSetting {
+    fn default() -> Self {
+        Self(TrackMuteQuantization::Immediate)
+    }
+}
+
 impl PerformState {
     pub const fn track_mute_quantization(&self) -> TrackMuteQuantization {
-        self.track_mute_quantization
+        self.track_mute_quantization.0
     }
 
     pub fn set_track_mute_quantization(&mut self, quantization: TrackMuteQuantization) {
-        self.track_mute_quantization = quantization;
+        self.track_mute_quantization.0 = quantization;
     }
 
     pub fn queue_track_mute_ui(

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -11,7 +11,7 @@ pub struct UiSettings {
     pub perform_input_mapping: crate::domains::perform::PerformInputMapping,
     #[serde(default = "default_fixed_computer_velocity")]
     pub fixed_computer_velocity: u8,
-    #[serde(default)]
+    #[serde(default = "default_track_mute_quantization")]
     pub track_mute_quantization: vibez_core::perform::TrackMuteQuantization,
     #[serde(default)]
     pub sample_library_roots: Vec<PathBuf>,
@@ -113,7 +113,7 @@ impl Default for UiSettings {
             recent_project_paths: Vec::new(),
             perform_input_mapping: crate::domains::perform::PerformInputMapping::default(),
             fixed_computer_velocity: default_fixed_computer_velocity(),
-            track_mute_quantization: vibez_core::perform::TrackMuteQuantization::default(),
+            track_mute_quantization: default_track_mute_quantization(),
             sample_library_roots: Vec::new(),
             sample_browser_open: default_sample_browser_open(),
             sample_browser_width: default_sample_browser_width(),
@@ -197,6 +197,13 @@ impl UiSettings {
 
 fn default_sample_browser_open() -> bool {
     true
+}
+
+/// Track Mutes default to Immediate for back-compat with settings written
+/// before quantization existed; the shared enum's own Default is the Section
+/// launch default (OneBar).
+const fn default_track_mute_quantization() -> vibez_core::perform::TrackMuteQuantization {
+    vibez_core::perform::TrackMuteQuantization::Immediate
 }
 
 const fn default_fixed_computer_velocity() -> u8 {


### PR DESCRIPTION
Addresses the duplicate-enum finding from the v0.1.5 release review.

`TrackMuteQuantization` was a 40-line verbatim copy of `SectionLaunchQuantization` (same four variants, `ALL`, `label()`, `musical_boundary()`, `Display`), differing only in which variant carried `#[default]`. Adding a fifth boundary meant editing both plus both test blocks.

- `TrackMuteQuantization` is now `pub type TrackMuteQuantization = SectionLaunchQuantization`. Serde is wire-compatible: variant names and snake_case representation are identical.
- The differing default (Immediate for mutes, OneBar for section launches) now lives where the setting is stored instead of on the type: `UiSettings.track_mute_quantization` gets `#[serde(default = "default_track_mute_quantization")]`, and `PerformState` stores the value in a private `TrackMuteQuantizationSetting` newtype whose `Default` is Immediate, so the derive on `PerformState` keeps working and a fresh state still queues immediate mutes.
- Existing tests pin both defaults: `ui_settings` asserts empty-JSON settings deserialize to Immediate, and the perform-domain pad tests assert a fresh `PerformState` emits Immediate requests.

Full workspace tests pass, clippy clean.