### PR TITLE
chore: fold duplicated helper functions

### DIFF
--- a/crates/vibez-ui/src/app/async_helpers.rs
+++ b/crates/vibez-ui/src/app/async_helpers.rs
@@ -571,34 +571,51 @@ pub(super) async fn finish_loaded_clip(
     }
 }
 
+/// Run CPU-bound work on the tokio blocking pool, labelling join failures.
+/// Every off-UI-thread hop in the app routes through here so the idiom (and
+/// its error shape) exists exactly once.
+pub(crate) async fn run_off_ui_thread<T, F>(label: &'static str, work: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    tokio::task::spawn_blocking(work)
+        .await
+        .map_err(|error| format!("{label} task failed: {error}"))
+}
+
+/// One rule for what counts as a missing project: only a confirmed
+/// `NotFound` io error prunes a Recent Projects entry; everything else is
+/// treated as transient.
+fn classify_load_error(
+    io_error: Option<&std::io::Error>,
+    message: String,
+) -> crate::message::ProjectLoadError {
+    if io_error.is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound) {
+        crate::message::ProjectLoadError::missing_project(message)
+    } else {
+        crate::message::ProjectLoadError::other(message)
+    }
+}
+
 fn classify_project_format_load_error(
     error: vibez_project::project_format_v1::ProjectFormatError,
 ) -> crate::message::ProjectLoadError {
-    let missing = matches!(
-        &error,
-        vibez_project::project_format_v1::ProjectFormatError::Io(io_error)
-            if io_error.kind() == std::io::ErrorKind::NotFound
-    );
-    if missing {
-        crate::message::ProjectLoadError::missing_project(error.to_string())
-    } else {
-        crate::message::ProjectLoadError::other(error.to_string())
-    }
+    let io_error = match &error {
+        vibez_project::project_format_v1::ProjectFormatError::Io(io_error) => Some(io_error),
+        _ => None,
+    };
+    classify_load_error(io_error, error.to_string())
 }
 
 fn classify_legacy_project_load_error(
     error: vibez_project::ProjectError,
 ) -> crate::message::ProjectLoadError {
-    let missing = matches!(
-        &error,
-        vibez_project::ProjectError::Io(io_error)
-            if io_error.kind() == std::io::ErrorKind::NotFound
-    );
-    if missing {
-        crate::message::ProjectLoadError::missing_project(error.to_string())
-    } else {
-        crate::message::ProjectLoadError::other(error.to_string())
-    }
+    let io_error = match &error {
+        vibez_project::ProjectError::Io(io_error) => Some(io_error),
+        _ => None,
+    };
+    classify_load_error(io_error, error.to_string())
 }
 
 pub(super) async fn load_project_async(
@@ -910,6 +927,28 @@ mod export_tests {
             0,
             "failed export must clean up every temporary file"
         );
+    }
+}
+
+#[cfg(test)]
+mod off_ui_thread_tests {
+    use std::time::Duration;
+
+    use super::run_off_ui_thread;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocking_work_never_blocks_the_ui_executor() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let work = tokio::spawn(run_off_ui_thread("Test", move || {
+            release_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("UI executor should release the blocking worker");
+            42
+        }));
+
+        tokio::task::yield_now().await;
+        assert!(release_tx.send(()).is_ok());
+        assert_eq!(work.await.unwrap().unwrap(), 42);
     }
 }
 

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -12,29 +12,9 @@ pub(super) const REMOTE_SELECTION_DEBOUNCE: std::time::Duration =
     std::time::Duration::from_millis(200);
 pub(super) const REMOTE_CATALOG_SAVE_PAGE_INTERVAL: usize = 10;
 
-async fn run_remote_startup_loader<T, F>(loader: F) -> Result<T, String>
-where
-    T: Send + 'static,
-    F: FnOnce() -> T + Send + 'static,
-{
-    tokio::task::spawn_blocking(loader)
-        .await
-        .map_err(|error| format!("Remote catalog startup task failed: {error}"))
-}
-
-async fn run_remote_refresh_preparer<T, F>(preparer: F) -> Result<T, String>
-where
-    T: Send + 'static,
-    F: FnOnce() -> T + Send + 'static,
-{
-    tokio::task::spawn_blocking(preparer)
-        .await
-        .map_err(|error| format!("Remote catalog refresh task failed: {error}"))
-}
-
 pub(super) fn remote_catalog_startup_task(cache: DropboxCache) -> Task<Message> {
     Task::perform(
-        run_remote_startup_loader(move || {
+        run_off_ui_thread("Remote catalog startup", move || {
             let store = crate::remote_provider::RemoteCatalogStore::for_dropbox();
             let (catalog, load_error) = match store.load() {
                 Ok(catalog) => (catalog, None),
@@ -220,7 +200,7 @@ impl App {
         let changes = std::mem::take(&mut self.remote_catalog_pending);
         let cache = self.dropbox_cache.clone();
         Task::perform(
-            run_remote_refresh_preparer(move || {
+            run_off_ui_thread("Remote catalog refresh", move || {
                 if changes.is_empty() {
                     let catalog =
                         catalog_with_refresh_checkpoint(Arc::clone(&previous_catalog), checkpoint);
@@ -282,7 +262,7 @@ impl App {
         let live_availability = self.state.browser.remote.availability.clone();
         let live_runtime_revision = self.state.browser.remote.catalog_runtime_revision;
         Task::perform(
-            run_remote_refresh_preparer(move || {
+            run_off_ui_thread("Remote catalog refresh", move || {
                 rebase_remote_catalog_refresh(
                     data,
                     live_catalog,
@@ -544,43 +524,6 @@ impl App {
             return Task::none();
         };
         self.start_remote_import(entry, target, treatment)
-    }
-}
-
-#[cfg(test)]
-mod startup_tests {
-    use std::time::Duration;
-
-    use super::{run_remote_refresh_preparer, run_remote_startup_loader};
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn remote_startup_loader_never_blocks_the_ui_executor() {
-        let (release_tx, release_rx) = std::sync::mpsc::channel();
-        let loader = tokio::spawn(run_remote_startup_loader(move || {
-            release_rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("UI executor should release the background loader");
-            42
-        }));
-
-        tokio::task::yield_now().await;
-        assert!(release_tx.send(()).is_ok());
-        assert_eq!(loader.await.unwrap().unwrap(), 42);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn remote_refresh_preparation_never_blocks_the_ui_executor() {
-        let (release_tx, release_rx) = std::sync::mpsc::channel();
-        let preparation = tokio::spawn(run_remote_refresh_preparer(move || {
-            release_rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("UI executor should release Remote refresh preparation");
-            42
-        }));
-
-        tokio::task::yield_now().await;
-        assert!(release_tx.send(()).is_ok());
-        assert_eq!(preparation.await.unwrap().unwrap(), 42);
     }
 }
 


### PR DESCRIPTION
Last of the small DRY items from the v0.1.5 release review, plus the twin classify helpers noted in the #154 review.

- `run_remote_startup_loader` / `run_remote_refresh_preparer` (byte-identical apart from the error label) become one `run_off_ui_thread(label, work)` in `async_helpers.rs`, next to the crate's other off-thread wrappers. Error strings are unchanged at both call sites. Their two near-identical executor tests fold into one.
- `classify_project_format_load_error` / `classify_legacy_project_load_error` now delegate to a single `classify_load_error`, so the NotFound-means-missing rule that guards Recent Projects pruning exists exactly once.

Still open as future cards, deliberately not bundled here: the status-pill chrome duplicated across four views, and the `TakeOnce`-style take-once wrappers in `message.rs`.

507 vibez-ui tests pass (two duplicate tests folded into one), clippy clean.