### PR TITLE
Release v0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5085,7 +5085,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibez"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "iced",
  "libloading 0.8.9",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-audio-io"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "audio_thread_priority",
  "cpal",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-dropbox"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "base64",
  "dirs 5.0.1",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-dsp"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "signalsmith-stretch",
  "vibez-core",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-engine"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "rtrb",
  "vibez-core",
@@ -5154,14 +5154,14 @@ dependencies = [
 
 [[package]]
 name = "vibez-instruments"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "vibez-core",
 ]
 
 [[package]]
 name = "vibez-plugin-host"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap-sys",
  "dirs 5.0.1",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-project"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "rusqlite",
  "serde",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "vibez-ui"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "base64",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/vibez-daw/vibez"

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -435,7 +435,8 @@ impl App {
             app.state.update_check.enabled,
             app.state.update_check.last_check_unix,
             crate::update_check::now_unix(),
-        ) {
+        ) && app.state.update_check.begin_check()
+        {
             Task::perform(
                 crate::update_check::fetch_latest_tag(),
                 Message::UpdateCheckCompleted,

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -701,6 +701,14 @@ impl App {
                 self.state.update_check.enabled = !self.state.update_check.enabled;
                 self.persist_ui_settings();
             }
+            Message::CheckForUpdatesNow => {
+                if self.state.update_check.begin_check() {
+                    return Task::perform(
+                        crate::update_check::fetch_latest_tag(),
+                        Message::UpdateCheckCompleted,
+                    );
+                }
+            }
             Message::UpdateCheckCompleted(tag) => {
                 self.state
                     .update_check

--- a/crates/vibez-ui/src/app/views_settings_updates.rs
+++ b/crates/vibez-ui/src/app/views_settings_updates.rs
@@ -56,6 +56,37 @@ impl App {
         .size(11)
         .color(th::text_dim());
 
+        // Manual escape hatch from the once-a-day throttle. Deliberately
+        // available even when the startup check is off: the toggle governs
+        // unattended traffic, and an explicit click is consent for one
+        // request.
+        let check_now: Element<'_, Message> = if state.in_flight {
+            text("Checking…").size(11).color(th::text_dim()).into()
+        } else {
+            button(text("Check now").size(11).color(th::text()))
+                .on_press(Message::CheckForUpdatesNow)
+                .padding([3, 10])
+                .style(|_theme: &Theme, status| {
+                    let bg = match status {
+                        button::Status::Hovered | button::Status::Pressed => {
+                            Some(th::bg_hover().into())
+                        }
+                        _ => None,
+                    };
+                    button::Style {
+                        background: bg,
+                        text_color: th::text(),
+                        border: iced::Border {
+                            color: th::border_light(),
+                            width: 1.0,
+                            radius: 4.0.into(),
+                        },
+                        ..Default::default()
+                    }
+                })
+                .into()
+        };
+
         // Report only what the user can act on. A failed check is
         // indistinguishable from "nothing new" by design, so the
         // absence of a version here is never framed as an error.
@@ -102,7 +133,11 @@ impl App {
             },
         );
 
-        column![title, hint, toggle_btn, divider, current, found]
+        let status_row = row![check_now, found]
+            .spacing(10)
+            .align_y(iced::Alignment::Center);
+
+        column![title, hint, toggle_btn, divider, current, status_row]
             .spacing(10)
             .into()
     }

--- a/crates/vibez-ui/src/app/views_settings_updates.rs
+++ b/crates/vibez-ui/src/app/views_settings_updates.rs
@@ -56,10 +56,6 @@ impl App {
         .size(11)
         .color(th::text_dim());
 
-        // Manual escape hatch from the once-a-day throttle. Deliberately
-        // available even when the startup check is off: the toggle governs
-        // unattended traffic, and an explicit click is consent for one
-        // request.
         let check_now: Element<'_, Message> = if state.in_flight {
             text("Checking…").size(11).color(th::text_dim()).into()
         } else {

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -529,6 +529,10 @@ pub enum Message {
     /// Settings: opt in or out of the startup release check. Takes
     /// effect at the next launch; it never triggers a check itself.
     ToggleCheckForUpdates,
+    /// User-initiated release check from Settings. Bypasses the once-a-day
+    /// startup throttle: an explicit click is consent for one request even
+    /// when the automatic startup check is switched off.
+    CheckForUpdatesNow,
     /// The startup release check finished. `Some` carries the newest
     /// upstream tag; `None` means the request failed and is reported
     /// only by advancing the throttle.

--- a/crates/vibez-ui/src/update_check.rs
+++ b/crates/vibez-ui/src/update_check.rs
@@ -133,6 +133,9 @@ pub struct UpdateCheckState {
     /// re-raises it, which is the gentlest way to keep a genuinely
     /// stale install from going unnoticed forever.
     pub dismissed: bool,
+    /// A check is currently on the wire. Runtime-only: gates the manual
+    /// "Check now" button so a slow request cannot be stacked.
+    pub in_flight: bool,
 }
 
 impl Default for UpdateCheckState {
@@ -142,6 +145,7 @@ impl Default for UpdateCheckState {
             last_check_unix: None,
             available: None,
             dismissed: false,
+            in_flight: false,
         }
     }
 }
@@ -155,9 +159,20 @@ impl UpdateCheckState {
         self.available.as_deref()
     }
 
+    /// Claim the right to start a check. Returns false when one is
+    /// already on the wire, so callers can skip spawning a duplicate.
+    pub fn begin_check(&mut self) -> bool {
+        if self.in_flight {
+            return false;
+        }
+        self.in_flight = true;
+        true
+    }
+
     /// Fold the outcome of a check into the state. Called for both
     /// outcomes so the throttle advances even when the request failed.
     pub fn record_result(&mut self, tag: Option<String>, now_unix: u64) {
+        self.in_flight = false;
         self.last_check_unix = Some(now_unix);
         let Some(tag) = tag else {
             return;
@@ -225,6 +240,19 @@ mod tests {
     #[test]
     fn an_identical_release_offers_no_update() {
         assert_eq!(newer_release("0.1.2", "0.1.2"), None);
+    }
+
+    #[test]
+    fn a_check_can_be_claimed_once_until_its_result_is_recorded() {
+        let mut state = UpdateCheckState::default();
+
+        assert!(state.begin_check());
+        assert!(!state.begin_check());
+
+        state.record_result(None, DAY);
+        assert!(!state.in_flight);
+        assert_eq!(state.last_check_unix, Some(DAY));
+        assert!(state.begin_check());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Small quality-of-life release.

- Settings → Updates gains a **Check now** button: a user-initiated release check that bypasses the once-a-day startup throttle. An explicit click is consent for one request, so it works even with the automatic startup check switched off (#161). A new runtime-only in-flight guard prevents stacked requests and renders as 'Checking…'; manual checks still advance the startup throttle's timestamp.

## Test plan
- Full workspace suite green in CI on Linux, macOS, and Windows; clippy and rustfmt clean
- New unit test pins the check claim/release lifecycle
- Manual smoke: Check now surfaces the latest release chip immediately after a fresh release, with the startup toggle both on and off

🤖 Generated with [Claude Code](https://claude.com/claude-code)