### PR TITLE
refactor: split File menu overlay out of views_overlays

### DIFF
--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -185,6 +185,7 @@ mod views_clip_swing;
 mod views_close_confirm;
 mod views_detail;
 mod views_devices;
+mod views_file_menu;
 mod views_mixer;
 mod views_overlays;
 mod views_perform;

--- a/crates/vibez-ui/src/app/views_file_menu.rs
+++ b/crates/vibez-ui/src/app/views_file_menu.rs
@@ -1,0 +1,275 @@
+//! File menu overlay and its Recent Projects submenu.
+//!
+//! Split out of views_overlays.rs; inherent methods on [`super::App`]. The
+//! submenu is aligned to its parent row by arithmetic over fixed row heights,
+//! so every row in the menu column MUST carry
+//! `.height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))`.
+
+use iced::widget::{
+    button, column, container, horizontal_space, mouse_area, row, text, vertical_space,
+};
+use iced::{Element, Length, Theme};
+
+use crate::domains::project::ProjectMsg;
+
+use crate::icons;
+use crate::message::{MenuOverlay, Message};
+use crate::theme as th;
+
+use super::*;
+
+const FILE_MENU_ITEM_HEIGHT: f32 = 32.0;
+const FILE_MENU_ITEM_SPACING: f32 = 2.0;
+const FILE_MENU_CONTENT_PADDING: f32 = 4.0;
+const RECENT_PROJECTS_MENU_ITEM_INDEX: usize = 2;
+
+fn file_menu_item_top(item_index: usize) -> f32 {
+    FILE_MENU_CONTENT_PADDING + item_index as f32 * (FILE_MENU_ITEM_HEIGHT + FILE_MENU_ITEM_SPACING)
+}
+
+impl App {
+    pub(super) fn view_file_menu_overlay(&self) -> Element<'_, Message> {
+        let make_menu_btn = |label: &'static str, icon: char, msg: Message| {
+            button(
+                row![
+                    icons::icon(icon).size(12).color(th::text()),
+                    text(label).size(12).color(th::text())
+                ]
+                .spacing(6)
+                .align_y(iced::Alignment::Center),
+            )
+            .on_press(Message::menu_item(MenuOverlay::File, msg))
+            .padding([8, 16])
+            .height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))
+            .width(Length::Fill)
+            .style(|_theme: &Theme, status| {
+                let bg = match status {
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => None,
+                };
+                button::Style {
+                    background: bg,
+                    text_color: th::text(),
+                    border: iced::Border::default(),
+                    ..Default::default()
+                }
+            })
+        };
+
+        let new_btn = make_menu_btn("New (Empty)", icons::PLUS, Message::NewProject);
+        let export_btn = make_menu_btn(
+            "Export to WAV...",
+            icons::AUDIO_WAVEFORM,
+            Message::ExportProject,
+        );
+
+        let open_btn = make_menu_btn("Open...", icons::MUSIC, Message::OpenProject);
+        let recent_btn = button(
+            row![
+                icons::icon(icons::MUSIC).size(12).color(th::text()),
+                text("Recent Projects").size(12).color(th::text()),
+                horizontal_space(),
+                text("›")
+                    .size(16)
+                    .color(if self.state.project.recent_projects_open {
+                        th::accent()
+                    } else {
+                        th::text_dim()
+                    }),
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::Project(ProjectMsg::ToggleRecentProjects))
+        .padding([8, 16])
+        .height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))
+        .width(Length::Fill)
+        .style(|_theme: &Theme, status| button::Style {
+            background: match status {
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
+                _ => None,
+            },
+            text_color: th::text(),
+            border: iced::Border::default(),
+            ..Default::default()
+        });
+        let save_label = if self.state.project.dirty {
+            "Save*"
+        } else {
+            "Save"
+        };
+        let save_btn = make_menu_btn(save_label, icons::COPY, Message::SaveProject);
+        let save_as_btn = make_menu_btn("Save As...", icons::COPY, Message::SaveProjectAs);
+        let settings_btn = button(
+            row![
+                icons::icon(icons::SLIDERS_VERTICAL)
+                    .size(12)
+                    .color(th::text()),
+                text("Settings...").size(12).color(th::text())
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::menu_item(MenuOverlay::File, Message::OpenSettings))
+        .padding([8, 16])
+        .height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))
+        .width(Length::Fill)
+        .style(|_theme: &Theme, status| {
+            let bg = match status {
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
+                _ => None,
+            };
+            button::Style {
+                background: bg,
+                text_color: th::text(),
+                border: iced::Border::default(),
+                ..Default::default()
+            }
+        });
+
+        let about_btn = make_menu_btn("About vibez", icons::CIRCLE_DOT, Message::OpenAbout);
+
+        let menu_content = column![new_btn]
+            .spacing(FILE_MENU_ITEM_SPACING)
+            .push(open_btn)
+            .push(recent_btn)
+            .push(save_btn)
+            .push(save_as_btn)
+            .push(export_btn)
+            .push(settings_btn)
+            .push(about_btn)
+            .padding(FILE_MENU_CONTENT_PADDING)
+            .width(Length::Fixed(220.0));
+
+        let menu_card = container(menu_content).style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_surface().into()),
+            border: iced::Border {
+                color: th::border(),
+                width: 1.0,
+                radius: 6.0.into(),
+            },
+            ..Default::default()
+        });
+
+        let recent_card = self.state.project.recent_projects_open.then(|| {
+            let mut items = column![text("RECENT PROJECTS").size(9).color(th::text_muted())]
+                .spacing(2)
+                .padding(4)
+                .width(Length::Fixed(320.0));
+            if self.state.project.recent_project_paths.is_empty() {
+                items = items.push(
+                    container(text("No recent projects").size(11).color(th::text_dim()))
+                        .padding([10, 12]),
+                );
+            } else {
+                for path in &self.state.project.recent_project_paths {
+                    let name = path
+                        .file_name()
+                        .unwrap_or(path.as_os_str())
+                        .to_string_lossy()
+                        .into_owned();
+                    let parent = path
+                        .parent()
+                        .map(|parent| parent.display().to_string())
+                        .unwrap_or_default();
+                    let open_path = path.clone();
+                    items = items.push(
+                        button(
+                            column![
+                                text(name).size(11).color(th::text()),
+                                text(parent).size(9).color(th::text_muted()),
+                            ]
+                            .spacing(1),
+                        )
+                        .on_press(Message::menu_item(
+                            MenuOverlay::File,
+                            Message::ProjectOpenPathSelected(Some(open_path)),
+                        ))
+                        .padding([6, 10])
+                        .width(Length::Fill)
+                        .style(|_theme: &Theme, status| button::Style {
+                            background: match status {
+                                button::Status::Hovered | button::Status::Pressed => {
+                                    Some(th::bg_hover().into())
+                                }
+                                _ => None,
+                            },
+                            text_color: th::text(),
+                            border: iced::Border::default(),
+                            ..Default::default()
+                        }),
+                    );
+                }
+                items = items.push(
+                    button(
+                        row![
+                            icons::icon(icons::TRASH_2).size(11).color(th::text_dim()),
+                            text("Clear Recent Projects").size(11).color(th::text_dim()),
+                        ]
+                        .spacing(6),
+                    )
+                    .on_press(Message::menu_item(
+                        MenuOverlay::File,
+                        Message::Project(ProjectMsg::ClearRecentProjects),
+                    ))
+                    .padding([8, 10])
+                    .width(Length::Fill)
+                    .style(|_theme: &Theme, status| button::Style {
+                        background: match status {
+                            button::Status::Hovered | button::Status::Pressed => {
+                                Some(th::bg_hover().into())
+                            }
+                            _ => None,
+                        },
+                        text_color: th::text_dim(),
+                        border: iced::Border::default(),
+                        ..Default::default()
+                    }),
+                );
+            }
+            container(items).style(|_theme: &Theme| container::Style {
+                background: Some(th::bg_surface().into()),
+                border: iced::Border {
+                    color: th::border(),
+                    width: 1.0,
+                    radius: 6.0.into(),
+                },
+                ..Default::default()
+            })
+        });
+
+        // Position below the header, near the File button.
+        let menus = if let Some(recent_card) = recent_card {
+            let aligned_recent_card = column![
+                vertical_space().height(Length::Fixed(file_menu_item_top(
+                    RECENT_PROJECTS_MENU_ITEM_INDEX
+                ))),
+                recent_card
+            ];
+            row![menu_card, aligned_recent_card].spacing(4)
+        } else {
+            row![menu_card]
+        };
+        let padded = column![
+            vertical_space().height(Length::Fixed(42.0)),
+            row![horizontal_space().width(Length::Fixed(60.0)), menus,]
+        ];
+
+        mouse_area(container(padded).width(Length::Fill).height(Length::Fill))
+            .on_press(Message::dismiss_menu(MenuOverlay::File))
+            .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::file_menu_item_top;
+
+    #[test]
+    fn file_submenu_starts_at_its_parent_row() {
+        assert_eq!(file_menu_item_top(0), 4.0);
+        assert_eq!(file_menu_item_top(2), 72.0);
+    }
+}

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -1,4 +1,5 @@
-//! Modal overlays: context menus, file menu, rename prompt.
+//! Modal overlays: context menus, rename prompt, track deletion. The File
+//! menu lives in views_file_menu.rs.
 
 //! Split out of app.rs; inherent methods on [`super::App`].
 
@@ -10,7 +11,6 @@ use iced::{Element, Length, Theme};
 
 use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::piano_roll::PianoRollMsg;
-use crate::domains::project::ProjectMsg;
 use crate::domains::view::ViewMsg;
 use vibez_core::effect::EffectType;
 use vibez_core::midi::InstrumentKind;
@@ -28,15 +28,6 @@ fn project_track_deletion_list_height(location_count: usize) -> f32 {
         0 | 1 => 28.0,
         count => (count as f32 * 28.0 + (count - 1) as f32 * 4.0).min(120.0),
     }
-}
-
-const FILE_MENU_ITEM_HEIGHT: f32 = 32.0;
-const FILE_MENU_ITEM_SPACING: f32 = 2.0;
-const FILE_MENU_CONTENT_PADDING: f32 = 4.0;
-const RECENT_PROJECTS_MENU_ITEM_INDEX: usize = 2;
-
-fn file_menu_item_top(item_index: usize) -> f32 {
-    FILE_MENU_CONTENT_PADDING + item_index as f32 * (FILE_MENU_ITEM_HEIGHT + FILE_MENU_ITEM_SPACING)
 }
 
 impl App {
@@ -559,238 +550,6 @@ impl App {
             .into()
     }
 
-    pub(super) fn view_file_menu_overlay(&self) -> Element<'_, Message> {
-        let make_menu_btn = |label: &'static str, icon: char, msg: Message| {
-            button(
-                row![
-                    icons::icon(icon).size(12).color(th::text()),
-                    text(label).size(12).color(th::text())
-                ]
-                .spacing(6)
-                .align_y(iced::Alignment::Center),
-            )
-            .on_press(Message::menu_item(MenuOverlay::File, msg))
-            .padding([8, 16])
-            .height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))
-            .width(Length::Fill)
-            .style(|_theme: &Theme, status| {
-                let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::bg_hover().into())
-                    }
-                    _ => None,
-                };
-                button::Style {
-                    background: bg,
-                    text_color: th::text(),
-                    border: iced::Border::default(),
-                    ..Default::default()
-                }
-            })
-        };
-
-        let new_btn = make_menu_btn("New (Empty)", icons::PLUS, Message::NewProject);
-        let export_btn = make_menu_btn(
-            "Export to WAV...",
-            icons::AUDIO_WAVEFORM,
-            Message::ExportProject,
-        );
-
-        let open_btn = make_menu_btn("Open...", icons::MUSIC, Message::OpenProject);
-        let recent_btn = button(
-            row![
-                icons::icon(icons::MUSIC).size(12).color(th::text()),
-                text("Recent Projects").size(12).color(th::text()),
-                horizontal_space(),
-                text("›")
-                    .size(16)
-                    .color(if self.state.project.recent_projects_open {
-                        th::accent()
-                    } else {
-                        th::text_dim()
-                    }),
-            ]
-            .spacing(6)
-            .align_y(iced::Alignment::Center),
-        )
-        .on_press(Message::Project(ProjectMsg::ToggleRecentProjects))
-        .padding([8, 16])
-        .width(Length::Fill)
-        .style(|_theme: &Theme, status| button::Style {
-            background: match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
-                _ => None,
-            },
-            text_color: th::text(),
-            border: iced::Border::default(),
-            ..Default::default()
-        });
-        let save_label = if self.state.project.dirty {
-            "Save*"
-        } else {
-            "Save"
-        };
-        let save_btn = make_menu_btn(save_label, icons::COPY, Message::SaveProject);
-        let save_as_btn = make_menu_btn("Save As...", icons::COPY, Message::SaveProjectAs);
-        let settings_btn = button(
-            row![
-                icons::icon(icons::SLIDERS_VERTICAL)
-                    .size(12)
-                    .color(th::text()),
-                text("Settings...").size(12).color(th::text())
-            ]
-            .spacing(6)
-            .align_y(iced::Alignment::Center),
-        )
-        .on_press(Message::menu_item(MenuOverlay::File, Message::OpenSettings))
-        .padding([8, 16])
-        .width(Length::Fill)
-        .style(|_theme: &Theme, status| {
-            let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
-                _ => None,
-            };
-            button::Style {
-                background: bg,
-                text_color: th::text(),
-                border: iced::Border::default(),
-                ..Default::default()
-            }
-        });
-
-        let about_btn = make_menu_btn("About vibez", icons::CIRCLE_DOT, Message::OpenAbout);
-
-        let menu_content = column![new_btn]
-            .spacing(FILE_MENU_ITEM_SPACING)
-            .push(open_btn)
-            .push(recent_btn)
-            .push(save_btn)
-            .push(save_as_btn)
-            .push(export_btn)
-            .push(settings_btn)
-            .push(about_btn)
-            .padding(FILE_MENU_CONTENT_PADDING)
-            .width(Length::Fixed(220.0));
-
-        let menu_card = container(menu_content).style(|_theme: &Theme| container::Style {
-            background: Some(th::bg_surface().into()),
-            border: iced::Border {
-                color: th::border(),
-                width: 1.0,
-                radius: 6.0.into(),
-            },
-            ..Default::default()
-        });
-
-        let recent_card = self.state.project.recent_projects_open.then(|| {
-            let mut items = column![text("RECENT PROJECTS").size(9).color(th::text_muted())]
-                .spacing(2)
-                .padding(4)
-                .width(Length::Fixed(320.0));
-            if self.state.project.recent_project_paths.is_empty() {
-                items = items.push(
-                    container(text("No recent projects").size(11).color(th::text_dim()))
-                        .padding([10, 12]),
-                );
-            } else {
-                for path in &self.state.project.recent_project_paths {
-                    let name = path
-                        .file_name()
-                        .unwrap_or(path.as_os_str())
-                        .to_string_lossy()
-                        .into_owned();
-                    let parent = path
-                        .parent()
-                        .map(|parent| parent.display().to_string())
-                        .unwrap_or_default();
-                    let open_path = path.clone();
-                    items = items.push(
-                        button(
-                            column![
-                                text(name).size(11).color(th::text()),
-                                text(parent).size(9).color(th::text_muted()),
-                            ]
-                            .spacing(1),
-                        )
-                        .on_press(Message::menu_item(
-                            MenuOverlay::File,
-                            Message::ProjectOpenPathSelected(Some(open_path)),
-                        ))
-                        .padding([6, 10])
-                        .width(Length::Fill)
-                        .style(|_theme: &Theme, status| button::Style {
-                            background: match status {
-                                button::Status::Hovered | button::Status::Pressed => {
-                                    Some(th::bg_hover().into())
-                                }
-                                _ => None,
-                            },
-                            text_color: th::text(),
-                            border: iced::Border::default(),
-                            ..Default::default()
-                        }),
-                    );
-                }
-                items = items.push(
-                    button(
-                        row![
-                            icons::icon(icons::TRASH_2).size(11).color(th::text_dim()),
-                            text("Clear Recent Projects").size(11).color(th::text_dim()),
-                        ]
-                        .spacing(6),
-                    )
-                    .on_press(Message::menu_item(
-                        MenuOverlay::File,
-                        Message::Project(ProjectMsg::ClearRecentProjects),
-                    ))
-                    .padding([8, 10])
-                    .width(Length::Fill)
-                    .style(|_theme: &Theme, status| button::Style {
-                        background: match status {
-                            button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::bg_hover().into())
-                            }
-                            _ => None,
-                        },
-                        text_color: th::text_dim(),
-                        border: iced::Border::default(),
-                        ..Default::default()
-                    }),
-                );
-            }
-            container(items).style(|_theme: &Theme| container::Style {
-                background: Some(th::bg_surface().into()),
-                border: iced::Border {
-                    color: th::border(),
-                    width: 1.0,
-                    radius: 6.0.into(),
-                },
-                ..Default::default()
-            })
-        });
-
-        // Position below the header, near the File button.
-        let menus = if let Some(recent_card) = recent_card {
-            let aligned_recent_card = column![
-                vertical_space().height(Length::Fixed(file_menu_item_top(
-                    RECENT_PROJECTS_MENU_ITEM_INDEX
-                ))),
-                recent_card
-            ];
-            row![menu_card, aligned_recent_card].spacing(4)
-        } else {
-            row![menu_card]
-        };
-        let padded = column![
-            vertical_space().height(Length::Fixed(42.0)),
-            row![horizontal_space().width(Length::Fixed(60.0)), menus,]
-        ];
-
-        mouse_area(container(padded).width(Length::Fill).height(Length::Fill))
-            .on_press(Message::dismiss_menu(MenuOverlay::File))
-            .into()
-    }
-
     pub(super) fn view_rename_overlay(&self) -> Element<'_, Message> {
         let input = text_input("Name", &self.state.view.edit_name_text)
             .on_input(|t| Message::View(ViewMsg::EditNameText(t)))
@@ -1038,7 +797,7 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::{file_menu_item_top, project_track_deletion_list_height};
+    use super::project_track_deletion_list_height;
 
     #[test]
     fn deletion_location_list_grows_with_content_then_caps() {
@@ -1046,11 +805,5 @@ mod tests {
         assert_eq!(project_track_deletion_list_height(1), 28.0);
         assert_eq!(project_track_deletion_list_height(2), 60.0);
         assert_eq!(project_track_deletion_list_height(8), 120.0);
-    }
-
-    #[test]
-    fn file_submenu_starts_at_its_parent_row() {
-        assert_eq!(file_menu_item_top(0), 4.0);
-        assert_eq!(file_menu_item_top(2), 72.0);
     }
 }


### PR DESCRIPTION
Addresses the file-size finding from the v0.1.5 release review: views_overlays.rs crossed the hard 1,000-line ceiling (901 → 1,056) when the recent-projects card landed, and the natural seam is the File menu.

- `view_file_menu_overlay`, the `FILE_MENU_*` alignment constants, `file_menu_item_top`, and their test move verbatim to a new `views_file_menu.rs` (275 lines). `views_overlays.rs` drops to 809.
- Fixes the review's alignment nit while the code is in hand: `recent_btn` and `settings_btn` were the only File-menu rows missing `.height(FILE_MENU_ITEM_HEIGHT)`, so the Recent row rendered ~5px taller than the 32px the submenu offset arithmetic assumes and every row below it shifted. All eight rows now carry the fixed height, and the module doc states the invariant.

The hardcoded `RECENT_PROJECTS_MENU_ITEM_INDEX` is unchanged; deriving the offset from a row-descriptor array is a follow-up if the menu ever grows again.

508 vibez-ui tests pass, clippy clean.