### PR TITLE
Release v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5085,7 +5085,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibez"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "iced",
  "libloading 0.8.9",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-audio-io"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "audio_thread_priority",
  "cpal",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-dropbox"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64",
  "dirs 5.0.1",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-dsp"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "signalsmith-stretch",
  "vibez-core",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-engine"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "rtrb",
  "vibez-core",
@@ -5154,14 +5154,14 @@ dependencies = [
 
 [[package]]
 name = "vibez-instruments"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "vibez-core",
 ]
 
 [[package]]
 name = "vibez-plugin-host"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap-sys",
  "dirs 5.0.1",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-project"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "rusqlite",
  "serde",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-ui"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/vibez-daw/vibez"

--- a/crates/vibez-core/src/perform.rs
+++ b/crates/vibez-core/src/perform.rs
@@ -405,48 +405,12 @@ impl std::fmt::Display for SectionLaunchQuantization {
     }
 }
 
-/// Musical boundary at which a queued Track Mute becomes effective.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TrackMuteQuantization {
-    #[default]
-    Immediate,
-    OneBeat,
-    OneBar,
-    EndOfSection,
-}
-
-impl TrackMuteQuantization {
-    pub const ALL: [Self; 4] = [
-        Self::Immediate,
-        Self::OneBeat,
-        Self::OneBar,
-        Self::EndOfSection,
-    ];
-
-    pub const fn label(self) -> &'static str {
-        if let Some(boundary) = self.musical_boundary() {
-            boundary.label()
-        } else {
-            "End of Section"
-        }
-    }
-
-    pub const fn musical_boundary(self) -> Option<MusicalBoundary> {
-        match self {
-            Self::Immediate => Some(MusicalBoundary::Immediate),
-            Self::OneBeat => Some(MusicalBoundary::OneBeat),
-            Self::OneBar => Some(MusicalBoundary::OneBar),
-            Self::EndOfSection => None,
-        }
-    }
-}
-
-impl std::fmt::Display for TrackMuteQuantization {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(self.label())
-    }
-}
+/// Musical boundary at which a queued Track Mute becomes effective. Shares
+/// [`SectionLaunchQuantization`]'s definition (and serde representation); the
+/// Track Mute compatibility default of `Immediate` is expressed where the
+/// setting is stored (`UiSettings` in vibez-ui), NOT by this type's
+/// `Default`, which is the Section launch default of `OneBar`.
+pub type TrackMuteQuantization = SectionLaunchQuantization;
 
 #[cfg(test)]
 mod track_mute_quantization_tests {
@@ -464,11 +428,7 @@ mod track_mute_quantization_tests {
     }
 
     #[test]
-    fn immediate_is_the_stable_compatibility_default() {
-        assert_eq!(
-            TrackMuteQuantization::default(),
-            TrackMuteQuantization::Immediate
-        );
+    fn track_mute_quantization_shares_the_section_launch_definition() {
         assert_eq!(
             TrackMuteQuantization::ALL.map(TrackMuteQuantization::label),
             ["Immediate", "1 Beat", "1 Bar", "End of Section"]
@@ -480,6 +440,13 @@ mod track_mute_quantization_tests {
         assert_eq!(
             serde_json::to_string(&TrackMuteQuantization::EndOfSection).unwrap(),
             "\"end_of_section\""
+        );
+        // The Track Mute compatibility default (Immediate) lives on the
+        // UiSettings field, not here: this shared type defaults to the
+        // Section launch default.
+        assert_eq!(
+            TrackMuteQuantization::default(),
+            SectionLaunchQuantization::OneBar
         );
     }
 }

--- a/crates/vibez-ui/src/app/async_helpers.rs
+++ b/crates/vibez-ui/src/app/async_helpers.rs
@@ -571,33 +571,63 @@ pub(super) async fn finish_loaded_clip(
     }
 }
 
+fn classify_project_format_load_error(
+    error: vibez_project::project_format_v1::ProjectFormatError,
+) -> crate::message::ProjectLoadError {
+    let missing = matches!(
+        &error,
+        vibez_project::project_format_v1::ProjectFormatError::Io(io_error)
+            if io_error.kind() == std::io::ErrorKind::NotFound
+    );
+    if missing {
+        crate::message::ProjectLoadError::missing_project(error.to_string())
+    } else {
+        crate::message::ProjectLoadError::other(error.to_string())
+    }
+}
+
+fn classify_legacy_project_load_error(
+    error: vibez_project::ProjectError,
+) -> crate::message::ProjectLoadError {
+    let missing = matches!(
+        &error,
+        vibez_project::ProjectError::Io(io_error)
+            if io_error.kind() == std::io::ErrorKind::NotFound
+    );
+    if missing {
+        crate::message::ProjectLoadError::missing_project(error.to_string())
+    } else {
+        crate::message::ProjectLoadError::other(error.to_string())
+    }
+}
+
 pub(super) async fn load_project_async(
     path: PathBuf,
     dropbox: Option<(Arc<DropboxClient>, DropboxCache)>,
-) -> Result<ProjectLoadResult, String> {
+) -> Result<ProjectLoadResult, crate::message::ProjectLoadError> {
     let load_path = path.clone();
     let (project, container_path) = tokio::task::spawn_blocking(move || {
         match vibez_project::project_format_v1::detect_project_format(&load_path)
-            .map_err(|error| error.to_string())?
+            .map_err(classify_project_format_load_error)?
         {
             vibez_project::project_format_v1::ProjectFileFormat::V1 => {
                 let container =
                     vibez_project::project_format_v1::ProjectContainer::open(&load_path)
-                        .map_err(|error| error.to_string())?;
+                        .map_err(classify_project_format_load_error)?;
                 let document = container
                     .load_document()
-                    .map_err(|error| error.to_string())?;
+                    .map_err(classify_project_format_load_error)?;
                 Ok((document.project, Some(load_path)))
             }
             vibez_project::project_format_v1::ProjectFileFormat::LegacyJson => {
                 Project::load_from_file(&load_path)
                     .map(|project| (project, None))
-                    .map_err(|error| error.to_string())
+                    .map_err(classify_legacy_project_load_error)
             }
         }
     })
     .await
-    .map_err(|err| format!("load task failed: {err}"))??;
+    .map_err(|err| crate::message::ProjectLoadError::other(format!("load task failed: {err}")))??;
 
     let mut clips = Vec::new();
     let mut unresolved_clips = Vec::new();
@@ -880,5 +910,34 @@ mod export_tests {
             0,
             "failed export must clean up every temporary file"
         );
+    }
+}
+
+#[cfg(test)]
+mod project_load_error_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_missing_top_level_project_is_classified_for_recent_path_pruning() {
+        let directory = tempfile::tempdir().unwrap();
+        let missing = directory.path().join("removed.vzp");
+
+        let error = load_project_async(missing, None).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            crate::message::ProjectLoadError::MissingProject(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_existing_but_invalid_project_is_not_classified_as_missing() {
+        let directory = tempfile::tempdir().unwrap();
+        let invalid = directory.path().join("invalid.vzp");
+        std::fs::write(&invalid, "not a Vibez project").unwrap();
+
+        let error = load_project_async(invalid, None).await.unwrap_err();
+
+        assert!(matches!(error, crate::message::ProjectLoadError::Other(_)));
     }
 }

--- a/crates/vibez-ui/src/app/async_helpers.rs
+++ b/crates/vibez-ui/src/app/async_helpers.rs
@@ -571,34 +571,51 @@ pub(super) async fn finish_loaded_clip(
     }
 }
 
+/// Run CPU-bound work on the tokio blocking pool, labelling join failures.
+/// Every off-UI-thread hop in the app routes through here so the idiom (and
+/// its error shape) exists exactly once.
+pub(crate) async fn run_off_ui_thread<T, F>(label: &'static str, work: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    tokio::task::spawn_blocking(work)
+        .await
+        .map_err(|error| format!("{label} task failed: {error}"))
+}
+
+/// One rule for what counts as a missing project: only a confirmed
+/// `NotFound` io error prunes a Recent Projects entry; everything else is
+/// treated as transient.
+fn classify_load_error(
+    io_error: Option<&std::io::Error>,
+    message: String,
+) -> crate::message::ProjectLoadError {
+    if io_error.is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound) {
+        crate::message::ProjectLoadError::missing_project(message)
+    } else {
+        crate::message::ProjectLoadError::other(message)
+    }
+}
+
 fn classify_project_format_load_error(
     error: vibez_project::project_format_v1::ProjectFormatError,
 ) -> crate::message::ProjectLoadError {
-    let missing = matches!(
-        &error,
-        vibez_project::project_format_v1::ProjectFormatError::Io(io_error)
-            if io_error.kind() == std::io::ErrorKind::NotFound
-    );
-    if missing {
-        crate::message::ProjectLoadError::missing_project(error.to_string())
-    } else {
-        crate::message::ProjectLoadError::other(error.to_string())
-    }
+    let io_error = match &error {
+        vibez_project::project_format_v1::ProjectFormatError::Io(io_error) => Some(io_error),
+        _ => None,
+    };
+    classify_load_error(io_error, error.to_string())
 }
 
 fn classify_legacy_project_load_error(
     error: vibez_project::ProjectError,
 ) -> crate::message::ProjectLoadError {
-    let missing = matches!(
-        &error,
-        vibez_project::ProjectError::Io(io_error)
-            if io_error.kind() == std::io::ErrorKind::NotFound
-    );
-    if missing {
-        crate::message::ProjectLoadError::missing_project(error.to_string())
-    } else {
-        crate::message::ProjectLoadError::other(error.to_string())
-    }
+    let io_error = match &error {
+        vibez_project::ProjectError::Io(io_error) => Some(io_error),
+        _ => None,
+    };
+    classify_load_error(io_error, error.to_string())
 }
 
 pub(super) async fn load_project_async(
@@ -910,6 +927,28 @@ mod export_tests {
             0,
             "failed export must clean up every temporary file"
         );
+    }
+}
+
+#[cfg(test)]
+mod off_ui_thread_tests {
+    use std::time::Duration;
+
+    use super::run_off_ui_thread;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocking_work_never_blocks_the_ui_executor() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let work = tokio::spawn(run_off_ui_thread("Test", move || {
+            release_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("UI executor should release the blocking worker");
+            42
+        }));
+
+        tokio::task::yield_now().await;
+        assert!(release_tx.send(()).is_ok());
+        assert_eq!(work.await.unwrap().unwrap(), 42);
     }
 }
 

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -12,29 +12,9 @@ pub(super) const REMOTE_SELECTION_DEBOUNCE: std::time::Duration =
     std::time::Duration::from_millis(200);
 pub(super) const REMOTE_CATALOG_SAVE_PAGE_INTERVAL: usize = 10;
 
-async fn run_remote_startup_loader<T, F>(loader: F) -> Result<T, String>
-where
-    T: Send + 'static,
-    F: FnOnce() -> T + Send + 'static,
-{
-    tokio::task::spawn_blocking(loader)
-        .await
-        .map_err(|error| format!("Remote catalog startup task failed: {error}"))
-}
-
-async fn run_remote_refresh_preparer<T, F>(preparer: F) -> Result<T, String>
-where
-    T: Send + 'static,
-    F: FnOnce() -> T + Send + 'static,
-{
-    tokio::task::spawn_blocking(preparer)
-        .await
-        .map_err(|error| format!("Remote catalog refresh task failed: {error}"))
-}
-
 pub(super) fn remote_catalog_startup_task(cache: DropboxCache) -> Task<Message> {
     Task::perform(
-        run_remote_startup_loader(move || {
+        run_off_ui_thread("Remote catalog startup", move || {
             let store = crate::remote_provider::RemoteCatalogStore::for_dropbox();
             let (catalog, load_error) = match store.load() {
                 Ok(catalog) => (catalog, None),
@@ -220,7 +200,7 @@ impl App {
         let changes = std::mem::take(&mut self.remote_catalog_pending);
         let cache = self.dropbox_cache.clone();
         Task::perform(
-            run_remote_refresh_preparer(move || {
+            run_off_ui_thread("Remote catalog refresh", move || {
                 if changes.is_empty() {
                     let catalog =
                         catalog_with_refresh_checkpoint(Arc::clone(&previous_catalog), checkpoint);
@@ -282,7 +262,7 @@ impl App {
         let live_availability = self.state.browser.remote.availability.clone();
         let live_runtime_revision = self.state.browser.remote.catalog_runtime_revision;
         Task::perform(
-            run_remote_refresh_preparer(move || {
+            run_off_ui_thread("Remote catalog refresh", move || {
                 rebase_remote_catalog_refresh(
                     data,
                     live_catalog,
@@ -544,43 +524,6 @@ impl App {
             return Task::none();
         };
         self.start_remote_import(entry, target, treatment)
-    }
-}
-
-#[cfg(test)]
-mod startup_tests {
-    use std::time::Duration;
-
-    use super::{run_remote_refresh_preparer, run_remote_startup_loader};
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn remote_startup_loader_never_blocks_the_ui_executor() {
-        let (release_tx, release_rx) = std::sync::mpsc::channel();
-        let loader = tokio::spawn(run_remote_startup_loader(move || {
-            release_rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("UI executor should release the background loader");
-            42
-        }));
-
-        tokio::task::yield_now().await;
-        assert!(release_tx.send(()).is_ok());
-        assert_eq!(loader.await.unwrap().unwrap(), 42);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn remote_refresh_preparation_never_blocks_the_ui_executor() {
-        let (release_tx, release_rx) = std::sync::mpsc::channel();
-        let preparation = tokio::spawn(run_remote_refresh_preparer(move || {
-            release_rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("UI executor should release Remote refresh preparation");
-            42
-        }));
-
-        tokio::task::yield_now().await;
-        assert!(release_tx.send(()).is_ok());
-        assert_eq!(preparation.await.unwrap().unwrap(), 42);
     }
 }
 

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -44,23 +44,16 @@ pub(super) fn remote_catalog_startup_task(cache: DropboxCache) -> Task<Message> 
                 ),
             };
             let catalog_children = crate::remote_provider::build_remote_catalog_children(&catalog);
-            let cached_identities: std::collections::HashMap<String, Option<String>> =
-                cache.cached_identities().into_iter().collect();
-            let cached_provider_item_ids = catalog
-                .entries
-                .iter()
-                .filter(|entry| {
-                    cached_identities
-                        .get(&entry.provider_item_id)
-                        .is_some_and(|revision| revision.as_deref() == entry.revision.as_deref())
-                })
-                .map(|entry| entry.provider_item_id.clone())
-                .collect();
+            let availability = refreshed_remote_availability(
+                &cache,
+                &catalog,
+                std::collections::HashMap::new(),
+            );
             let cache_usage = cache.usage().unwrap_or_default();
             crate::message::RemoteCatalogStartupData {
                 catalog,
                 catalog_children,
-                cached_provider_item_ids,
+                availability,
                 cache_usage,
                 load_error,
             }
@@ -104,12 +97,12 @@ pub(super) fn seed_remote_availability(
     cache: &DropboxCache,
     remote: &mut crate::state::RemoteUiState,
 ) {
-    remote.availability = refreshed_remote_availability(
+    let refreshed = refreshed_remote_availability(
         cache,
         &remote.catalog,
         std::mem::take(&mut remote.availability),
     );
-    remote.mark_catalog_runtime_changed();
+    remote.replace_availability(refreshed);
 }
 
 fn refreshed_remote_availability(
@@ -365,7 +358,7 @@ impl App {
         self.remote_audition_cache_lease = None;
         let maintenance = self.media_cache_maintenance_task();
         let request_id = self.remote_import_request.begin();
-        self.state.browser.remote.availability.insert(
+        self.state.browser.remote.set_availability(
             entry.path_lower.clone(),
             if self
                 .dropbox_cache
@@ -376,7 +369,6 @@ impl App {
                 crate::state::RemoteAvailability::Fetching
             },
         );
-        self.state.browser.remote.mark_catalog_runtime_changed();
         self.state.status_text = format!("Importing Remote media: {}", entry.name);
         let client = self.dropbox_client.clone();
         let cache = self.dropbox_cache.clone();
@@ -465,11 +457,10 @@ impl App {
             .is_cached(&entry.path_lower, entry.rev.as_deref());
         if !cached && self.dropbox_client.is_none() {
             self.state.browser.remote.preview_in_progress = false;
-            self.state.browser.remote.availability.insert(
+            self.state.browser.remote.set_availability(
                 entry.path_lower,
                 crate::state::RemoteAvailability::ReconnectRequired,
             );
-            self.state.browser.remote.mark_catalog_runtime_changed();
             self.state.status_text =
                 "Reconnect Required · this Remote item is not in Media Cache".into();
             self.state
@@ -486,7 +477,7 @@ impl App {
             self.state.browser.audition_generation
         };
         self.state.browser.remote.preview_in_progress = !cached;
-        self.state.browser.remote.availability.insert(
+        self.state.browser.remote.set_availability(
             entry.path_lower.clone(),
             if cached {
                 crate::state::RemoteAvailability::Cached
@@ -494,7 +485,6 @@ impl App {
                 crate::state::RemoteAvailability::Fetching
             },
         );
-        self.state.browser.remote.mark_catalog_runtime_changed();
         self.state.status_text = if cached {
             format!("Preparing cached Audition: {}", entry.name)
         } else {

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -44,11 +44,8 @@ pub(super) fn remote_catalog_startup_task(cache: DropboxCache) -> Task<Message> 
                 ),
             };
             let catalog_children = crate::remote_provider::build_remote_catalog_children(&catalog);
-            let availability = refreshed_remote_availability(
-                &cache,
-                &catalog,
-                std::collections::HashMap::new(),
-            );
+            let availability =
+                refreshed_remote_availability(&cache, &catalog, std::collections::HashMap::new());
             let cache_usage = cache.usage().unwrap_or_default();
             crate::message::RemoteCatalogStartupData {
                 catalog,

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -185,6 +185,7 @@ mod views_clip_swing;
 mod views_close_confirm;
 mod views_detail;
 mod views_devices;
+mod views_file_menu;
 mod views_mixer;
 mod views_overlays;
 mod views_perform;

--- a/crates/vibez-ui/src/app/update_project.rs
+++ b/crates/vibez-ui/src/app/update_project.rs
@@ -165,7 +165,7 @@ impl App {
     pub(super) fn route_project_loaded(
         &mut self,
         attempted_path: PathBuf,
-        result: Result<ProjectLoadResult, String>,
+        result: Result<ProjectLoadResult, crate::message::ProjectLoadError>,
     ) -> Task<Message> {
         match result {
             Ok(loaded) => {
@@ -174,7 +174,9 @@ impl App {
                 self.remember_recent_project(path);
             }
             Err(err) => {
-                self.forget_recent_project(&attempted_path);
+                if err.is_missing_project() {
+                    self.forget_recent_project(&attempted_path);
+                }
                 self.state.status_text = format!("Project load error: {err}");
             }
         }
@@ -266,5 +268,23 @@ impl App {
         self.state.project.close_confirm_open = false;
         self.state.project.exit_after_save = false;
         Task::none()
+    }
+}
+
+#[cfg(test)]
+mod recent_project_load_error_tests {
+    #[test]
+    fn transient_load_errors_keep_the_recent_project_path() {
+        let error = crate::message::ProjectLoadError::other("permission temporarily denied");
+
+        assert!(!error.is_missing_project());
+    }
+
+    #[test]
+    fn a_confirmed_missing_project_prunes_the_recent_project_path() {
+        let error =
+            crate::message::ProjectLoadError::MissingProject("project file was not found".into());
+
+        assert!(error.is_missing_project());
     }
 }

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -26,15 +26,10 @@ impl App {
                 let item_count = data.catalog.entries.len();
                 self.state.browser.remote.catalog = Arc::new(data.catalog);
                 self.state.browser.remote.catalog_children = data.catalog_children;
-                self.state.browser.remote.availability.clear();
-                self.state.browser.remote.availability.extend(
-                    data.cached_provider_item_ids
-                        .into_iter()
-                        .map(|provider_item_id| {
-                            (provider_item_id, crate::state::RemoteAvailability::Cached)
-                        }),
-                );
-                self.state.browser.remote.mark_catalog_runtime_changed();
+                self.state
+                    .browser
+                    .remote
+                    .replace_availability(data.availability);
                 self.state.browser.remote.cache_usage_bytes = data.cache_usage.bytes;
                 self.state.browser.remote.cache_entries = data.cache_usage.entries;
                 self.state.browser.remote.refresh_items = item_count;
@@ -493,16 +488,11 @@ impl App {
                 self.state
                     .browser
                     .remote
-                    .availability
-                    .insert(path_lower.clone(), crate::state::RemoteAvailability::Cached);
-                if let Some(entry) = Arc::make_mut(&mut self.state.browser.remote.catalog)
-                    .entries
-                    .iter_mut()
-                    .find(|entry| entry.provider_item_id == path_lower)
-                {
-                    entry.derived_metadata = Some(materialized.metadata.clone());
-                }
-                self.state.browser.remote.mark_catalog_runtime_changed();
+                    .set_availability(path_lower.clone(), crate::state::RemoteAvailability::Cached);
+                self.state
+                    .browser
+                    .remote
+                    .set_entry_derived_metadata(&path_lower, materialized.metadata.clone());
                 let persist = self.remote_catalog_persist_task(None);
                 let maintenance = self.media_cache_maintenance_task();
                 self.remote_audition_cache_lease = Some(materialized.lease);
@@ -538,9 +528,7 @@ impl App {
                 self.state
                     .browser
                     .remote
-                    .availability
-                    .insert(path_lower, availability);
-                self.state.browser.remote.mark_catalog_runtime_changed();
+                    .set_availability(path_lower, availability);
                 self.state
                     .browser
                     .fail_waveform_load(&source, error.clone());

--- a/crates/vibez-ui/src/app/views_file_menu.rs
+++ b/crates/vibez-ui/src/app/views_file_menu.rs
@@ -1,0 +1,275 @@
+//! File menu overlay and its Recent Projects submenu.
+//!
+//! Split out of views_overlays.rs; inherent methods on [`super::App`]. The
+//! submenu is aligned to its parent row by arithmetic over fixed row heights,
+//! so every row in the menu column MUST carry
+//! `.height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))`.
+
+use iced::widget::{
+    button, column, container, horizontal_space, mouse_area, row, text, vertical_space,
+};
+use iced::{Element, Length, Theme};
+
+use crate::domains::project::ProjectMsg;
+
+use crate::icons;
+use crate::message::{MenuOverlay, Message};
+use crate::theme as th;
+
+use super::*;
+
+const FILE_MENU_ITEM_HEIGHT: f32 = 32.0;
+const FILE_MENU_ITEM_SPACING: f32 = 2.0;
+const FILE_MENU_CONTENT_PADDING: f32 = 4.0;
+const RECENT_PROJECTS_MENU_ITEM_INDEX: usize = 2;
+
+fn file_menu_item_top(item_index: usize) -> f32 {
+    FILE_MENU_CONTENT_PADDING + item_index as f32 * (FILE_MENU_ITEM_HEIGHT + FILE_MENU_ITEM_SPACING)
+}
+
+impl App {
+    pub(super) fn view_file_menu_overlay(&self) -> Element<'_, Message> {
+        let make_menu_btn = |label: &'static str, icon: char, msg: Message| {
+            button(
+                row![
+                    icons::icon(icon).size(12).color(th::text()),
+                    text(label).size(12).color(th::text())
+                ]
+                .spacing(6)
+                .align_y(iced::Alignment::Center),
+            )
+            .on_press(Message::menu_item(MenuOverlay::File, msg))
+            .padding([8, 16])
+            .height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))
+            .width(Length::Fill)
+            .style(|_theme: &Theme, status| {
+                let bg = match status {
+                    button::Status::Hovered | button::Status::Pressed => {
+                        Some(th::bg_hover().into())
+                    }
+                    _ => None,
+                };
+                button::Style {
+                    background: bg,
+                    text_color: th::text(),
+                    border: iced::Border::default(),
+                    ..Default::default()
+                }
+            })
+        };
+
+        let new_btn = make_menu_btn("New (Empty)", icons::PLUS, Message::NewProject);
+        let export_btn = make_menu_btn(
+            "Export to WAV...",
+            icons::AUDIO_WAVEFORM,
+            Message::ExportProject,
+        );
+
+        let open_btn = make_menu_btn("Open...", icons::MUSIC, Message::OpenProject);
+        let recent_btn = button(
+            row![
+                icons::icon(icons::MUSIC).size(12).color(th::text()),
+                text("Recent Projects").size(12).color(th::text()),
+                horizontal_space(),
+                text("›")
+                    .size(16)
+                    .color(if self.state.project.recent_projects_open {
+                        th::accent()
+                    } else {
+                        th::text_dim()
+                    }),
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::Project(ProjectMsg::ToggleRecentProjects))
+        .padding([8, 16])
+        .height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))
+        .width(Length::Fill)
+        .style(|_theme: &Theme, status| button::Style {
+            background: match status {
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
+                _ => None,
+            },
+            text_color: th::text(),
+            border: iced::Border::default(),
+            ..Default::default()
+        });
+        let save_label = if self.state.project.dirty {
+            "Save*"
+        } else {
+            "Save"
+        };
+        let save_btn = make_menu_btn(save_label, icons::COPY, Message::SaveProject);
+        let save_as_btn = make_menu_btn("Save As...", icons::COPY, Message::SaveProjectAs);
+        let settings_btn = button(
+            row![
+                icons::icon(icons::SLIDERS_VERTICAL)
+                    .size(12)
+                    .color(th::text()),
+                text("Settings...").size(12).color(th::text())
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(Message::menu_item(MenuOverlay::File, Message::OpenSettings))
+        .padding([8, 16])
+        .height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))
+        .width(Length::Fill)
+        .style(|_theme: &Theme, status| {
+            let bg = match status {
+                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
+                _ => None,
+            };
+            button::Style {
+                background: bg,
+                text_color: th::text(),
+                border: iced::Border::default(),
+                ..Default::default()
+            }
+        });
+
+        let about_btn = make_menu_btn("About vibez", icons::CIRCLE_DOT, Message::OpenAbout);
+
+        let menu_content = column![new_btn]
+            .spacing(FILE_MENU_ITEM_SPACING)
+            .push(open_btn)
+            .push(recent_btn)
+            .push(save_btn)
+            .push(save_as_btn)
+            .push(export_btn)
+            .push(settings_btn)
+            .push(about_btn)
+            .padding(FILE_MENU_CONTENT_PADDING)
+            .width(Length::Fixed(220.0));
+
+        let menu_card = container(menu_content).style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_surface().into()),
+            border: iced::Border {
+                color: th::border(),
+                width: 1.0,
+                radius: 6.0.into(),
+            },
+            ..Default::default()
+        });
+
+        let recent_card = self.state.project.recent_projects_open.then(|| {
+            let mut items = column![text("RECENT PROJECTS").size(9).color(th::text_muted())]
+                .spacing(2)
+                .padding(4)
+                .width(Length::Fixed(320.0));
+            if self.state.project.recent_project_paths.is_empty() {
+                items = items.push(
+                    container(text("No recent projects").size(11).color(th::text_dim()))
+                        .padding([10, 12]),
+                );
+            } else {
+                for path in &self.state.project.recent_project_paths {
+                    let name = path
+                        .file_name()
+                        .unwrap_or(path.as_os_str())
+                        .to_string_lossy()
+                        .into_owned();
+                    let parent = path
+                        .parent()
+                        .map(|parent| parent.display().to_string())
+                        .unwrap_or_default();
+                    let open_path = path.clone();
+                    items = items.push(
+                        button(
+                            column![
+                                text(name).size(11).color(th::text()),
+                                text(parent).size(9).color(th::text_muted()),
+                            ]
+                            .spacing(1),
+                        )
+                        .on_press(Message::menu_item(
+                            MenuOverlay::File,
+                            Message::ProjectOpenPathSelected(Some(open_path)),
+                        ))
+                        .padding([6, 10])
+                        .width(Length::Fill)
+                        .style(|_theme: &Theme, status| button::Style {
+                            background: match status {
+                                button::Status::Hovered | button::Status::Pressed => {
+                                    Some(th::bg_hover().into())
+                                }
+                                _ => None,
+                            },
+                            text_color: th::text(),
+                            border: iced::Border::default(),
+                            ..Default::default()
+                        }),
+                    );
+                }
+                items = items.push(
+                    button(
+                        row![
+                            icons::icon(icons::TRASH_2).size(11).color(th::text_dim()),
+                            text("Clear Recent Projects").size(11).color(th::text_dim()),
+                        ]
+                        .spacing(6),
+                    )
+                    .on_press(Message::menu_item(
+                        MenuOverlay::File,
+                        Message::Project(ProjectMsg::ClearRecentProjects),
+                    ))
+                    .padding([8, 10])
+                    .width(Length::Fill)
+                    .style(|_theme: &Theme, status| button::Style {
+                        background: match status {
+                            button::Status::Hovered | button::Status::Pressed => {
+                                Some(th::bg_hover().into())
+                            }
+                            _ => None,
+                        },
+                        text_color: th::text_dim(),
+                        border: iced::Border::default(),
+                        ..Default::default()
+                    }),
+                );
+            }
+            container(items).style(|_theme: &Theme| container::Style {
+                background: Some(th::bg_surface().into()),
+                border: iced::Border {
+                    color: th::border(),
+                    width: 1.0,
+                    radius: 6.0.into(),
+                },
+                ..Default::default()
+            })
+        });
+
+        // Position below the header, near the File button.
+        let menus = if let Some(recent_card) = recent_card {
+            let aligned_recent_card = column![
+                vertical_space().height(Length::Fixed(file_menu_item_top(
+                    RECENT_PROJECTS_MENU_ITEM_INDEX
+                ))),
+                recent_card
+            ];
+            row![menu_card, aligned_recent_card].spacing(4)
+        } else {
+            row![menu_card]
+        };
+        let padded = column![
+            vertical_space().height(Length::Fixed(42.0)),
+            row![horizontal_space().width(Length::Fixed(60.0)), menus,]
+        ];
+
+        mouse_area(container(padded).width(Length::Fill).height(Length::Fill))
+            .on_press(Message::dismiss_menu(MenuOverlay::File))
+            .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::file_menu_item_top;
+
+    #[test]
+    fn file_submenu_starts_at_its_parent_row() {
+        assert_eq!(file_menu_item_top(0), 4.0);
+        assert_eq!(file_menu_item_top(2), 72.0);
+    }
+}

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -1,4 +1,5 @@
-//! Modal overlays: context menus, file menu, rename prompt.
+//! Modal overlays: context menus, rename prompt, track deletion. The File
+//! menu lives in views_file_menu.rs.
 
 //! Split out of app.rs; inherent methods on [`super::App`].
 
@@ -10,7 +11,6 @@ use iced::{Element, Length, Theme};
 
 use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::piano_roll::PianoRollMsg;
-use crate::domains::project::ProjectMsg;
 use crate::domains::view::ViewMsg;
 use vibez_core::effect::EffectType;
 use vibez_core::midi::InstrumentKind;
@@ -28,15 +28,6 @@ fn project_track_deletion_list_height(location_count: usize) -> f32 {
         0 | 1 => 28.0,
         count => (count as f32 * 28.0 + (count - 1) as f32 * 4.0).min(120.0),
     }
-}
-
-const FILE_MENU_ITEM_HEIGHT: f32 = 32.0;
-const FILE_MENU_ITEM_SPACING: f32 = 2.0;
-const FILE_MENU_CONTENT_PADDING: f32 = 4.0;
-const RECENT_PROJECTS_MENU_ITEM_INDEX: usize = 2;
-
-fn file_menu_item_top(item_index: usize) -> f32 {
-    FILE_MENU_CONTENT_PADDING + item_index as f32 * (FILE_MENU_ITEM_HEIGHT + FILE_MENU_ITEM_SPACING)
 }
 
 impl App {
@@ -559,238 +550,6 @@ impl App {
             .into()
     }
 
-    pub(super) fn view_file_menu_overlay(&self) -> Element<'_, Message> {
-        let make_menu_btn = |label: &'static str, icon: char, msg: Message| {
-            button(
-                row![
-                    icons::icon(icon).size(12).color(th::text()),
-                    text(label).size(12).color(th::text())
-                ]
-                .spacing(6)
-                .align_y(iced::Alignment::Center),
-            )
-            .on_press(Message::menu_item(MenuOverlay::File, msg))
-            .padding([8, 16])
-            .height(Length::Fixed(FILE_MENU_ITEM_HEIGHT))
-            .width(Length::Fill)
-            .style(|_theme: &Theme, status| {
-                let bg = match status {
-                    button::Status::Hovered | button::Status::Pressed => {
-                        Some(th::bg_hover().into())
-                    }
-                    _ => None,
-                };
-                button::Style {
-                    background: bg,
-                    text_color: th::text(),
-                    border: iced::Border::default(),
-                    ..Default::default()
-                }
-            })
-        };
-
-        let new_btn = make_menu_btn("New (Empty)", icons::PLUS, Message::NewProject);
-        let export_btn = make_menu_btn(
-            "Export to WAV...",
-            icons::AUDIO_WAVEFORM,
-            Message::ExportProject,
-        );
-
-        let open_btn = make_menu_btn("Open...", icons::MUSIC, Message::OpenProject);
-        let recent_btn = button(
-            row![
-                icons::icon(icons::MUSIC).size(12).color(th::text()),
-                text("Recent Projects").size(12).color(th::text()),
-                horizontal_space(),
-                text("›")
-                    .size(16)
-                    .color(if self.state.project.recent_projects_open {
-                        th::accent()
-                    } else {
-                        th::text_dim()
-                    }),
-            ]
-            .spacing(6)
-            .align_y(iced::Alignment::Center),
-        )
-        .on_press(Message::Project(ProjectMsg::ToggleRecentProjects))
-        .padding([8, 16])
-        .width(Length::Fill)
-        .style(|_theme: &Theme, status| button::Style {
-            background: match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
-                _ => None,
-            },
-            text_color: th::text(),
-            border: iced::Border::default(),
-            ..Default::default()
-        });
-        let save_label = if self.state.project.dirty {
-            "Save*"
-        } else {
-            "Save"
-        };
-        let save_btn = make_menu_btn(save_label, icons::COPY, Message::SaveProject);
-        let save_as_btn = make_menu_btn("Save As...", icons::COPY, Message::SaveProjectAs);
-        let settings_btn = button(
-            row![
-                icons::icon(icons::SLIDERS_VERTICAL)
-                    .size(12)
-                    .color(th::text()),
-                text("Settings...").size(12).color(th::text())
-            ]
-            .spacing(6)
-            .align_y(iced::Alignment::Center),
-        )
-        .on_press(Message::menu_item(MenuOverlay::File, Message::OpenSettings))
-        .padding([8, 16])
-        .width(Length::Fill)
-        .style(|_theme: &Theme, status| {
-            let bg = match status {
-                button::Status::Hovered | button::Status::Pressed => Some(th::bg_hover().into()),
-                _ => None,
-            };
-            button::Style {
-                background: bg,
-                text_color: th::text(),
-                border: iced::Border::default(),
-                ..Default::default()
-            }
-        });
-
-        let about_btn = make_menu_btn("About vibez", icons::CIRCLE_DOT, Message::OpenAbout);
-
-        let menu_content = column![new_btn]
-            .spacing(FILE_MENU_ITEM_SPACING)
-            .push(open_btn)
-            .push(recent_btn)
-            .push(save_btn)
-            .push(save_as_btn)
-            .push(export_btn)
-            .push(settings_btn)
-            .push(about_btn)
-            .padding(FILE_MENU_CONTENT_PADDING)
-            .width(Length::Fixed(220.0));
-
-        let menu_card = container(menu_content).style(|_theme: &Theme| container::Style {
-            background: Some(th::bg_surface().into()),
-            border: iced::Border {
-                color: th::border(),
-                width: 1.0,
-                radius: 6.0.into(),
-            },
-            ..Default::default()
-        });
-
-        let recent_card = self.state.project.recent_projects_open.then(|| {
-            let mut items = column![text("RECENT PROJECTS").size(9).color(th::text_muted())]
-                .spacing(2)
-                .padding(4)
-                .width(Length::Fixed(320.0));
-            if self.state.project.recent_project_paths.is_empty() {
-                items = items.push(
-                    container(text("No recent projects").size(11).color(th::text_dim()))
-                        .padding([10, 12]),
-                );
-            } else {
-                for path in &self.state.project.recent_project_paths {
-                    let name = path
-                        .file_name()
-                        .unwrap_or(path.as_os_str())
-                        .to_string_lossy()
-                        .into_owned();
-                    let parent = path
-                        .parent()
-                        .map(|parent| parent.display().to_string())
-                        .unwrap_or_default();
-                    let open_path = path.clone();
-                    items = items.push(
-                        button(
-                            column![
-                                text(name).size(11).color(th::text()),
-                                text(parent).size(9).color(th::text_muted()),
-                            ]
-                            .spacing(1),
-                        )
-                        .on_press(Message::menu_item(
-                            MenuOverlay::File,
-                            Message::ProjectOpenPathSelected(Some(open_path)),
-                        ))
-                        .padding([6, 10])
-                        .width(Length::Fill)
-                        .style(|_theme: &Theme, status| button::Style {
-                            background: match status {
-                                button::Status::Hovered | button::Status::Pressed => {
-                                    Some(th::bg_hover().into())
-                                }
-                                _ => None,
-                            },
-                            text_color: th::text(),
-                            border: iced::Border::default(),
-                            ..Default::default()
-                        }),
-                    );
-                }
-                items = items.push(
-                    button(
-                        row![
-                            icons::icon(icons::TRASH_2).size(11).color(th::text_dim()),
-                            text("Clear Recent Projects").size(11).color(th::text_dim()),
-                        ]
-                        .spacing(6),
-                    )
-                    .on_press(Message::menu_item(
-                        MenuOverlay::File,
-                        Message::Project(ProjectMsg::ClearRecentProjects),
-                    ))
-                    .padding([8, 10])
-                    .width(Length::Fill)
-                    .style(|_theme: &Theme, status| button::Style {
-                        background: match status {
-                            button::Status::Hovered | button::Status::Pressed => {
-                                Some(th::bg_hover().into())
-                            }
-                            _ => None,
-                        },
-                        text_color: th::text_dim(),
-                        border: iced::Border::default(),
-                        ..Default::default()
-                    }),
-                );
-            }
-            container(items).style(|_theme: &Theme| container::Style {
-                background: Some(th::bg_surface().into()),
-                border: iced::Border {
-                    color: th::border(),
-                    width: 1.0,
-                    radius: 6.0.into(),
-                },
-                ..Default::default()
-            })
-        });
-
-        // Position below the header, near the File button.
-        let menus = if let Some(recent_card) = recent_card {
-            let aligned_recent_card = column![
-                vertical_space().height(Length::Fixed(file_menu_item_top(
-                    RECENT_PROJECTS_MENU_ITEM_INDEX
-                ))),
-                recent_card
-            ];
-            row![menu_card, aligned_recent_card].spacing(4)
-        } else {
-            row![menu_card]
-        };
-        let padded = column![
-            vertical_space().height(Length::Fixed(42.0)),
-            row![horizontal_space().width(Length::Fixed(60.0)), menus,]
-        ];
-
-        mouse_area(container(padded).width(Length::Fill).height(Length::Fill))
-            .on_press(Message::dismiss_menu(MenuOverlay::File))
-            .into()
-    }
-
     pub(super) fn view_rename_overlay(&self) -> Element<'_, Message> {
         let input = text_input("Name", &self.state.view.edit_name_text)
             .on_input(|t| Message::View(ViewMsg::EditNameText(t)))
@@ -1038,7 +797,7 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::{file_menu_item_top, project_track_deletion_list_height};
+    use super::project_track_deletion_list_height;
 
     #[test]
     fn deletion_location_list_grows_with_content_then_caps() {
@@ -1046,11 +805,5 @@ mod tests {
         assert_eq!(project_track_deletion_list_height(1), 28.0);
         assert_eq!(project_track_deletion_list_height(2), 60.0);
         assert_eq!(project_track_deletion_list_height(8), 120.0);
-    }
-
-    #[test]
-    fn file_submenu_starts_at_its_parent_row() {
-        assert_eq!(file_menu_item_top(0), 4.0);
-        assert_eq!(file_menu_item_top(2), 72.0);
     }
 }

--- a/crates/vibez-ui/src/domains/arrangement/media_ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/media_ops.rs
@@ -235,31 +235,14 @@ impl TimelineEditorState {
                         track_id,
                         clip_id: original_id,
                     });
-                    engine.send(EngineCommand::RemoveClip(track_id, original_id));
-                    if let Some(content) = self.find_content_mut(track_id) {
-                        content.clips.retain(|clip| clip.id != original_id);
-                    }
                     for clip in &clips {
-                        engine.send(EngineCommand::AddClip {
-                            track_id,
-                            clip_id: clip.id,
-                            audio: Arc::clone(&clip.audio),
-                            position: clip.position,
-                            source_offset: clip.source_offset,
-                            duration: clip.duration,
-                            loop_enabled: clip.loop_enabled,
-                            loop_start: clip.loop_start,
-                            loop_end: clip.loop_end,
-                        });
                         new_selection.insert(ArrangementSelection::AudioClip {
                             track_id,
                             clip_id: clip.id,
                         });
                     }
                     fragment_count += clips.len();
-                    if let Some(content) = self.find_content_mut(track_id) {
-                        content.clips.extend(clips);
-                    }
+                    self.replace_audio_clip(engine, track_id, original_id, clips);
                 }
                 Replacement::Notes {
                     track_id,
@@ -270,37 +253,14 @@ impl TimelineEditorState {
                         track_id,
                         clip_id: original_id,
                     });
-                    engine.send(EngineCommand::RemoveNoteClip(track_id, original_id));
-                    if let Some(content) = self.find_content_mut(track_id) {
-                        content.note_clips.retain(|clip| clip.id != original_id);
-                    }
                     for clip in &clips {
-                        engine.send(EngineCommand::AddNoteClip {
-                            track_id,
-                            clip_id: clip.id,
-                            position_beats: clip.position_beats,
-                            duration_beats: clip.duration_beats,
-                            loop_enabled: clip.loop_enabled,
-                            loop_start_beats: clip.loop_start_beats,
-                            loop_end_beats: clip.loop_end_beats,
-                            groove_grid: clip.groove_grid,
-                        });
-                        for note in &clip.notes {
-                            engine.send(EngineCommand::AddNote {
-                                track_id,
-                                clip_id: clip.id,
-                                note: *note,
-                            });
-                        }
                         new_selection.insert(ArrangementSelection::NoteClip {
                             track_id,
                             clip_id: clip.id,
                         });
                     }
                     fragment_count += clips.len();
-                    if let Some(content) = self.find_content_mut(track_id) {
-                        content.note_clips.extend(clips);
-                    }
+                    self.replace_note_clip(engine, track_id, original_id, clips);
                 }
             }
         }
@@ -833,6 +793,75 @@ impl TimelineEditorState {
         Some("Joined note clips".to_string())
     }
 
+    /// Replace `original_id` on `track_id` with `fragments` in both the
+    /// engine and UI state. Every op that fragments a clip (split, trim) must
+    /// route through here so the engine command list stays in one place;
+    /// selection bookkeeping stays with the caller.
+    fn replace_audio_clip(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        track_id: TrackId,
+        original_id: ClipId,
+        fragments: Vec<UiClip>,
+    ) {
+        engine.send(EngineCommand::RemoveClip(track_id, original_id));
+        if let Some(content) = self.find_content_mut(track_id) {
+            content.clips.retain(|clip| clip.id != original_id);
+        }
+        for clip in &fragments {
+            engine.send(EngineCommand::AddClip {
+                track_id,
+                clip_id: clip.id,
+                audio: Arc::clone(&clip.audio),
+                position: clip.position,
+                source_offset: clip.source_offset,
+                duration: clip.duration,
+                loop_enabled: clip.loop_enabled,
+                loop_start: clip.loop_start,
+                loop_end: clip.loop_end,
+            });
+        }
+        if let Some(content) = self.find_content_mut(track_id) {
+            content.clips.extend(fragments);
+        }
+    }
+
+    /// Note-clip counterpart of [`Self::replace_audio_clip`].
+    fn replace_note_clip(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        track_id: TrackId,
+        original_id: ClipId,
+        fragments: Vec<UiNoteClip>,
+    ) {
+        engine.send(EngineCommand::RemoveNoteClip(track_id, original_id));
+        if let Some(content) = self.find_content_mut(track_id) {
+            content.note_clips.retain(|clip| clip.id != original_id);
+        }
+        for clip in &fragments {
+            engine.send(EngineCommand::AddNoteClip {
+                track_id,
+                clip_id: clip.id,
+                position_beats: clip.position_beats,
+                duration_beats: clip.duration_beats,
+                loop_enabled: clip.loop_enabled,
+                loop_start_beats: clip.loop_start_beats,
+                loop_end_beats: clip.loop_end_beats,
+                groove_grid: clip.groove_grid,
+            });
+            for note in &clip.notes {
+                engine.send(EngineCommand::AddNote {
+                    track_id,
+                    clip_id: clip.id,
+                    note: *note,
+                });
+            }
+        }
+        if let Some(content) = self.find_content_mut(track_id) {
+            content.note_clips.extend(fragments);
+        }
+    }
+
     pub(super) fn op_split_audio_clip(
         &mut self,
         engine: &mut impl EngineHandle,
@@ -866,28 +895,7 @@ impl TimelineEditorState {
             });
         if let Some((left, right)) = split {
             let left_id = left.id;
-
-            engine.send(EngineCommand::RemoveClip(track_id, clip_id));
-            if let Some(track) = self.find_content_mut(track_id) {
-                track.clips.retain(|c| c.id != clip_id);
-            }
-
-            for clip in [&left, &right] {
-                engine.send(EngineCommand::AddClip {
-                    track_id,
-                    clip_id: clip.id,
-                    audio: Arc::clone(&clip.audio),
-                    position: clip.position,
-                    source_offset: clip.source_offset,
-                    duration: clip.duration,
-                    loop_enabled: clip.loop_enabled,
-                    loop_start: clip.loop_start,
-                    loop_end: clip.loop_end,
-                });
-            }
-            if let Some(track) = self.find_content_mut(track_id) {
-                track.clips.extend([left, right]);
-            }
+            self.replace_audio_clip(engine, track_id, clip_id, vec![left, right]);
 
             self.selected_clips
                 .remove(&ArrangementSelection::AudioClip { track_id, clip_id });
@@ -943,33 +951,7 @@ impl TimelineEditorState {
             });
         if let Some((left, right)) = split {
             let left_id = left.id;
-            engine.send(EngineCommand::RemoveNoteClip(track_id, clip_id));
-            if let Some(track) = self.find_content_mut(track_id) {
-                track.note_clips.retain(|c| c.id != clip_id);
-            }
-
-            for clip in [&left, &right] {
-                engine.send(EngineCommand::AddNoteClip {
-                    track_id,
-                    clip_id: clip.id,
-                    position_beats: clip.position_beats,
-                    duration_beats: clip.duration_beats,
-                    loop_enabled: clip.loop_enabled,
-                    loop_start_beats: clip.loop_start_beats,
-                    loop_end_beats: clip.loop_end_beats,
-                    groove_grid: clip.groove_grid,
-                });
-                for note in &clip.notes {
-                    engine.send(EngineCommand::AddNote {
-                        track_id,
-                        clip_id: clip.id,
-                        note: *note,
-                    });
-                }
-            }
-            if let Some(track) = self.find_content_mut(track_id) {
-                track.note_clips.extend([left, right]);
-            }
+            self.replace_note_clip(engine, track_id, clip_id, vec![left, right]);
 
             self.selected_clips
                 .remove(&ArrangementSelection::NoteClip { track_id, clip_id });

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -186,7 +186,7 @@ pub struct PerformState {
     note_repeat_momentary: bool,
     note_repeat_momentary_key_id: Option<String>,
     note_repeat_latched: bool,
-    track_mute_quantization: TrackMuteQuantization,
+    track_mute_quantization: track_mutes::TrackMuteQuantizationSetting,
     pending_track_mutes: HashMap<TrackId, PendingTrackMute>,
     pub capture: CaptureState,
     pub section_record: section_record::SectionRecordState,
@@ -376,7 +376,7 @@ impl PerformState {
         Some(TrackMuteRequest {
             track_id,
             muted: !track.mute,
-            quantization: self.track_mute_quantization,
+            quantization: self.track_mute_quantization.0,
         })
     }
 
@@ -654,7 +654,7 @@ impl PerformState {
                 }
             }
             PerformMsg::SetTrackMuteQuantization(quantization) => {
-                self.track_mute_quantization = quantization;
+                self.track_mute_quantization.0 = quantization;
                 return PerformAction {
                     persist_settings: true,
                     ..PerformAction::default()

--- a/crates/vibez-ui/src/domains/perform/track_mutes.rs
+++ b/crates/vibez-ui/src/domains/perform/track_mutes.rs
@@ -17,13 +17,26 @@ pub struct PendingTrackMute {
     pub effective_at_samples: u64,
 }
 
+/// Private storage for the Perform-owned quantization setting. Exists so a
+/// fresh [`PerformState`] defaults to `Immediate` (the Track Mute
+/// compatibility default) while the shared quantization enum's own `Default`
+/// is the Section launch value (`OneBar`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct TrackMuteQuantizationSetting(pub(super) TrackMuteQuantization);
+
+impl Default for TrackMuteQuantizationSetting {
+    fn default() -> Self {
+        Self(TrackMuteQuantization::Immediate)
+    }
+}
+
 impl PerformState {
     pub const fn track_mute_quantization(&self) -> TrackMuteQuantization {
-        self.track_mute_quantization
+        self.track_mute_quantization.0
     }
 
     pub fn set_track_mute_quantization(&mut self, quantization: TrackMuteQuantization) {
-        self.track_mute_quantization = quantization;
+        self.track_mute_quantization.0 = quantization;
     }
 
     pub fn queue_track_mute_ui(

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -173,7 +173,7 @@ pub struct RemoteMaterializedSample {
 pub struct RemoteCatalogStartupData {
     pub catalog: crate::remote_provider::RemoteCatalogSnapshot,
     pub catalog_children: HashMap<String, Vec<usize>>,
-    pub cached_provider_item_ids: HashSet<String>,
+    pub availability: HashMap<String, crate::state::RemoteAvailability>,
     pub cache_usage: vibez_dropbox::CacheUsage,
     pub load_error: Option<String>,
 }

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -338,6 +338,34 @@ pub struct ProjectLoadResult {
 }
 
 #[derive(Debug, Clone)]
+pub enum ProjectLoadError {
+    MissingProject(String),
+    Other(String),
+}
+
+impl ProjectLoadError {
+    pub fn missing_project(error: impl Into<String>) -> Self {
+        Self::MissingProject(error.into())
+    }
+
+    pub fn other(error: impl Into<String>) -> Self {
+        Self::Other(error.into())
+    }
+
+    pub fn is_missing_project(&self) -> bool {
+        matches!(self, Self::MissingProject(_))
+    }
+}
+
+impl std::fmt::Display for ProjectLoadError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingProject(error) | Self::Other(error) => formatter.write_str(error),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct ProjectSaveResult {
     pub path: PathBuf,
     pub project: Project,
@@ -472,7 +500,7 @@ pub enum Message {
     ProjectSavePathSelected(Option<PathBuf>),
     ProjectLoaded {
         path: PathBuf,
-        result: Box<Result<ProjectLoadResult, String>>,
+        result: Box<Result<ProjectLoadResult, ProjectLoadError>>,
     },
     ProjectSaved(Box<ProjectSaveCompleted>),
 

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -810,10 +810,16 @@ pub struct RemoteUiState {
     pub selected_path: Option<String>,
     /// A preview fetch / playback is in flight.
     pub preview_in_progress: bool,
+    /// UI-owned availability per provider item. Mutate ONLY through
+    /// [`Self::set_availability`] / [`Self::replace_availability`] so the
+    /// runtime revision below stays in sync; direct inserts reintroduce the
+    /// refresh-clobber race those methods exist to prevent.
     pub availability: HashMap<String, RemoteAvailability>,
     /// Changes made by materialization/import flows while a catalog refresh
     /// snapshot is being prepared. Prepared snapshots use this to detect and
-    /// rebase over newer UI-owned metadata instead of replacing it.
+    /// rebase over newer UI-owned metadata instead of replacing it. Bumped
+    /// internally by the mutation methods on this type; never write it
+    /// directly.
     pub catalog_runtime_revision: u64,
     pub cache_usage_bytes: u64,
     pub cache_entries: usize,
@@ -854,8 +860,47 @@ impl Default for RemoteUiState {
 }
 
 impl RemoteUiState {
-    pub(crate) fn mark_catalog_runtime_changed(&mut self) {
+    fn mark_catalog_runtime_changed(&mut self) {
         self.catalog_runtime_revision = self.catalog_runtime_revision.wrapping_add(1);
+    }
+
+    /// Record a UI-owned availability change and bump the runtime revision so
+    /// an in-flight refresh preparation rebases over it instead of clobbering
+    /// it.
+    pub(crate) fn set_availability(
+        &mut self,
+        provider_item_id: String,
+        availability: RemoteAvailability,
+    ) {
+        self.availability.insert(provider_item_id, availability);
+        self.mark_catalog_runtime_changed();
+    }
+
+    /// Replace the whole availability map (startup load, cache reseed) and
+    /// bump the runtime revision.
+    pub(crate) fn replace_availability(
+        &mut self,
+        availability: HashMap<String, RemoteAvailability>,
+    ) {
+        self.availability = availability;
+        self.mark_catalog_runtime_changed();
+    }
+
+    /// Write derived metadata for one catalog entry (post-materialization)
+    /// and bump the runtime revision.
+    pub(crate) fn set_entry_derived_metadata(
+        &mut self,
+        provider_item_id: &str,
+        metadata: vibez_dropbox::DerivedMetadata,
+    ) {
+        if let Some(entry) = Arc::make_mut(&mut self.catalog)
+            .entries
+            .iter_mut()
+            .find(|entry| entry.provider_item_id == provider_item_id)
+        {
+            entry.derived_metadata = Some(metadata);
+        }
+        self.mark_catalog_runtime_changed();
     }
 
     /// Rebuild the parent/children lookup after the catalog is loaded or

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -11,7 +11,7 @@ pub struct UiSettings {
     pub perform_input_mapping: crate::domains::perform::PerformInputMapping,
     #[serde(default = "default_fixed_computer_velocity")]
     pub fixed_computer_velocity: u8,
-    #[serde(default)]
+    #[serde(default = "default_track_mute_quantization")]
     pub track_mute_quantization: vibez_core::perform::TrackMuteQuantization,
     #[serde(default)]
     pub sample_library_roots: Vec<PathBuf>,
@@ -113,7 +113,7 @@ impl Default for UiSettings {
             recent_project_paths: Vec::new(),
             perform_input_mapping: crate::domains::perform::PerformInputMapping::default(),
             fixed_computer_velocity: default_fixed_computer_velocity(),
-            track_mute_quantization: vibez_core::perform::TrackMuteQuantization::default(),
+            track_mute_quantization: default_track_mute_quantization(),
             sample_library_roots: Vec::new(),
             sample_browser_open: default_sample_browser_open(),
             sample_browser_width: default_sample_browser_width(),
@@ -197,6 +197,13 @@ impl UiSettings {
 
 fn default_sample_browser_open() -> bool {
     true
+}
+
+/// Track Mutes default to Immediate for back-compat with settings written
+/// before quantization existed; the shared enum's own Default is the Section
+/// launch default (OneBar).
+const fn default_track_mute_quantization() -> vibez_core::perform::TrackMuteQuantization {
+    vibez_core::perform::TrackMuteQuantization::Immediate
 }
 
 const fn default_fixed_computer_velocity() -> u8 {


### PR DESCRIPTION
## Summary

Patch release: closes every correctness issue found in the v0.1.5 release review, then pays down the architectural debt the same review flagged.

**Fixes**
- Remote catalog refresh: preserve the Dropbox delta checkpoint on empty save intervals, rebase prepared refreshes over concurrent UI changes (new catalog runtime revision), and generation-guard failed prepares (#153)
- End of Section track mutes now apply when a one-shot section stops instead of being silently cancelled (#153)
- Recent Projects entries survive transient load errors; only a confirmed missing file prunes (#154)

**Refactors**
- Shared clip replacement helpers back split and trim, so the engine command list exists once (#155)
- RemoteUiState owns availability mutations and bumps its runtime revision internally, closing the forgotten-bump hazard; startup reuses the shared cached-revision rule (#156)
- One shared quantization enum for section launches and track mutes, defaults expressed at the storage sites (#157)
- File menu overlay split into views_file_menu.rs, bringing views_overlays.rs back under the 1,000-line ceiling, with the submenu row-height invariant fixed (#158)
- Duplicated off-thread and load-error-classification helpers folded (#159)

## Test plan
- Full workspace test suite green locally and in CI on all three platforms (Linux, macOS, Windows), clippy and rustfmt clean
- Refresh-race behavior covered by new rebase/checkpoint/generation unit tests; one-shot section mute covered by a new engine test
- Manual smoke: release build boots, project open/save, Perform section launch with End of Section mute, Remote browser refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)