### PR TITLE
feat: add MIDI velocity editing lane

### DIFF
--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -18,11 +18,12 @@ use crate::message::Message;
 use crate::state::{ArrangementSelection, DetailPanelTab, TimelineEditorState, UiClip};
 use crate::theme as th;
 use crate::widgets::audio_clip_detail::AudioClipDetailWidget;
-use crate::widgets::piano_roll::PianoRollWidget;
+use crate::widgets::piano_roll::{PianoRollWidget, VelocityLaneWidget};
 
 use super::*;
 
 const DETAIL_PANEL_MIN_HEIGHT: f32 = 180.0;
+const MIDI_DETAIL_PANEL_MIN_HEIGHT: f32 = 360.0;
 const SHELL_AND_WORKSPACE_MIN_HEIGHT: f32 = 360.0;
 const STATUS_BAR_HEIGHT: f32 = 24.0;
 
@@ -41,8 +42,17 @@ fn resolved_detail_playhead_samples(
         .map(|_| section_samples)
 }
 
-fn effective_detail_panel_height(preferred_height: f32, window_height: f32) -> f32 {
+fn effective_detail_panel_height(
+    preferred_height: f32,
+    window_height: f32,
+    midi_clip_editor_visible: bool,
+) -> f32 {
     let maximum = (window_height - SHELL_AND_WORKSPACE_MIN_HEIGHT).max(DETAIL_PANEL_MIN_HEIGHT);
+    let preferred_height = if midi_clip_editor_visible {
+        preferred_height.max(MIDI_DETAIL_PANEL_MIN_HEIGHT)
+    } else {
+        preferred_height
+    };
     preferred_height.clamp(DETAIL_PANEL_MIN_HEIGHT, maximum)
 }
 
@@ -227,9 +237,12 @@ impl App {
                 .into()
         };
 
+        let midi_clip_editor_visible = self.state.view.detail_panel_tab == DetailPanelTab::Clip
+            && self.visible_piano_roll_clip().is_some();
         let panel_height = effective_detail_panel_height(
             self.state.view.detail_panel_height,
             self.state.view.window_height,
+            midi_clip_editor_visible,
         );
         container(detail_content)
             .width(Length::Fill)
@@ -247,9 +260,12 @@ impl App {
     }
 
     pub(super) fn detail_panel_drag_height(&self, cursor_y: f32) -> f32 {
+        let midi_clip_editor_visible = self.state.view.detail_panel_tab == DetailPanelTab::Clip
+            && self.visible_piano_roll_clip().is_some();
         effective_detail_panel_height(
             self.state.view.window_height - cursor_y - STATUS_BAR_HEIGHT,
             self.state.view.window_height,
+            midi_clip_editor_visible,
         )
     }
 
@@ -305,33 +321,55 @@ impl App {
                     })
             });
 
-        let piano_widget = if let Some(ref cd) = clip_data {
+        let (piano_widget, velocity_widget) = if let Some(ref cd) = clip_data {
             if let Some(content) = self.state.active_timeline_content(track_id) {
                 if let Some(clip) = content.note_clips.iter().find(|c| c.id == cd.6) {
                     let clip_relative_playhead = playhead_beats - clip.position_beats;
-                    PianoRollWidget::from_clip(
-                        track_id,
-                        clip,
-                        clip_relative_playhead,
-                        clip.duration_beats,
-                        track_color,
-                        self.state.view.grid_config(),
-                        self.state.piano_roll.scroll_y,
-                        self.state.piano_roll.edit_mode,
+                    (
+                        PianoRollWidget::from_clip(
+                            track_id,
+                            clip,
+                            clip_relative_playhead,
+                            clip.duration_beats,
+                            track_color,
+                            self.state.view.grid_config(),
+                            self.state.piano_roll.scroll_y,
+                            self.state.piano_roll.edit_mode,
+                        ),
+                        VelocityLaneWidget::from_clip(
+                            track_id,
+                            clip,
+                            clip.duration_beats,
+                            track_color,
+                            self.state.view.grid_config(),
+                        ),
                     )
                 } else {
-                    PianoRollWidget::empty(track_id, playhead_beats, track_color)
+                    (
+                        PianoRollWidget::empty(track_id, playhead_beats, track_color),
+                        VelocityLaneWidget::empty(track_id, track_color),
+                    )
                 }
             } else {
-                PianoRollWidget::empty(track_id, playhead_beats, track_color)
+                (
+                    PianoRollWidget::empty(track_id, playhead_beats, track_color),
+                    VelocityLaneWidget::empty(track_id, track_color),
+                )
             }
         } else {
-            PianoRollWidget::empty(track_id, playhead_beats, track_color)
+            (
+                PianoRollWidget::empty(track_id, playhead_beats, track_color),
+                VelocityLaneWidget::empty(track_id, track_color),
+            )
         };
 
         let piano_canvas: Element<'_, Message> = canvas(piano_widget)
             .width(Length::Fill)
             .height(Length::Fill)
+            .into();
+        let velocity_canvas: Element<'_, Message> = canvas(velocity_widget)
+            .width(Length::Fill)
+            .height(Length::Fixed(92.0))
             .into();
 
         // ── Clip properties bar (shown when a clip is selected) ──
@@ -520,9 +558,12 @@ impl App {
             .spacing(4)
             .align_y(iced::Alignment::Center);
 
-        content_col = content_col.push(header_row).push(piano_canvas);
+        content_col = content_col
+            .push(header_row)
+            .push(piano_canvas)
+            .push(velocity_canvas);
 
-        container(content_col)
+        container(content_col.height(Length::Fill))
             .width(Length::FillPortion(1))
             .height(Length::Fill)
             .style(|_theme: &Theme| container::Style {
@@ -781,10 +822,17 @@ mod tests {
 
     #[test]
     fn detail_panel_height_preserves_the_workspace_at_small_windows() {
-        assert_eq!(effective_detail_panel_height(80.0, 900.0), 180.0);
-        assert_eq!(effective_detail_panel_height(360.0, 900.0), 360.0);
-        assert_eq!(effective_detail_panel_height(800.0, 900.0), 540.0);
-        assert_eq!(effective_detail_panel_height(320.0, 520.0), 180.0);
+        assert_eq!(effective_detail_panel_height(80.0, 900.0, false), 180.0);
+        assert_eq!(effective_detail_panel_height(360.0, 900.0, false), 360.0);
+        assert_eq!(effective_detail_panel_height(800.0, 900.0, false), 540.0);
+        assert_eq!(effective_detail_panel_height(320.0, 520.0, false), 180.0);
+    }
+
+    #[test]
+    fn visible_midi_clip_keeps_both_note_and_velocity_editors_usable() {
+        assert_eq!(effective_detail_panel_height(280.0, 900.0, true), 360.0);
+        assert_eq!(effective_detail_panel_height(420.0, 900.0, true), 420.0);
+        assert_eq!(effective_detail_panel_height(280.0, 520.0, true), 180.0);
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -117,6 +117,10 @@ impl App {
         Some((track_id, clip_id))
     }
 
+    fn midi_clip_editor_visible(&self) -> bool {
+        self.visible_piano_roll_clip().is_some()
+    }
+
     pub(super) fn view_detail_panel(&self) -> Element<'_, Message> {
         let detail_content: Element<'_, Message> = if let Some(track) = self
             .state
@@ -236,12 +240,10 @@ impl App {
                 .into()
         };
 
-        let midi_clip_editor_visible = self.state.view.detail_panel_tab == DetailPanelTab::Clip
-            && self.visible_piano_roll_clip().is_some();
         let panel_height = effective_detail_panel_height(
             self.state.view.detail_panel_height,
             self.state.view.window_height,
-            midi_clip_editor_visible,
+            self.midi_clip_editor_visible(),
         );
         container(detail_content)
             .width(Length::Fill)
@@ -259,12 +261,10 @@ impl App {
     }
 
     pub(super) fn detail_panel_drag_height(&self, cursor_y: f32) -> f32 {
-        let midi_clip_editor_visible = self.state.view.detail_panel_tab == DetailPanelTab::Clip
-            && self.visible_piano_roll_clip().is_some();
         effective_detail_panel_height(
             self.state.view.window_height - cursor_y - STATUS_BAR_HEIGHT,
             self.state.view.window_height,
-            midi_clip_editor_visible,
+            self.midi_clip_editor_visible(),
         )
     }
 

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -342,7 +342,7 @@ impl App {
             .into();
         let velocity_canvas: Element<'_, Message> = canvas(velocity_widget)
             .width(Length::Fill)
-            .height(Length::Fixed(92.0))
+            .height(Length::Fixed(VelocityLaneWidget::HEIGHT))
             .into();
 
         // ── Clip properties bar (shown when a clip is selected) ──

--- a/crates/vibez-ui/src/app/views_detail.rs
+++ b/crates/vibez-ui/src/app/views_detail.rs
@@ -11,7 +11,6 @@ use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::piano_roll::PianoRollMsg;
 use crate::domains::view::ViewMsg;
 use vibez_core::id::{ClipId, SectionId, TrackId};
-use vibez_core::perform::GrooveGrid;
 
 use crate::icons;
 use crate::message::Message;
@@ -300,67 +299,41 @@ impl App {
         })
         .unwrap_or(-1.0);
 
-        // Extract clip data as owned values (avoids lifetime conflicts with widget construction)
-        let clip_data: Option<(String, f64, f64, bool, GrooveGrid, TrackId, ClipId)> = self
+        let visible_clip = self
             .visible_piano_roll_clip()
             .filter(|(open_track_id, _)| *open_track_id == track_id)
-            .and_then(|(tid, cid)| {
-                self.state
-                    .active_timeline_content(track_id)
-                    .and_then(|content| content.note_clips.iter().find(|c| c.id == cid))
-                    .map(|c| {
-                        (
-                            c.name.clone(),
-                            c.position_beats,
-                            c.duration_beats,
-                            c.loop_enabled,
-                            c.groove_grid,
-                            tid,
-                            cid,
-                        )
-                    })
+            .and_then(|(_, clip_id)| {
+                let content = self.state.active_timeline_content(track_id)?;
+                content.note_clips.iter().find(|clip| clip.id == clip_id)
             });
 
-        let (piano_widget, velocity_widget) = if let Some(ref cd) = clip_data {
-            if let Some(content) = self.state.active_timeline_content(track_id) {
-                if let Some(clip) = content.note_clips.iter().find(|c| c.id == cd.6) {
-                    let clip_relative_playhead = playhead_beats - clip.position_beats;
-                    (
-                        PianoRollWidget::from_clip(
-                            track_id,
-                            clip,
-                            clip_relative_playhead,
-                            clip.duration_beats,
-                            track_color,
-                            self.state.view.grid_config(),
-                            self.state.piano_roll.scroll_y,
-                            self.state.piano_roll.edit_mode,
-                        ),
-                        VelocityLaneWidget::from_clip(
-                            track_id,
-                            clip,
-                            clip.duration_beats,
-                            track_color,
-                            self.state.view.grid_config(),
-                        ),
-                    )
-                } else {
-                    (
-                        PianoRollWidget::empty(track_id, playhead_beats, track_color),
-                        VelocityLaneWidget::empty(track_id, track_color),
-                    )
-                }
-            } else {
+        let (piano_widget, velocity_widget) = match visible_clip {
+            Some(clip) => {
+                let clip_relative_playhead = playhead_beats - clip.position_beats;
                 (
-                    PianoRollWidget::empty(track_id, playhead_beats, track_color),
-                    VelocityLaneWidget::empty(track_id, track_color),
+                    PianoRollWidget::from_clip(
+                        track_id,
+                        clip,
+                        clip_relative_playhead,
+                        clip.duration_beats,
+                        track_color,
+                        self.state.view.grid_config(),
+                        self.state.piano_roll.scroll_y,
+                        self.state.piano_roll.edit_mode,
+                    ),
+                    VelocityLaneWidget::from_clip(
+                        track_id,
+                        clip,
+                        clip.duration_beats,
+                        track_color,
+                        self.state.view.grid_config(),
+                    ),
                 )
             }
-        } else {
-            (
+            None => (
                 PianoRollWidget::empty(track_id, playhead_beats, track_color),
                 VelocityLaneWidget::empty(track_id, track_color),
-            )
+            ),
         };
 
         let piano_canvas: Element<'_, Message> = canvas(piano_widget)
@@ -375,19 +348,23 @@ impl App {
         // ── Clip properties bar (shown when a clip is selected) ──
         let mut content_col = column![].spacing(2).padding(4);
 
-        if let Some((ref clip_name_str, clip_pos, clip_dur, clip_loop, groove_grid, tid, cid)) =
-            clip_data
-        {
-            let clip_name = text(clip_name_str.clone()).size(11).color(th::text());
-            let pos_label = text(format!("Pos: {clip_pos:.1}"))
+        if let Some(clip) = visible_clip {
+            let clip_id = clip.id;
+            let clip_loop = clip.loop_enabled;
+            let groove_grid = clip.groove_grid;
+            let clip_name = text(clip.name.clone()).size(11).color(th::text());
+            let pos_label = text(format!("Pos: {:.1}", clip.position_beats))
                 .size(10)
                 .color(th::text_dim());
-            let dur_label = text(format!("Dur: {clip_dur:.1}"))
+            let dur_label = text(format!("Dur: {:.1}", clip.duration_beats))
                 .size(10)
                 .color(th::text_dim());
 
-            let swing_relationship =
-                self.view_clip_swing_relationship(tid, track_color, Some((cid, groove_grid)));
+            let swing_relationship = self.view_clip_swing_relationship(
+                track_id,
+                track_color,
+                Some((clip_id, groove_grid)),
+            );
 
             // Loop toggle
             let loop_icon_color = if clip_loop {
@@ -397,7 +374,7 @@ impl App {
             };
             let loop_btn = button(icons::icon(icons::REPEAT).size(10).color(loop_icon_color))
                 .on_press(Message::PianoRoll(PianoRollMsg::ToggleNoteClipLoop(
-                    tid, cid,
+                    track_id, clip_id,
                 )))
                 .padding([2, 4])
                 .style(move |_theme: &Theme, _status| button::Style {
@@ -439,17 +416,21 @@ impl App {
                 .spacing(2)
                 .align_y(iced::Alignment::Center),
             )
-            .on_press(Message::duplicate_note_clip(tid, cid))
+            .on_press(Message::duplicate_note_clip(track_id, clip_id))
             .padding([2, 6])
             .style(op_btn_style);
 
             let double_btn = button(text("2x").size(10).color(th::text_dim()))
-                .on_press(Message::PianoRoll(PianoRollMsg::DoubleNoteClip(tid, cid)))
+                .on_press(Message::PianoRoll(PianoRollMsg::DoubleNoteClip(
+                    track_id, clip_id,
+                )))
                 .padding([2, 6])
                 .style(op_btn_style);
 
             let halve_btn = button(text("\u{00BD}x").size(10).color(th::text_dim()))
-                .on_press(Message::PianoRoll(PianoRollMsg::HalveNoteClip(tid, cid)))
+                .on_press(Message::PianoRoll(PianoRollMsg::HalveNoteClip(
+                    track_id, clip_id,
+                )))
                 .padding([2, 6])
                 .style(op_btn_style);
 
@@ -461,7 +442,9 @@ impl App {
                 .spacing(2)
                 .align_y(iced::Alignment::Center),
             )
-            .on_press(Message::PianoRoll(PianoRollMsg::CropNoteClip(tid, cid)))
+            .on_press(Message::PianoRoll(PianoRollMsg::CropNoteClip(
+                track_id, clip_id,
+            )))
             .padding([2, 6])
             .style(op_btn_style);
 

--- a/crates/vibez-ui/src/domains/piano_roll.rs
+++ b/crates/vibez-ui/src/domains/piano_roll.rs
@@ -42,6 +42,13 @@ pub enum PianoRollMsg {
     },
     RemoveNote(TrackId, ClipId, usize),
     EditNote(TrackId, ClipId, usize, MidiNote),
+    /// Set attack Velocity for one or more MIDI Notes as one project edit.
+    /// Invalid note indices are ignored and values are clamped to `1..127`.
+    SetNoteVelocities {
+        track_id: TrackId,
+        clip_id: ClipId,
+        velocities: Vec<(usize, u8)>,
+    },
     SelectNote(TrackId, ClipId, Option<usize>, bool),
     SelectAllNotes(TrackId, ClipId),
     /// Rubber-band selection: catch every note overlapping the beat span
@@ -373,6 +380,32 @@ impl PianoRollState {
                     note_index,
                     note: new_note,
                 });
+            }
+            PianoRollMsg::SetNoteVelocities {
+                track_id,
+                clip_id,
+                velocities,
+            } => {
+                let mut updates: Vec<(usize, MidiNote)> = Vec::new();
+                if let Some(track) = find_track_mut(tracks, track_id) {
+                    if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
+                        for (note_index, velocity) in velocities {
+                            let Some(note) = clip.notes.get_mut(note_index) else {
+                                continue;
+                            };
+                            note.velocity = velocity.clamp(1, 127);
+                            updates.push((note_index, *note));
+                        }
+                    }
+                }
+                for (note_index, note) in updates {
+                    engine.send(EngineCommand::EditNote {
+                        track_id,
+                        clip_id,
+                        note_index,
+                        note,
+                    });
+                }
             }
             PianoRollMsg::SelectNote(track_id, clip_id, note_index, shift_held) => {
                 if let Some(track) = find_track_mut(tracks, track_id) {
@@ -901,6 +934,69 @@ mod tests {
         );
         assert_eq!(tracks.get(tid).unwrap().note_clips[0].notes.len(), 3);
         assert!(matches!(engine.0[0], EngineCommand::AddNote { .. }));
+    }
+
+    #[test]
+    fn batch_velocity_edit_updates_valid_notes_and_the_engine() {
+        let (mut tracks, tid, cid) = midi_track_with_clip();
+        let mut piano_roll = PianoRollState::default();
+        let mut engine = RecordingEngine::default();
+
+        piano_roll.update(
+            PianoRollMsg::SetNoteVelocities {
+                track_id: tid,
+                clip_id: cid,
+                velocities: vec![(0, 72), (1, 118), (99, 64)],
+            },
+            &mut engine,
+            &mut tracks,
+            PianoRollCtx::default(),
+        );
+
+        let clip = &tracks.get(tid).unwrap().note_clips[0];
+        assert_eq!(clip.notes[0].velocity, 72);
+        assert_eq!(clip.notes[1].velocity, 118);
+        assert_eq!(engine.0.len(), 2);
+        assert!(matches!(
+            engine.0[0],
+            EngineCommand::EditNote {
+                note_index: 0,
+                note: MidiNote { velocity: 72, .. },
+                ..
+            }
+        ));
+        assert!(matches!(
+            engine.0[1],
+            EngineCommand::EditNote {
+                note_index: 1,
+                note: MidiNote { velocity: 118, .. },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn velocity_edit_clamps_zero_without_changing_shared_selection() {
+        let (mut tracks, tid, cid) = midi_track_with_clip();
+        tracks.get_mut(tid).unwrap().note_clips[0].selected_notes = HashSet::from([0, 1]);
+        let mut piano_roll = PianoRollState::default();
+        let mut engine = RecordingEngine::default();
+
+        piano_roll.update(
+            PianoRollMsg::SetNoteVelocities {
+                track_id: tid,
+                clip_id: cid,
+                velocities: vec![(0, 0), (1, u8::MAX)],
+            },
+            &mut engine,
+            &mut tracks,
+            PianoRollCtx::default(),
+        );
+
+        let clip = &tracks.get(tid).unwrap().note_clips[0];
+        assert_eq!(clip.notes[0].velocity, 1);
+        assert_eq!(clip.notes[1].velocity, 127);
+        assert_eq!(clip.selected_notes, HashSet::from([0, 1]));
     }
 
     #[test]

--- a/crates/vibez-ui/src/domains/piano_roll.rs
+++ b/crates/vibez-ui/src/domains/piano_roll.rs
@@ -148,6 +148,17 @@ fn find_track_mut(
     timeline.get_mut(track_id)
 }
 
+fn find_note_clip_mut(
+    timeline: &mut TimelineContent,
+    track_id: TrackId,
+    clip_id: ClipId,
+) -> Option<&mut UiNoteClip> {
+    find_track_mut(timeline, track_id)?
+        .note_clips
+        .iter_mut()
+        .find(|clip| clip.id == clip_id)
+}
+
 /// Loop region that covers the note content, rounded up to whole
 /// bars (Ableton semantics; dogfood bug #3).
 pub fn default_loop_end(notes: &[MidiNote], duration_beats: f64) -> f64 {
@@ -387,15 +398,13 @@ impl PianoRollState {
                 velocities,
             } => {
                 let mut updates: Vec<(usize, MidiNote)> = Vec::new();
-                if let Some(track) = find_track_mut(tracks, track_id) {
-                    if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
-                        for (note_index, velocity) in velocities {
-                            let Some(note) = clip.notes.get_mut(note_index) else {
-                                continue;
-                            };
-                            note.velocity = velocity.clamp(1, 127);
-                            updates.push((note_index, *note));
-                        }
+                if let Some(clip) = find_note_clip_mut(tracks, track_id, clip_id) {
+                    for (note_index, velocity) in velocities {
+                        let Some(note) = clip.notes.get_mut(note_index) else {
+                            continue;
+                        };
+                        note.velocity = velocity.clamp(1, 127);
+                        updates.push((note_index, *note));
                     }
                 }
                 for (note_index, note) in updates {

--- a/crates/vibez-ui/src/widgets/piano_roll/mod.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/mod.rs
@@ -1021,3 +1021,6 @@ mod tests {
 }
 
 mod draw;
+mod velocity_lane;
+
+pub use velocity_lane::VelocityLaneWidget;

--- a/crates/vibez-ui/src/widgets/piano_roll/velocity_lane.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/velocity_lane.rs
@@ -11,11 +11,11 @@ use crate::widgets::local_drag::LocalDrag;
 
 use super::*;
 
-const TOP_PADDING: f32 = 8.0;
-const BOTTOM_PADDING: f32 = 14.0;
-const BAR_MIN_WIDTH: f32 = 5.0;
-const BAR_MAX_WIDTH: f32 = 12.0;
-const BAR_HEAD_HEIGHT: f32 = 4.0;
+const TOP_PADDING: f32 = 6.0;
+const BOTTOM_PADDING: f32 = 10.0;
+const BAR_MIN_WIDTH: f32 = 3.0;
+const BAR_MAX_WIDTH: f32 = 7.0;
+const BAR_HEAD_HEIGHT: f32 = 3.0;
 const HIT_SLOP: f32 = 3.0;
 
 /// Fixed-height editor for the attack Velocity stored on MIDI Notes.
@@ -28,6 +28,8 @@ pub struct VelocityLaneWidget {
 }
 
 impl VelocityLaneWidget {
+    pub const HEIGHT: f32 = 64.0;
+
     pub fn from_clip(
         track_id: TrackId,
         clip: &UiNoteClip,
@@ -506,7 +508,7 @@ mod tests {
             Color::WHITE,
             GridConfig::new(SnapGrid::SIXTEENTH, true, false, 0),
         );
-        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, 92.0));
+        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, VelocityLaneWidget::HEIGHT));
         let x = widget.geometry(&bounds).beat_to_x(0.0) + 2.0;
         let start_y = VelocityLaneWidget::velocity_y(50, &bounds) + 2.0;
         let mut state = VelocityLaneState::default();
@@ -590,7 +592,7 @@ mod tests {
             Color::WHITE,
             GridConfig::new(SnapGrid::SIXTEENTH, true, false, 0),
         );
-        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, 92.0));
+        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, VelocityLaneWidget::HEIGHT));
         let x = widget.geometry(&bounds).beat_to_x(0.0) + 2.0;
         let start_y = VelocityLaneWidget::velocity_y(50, &bounds) + 2.0;
         let mut state = VelocityLaneState::default();
@@ -649,7 +651,7 @@ mod tests {
             Color::WHITE,
             GridConfig::new(SnapGrid::SIXTEENTH, true, false, 0),
         );
-        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, 92.0));
+        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, VelocityLaneWidget::HEIGHT));
         let x = widget.geometry(&bounds).beat_to_x(0.0) + 2.0;
         let start_y = VelocityLaneWidget::velocity_y(1, &bounds);
         let mut state = VelocityLaneState::default();
@@ -689,7 +691,7 @@ mod tests {
             Color::WHITE,
             GridConfig::new(SnapGrid::SIXTEENTH, true, false, 0),
         );
-        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, 92.0));
+        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, VelocityLaneWidget::HEIGHT));
         let x = widget.geometry(&bounds).beat_to_x(1.0) + 2.0;
         let y = VelocityLaneWidget::velocity_y(80, &bounds) + 2.0;
         let mut state = VelocityLaneState::default();

--- a/crates/vibez-ui/src/widgets/piano_roll/velocity_lane.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/velocity_lane.rs
@@ -1,0 +1,609 @@
+//! Time-aligned MIDI Note Velocity editing beneath the piano roll.
+
+use iced::keyboard;
+use iced::mouse;
+use iced::widget::canvas;
+use iced::{Point, Rectangle, Renderer, Theme};
+
+use crate::state::UndoGestureId;
+use crate::theme;
+use crate::widgets::local_drag::LocalDrag;
+
+use super::*;
+
+const TOP_PADDING: f32 = 8.0;
+const BOTTOM_PADDING: f32 = 14.0;
+const BAR_MIN_WIDTH: f32 = 5.0;
+const BAR_MAX_WIDTH: f32 = 12.0;
+const BAR_HEAD_HEIGHT: f32 = 4.0;
+const HIT_SLOP: f32 = 3.0;
+
+/// Fixed-height editor for the attack Velocity stored on MIDI Notes.
+pub struct VelocityLaneWidget {
+    track_id: TrackId,
+    clip: Option<PianoRollClipData>,
+    total_beats: f64,
+    track_color: Color,
+    grid: GridConfig,
+}
+
+impl VelocityLaneWidget {
+    pub fn from_clip(
+        track_id: TrackId,
+        clip: &UiNoteClip,
+        total_beats: f64,
+        track_color: Color,
+        grid: GridConfig,
+    ) -> Self {
+        Self {
+            track_id,
+            clip: Some(PianoRollClipData {
+                clip_id: clip.id,
+                notes: clip.notes.clone(),
+                selected_notes: clip.selected_notes.clone(),
+                loop_enabled: clip.loop_enabled,
+                loop_start_beats: clip.loop_start_beats,
+                loop_end_beats: clip.loop_end_beats,
+            }),
+            total_beats,
+            track_color,
+            grid,
+        }
+    }
+
+    pub fn empty(track_id: TrackId, track_color: Color) -> Self {
+        Self {
+            track_id,
+            clip: None,
+            total_beats: 16.0,
+            track_color,
+            grid: GridConfig::new(SnapGrid::EIGHTH, true, false, 0),
+        }
+    }
+
+    fn geometry(&self, bounds: &Rectangle) -> TimelineGeometry {
+        TimelineGeometry::fitted(self.total_beats.max(1.0), bounds.width, KEY_WIDTH)
+    }
+
+    fn baseline(bounds: &Rectangle) -> f32 {
+        (bounds.height - BOTTOM_PADDING).max(TOP_PADDING)
+    }
+
+    fn usable_height(bounds: &Rectangle) -> f32 {
+        (Self::baseline(bounds) - TOP_PADDING).max(1.0)
+    }
+
+    fn velocity_y(velocity: u8, bounds: &Rectangle) -> f32 {
+        let normalized = f32::from(velocity.clamp(1, 127) - 1) / 126.0;
+        Self::baseline(bounds) - normalized * Self::usable_height(bounds)
+    }
+
+    fn bar_width(&self, note: &MidiNote, bounds: &Rectangle) -> f32 {
+        self.geometry(bounds)
+            .width_for_beats(note.duration_beats)
+            .clamp(BAR_MIN_WIDTH, BAR_MAX_WIDTH)
+    }
+
+    fn hit_test_bar(&self, position: Point, bounds: &Rectangle) -> Option<usize> {
+        let clip = self.clip.as_ref()?;
+        let geometry = self.geometry(bounds);
+        let baseline = Self::baseline(bounds);
+
+        // Match piano-roll stacking: the last drawn Note wins when Notes share
+        // an onset and their Velocity Bars overlap.
+        clip.notes
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(index, note)| {
+                let x = geometry.beat_to_x(note.start_beat);
+                let top = Self::velocity_y(note.velocity, bounds) - HIT_SLOP;
+                let width = self.bar_width(note, bounds);
+                (position.x >= x - HIT_SLOP
+                    && position.x <= x + width + HIT_SLOP
+                    && position.y >= top
+                    && position.y <= baseline + HIT_SLOP)
+                    .then_some(index)
+            })
+    }
+
+    fn draw_lane(
+        &self,
+        renderer: &Renderer,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let geometry = self.geometry(&bounds);
+        let baseline = Self::baseline(&bounds);
+
+        frame.fill_rectangle(Point::ORIGIN, bounds.size(), theme::bg_dark());
+        frame.fill_rectangle(
+            Point::ORIGIN,
+            iced::Size::new(KEY_WIDTH, bounds.height),
+            theme::bg_elevated(),
+        );
+
+        frame.fill_text(canvas::Text {
+            content: "VEL".into(),
+            position: Point::new(5.0, 13.0),
+            color: theme::text_dim(),
+            size: iced::Pixels(9.0),
+            ..Default::default()
+        });
+        for (velocity, label) in [(127_u8, "127"), (64, "64"), (1, "1")] {
+            let y = Self::velocity_y(velocity, &bounds);
+            let line = canvas::Path::line(Point::new(KEY_WIDTH, y), Point::new(bounds.width, y));
+            frame.stroke(
+                &line,
+                canvas::Stroke::default()
+                    .with_color(theme::grid_sub())
+                    .with_width(if velocity == 64 { 1.0 } else { 0.5 }),
+            );
+            frame.fill_text(canvas::Text {
+                content: label.into(),
+                position: Point::new(34.0, (y + 3.0).min(bounds.height - 2.0)),
+                color: theme::text_muted(),
+                size: iced::Pixels(8.0),
+                ..Default::default()
+            });
+        }
+
+        let grid_step = self
+            .grid
+            .effective_grid(geometry.pixels_per_beat())
+            .beat_size();
+        let num_steps = (self.total_beats.max(1.0) / grid_step).ceil() as usize;
+        for step in 0..=num_steps {
+            let beat = step as f64 * grid_step;
+            let x = geometry.beat_to_x(beat).floor() + 0.5;
+            if x > bounds.width {
+                break;
+            }
+            let beat_millis = (beat * 1000.0).round() as i64;
+            let (color, width) = if beat_millis % 4000 == 0 {
+                (theme::grid_bar(), 1.5)
+            } else if beat_millis % 1000 == 0 {
+                (theme::grid_beat(), 1.0)
+            } else {
+                (theme::grid_sub(), 0.5)
+            };
+            let line = canvas::Path::line(Point::new(x, 0.0), Point::new(x, baseline));
+            frame.stroke(
+                &line,
+                canvas::Stroke::default()
+                    .with_color(color)
+                    .with_width(width),
+            );
+        }
+
+        let hovered = cursor
+            .position_in(bounds)
+            .and_then(|position| self.hit_test_bar(position, &bounds));
+        if let Some(clip) = &self.clip {
+            for (index, note) in clip.notes.iter().enumerate() {
+                let x = geometry.beat_to_x(note.start_beat);
+                if x + BAR_MAX_WIDTH < KEY_WIDTH || x > bounds.width {
+                    continue;
+                }
+                let y = Self::velocity_y(note.velocity, &bounds);
+                let width = self.bar_width(note, &bounds);
+                let selected = clip.selected_notes.contains(&index);
+                let color = if selected {
+                    theme::solo_active()
+                } else if hovered == Some(index) {
+                    theme::accent()
+                } else {
+                    self.track_color
+                };
+
+                frame.fill_rectangle(
+                    Point::new(x, y),
+                    iced::Size::new(width, (baseline - y).max(1.0)),
+                    theme::with_alpha(color, if selected { 0.85 } else { 0.6 }),
+                );
+                frame.fill_rectangle(
+                    Point::new(x, y - BAR_HEAD_HEIGHT / 2.0),
+                    iced::Size::new(width, BAR_HEAD_HEIGHT),
+                    color,
+                );
+            }
+        }
+
+        let separator = canvas::Path::line(
+            Point::new(KEY_WIDTH, 0.0),
+            Point::new(KEY_WIDTH, bounds.height),
+        );
+        frame.stroke(
+            &separator,
+            canvas::Stroke::default()
+                .with_color(theme::border())
+                .with_width(1.0),
+        );
+        let bottom = canvas::Path::line(
+            Point::new(KEY_WIDTH, baseline),
+            Point::new(bounds.width, baseline),
+        );
+        frame.stroke(
+            &bottom,
+            canvas::Stroke::default()
+                .with_color(theme::border())
+                .with_width(1.0),
+        );
+
+        vec![frame.into_geometry()]
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VelocityDrag {
+    start_y: f32,
+    original_velocities: Vec<(usize, u8)>,
+    undo_gesture: UndoGestureId,
+}
+
+#[derive(Debug, Default)]
+pub struct VelocityLaneState {
+    drag: Option<VelocityDrag>,
+    shift_held: bool,
+}
+
+impl canvas::Program<Message> for VelocityLaneWidget {
+    type State = VelocityLaneState;
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        self.draw_lane(renderer, bounds, cursor)
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if state.drag.is_some() {
+            mouse::Interaction::ResizingVertically
+        } else if cursor
+            .position_in(bounds)
+            .and_then(|position| self.hit_test_bar(position, &bounds))
+            .is_some()
+        {
+            mouse::Interaction::Grab
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: canvas::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<Message>) {
+        match event {
+            canvas::Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
+                state.shift_held = modifiers.shift();
+            }
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                let Some(position) = cursor.position_in(bounds) else {
+                    return (canvas::event::Status::Ignored, None);
+                };
+                let Some(clip) = &self.clip else {
+                    return (canvas::event::Status::Ignored, None);
+                };
+                let Some(note_index) = self.hit_test_bar(position, &bounds) else {
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::PianoRoll(PianoRollMsg::SelectNote(
+                            self.track_id,
+                            clip.clip_id,
+                            None,
+                            false,
+                        ))),
+                    );
+                };
+
+                if state.shift_held && clip.selected_notes.contains(&note_index) {
+                    return (
+                        canvas::event::Status::Captured,
+                        Some(Message::PianoRoll(PianoRollMsg::SelectNote(
+                            self.track_id,
+                            clip.clip_id,
+                            Some(note_index),
+                            true,
+                        ))),
+                    );
+                }
+
+                let selected = if state.shift_held {
+                    let mut selected = clip.selected_notes.clone();
+                    selected.insert(note_index);
+                    selected
+                } else if clip.selected_notes.contains(&note_index) {
+                    clip.selected_notes.clone()
+                } else {
+                    HashSet::from([note_index])
+                };
+                let mut original_velocities: Vec<(usize, u8)> = selected
+                    .into_iter()
+                    .filter_map(|index| clip.notes.get(index).map(|note| (index, note.velocity)))
+                    .collect();
+                original_velocities.sort_unstable_by_key(|(index, _)| *index);
+                state.drag = Some(VelocityDrag {
+                    start_y: position.y,
+                    original_velocities,
+                    undo_gesture: UndoGestureId::new(),
+                });
+
+                let selection_message = if clip.selected_notes.contains(&note_index) {
+                    None
+                } else {
+                    Some(Message::PianoRoll(PianoRollMsg::SelectNote(
+                        self.track_id,
+                        clip.clip_id,
+                        Some(note_index),
+                        state.shift_held,
+                    )))
+                };
+                return (canvas::event::Status::Captured, selection_message);
+            }
+            canvas::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                let Some(drag) = &state.drag else {
+                    return (canvas::event::Status::Ignored, None);
+                };
+                let Some(position) = LocalDrag::unclamped().position(cursor, bounds) else {
+                    return (canvas::event::Status::Captured, None);
+                };
+                let velocities = velocities_after_drag(
+                    &drag.original_velocities,
+                    drag.start_y,
+                    position.y,
+                    VelocityLaneWidget::usable_height(&bounds),
+                );
+                if velocities == drag.original_velocities {
+                    return (canvas::event::Status::Captured, None);
+                }
+                let Some(clip) = &self.clip else {
+                    return (canvas::event::Status::Captured, None);
+                };
+                return (
+                    canvas::event::Status::Captured,
+                    Some(
+                        Message::PianoRoll(PianoRollMsg::SetNoteVelocities {
+                            track_id: self.track_id,
+                            clip_id: clip.clip_id,
+                            velocities,
+                        })
+                        .in_undo_gesture(drag.undo_gesture),
+                    ),
+                );
+            }
+            canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+                if state.drag.take().is_some() =>
+            {
+                return (canvas::event::Status::Captured, None);
+            }
+            _ => {}
+        }
+
+        (canvas::event::Status::Ignored, None)
+    }
+}
+
+fn velocities_after_drag(
+    originals: &[(usize, u8)],
+    start_y: f32,
+    current_y: f32,
+    usable_height: f32,
+) -> Vec<(usize, u8)> {
+    if originals.is_empty() {
+        return Vec::new();
+    }
+    let requested_delta = (((start_y - current_y) / usable_height.max(1.0)) * 126.0).round() as i16;
+    let min_velocity = originals
+        .iter()
+        .map(|(_, velocity)| i16::from(*velocity))
+        .min()
+        .unwrap_or(1);
+    let max_velocity = originals
+        .iter()
+        .map(|(_, velocity)| i16::from(*velocity))
+        .max()
+        .unwrap_or(127);
+    let delta = requested_delta.clamp(1 - min_velocity, 127 - max_velocity);
+
+    originals
+        .iter()
+        .map(|(index, velocity)| (*index, (i16::from(*velocity) + delta) as u8))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iced::widget::canvas::Program;
+    use iced::Size;
+
+    fn note(start_beat: f64, velocity: u8) -> MidiNote {
+        MidiNote {
+            pitch: 60,
+            velocity,
+            start_beat,
+            duration_beats: 0.5,
+        }
+    }
+
+    fn clip(notes: Vec<MidiNote>, selected_notes: HashSet<usize>) -> UiNoteClip {
+        UiNoteClip {
+            id: ClipId::new(),
+            name: "Velocity test".into(),
+            position_beats: 0.0,
+            duration_beats: 4.0,
+            notes,
+            selected_notes,
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 4.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
+        }
+    }
+
+    fn piano_roll_message(message: Option<Message>) -> Option<PianoRollMsg> {
+        match message {
+            Some(Message::UndoGesture { edit, .. }) => piano_roll_message(Some(*edit)),
+            Some(Message::PianoRoll(message)) => Some(message),
+            _ => None,
+        }
+    }
+
+    fn gesture_id(message: &Option<Message>) -> Option<UndoGestureId> {
+        match message {
+            Some(Message::UndoGesture { id, .. }) => Some(*id),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn relative_drag_preserves_differences_and_clamps_the_group_together() {
+        let originals = vec![(0, 40), (1, 72), (2, 100)];
+        assert_eq!(
+            velocities_after_drag(&originals, 80.0, 70.0, 126.0),
+            vec![(0, 50), (1, 82), (2, 110)]
+        );
+        assert_eq!(
+            velocities_after_drag(&originals, 80.0, -80.0, 126.0),
+            vec![(0, 67), (1, 99), (2, 127)]
+        );
+        assert_eq!(
+            velocities_after_drag(&originals, 80.0, 300.0, 126.0),
+            vec![(0, 1), (1, 33), (2, 61)]
+        );
+    }
+
+    #[test]
+    fn selected_bar_drag_edits_the_complete_selection_with_one_gesture_id() {
+        let track_id = TrackId::new();
+        let clip = clip(vec![note(0.0, 50), note(1.0, 80)], HashSet::from([0, 1]));
+        let widget = VelocityLaneWidget::from_clip(
+            track_id,
+            &clip,
+            4.0,
+            Color::WHITE,
+            GridConfig::new(SnapGrid::SIXTEENTH, true, false, 0),
+        );
+        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, 92.0));
+        let x = widget.geometry(&bounds).beat_to_x(0.0) + 2.0;
+        let start_y = VelocityLaneWidget::velocity_y(50, &bounds) + 2.0;
+        let mut state = VelocityLaneState::default();
+        let at = |y| mouse::Cursor::Available(Point::new(x, y));
+
+        let press = widget
+            .update(
+                &mut state,
+                canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
+                bounds,
+                at(start_y),
+            )
+            .1;
+        assert!(
+            press.is_none(),
+            "already-selected bar keeps shared selection"
+        );
+
+        let first = widget
+            .update(
+                &mut state,
+                canvas::Event::Mouse(mouse::Event::CursorMoved {
+                    position: Point::new(x, start_y - 10.0),
+                }),
+                bounds,
+                at(start_y - 10.0),
+            )
+            .1;
+        let second = widget
+            .update(
+                &mut state,
+                canvas::Event::Mouse(mouse::Event::CursorMoved {
+                    position: Point::new(x, start_y - 20.0),
+                }),
+                bounds,
+                at(start_y - 20.0),
+            )
+            .1;
+
+        assert!(matches!(
+            piano_roll_message(first.clone()),
+            Some(PianoRollMsg::SetNoteVelocities { ref velocities, .. })
+                if velocities.len() == 2 && velocities[1].1 - velocities[0].1 == 30
+        ));
+        assert_eq!(gesture_id(&first), gesture_id(&second));
+        assert!(gesture_id(&first).is_some());
+
+        widget.update(
+            &mut state,
+            canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)),
+            bounds,
+            at(start_y - 20.0),
+        );
+        widget.update(
+            &mut state,
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
+            bounds,
+            at(start_y),
+        );
+        let later_drag = widget
+            .update(
+                &mut state,
+                canvas::Event::Mouse(mouse::Event::CursorMoved {
+                    position: Point::new(x, start_y - 10.0),
+                }),
+                bounds,
+                at(start_y - 10.0),
+            )
+            .1;
+        assert_ne!(gesture_id(&first), gesture_id(&later_drag));
+    }
+
+    #[test]
+    fn unselected_bar_press_selects_only_that_note_before_dragging() {
+        let track_id = TrackId::new();
+        let clip = clip(vec![note(0.0, 50), note(1.0, 80)], HashSet::from([0]));
+        let widget = VelocityLaneWidget::from_clip(
+            track_id,
+            &clip,
+            4.0,
+            Color::WHITE,
+            GridConfig::new(SnapGrid::SIXTEENTH, true, false, 0),
+        );
+        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, 92.0));
+        let x = widget.geometry(&bounds).beat_to_x(1.0) + 2.0;
+        let y = VelocityLaneWidget::velocity_y(80, &bounds) + 2.0;
+        let mut state = VelocityLaneState::default();
+
+        let message = widget
+            .update(
+                &mut state,
+                canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
+                bounds,
+                mouse::Cursor::Available(Point::new(x, y)),
+            )
+            .1;
+
+        assert!(matches!(
+            piano_roll_message(message),
+            Some(PianoRollMsg::SelectNote(_, _, Some(1), false))
+        ));
+        assert_eq!(
+            state.drag.as_ref().unwrap().original_velocities,
+            vec![(1, 80)]
+        );
+    }
+}

--- a/crates/vibez-ui/src/widgets/piano_roll/velocity_lane.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/velocity_lane.rs
@@ -239,6 +239,7 @@ impl VelocityLaneWidget {
 struct VelocityDrag {
     start_y: f32,
     original_velocities: Vec<(usize, u8)>,
+    last_sent_velocities: Vec<(usize, u8)>,
     undo_gesture: UndoGestureId,
 }
 
@@ -334,11 +335,16 @@ impl canvas::Program<Message> for VelocityLaneWidget {
                 };
                 let mut original_velocities: Vec<(usize, u8)> = selected
                     .into_iter()
-                    .filter_map(|index| clip.notes.get(index).map(|note| (index, note.velocity)))
+                    .filter_map(|index| {
+                        clip.notes
+                            .get(index)
+                            .map(|note| (index, note.velocity.clamp(1, 127)))
+                    })
                     .collect();
                 original_velocities.sort_unstable_by_key(|(index, _)| *index);
                 state.drag = Some(VelocityDrag {
                     start_y: position.y,
+                    last_sent_velocities: original_velocities.clone(),
                     original_velocities,
                     undo_gesture: UndoGestureId::new(),
                 });
@@ -356,7 +362,7 @@ impl canvas::Program<Message> for VelocityLaneWidget {
                 return (canvas::event::Status::Captured, selection_message);
             }
             canvas::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
-                let Some(drag) = &state.drag else {
+                let Some(drag) = &mut state.drag else {
                     return (canvas::event::Status::Ignored, None);
                 };
                 let Some(position) = LocalDrag::unclamped().position(cursor, bounds) else {
@@ -368,12 +374,13 @@ impl canvas::Program<Message> for VelocityLaneWidget {
                     position.y,
                     VelocityLaneWidget::usable_height(&bounds),
                 );
-                if velocities == drag.original_velocities {
+                if velocities == drag.last_sent_velocities {
                     return (canvas::event::Status::Captured, None);
                 }
                 let Some(clip) = &self.clip else {
                     return (canvas::event::Status::Captured, None);
                 };
+                drag.last_sent_velocities.clone_from(&velocities);
                 return (
                     canvas::event::Status::Captured,
                     Some(
@@ -570,6 +577,105 @@ mod tests {
             )
             .1;
         assert_ne!(gesture_id(&first), gesture_id(&later_drag));
+    }
+
+    #[test]
+    fn returning_to_drag_origin_restores_the_original_velocities() {
+        let track_id = TrackId::new();
+        let clip = clip(vec![note(0.0, 50)], HashSet::from([0]));
+        let widget = VelocityLaneWidget::from_clip(
+            track_id,
+            &clip,
+            4.0,
+            Color::WHITE,
+            GridConfig::new(SnapGrid::SIXTEENTH, true, false, 0),
+        );
+        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, 92.0));
+        let x = widget.geometry(&bounds).beat_to_x(0.0) + 2.0;
+        let start_y = VelocityLaneWidget::velocity_y(50, &bounds) + 2.0;
+        let mut state = VelocityLaneState::default();
+        let at = |y| mouse::Cursor::Available(Point::new(x, y));
+
+        widget.update(
+            &mut state,
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
+            bounds,
+            at(start_y),
+        );
+        let upward_edit = widget
+            .update(
+                &mut state,
+                canvas::Event::Mouse(mouse::Event::CursorMoved {
+                    position: Point::new(x, start_y - 10.0),
+                }),
+                bounds,
+                at(start_y - 10.0),
+            )
+            .1;
+        assert!(matches!(
+            piano_roll_message(upward_edit),
+            Some(PianoRollMsg::SetNoteVelocities { ref velocities, .. })
+                if velocities != &vec![(0, 50)]
+        ));
+
+        let restored = widget
+            .update(
+                &mut state,
+                canvas::Event::Mouse(mouse::Event::CursorMoved {
+                    position: Point::new(x, start_y),
+                }),
+                bounds,
+                at(start_y),
+            )
+            .1;
+        assert!(matches!(
+            piano_roll_message(restored),
+            Some(PianoRollMsg::SetNoteVelocities { ref velocities, .. })
+                if velocities == &vec![(0, 50)]
+        ));
+    }
+
+    #[test]
+    fn drag_capture_normalizes_stored_velocities_before_group_clamping() {
+        let track_id = TrackId::new();
+        let clip = clip(
+            vec![note(0.0, 0), note(1.0, u8::MAX)],
+            HashSet::from([0, 1]),
+        );
+        let widget = VelocityLaneWidget::from_clip(
+            track_id,
+            &clip,
+            4.0,
+            Color::WHITE,
+            GridConfig::new(SnapGrid::SIXTEENTH, true, false, 0),
+        );
+        let bounds = Rectangle::new(Point::ORIGIN, Size::new(452.0, 92.0));
+        let x = widget.geometry(&bounds).beat_to_x(0.0) + 2.0;
+        let start_y = VelocityLaneWidget::velocity_y(1, &bounds);
+        let mut state = VelocityLaneState::default();
+
+        widget.update(
+            &mut state,
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
+            bounds,
+            mouse::Cursor::Available(Point::new(x, start_y)),
+        );
+
+        let drag = state.drag.as_ref().expect("velocity drag should start");
+        assert_eq!(drag.original_velocities, vec![(0, 1), (1, 127)]);
+        assert_eq!(drag.last_sent_velocities, drag.original_velocities);
+
+        let message = widget
+            .update(
+                &mut state,
+                canvas::Event::Mouse(mouse::Event::CursorMoved {
+                    position: Point::new(x, start_y - 20.0),
+                }),
+                bounds,
+                mouse::Cursor::Available(Point::new(x, start_y - 20.0)),
+            )
+            .1;
+        assert!(message.is_none(), "the full-range group cannot move");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a time-aligned velocity lane beneath the piano roll
- edit one note or a selected group with relative, clamped drag behavior
- preserve shared note selection and group each drag into one undo gesture
- keep the MIDI detail editor usable with a velocity-aware minimum panel height
- synchronize velocity edits with the audio engine and project persistence

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --exclude vibez-plugin-host -- -D warnings`
- `cargo fmt --all -- --check`
- native UI QA: selection, drag to 127, undo, redo, autosave, and reopen persistence

## Release slice

Production Depth 01 — MIDI velocity lane.