### PR TITLE
feat: resample MIDI track output into audio

### DIFF
--- a/crates/vibez-audio-io/src/audio_input.rs
+++ b/crates/vibez-audio-io/src/audio_input.rs
@@ -128,6 +128,7 @@ pub struct AudioInputBridge {
     route: AtomicU32,
     target_track: AtomicU64,
     monitoring: AtomicBool,
+    resample_source_track: AtomicU64,
     recording: AtomicBool,
     recording_stopped: AtomicBool,
     record_start_position: AtomicU64,
@@ -151,6 +152,7 @@ impl AudioInputBridge {
             route: AtomicU32::new(0),
             target_track: AtomicU64::new(0),
             monitoring: AtomicBool::new(false),
+            resample_source_track: AtomicU64::new(0),
             recording: AtomicBool::new(false),
             recording_stopped: AtomicBool::new(true),
             record_start_position: AtomicU64::new(u64::MAX),
@@ -165,6 +167,7 @@ impl AudioInputBridge {
         let encoded = match route {
             AudioInputRoute::Mono { channel } => u32::from(channel),
             AudioInputRoute::Stereo { left } => STEREO_ROUTE_BIT | u32::from(left),
+            AudioInputRoute::Resample { .. } => return,
         };
         self.route.store(encoded, Ordering::Release);
     }
@@ -194,6 +197,20 @@ impl AudioInputBridge {
 
     pub fn target_track_raw(&self) -> Option<u64> {
         match self.target_track.load(Ordering::Acquire) {
+            0 => None,
+            raw => Some(raw),
+        }
+    }
+
+    pub fn set_resample_source(&self, source: Option<TrackId>) {
+        self.resample_source_track
+            .store(source.map_or(0, TrackId::raw), Ordering::Release);
+        self.peak_l.store(0, Ordering::Relaxed);
+        self.peak_r.store(0, Ordering::Relaxed);
+    }
+
+    pub fn resample_source_track_raw(&self) -> Option<u64> {
+        match self.resample_source_track.load(Ordering::Acquire) {
             0 => None,
             raw => Some(raw),
         }
@@ -263,7 +280,9 @@ impl AudioInputBridge {
     pub fn clock_output(&self, destination: &mut [f32], channels: usize) -> Option<u64> {
         let target = self.target_track_raw();
         let monitoring = target.is_some() && self.monitoring.load(Ordering::Acquire);
-        let recording = target.is_some() && self.recording.load(Ordering::Acquire);
+        let recording = target.is_some()
+            && self.resample_source_track_raw().is_none()
+            && self.recording.load(Ordering::Acquire);
         for frame in destination.chunks_mut(channels.max(1)) {
             let input = match self.input.pop() {
                 Some(input) => input,
@@ -297,11 +316,46 @@ impl AudioInputBridge {
         monitoring.then_some(target?)
     }
 
+    /// Capture one output-clock block tapped from a Project Track. The engine
+    /// supplies post-device/post-fader samples; this bridge owns only bounded
+    /// transfer, metering, and the Stop acknowledgement shared with hardware
+    /// input recording.
+    pub fn capture_track_output(&self, source: &[f32], channels: usize) {
+        if self.resample_source_track_raw().is_none() {
+            return;
+        }
+        let recording = self.recording.load(Ordering::Acquire);
+        let mut peak_l = 0.0f32;
+        let mut peak_r = 0.0f32;
+        for frame in source.chunks(channels.max(1)) {
+            let routed = [
+                frame.first().copied().unwrap_or(0.0),
+                frame
+                    .get(1)
+                    .copied()
+                    .unwrap_or_else(|| frame.first().copied().unwrap_or(0.0)),
+            ];
+            peak_l = peak_l.max(routed[0].abs());
+            peak_r = peak_r.max(routed[1].abs());
+            if recording && !self.recorded.push(routed) {
+                self.overflowed.store(true, Ordering::Release);
+            }
+        }
+        self.peak_l.fetch_max(peak_l.to_bits(), Ordering::Relaxed);
+        self.peak_r.fetch_max(peak_r.to_bits(), Ordering::Relaxed);
+        if !recording {
+            self.recording_stopped.store(true, Ordering::Release);
+        }
+    }
+
     fn push_interleaved<T>(&self, data: &[T], channels: usize)
     where
         T: Copy,
         f32: FromSample<T>,
     {
+        if self.resample_source_track_raw().is_some() {
+            return;
+        }
         let route = self.route();
         let mut peak_l = 0.0f32;
         let mut peak_r = 0.0f32;
@@ -330,6 +384,7 @@ impl AudioInputBridge {
                             .unwrap_or(0.0),
                     ]
                 }
+                AudioInputRoute::Resample { .. } => [0.0; 2],
             };
             peak_l = peak_l.max(routed[0].abs());
             peak_r = peak_r.max(routed[1].abs());
@@ -494,6 +549,24 @@ mod tests {
         bridge.clock_output(&mut output, 2);
         assert_eq!(bridge.underrun_frames(), 3);
         assert_eq!(output, [0.0; 6]);
+    }
+
+    #[test]
+    fn resample_capture_uses_track_output_without_hardware_underruns() {
+        let bridge = AudioInputBridge::new(8);
+        let source = TrackId::new();
+        bridge.set_resample_source(Some(source));
+        bridge.begin_recording();
+        bridge.capture_track_output(&[0.25, -0.5, 0.75, -1.0], 2);
+        let mut take = Vec::new();
+        bridge.drain_recorded(&mut take);
+        assert_eq!(take, vec![[0.25, -0.5], [0.75, -1.0]]);
+        assert_eq!(bridge.underrun_frames(), 0);
+        assert_eq!(bridge.meter(), (0.75, 1.0));
+
+        bridge.end_recording();
+        bridge.capture_track_output(&[0.0, 0.0], 2);
+        assert!(bridge.recording_stopped());
     }
 
     #[test]

--- a/crates/vibez-audio-io/src/audio_stream.rs
+++ b/crates/vibez-audio-io/src/audio_stream.rs
@@ -178,7 +178,7 @@ pub struct AudioOutputStream {
     params: Option<StreamParams>,
     active_device_name: Option<String>,
     /// Shared engine slot.  The audio callback `try_lock`s this each
-    /// invocation and calls `engine.process()` if the lock is obtained.
+    /// invocation and calls `engine.process_block()` if the lock is obtained.
     engine_slot: Arc<Mutex<Option<AudioEngine>>>,
     event_reporter: StreamEventReporter,
     event_rx: Receiver<AudioStreamEvent>,

--- a/crates/vibez-audio-io/src/audio_stream/callback.rs
+++ b/crates/vibez-audio-io/src/audio_stream/callback.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use crate::audio_input::AudioInputBridge;
 use cpal::traits::DeviceTrait;
 use cpal::{FromSample, SampleFormat, SizedSample, StreamConfig, SupportedBufferSize};
-use vibez_engine::engine::AudioEngine;
+use vibez_engine::engine::{AudioEngine, AudioProcessBlock};
 
 use crate::stream_config::StreamOpenError;
 
@@ -147,27 +147,14 @@ impl OutputCallback {
                 if resample_source.is_some() && resample_scratch.is_none() {
                     self.input_bridge.report_overflow();
                 }
-                match (live_input, resample_source, resample_scratch) {
-                    (Some((Some(target), input)), Some(source), Some(capture)) => engine
-                        .process_with_live_input_and_track_output_capture(
-                            data,
-                            self.channels,
-                            target,
-                            input,
-                            source,
-                            capture,
-                        ),
-                    (_, Some(source), Some(capture)) => engine.process_with_track_output_capture(
-                        data,
-                        self.channels,
-                        source,
-                        capture,
-                    ),
-                    (Some((Some(target), input)), _, _) => {
-                        engine.process_with_live_input(data, self.channels, target, input)
-                    }
-                    _ => engine.process(data, self.channels),
+                let mut block = AudioProcessBlock::new(data, self.channels);
+                if let Some((Some(target), input)) = live_input {
+                    block = block.with_live_input(target, input);
                 }
+                if let (Some(source), Some(capture)) = (resample_source, resample_scratch) {
+                    block = block.with_track_output_capture(source, capture);
+                }
+                engine.process_block(block);
                 if resample_source.is_some() {
                     if let Some(capture) = self.resample_scratch.get(..data.len()) {
                         self.input_bridge

--- a/crates/vibez-audio-io/src/audio_stream/callback.rs
+++ b/crates/vibez-audio-io/src/audio_stream/callback.rs
@@ -69,6 +69,7 @@ pub(super) struct OutputCallback {
     rt_state: Option<Result<audio_thread_priority::RtPriorityHandle, ()>>,
     input_bridge: Arc<AudioInputBridge>,
     input_scratch: Vec<f32>,
+    resample_scratch: Vec<f32>,
 }
 
 impl OutputCallback {
@@ -92,6 +93,7 @@ impl OutputCallback {
             rt_state: None,
             input_bridge,
             input_scratch: vec![0.0; scratch_frames as usize * channels],
+            resample_scratch: vec![0.0; scratch_frames as usize * channels],
         }
     }
 
@@ -140,11 +142,37 @@ impl OutputCallback {
                 if live_input.is_none() {
                     self.input_bridge.report_overflow();
                 }
-                match live_input {
-                    Some((Some(target), samples)) => {
-                        engine.process_with_live_input(data, self.channels, target, samples)
+                let resample_source = self.input_bridge.resample_source_track_raw();
+                let resample_scratch = self.resample_scratch.get_mut(..data.len());
+                if resample_source.is_some() && resample_scratch.is_none() {
+                    self.input_bridge.report_overflow();
+                }
+                match (live_input, resample_source, resample_scratch) {
+                    (Some((Some(target), input)), Some(source), Some(capture)) => engine
+                        .process_with_live_input_and_track_output_capture(
+                            data,
+                            self.channels,
+                            target,
+                            input,
+                            source,
+                            capture,
+                        ),
+                    (_, Some(source), Some(capture)) => engine.process_with_track_output_capture(
+                        data,
+                        self.channels,
+                        source,
+                        capture,
+                    ),
+                    (Some((Some(target), input)), _, _) => {
+                        engine.process_with_live_input(data, self.channels, target, input)
                     }
                     _ => engine.process(data, self.channels),
+                }
+                if resample_source.is_some() {
+                    if let Some(capture) = self.resample_scratch.get(..data.len()) {
+                        self.input_bridge
+                            .capture_track_output(capture, self.channels);
+                    }
                 }
                 processed = true;
             }

--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -12,8 +12,16 @@ use crate::perform::SwingOffset;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum AudioInputRoute {
-    Mono { channel: u16 },
-    Stereo { left: u16 },
+    Mono {
+        channel: u16,
+    },
+    Stereo {
+        left: u16,
+    },
+    /// Live post-device/post-fader output of one MIDI/instrument Project Track.
+    Resample {
+        track_id: TrackId,
+    },
 }
 
 impl Default for AudioInputRoute {
@@ -27,7 +35,21 @@ impl std::fmt::Display for AudioInputRoute {
         match self {
             Self::Mono { channel } => write!(formatter, "IN {}", channel + 1),
             Self::Stereo { left } => write!(formatter, "IN {}/{}", left + 1, left + 2),
+            Self::Resample { .. } => formatter.write_str("RESAMPLE"),
         }
+    }
+}
+
+impl AudioInputRoute {
+    pub fn resample_source(self) -> Option<TrackId> {
+        match self {
+            Self::Resample { track_id } => Some(track_id),
+            Self::Mono { .. } | Self::Stereo { .. } => None,
+        }
+    }
+
+    pub fn is_hardware(self) -> bool {
+        self.resample_source().is_none()
     }
 }
 
@@ -349,6 +371,16 @@ mod tests {
         let decoded: TrackInfo = serde_json::from_value(legacy).unwrap();
         assert_eq!(decoded.audio_input_route, AudioInputRoute::default());
         assert_eq!(decoded.input_monitoring, InputMonitoring::Off);
+
+        let source = TrackId::new();
+        let mut track = TrackInfo::new("Resample");
+        track.audio_input_route = AudioInputRoute::Resample { track_id: source };
+        let decoded: TrackInfo =
+            serde_json::from_str(&serde_json::to_string(&track).unwrap()).unwrap();
+        assert_eq!(
+            decoded.audio_input_route,
+            AudioInputRoute::Resample { track_id: source }
+        );
     }
 
     fn test_clip(position: u64, duration: u64) -> ClipInfo {

--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -281,7 +281,10 @@ pub enum EngineCommand {
         state: DrumPadState,
     },
 
-    // -- Arrangement loop --
+    // -- Arrangement recording / loop --
+    /// Suspend ordinary end-of-content auto-stop while an Audio Track take
+    /// extends Arrange. Stop restores the canonical content boundary.
+    SetArrangementRecording(bool),
     SetArrangementLoop(bool),
     SetArrangementLoopRegion {
         start: u64,

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -115,6 +115,13 @@ pub(super) struct LiveInputBlock<'a> {
     pub samples: &'a [f32],
 }
 
+/// One callback-lifetime buffer receiving a Project Track's direct audible
+/// output. The caller preallocates the slice; the engine never retains it.
+pub(super) struct TrackOutputCapture<'a> {
+    pub source_track_raw: u64,
+    pub samples: &'a mut [f32],
+}
+
 impl<'a> LiveInputBlock<'a> {
     pub(super) fn slice(self, frame_offset: usize, frames: usize, channels: usize) -> Self {
         let start = frame_offset.saturating_mul(channels);
@@ -193,7 +200,7 @@ impl AudioEngine {
     /// 4. Otherwise: falls back to legacy single-audio path.
     /// 5. Sends metering and position events to the UI thread.
     pub fn process(&mut self, output: &mut [f32], channels: usize) {
-        self.process_block(output, channels, None);
+        self.process_block(output, channels, None, None);
     }
 
     /// Process one output-clock block with a transient hardware-input source.
@@ -212,6 +219,52 @@ impl AudioEngine {
                 target_track_raw,
                 samples: input,
             }),
+            None,
+        );
+    }
+
+    /// Process one block while copying the selected Track's post-device,
+    /// post-fader direct output into caller-owned, preallocated scratch.
+    pub fn process_with_track_output_capture(
+        &mut self,
+        output: &mut [f32],
+        channels: usize,
+        source_track_raw: u64,
+        capture: &mut [f32],
+    ) {
+        self.process_block(
+            output,
+            channels,
+            None,
+            Some(TrackOutputCapture {
+                source_track_raw,
+                samples: capture,
+            }),
+        );
+    }
+
+    /// Hardware monitoring and internal Resample can coexist in one callback,
+    /// although a recording session chooses exactly one capture source.
+    pub fn process_with_live_input_and_track_output_capture(
+        &mut self,
+        output: &mut [f32],
+        channels: usize,
+        target_track_raw: u64,
+        input: &[f32],
+        source_track_raw: u64,
+        capture: &mut [f32],
+    ) {
+        self.process_block(
+            output,
+            channels,
+            Some(LiveInputBlock {
+                target_track_raw,
+                samples: input,
+            }),
+            Some(TrackOutputCapture {
+                source_track_raw,
+                samples: capture,
+            }),
         );
     }
 
@@ -225,6 +278,7 @@ impl AudioEngine {
         output: &mut [f32],
         channels: usize,
         live_input: Option<LiveInputBlock<'_>>,
+        mut track_output_capture: Option<TrackOutputCapture<'_>>,
     ) {
         // A musical boundary due at this block start owns the same timestamp
         // as commands drained below. Publish the recording start first so a
@@ -239,6 +293,9 @@ impl AudioEngine {
 
         // ---- 2. Zero output buffer --------------------------------------
         output.iter_mut().for_each(|s| *s = 0.0);
+        if let Some(capture) = track_output_capture.as_mut() {
+            capture.samples.fill(0.0);
+        }
 
         // Bus mixes accumulate from track sends during rendering;
         // start each block from silence.
@@ -248,7 +305,13 @@ impl AudioEngine {
 
         if !self.tracks.is_empty() {
             // ---- 3. Multi-track rendering path --------------------------
-            self.process_multitrack(output, frames, channels, live_input);
+            self.process_multitrack(
+                output,
+                frames,
+                channels,
+                live_input,
+                track_output_capture.as_mut(),
+            );
         } else {
             // ---- 4. Legacy single-audio path ----------------------------
             self.process_legacy(output, frames, channels);

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -82,6 +82,8 @@ pub struct AudioEngine {
     /// these frames advance the newly active Section's local playhead.
     section_advance_override: Option<u64>,
     arrangement_audio_length: Option<u64>,
+    /// Audio Track Recording may extend Arrange beyond existing content.
+    arrangement_recording: bool,
     /// Project Swing is engine state because generated-event consumers share
     /// it while existing playback remains untouched.
     project_swing: SwingAmount,
@@ -214,6 +216,7 @@ impl AudioEngine {
             active_section_record: None,
             section_advance_override: None,
             arrangement_audio_length: None,
+            arrangement_recording: false,
             project_swing: SwingAmount::default(),
             performance_position: 0,
             clock_domain: ClockDomain::Arrange,

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -30,9 +30,10 @@ const SPECTRUM_RING_CAPACITY: usize = 16_384;
 
 /// The real-time audio engine.
 ///
-/// `AudioEngine` lives on the audio thread.  Its [`process()`](AudioEngine::process)
-/// method is called once per audio callback to fill an output buffer with audio
-/// and communicate with the UI thread via lock-free ring buffers.
+/// `AudioEngine` lives on the audio thread. Its
+/// [`process_block()`](AudioEngine::process_block) method is called once per
+/// audio callback to fill an output buffer with audio and communicate with the
+/// UI thread via lock-free ring buffers.
 ///
 /// # Construction
 ///
@@ -122,6 +123,48 @@ pub(super) struct TrackOutputCapture<'a> {
     pub samples: &'a mut [f32],
 }
 
+/// All transient sources and destinations for one audio callback.
+///
+/// The builder keeps callback-only borrows together so adding another optional
+/// source does not multiply the public `AudioEngine` process API.
+pub struct AudioProcessBlock<'a> {
+    output: &'a mut [f32],
+    channels: usize,
+    live_input: Option<LiveInputBlock<'a>>,
+    track_output_capture: Option<TrackOutputCapture<'a>>,
+}
+
+impl<'a> AudioProcessBlock<'a> {
+    pub fn new(output: &'a mut [f32], channels: usize) -> Self {
+        Self {
+            output,
+            channels,
+            live_input: None,
+            track_output_capture: None,
+        }
+    }
+
+    pub fn with_live_input(mut self, target_track_raw: u64, samples: &'a [f32]) -> Self {
+        self.live_input = Some(LiveInputBlock {
+            target_track_raw,
+            samples,
+        });
+        self
+    }
+
+    pub fn with_track_output_capture(
+        mut self,
+        source_track_raw: u64,
+        samples: &'a mut [f32],
+    ) -> Self {
+        self.track_output_capture = Some(TrackOutputCapture {
+            source_track_raw,
+            samples,
+        });
+        self
+    }
+}
+
 impl<'a> LiveInputBlock<'a> {
     pub(super) fn slice(self, frame_offset: usize, frames: usize, channels: usize) -> Self {
         let start = frame_offset.saturating_mul(channels);
@@ -199,73 +242,9 @@ impl AudioEngine {
     /// 3. If tracks exist: renders each → applies gain/pan → sums into output.
     /// 4. Otherwise: falls back to legacy single-audio path.
     /// 5. Sends metering and position events to the UI thread.
-    pub fn process(&mut self, output: &mut [f32], channels: usize) {
-        self.process_block(output, channels, None, None);
-    }
-
-    /// Process one output-clock block with a transient hardware-input source.
-    /// The slice is borrowed only for this callback and is never retained.
-    pub fn process_with_live_input(
-        &mut self,
-        output: &mut [f32],
-        channels: usize,
-        target_track_raw: u64,
-        input: &[f32],
-    ) {
-        self.process_block(
-            output,
-            channels,
-            Some(LiveInputBlock {
-                target_track_raw,
-                samples: input,
-            }),
-            None,
-        );
-    }
-
-    /// Process one block while copying the selected Track's post-device,
-    /// post-fader direct output into caller-owned, preallocated scratch.
-    pub fn process_with_track_output_capture(
-        &mut self,
-        output: &mut [f32],
-        channels: usize,
-        source_track_raw: u64,
-        capture: &mut [f32],
-    ) {
-        self.process_block(
-            output,
-            channels,
-            None,
-            Some(TrackOutputCapture {
-                source_track_raw,
-                samples: capture,
-            }),
-        );
-    }
-
-    /// Hardware monitoring and internal Resample can coexist in one callback,
-    /// although a recording session chooses exactly one capture source.
-    pub fn process_with_live_input_and_track_output_capture(
-        &mut self,
-        output: &mut [f32],
-        channels: usize,
-        target_track_raw: u64,
-        input: &[f32],
-        source_track_raw: u64,
-        capture: &mut [f32],
-    ) {
-        self.process_block(
-            output,
-            channels,
-            Some(LiveInputBlock {
-                target_track_raw,
-                samples: input,
-            }),
-            Some(TrackOutputCapture {
-                source_track_raw,
-                samples: capture,
-            }),
-        );
+    #[cfg(test)]
+    fn process(&mut self, output: &mut [f32], channels: usize) {
+        self.process_block(AudioProcessBlock::new(output, channels));
     }
 
     /// Exact Arrange cursor at the next output-clock block boundary.
@@ -273,13 +252,13 @@ impl AudioEngine {
         self.transport.position()
     }
 
-    fn process_block(
-        &mut self,
-        output: &mut [f32],
-        channels: usize,
-        live_input: Option<LiveInputBlock<'_>>,
-        mut track_output_capture: Option<TrackOutputCapture<'_>>,
-    ) {
+    pub fn process_block(&mut self, block: AudioProcessBlock<'_>) {
+        let AudioProcessBlock {
+            output,
+            channels,
+            live_input,
+            mut track_output_capture,
+        } = block;
         // A musical boundary due at this block start owns the same timestamp
         // as commands drained below. Publish the recording start first so a
         // first pad strike at the boundary cannot reach consumers while the

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -23,6 +23,7 @@ impl AudioEngine {
                         effective_at_samples: self.effective_position(),
                     });
                     self.transport.stop();
+                    self.arrangement_recording = false;
                     self.clock_domain = ClockDomain::Arrange;
                     self.performance_position = self.transport.position();
                     self.cancel_section_queue();
@@ -171,7 +172,7 @@ impl AudioEngine {
                     let len = audio.num_frames() as u64;
                     self.audio = Some(audio);
                     self.arrangement_audio_length = Some(len);
-                    if self.active_section.is_none() {
+                    if self.active_section.is_none() && !self.arrangement_recording {
                         self.transport.set_audio_length(Some(len));
                     }
                 }
@@ -182,6 +183,7 @@ impl AudioEngine {
                     });
                     self.audio = None;
                     self.arrangement_audio_length = None;
+                    self.arrangement_recording = false;
                     self.active_section = None;
                     self.clock_domain = ClockDomain::Arrange;
                     self.transport.set_audio_length(None);
@@ -679,7 +681,17 @@ impl AudioEngine {
                     }
                 }
 
-                // -- Clip looping --
+                // -- Arrangement recording / looping --
+                EngineCommand::SetArrangementRecording(active) => {
+                    self.arrangement_recording = active;
+                    if self.active_section.is_none() {
+                        self.transport.set_audio_length(if active {
+                            None
+                        } else {
+                            self.arrangement_audio_length
+                        });
+                    }
+                }
                 EngineCommand::SetArrangementLoop(enabled) => {
                     self.transport.set_loop_enabled(enabled);
                 }
@@ -963,7 +975,7 @@ impl AudioEngine {
         } else {
             self.audio.as_ref().map(|audio| audio.num_frames() as u64)
         };
-        if self.active_section.is_none() {
+        if self.active_section.is_none() && !self.arrangement_recording {
             self.transport
                 .set_audio_length(self.arrangement_audio_length);
         }

--- a/crates/vibez-engine/src/engine_render.rs
+++ b/crates/vibez-engine/src/engine_render.rs
@@ -12,6 +12,41 @@ pub(super) struct MultitrackRenderBlock<'a> {
     pub live_input: Option<LiveInputBlock<'a>>,
 }
 
+fn split_track_output_capture<'a>(
+    capture: Option<&'a mut TrackOutputCapture<'_>>,
+    split: usize,
+) -> (
+    Option<TrackOutputCapture<'a>>,
+    Option<TrackOutputCapture<'a>>,
+) {
+    let Some(capture) = capture else {
+        return (None, None);
+    };
+    let split = split.min(capture.samples.len());
+    let source_track_raw = capture.source_track_raw;
+    let (first, rest) = capture.samples.split_at_mut(split);
+    (
+        Some(TrackOutputCapture {
+            source_track_raw,
+            samples: first,
+        }),
+        Some(TrackOutputCapture {
+            source_track_raw,
+            samples: rest,
+        }),
+    )
+}
+
+fn write_track_output_sample(
+    capture: Option<&mut TrackOutputCapture<'_>>,
+    index: usize,
+    sample: f32,
+) {
+    if let Some(destination) = capture.and_then(|capture| capture.samples.get_mut(index)) {
+        *destination = sample;
+    }
+}
+
 impl AudioEngine {
     /// Multi-track rendering: render each track, apply gain/pan, sum into output.
     ///
@@ -64,55 +99,10 @@ impl AudioEngine {
             if pos < loop_end && pos + frames as u64 >= loop_end {
                 let first = (loop_end - pos) as usize;
                 let rest = frames - first;
-                if let Some(capture) = track_output_capture.as_deref_mut() {
-                    let split = (first * channels).min(capture.samples.len());
-                    let (first_samples, rest_samples) = capture.samples.split_at_mut(split);
-                    let source_track_raw = capture.source_track_raw;
-                    let mut first_capture = TrackOutputCapture {
-                        source_track_raw,
-                        samples: first_samples,
-                    };
-                    self.render_multitrack_segment(
-                        &mut output[..first * channels],
-                        MultitrackRenderBlock {
-                            pos,
-                            repeat_pos: pos,
-                            frames: first,
-                            channels,
-                            loop_region: self.transport.active_loop_region(),
-                            live_input: live_input.map(|input| input.slice(0, first, channels)),
-                        },
-                        Some(&mut first_capture),
-                    );
-                    // The transport jumps directly from loop_end to loop_start.
-                    // Apply work owned by that exact musical boundary before the
-                    // clock wraps so it cannot remain pending forever.
-                    self.apply_track_mutes_due(loop_end);
-                    for track in &mut self.tracks {
-                        track.flush_notes();
-                    }
-                    if rest > 0 {
-                        let mut rest_capture = TrackOutputCapture {
-                            source_track_raw,
-                            samples: rest_samples,
-                        };
-                        self.render_multitrack_segment(
-                            &mut output[first * channels..],
-                            MultitrackRenderBlock {
-                                pos: loop_start,
-                                repeat_pos: loop_start,
-                                frames: rest,
-                                channels,
-                                loop_region: self.transport.active_loop_region(),
-                                live_input: live_input
-                                    .map(|input| input.slice(first, rest, channels)),
-                            },
-                            Some(&mut rest_capture),
-                        );
-                    }
-                    self.split_wrap_handled = true;
-                    return;
-                }
+                let (mut first_capture, mut rest_capture) = split_track_output_capture(
+                    track_output_capture.as_deref_mut(),
+                    first * channels,
+                );
                 self.render_multitrack_segment(
                     &mut output[..first * channels],
                     MultitrackRenderBlock {
@@ -123,7 +113,7 @@ impl AudioEngine {
                         loop_region: self.transport.active_loop_region(),
                         live_input: live_input.map(|input| input.slice(0, first, channels)),
                     },
-                    None,
+                    first_capture.as_mut(),
                 );
                 // The transport jumps directly from loop_end to loop_start.
                 // Apply work owned by that exact musical boundary before the
@@ -145,7 +135,7 @@ impl AudioEngine {
                             loop_region: self.transport.active_loop_region(),
                             live_input: live_input.map(|input| input.slice(first, rest, channels)),
                         },
-                        None,
+                        rest_capture.as_mut(),
                     );
                 }
                 self.split_wrap_handled = true;
@@ -393,11 +383,11 @@ impl AudioEngine {
                         output[idx] += panned;
                     }
                     if capture_this_track {
-                        if let Some(capture) = track_output_capture.as_deref_mut() {
-                            if let Some(destination) = capture.samples.get_mut(idx) {
-                                *destination = if dry_audible { panned } else { 0.0 };
-                            }
-                        }
+                        write_track_output_sample(
+                            track_output_capture.as_deref_mut(),
+                            idx,
+                            if dry_audible { panned } else { 0.0 },
+                        );
                     }
 
                     // Track per-channel peaks
@@ -588,11 +578,11 @@ impl AudioEngine {
                         output[idx] += panned;
                     }
                     if capture_this_track {
-                        if let Some(capture) = track_output_capture.as_deref_mut() {
-                            if let Some(destination) = capture.samples.get_mut(idx) {
-                                *destination = if dry_audible { panned } else { 0.0 };
-                            }
-                        }
+                        write_track_output_sample(
+                            track_output_capture.as_deref_mut(),
+                            idx,
+                            if dry_audible { panned } else { 0.0 },
+                        );
                     }
                 }
             }

--- a/crates/vibez-engine/src/engine_render.rs
+++ b/crates/vibez-engine/src/engine_render.rs
@@ -26,6 +26,7 @@ impl AudioEngine {
         frames: usize,
         channels: usize,
         live_input: Option<LiveInputBlock<'_>>,
+        mut track_output_capture: Option<&mut TrackOutputCapture<'_>>,
     ) {
         if !self.transport.is_playing() {
             // Stopped transport still renders instruments so
@@ -37,6 +38,7 @@ impl AudioEngine {
                 channels,
                 self.performance_position,
                 live_input,
+                track_output_capture,
             );
             return;
         }
@@ -62,6 +64,55 @@ impl AudioEngine {
             if pos < loop_end && pos + frames as u64 >= loop_end {
                 let first = (loop_end - pos) as usize;
                 let rest = frames - first;
+                if let Some(capture) = track_output_capture.as_deref_mut() {
+                    let split = (first * channels).min(capture.samples.len());
+                    let (first_samples, rest_samples) = capture.samples.split_at_mut(split);
+                    let source_track_raw = capture.source_track_raw;
+                    let mut first_capture = TrackOutputCapture {
+                        source_track_raw,
+                        samples: first_samples,
+                    };
+                    self.render_multitrack_segment(
+                        &mut output[..first * channels],
+                        MultitrackRenderBlock {
+                            pos,
+                            repeat_pos: pos,
+                            frames: first,
+                            channels,
+                            loop_region: self.transport.active_loop_region(),
+                            live_input: live_input.map(|input| input.slice(0, first, channels)),
+                        },
+                        Some(&mut first_capture),
+                    );
+                    // The transport jumps directly from loop_end to loop_start.
+                    // Apply work owned by that exact musical boundary before the
+                    // clock wraps so it cannot remain pending forever.
+                    self.apply_track_mutes_due(loop_end);
+                    for track in &mut self.tracks {
+                        track.flush_notes();
+                    }
+                    if rest > 0 {
+                        let mut rest_capture = TrackOutputCapture {
+                            source_track_raw,
+                            samples: rest_samples,
+                        };
+                        self.render_multitrack_segment(
+                            &mut output[first * channels..],
+                            MultitrackRenderBlock {
+                                pos: loop_start,
+                                repeat_pos: loop_start,
+                                frames: rest,
+                                channels,
+                                loop_region: self.transport.active_loop_region(),
+                                live_input: live_input
+                                    .map(|input| input.slice(first, rest, channels)),
+                            },
+                            Some(&mut rest_capture),
+                        );
+                    }
+                    self.split_wrap_handled = true;
+                    return;
+                }
                 self.render_multitrack_segment(
                     &mut output[..first * channels],
                     MultitrackRenderBlock {
@@ -72,6 +123,7 @@ impl AudioEngine {
                         loop_region: self.transport.active_loop_region(),
                         live_input: live_input.map(|input| input.slice(0, first, channels)),
                     },
+                    None,
                 );
                 // The transport jumps directly from loop_end to loop_start.
                 // Apply work owned by that exact musical boundary before the
@@ -93,6 +145,7 @@ impl AudioEngine {
                             loop_region: self.transport.active_loop_region(),
                             live_input: live_input.map(|input| input.slice(first, rest, channels)),
                         },
+                        None,
                     );
                 }
                 self.split_wrap_handled = true;
@@ -109,6 +162,7 @@ impl AudioEngine {
                 loop_region: self.transport.active_loop_region(),
                 live_input,
             },
+            track_output_capture,
         );
     }
 
@@ -116,6 +170,7 @@ impl AudioEngine {
         &mut self,
         output: &mut [f32],
         block: MultitrackRenderBlock<'_>,
+        mut track_output_capture: Option<&mut TrackOutputCapture<'_>>,
     ) {
         let MultitrackRenderBlock {
             pos,
@@ -138,6 +193,13 @@ impl AudioEngine {
                 .unwrap_or(frames - rendered_frames);
             let start = rendered_frames * channels;
             let end = (rendered_frames + segment_frames) * channels;
+            let mut segment_capture = track_output_capture.as_deref_mut().map(|capture| {
+                let samples = capture.samples.get_mut(start..end).unwrap_or(&mut []);
+                TrackOutputCapture {
+                    source_track_raw: capture.source_track_raw,
+                    samples,
+                }
+            });
             self.render_multitrack_frames(
                 &mut output[start..end],
                 MultitrackRenderBlock {
@@ -149,12 +211,18 @@ impl AudioEngine {
                     live_input: live_input
                         .map(|input| input.slice(rendered_frames, segment_frames, channels)),
                 },
+                segment_capture.as_mut(),
             );
             rendered_frames += segment_frames;
         }
     }
 
-    fn render_multitrack_frames(&mut self, output: &mut [f32], block: MultitrackRenderBlock<'_>) {
+    fn render_multitrack_frames(
+        &mut self,
+        output: &mut [f32],
+        block: MultitrackRenderBlock<'_>,
+        mut track_output_capture: Option<&mut TrackOutputCapture<'_>>,
+    ) {
         let MultitrackRenderBlock {
             pos,
             repeat_pos,
@@ -292,6 +360,9 @@ impl AudioEngine {
             let gain = auto_gain.unwrap_or(track.gain);
             let (pan_l, pan_r) = equal_power_pan(auto_pan.unwrap_or(track.pan));
             let track_id = track.id;
+            let capture_this_track = track_output_capture
+                .as_ref()
+                .is_some_and(|capture| capture.source_track_raw == track_id.raw());
             let buf_size = frames * channels;
             let dry_audible = (!has_track_solo && !has_bus_solo) || track.solo;
 
@@ -320,6 +391,13 @@ impl AudioEngine {
 
                     if dry_audible {
                         output[idx] += panned;
+                    }
+                    if capture_this_track {
+                        if let Some(capture) = track_output_capture.as_deref_mut() {
+                            if let Some(destination) = capture.samples.get_mut(idx) {
+                                *destination = if dry_audible { panned } else { 0.0 };
+                            }
+                        }
                     }
 
                     // Track per-channel peaks
@@ -408,6 +486,7 @@ impl AudioEngine {
         channels: usize,
         repeat_pos: u64,
         live_input: Option<LiveInputBlock<'_>>,
+        mut track_output_capture: Option<&mut TrackOutputCapture<'_>>,
     ) {
         let has_track_solo = any_solo(&self.tracks);
         let has_bus_solo = any_solo(&self.buses);
@@ -486,6 +565,9 @@ impl AudioEngine {
             let (pan_l, pan_r) = equal_power_pan(track.pan);
             let buf_size = frames * channels;
             let dry_audible = (!has_track_solo && !has_bus_solo) || track.solo;
+            let capture_this_track = track_output_capture
+                .as_ref()
+                .is_some_and(|capture| capture.source_track_raw == track.id.raw());
             for frame in 0..frames {
                 for ch in 0..channels {
                     let idx = frame * channels + ch;
@@ -504,6 +586,13 @@ impl AudioEngine {
                     };
                     if dry_audible {
                         output[idx] += panned;
+                    }
+                    if capture_this_track {
+                        if let Some(capture) = track_output_capture.as_deref_mut() {
+                            if let Some(destination) = capture.samples.get_mut(idx) {
+                                *destination = if dry_audible { panned } else { 0.0 };
+                            }
+                        }
                     }
                 }
             }

--- a/crates/vibez-engine/src/engine_section_queue.rs
+++ b/crates/vibez-engine/src/engine_section_queue.rs
@@ -238,6 +238,7 @@ impl AudioEngine {
                     loop_region: None,
                     live_input: None,
                 },
+                None,
             );
             for track in &mut self.tracks {
                 track.suppress_source_notes = false;

--- a/crates/vibez-engine/src/engine_section_record.rs
+++ b/crates/vibez-engine/src/engine_section_record.rs
@@ -210,7 +210,7 @@ impl AudioEngine {
             return false;
         }
         if timing.boundary >= block_end {
-            self.render_idle_instruments(output, frames, channels, block_start, None);
+            self.render_idle_instruments(output, frames, channels, block_start, None, None);
             self.mix_section_record_count_in_click(output, frames, channels, block_start, timing);
             return true;
         }
@@ -222,6 +222,7 @@ impl AudioEngine {
                 frames_before,
                 channels,
                 block_start,
+                None,
                 None,
             );
             self.mix_section_record_count_in_click(

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -1303,6 +1303,125 @@ fn constant_clip_track(
 }
 
 #[test]
+fn track_output_capture_is_post_fader_and_excludes_other_tracks() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let (source, _) = constant_clip_track(&mut cmd_tx, 4096);
+    let (_other, _) = constant_clip_track(&mut cmd_tx, 4096);
+    cmd_tx
+        .push(EngineCommand::SetTrackGain(source, 0.5))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetTrackPan(source, 0.0))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut output = vec![0.0; 256];
+    let mut capture = vec![0.0; output.len()];
+    engine.process_with_track_output_capture(&mut output, 2, source.raw(), &mut capture);
+
+    assert!(capture
+        .iter()
+        .step_by(2)
+        .all(|sample| (*sample - 0.25).abs() < 1e-6));
+    assert!(capture
+        .iter()
+        .skip(1)
+        .step_by(2)
+        .all(|sample| sample.abs() < 1e-6));
+    assert!(output.iter().skip(1).step_by(2).any(|sample| *sample > 0.3));
+}
+
+#[test]
+fn track_output_capture_excludes_sends_returns_master_and_inaudible_sources() {
+    let (mut engine, mut cmd_tx, source, _bus) = engine_with_send(1.0);
+    cmd_tx
+        .push(EngineCommand::SetTrackGain(TrackId::MASTER, 0.25))
+        .unwrap();
+    let mut output = vec![0.0; 256];
+    let mut capture = vec![0.0; output.len()];
+    engine.process_with_track_output_capture(&mut output, 2, source.raw(), &mut capture);
+    let direct = 0.5 * std::f32::consts::FRAC_1_SQRT_2;
+    assert!((capture[0] - direct).abs() < 1e-6);
+    assert!((output[0] - direct * 0.5).abs() < 1e-3);
+
+    cmd_tx
+        .push(start_audition(make_constant_audio(4096, 0.8)))
+        .unwrap();
+    engine.process_with_track_output_capture(&mut output, 2, source.raw(), &mut capture);
+    assert!((capture[0] - direct).abs() < 1e-6);
+    let output_peak = output.iter().copied().fold(0.0_f32, f32::max);
+    let capture_peak = capture.iter().copied().fold(0.0_f32, f32::max);
+    assert!(
+        output_peak > capture_peak,
+        "Browser Audition must stay outside the Track tap"
+    );
+
+    let solo = TrackId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(solo, "Solo".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddClip {
+            track_id: solo,
+            clip_id: ClipId::new(),
+            audio: make_constant_audio(4096, 0.5),
+            position: 0,
+            source_offset: 0,
+            duration: 4096,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetTrackSolo(solo, true))
+        .unwrap();
+    capture.fill(1.0);
+    engine.process_with_track_output_capture(&mut output, 2, source.raw(), &mut capture);
+    assert!(capture.iter().all(|sample| *sample == 0.0));
+}
+
+#[test]
+fn track_output_capture_follows_active_gain_and_pan_automation() {
+    use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
+
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let (source, _) = constant_clip_track(&mut cmd_tx, 4096);
+    let mut gain = AutomationLane::new(AutomationTarget::TrackGain);
+    gain.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 0.25,
+        curve: 0.0,
+    });
+    let mut pan = AutomationLane::new(AutomationTarget::TrackPan);
+    pan.insert_point(AutomationPoint {
+        beat: 0.0,
+        value: 1.0,
+        curve: 0.0,
+    });
+    for lane in [gain, pan] {
+        cmd_tx
+            .push(EngineCommand::SetAutomationLane {
+                track_id: source,
+                lane,
+            })
+            .unwrap();
+    }
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut output = vec![0.0; 256];
+    let mut capture = vec![0.0; output.len()];
+    engine.process_with_track_output_capture(&mut output, 2, source.raw(), &mut capture);
+
+    assert!(capture.iter().step_by(2).all(|sample| sample.abs() < 1e-6));
+    assert!(capture
+        .iter()
+        .skip(1)
+        .step_by(2)
+        .all(|sample| (*sample - 0.25).abs() < 1e-6));
+}
+
+#[test]
 fn gain_lane_ramps_track_volume_down() {
     use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
 

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -319,6 +319,26 @@ fn auto_stop_at_end_of_audio() {
 }
 
 #[test]
+fn arrangement_recording_advances_past_the_existing_content_end() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    constant_clip_track(&mut cmd_tx, 16);
+    cmd_tx.push(EngineCommand::Seek(16)).unwrap();
+    cmd_tx
+        .push(EngineCommand::SetArrangementRecording(true))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    engine.process(&mut [0.0; 32], 2);
+
+    assert_eq!(engine.transport().position(), 32);
+    assert!(engine.transport().is_playing());
+
+    cmd_tx.push(EngineCommand::Stop).unwrap();
+    engine.process(&mut [0.0; 2], 2);
+    assert_eq!(engine.transport().audio_length(), Some(16));
+}
+
+#[test]
 fn multiple_process_calls_advance_position() {
     let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
     let audio = make_test_audio(1024);

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -57,7 +57,9 @@ fn live_input_uses_the_target_track_while_transport_is_stopped() {
     let input = [0.5f32, -0.25, 0.25, -0.5];
     let mut output = [0.0; 4];
 
-    engine.process_with_live_input(&mut output, 2, target.raw(), &input);
+    engine.process_block(
+        AudioProcessBlock::new(&mut output, 2).with_live_input(target.raw(), &input),
+    );
 
     let centre = std::f32::consts::FRAC_1_SQRT_2;
     assert!((output[0] - 0.5 * centre).abs() < 1e-6);
@@ -70,7 +72,9 @@ fn live_input_uses_the_target_track_while_transport_is_stopped() {
 fn live_input_is_silent_when_its_target_does_not_exist() {
     let (mut engine, _cmd_tx, _event_rx) = AudioEngine::new();
     let mut output = [1.0; 4];
-    engine.process_with_live_input(&mut output, 2, TrackId::new().raw(), &[0.5; 4]);
+    engine.process_block(
+        AudioProcessBlock::new(&mut output, 2).with_live_input(TrackId::new().raw(), &[0.5; 4]),
+    );
     assert_eq!(output, [0.0; 4]);
 }
 
@@ -1317,7 +1321,10 @@ fn track_output_capture_is_post_fader_and_excludes_other_tracks() {
 
     let mut output = vec![0.0; 256];
     let mut capture = vec![0.0; output.len()];
-    engine.process_with_track_output_capture(&mut output, 2, source.raw(), &mut capture);
+    engine.process_block(
+        AudioProcessBlock::new(&mut output, 2)
+            .with_track_output_capture(source.raw(), &mut capture),
+    );
 
     assert!(capture
         .iter()
@@ -1332,6 +1339,45 @@ fn track_output_capture_is_post_fader_and_excludes_other_tracks() {
 }
 
 #[test]
+fn track_output_capture_stays_aligned_across_arrangement_loop_wrap() {
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let source = TrackId::new();
+    cmd_tx
+        .push(EngineCommand::AddTrack(source, "Source".into()))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddClip {
+            track_id: source,
+            clip_id: ClipId::new(),
+            audio: make_test_audio(32),
+            position: 0,
+            source_offset: 0,
+            duration: 32,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 0,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetArrangementLoopRegion { start: 4, end: 16 })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetArrangementLoop(true))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut output = vec![0.0; 24 * 2];
+    let mut capture = vec![0.0; output.len()];
+    engine.process_block(
+        AudioProcessBlock::new(&mut output, 2)
+            .with_track_output_capture(source.raw(), &mut capture),
+    );
+
+    assert_eq!(capture, output);
+    assert_eq!(&capture[16 * 2..24 * 2], &capture[4 * 2..12 * 2]);
+}
+
+#[test]
 fn track_output_capture_excludes_sends_returns_master_and_inaudible_sources() {
     let (mut engine, mut cmd_tx, source, _bus) = engine_with_send(1.0);
     cmd_tx
@@ -1339,7 +1385,10 @@ fn track_output_capture_excludes_sends_returns_master_and_inaudible_sources() {
         .unwrap();
     let mut output = vec![0.0; 256];
     let mut capture = vec![0.0; output.len()];
-    engine.process_with_track_output_capture(&mut output, 2, source.raw(), &mut capture);
+    engine.process_block(
+        AudioProcessBlock::new(&mut output, 2)
+            .with_track_output_capture(source.raw(), &mut capture),
+    );
     let direct = 0.5 * std::f32::consts::FRAC_1_SQRT_2;
     assert!((capture[0] - direct).abs() < 1e-6);
     assert!((output[0] - direct * 0.5).abs() < 1e-3);
@@ -1347,7 +1396,10 @@ fn track_output_capture_excludes_sends_returns_master_and_inaudible_sources() {
     cmd_tx
         .push(start_audition(make_constant_audio(4096, 0.8)))
         .unwrap();
-    engine.process_with_track_output_capture(&mut output, 2, source.raw(), &mut capture);
+    engine.process_block(
+        AudioProcessBlock::new(&mut output, 2)
+            .with_track_output_capture(source.raw(), &mut capture),
+    );
     assert!((capture[0] - direct).abs() < 1e-6);
     let output_peak = output.iter().copied().fold(0.0_f32, f32::max);
     let capture_peak = capture.iter().copied().fold(0.0_f32, f32::max);
@@ -1377,7 +1429,10 @@ fn track_output_capture_excludes_sends_returns_master_and_inaudible_sources() {
         .push(EngineCommand::SetTrackSolo(solo, true))
         .unwrap();
     capture.fill(1.0);
-    engine.process_with_track_output_capture(&mut output, 2, source.raw(), &mut capture);
+    engine.process_block(
+        AudioProcessBlock::new(&mut output, 2)
+            .with_track_output_capture(source.raw(), &mut capture),
+    );
     assert!(capture.iter().all(|sample| *sample == 0.0));
 }
 
@@ -1411,7 +1466,10 @@ fn track_output_capture_follows_active_gain_and_pan_automation() {
 
     let mut output = vec![0.0; 256];
     let mut capture = vec![0.0; output.len()];
-    engine.process_with_track_output_capture(&mut output, 2, source.raw(), &mut capture);
+    engine.process_block(
+        AudioProcessBlock::new(&mut output, 2)
+            .with_track_output_capture(source.raw(), &mut capture),
+    );
 
     assert!(capture.iter().step_by(2).all(|sample| sample.abs() < 1e-6));
     assert!(capture

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -247,11 +247,18 @@ impl App {
                 PluginGuiKey::Instrument { track_id: tid } => *tid != track_id,
             });
         }
+        let track_removed = action.remove_track_from_sections.is_some();
         if let Some(track_id) = action.remove_track_from_sections {
             Arc::make_mut(&mut self.state.perform.sections).remove_track(track_id);
         }
         if let Some(status) = action.status {
             self.state.status_text = status;
+        }
+        if track_removed {
+            if let Err(error) = self.sync_audio_input_runtime() {
+                self.state.status_text =
+                    format!("Track removed · Audio Track input could not recover — {error}");
+            }
         }
         if action.mark_dirty {
             self.mark_project_dirty();

--- a/crates/vibez-ui/src/app/audio_recording.rs
+++ b/crates/vibez-ui/src/app/audio_recording.rs
@@ -1,4 +1,4 @@
-//! Arrange hardware-input recording lifecycle and Project Media commit.
+//! Arrange Audio Track Recording and live Resample lifecycle.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -12,10 +12,10 @@ use vibez_core::midi::TrackKind;
 use vibez_core::track::{AudioInputRoute, InputMonitoring};
 use vibez_engine::commands::EngineCommand;
 
-use crate::domains::audio_recording::AudioRecordingPhase;
+use crate::domains::audio_recording::{AudioRecordingPhase, AudioRecordingSource};
 use crate::domains::transport::TransportMsg;
 use crate::message::{AudioRecordingOutcome, Message};
-use crate::state::{ArrangementSelection, UiClip, Workspace};
+use crate::state::{ArrangementSelection, ProjectTrack, UiClip, Workspace};
 
 use super::*;
 
@@ -51,7 +51,15 @@ impl App {
                 self.input_bridge.set_target(None, false);
                 self.state.status_text = format!("Could not arm {name} — {error}");
             } else {
-                self.state.status_text = format!("{name} armed for Audio Input");
+                self.state.status_text = match track_recording_source_label(
+                    self.state
+                        .find_track(track_id)
+                        .map(|track| track.audio_input_route),
+                    &self.state,
+                ) {
+                    Some(source) => format!("{name} armed for {source}"),
+                    None => format!("{name} armed"),
+                };
             }
         }
         Task::none()
@@ -66,8 +74,8 @@ impl App {
             self.state.status_text = "Stop recording before changing the Audio Input route".into();
             return Task::none();
         }
-        if !self.input_route_is_available(route) {
-            self.state.status_text = "That Audio Input channel is unavailable".into();
+        if !self.input_route_is_available(track_id, route) {
+            self.state.status_text = "That Audio Track input is unavailable".into();
             return Task::none();
         }
         let unchanged = self
@@ -80,7 +88,11 @@ impl App {
         self.push_undo_snapshot(None);
         if let Some(track) = Arc::make_mut(&mut self.state.project_tracks).find_mut(track_id) {
             track.audio_input_route = route;
+            if route.resample_source().is_some() {
+                track.input_monitoring = InputMonitoring::Off;
+            }
         }
+        self.state.audio_recording.monitor_track = self.persisted_monitor_on_track();
         self.mark_project_dirty();
         if let Err(error) = self.sync_audio_input_runtime() {
             self.state.status_text =
@@ -96,6 +108,16 @@ impl App {
     ) -> Task<Message> {
         if self.state.audio_recording.is_busy() {
             self.state.status_text = "Stop recording before changing input monitoring".into();
+            return Task::none();
+        }
+        if self
+            .state
+            .find_track(track_id)
+            .is_some_and(|track| track.audio_input_route.resample_source().is_some())
+        {
+            self.state.status_text =
+                "Resample follows the source Track's audible output; input monitoring is not needed"
+                    .into();
             return Task::none();
         }
         if monitoring == InputMonitoring::On
@@ -178,7 +200,11 @@ impl App {
             self.state.status_text = "Arm an Audio Project Track before recording".into();
             return Task::none();
         };
-        if self._input_stream.is_none() {
+        let Some(source) = self.recording_source_for_target(track_id) else {
+            self.state.status_text = "The armed Audio Track input is unavailable".into();
+            return Task::none();
+        };
+        if source == AudioRecordingSource::HardwareInput && self._input_stream.is_none() {
             if let Err(error) = self.sync_audio_input_runtime() {
                 self.state.status_text = format!("Audio Input could not start — {error}");
                 return Task::none();
@@ -189,7 +215,7 @@ impl App {
             return Task::none();
         }
         let start = self.state.transport.position_samples;
-        if !self.state.audio_recording.begin(start) {
+        if !self.state.audio_recording.begin(start, source) {
             self.discard_audio_recording_transaction();
             return Task::none();
         }
@@ -199,7 +225,18 @@ impl App {
             .state
             .find_track(track_id)
             .map_or("Audio Track", |track| track.name.as_str());
-        self.state.status_text = format!("Recording Audio Input into {track_name}");
+        self.state.status_text = match source {
+            AudioRecordingSource::HardwareInput => {
+                format!("Recording Audio Input into {track_name}")
+            }
+            AudioRecordingSource::TrackOutput(source_id) => {
+                let source_name = self
+                    .state
+                    .find_track(source_id)
+                    .map_or("MIDI Track", |track| track.name.as_str());
+                format!("Resampling {source_name} into {track_name}")
+            }
+        };
         if self.state.transport.playing {
             Task::none()
         } else {
@@ -224,6 +261,21 @@ impl App {
             .drain_recorded(&mut self.state.audio_recording.captured_frames);
         let truncated = self.state.audio_recording.truncated;
         let underrun_frames = self.input_bridge.underrun_frames();
+        let source = self
+            .state
+            .audio_recording
+            .source
+            .unwrap_or(AudioRecordingSource::HardwareInput);
+        let completion_label = match source {
+            AudioRecordingSource::HardwareInput => "Recorded Audio Input".into(),
+            AudioRecordingSource::TrackOutput(source_id) => {
+                let source_name = self
+                    .state
+                    .find_track(source_id)
+                    .map_or("MIDI Track", |track| track.name.as_str());
+                format!("Resampled {source_name}")
+            }
+        };
         let Some((track_id, fallback_start_position, frames)) =
             self.state.audio_recording.begin_finalizing()
         else {
@@ -236,14 +288,16 @@ impl App {
         let sample_rate = self.state.transport.sample_rate;
         self.state.status_text = "Writing recorded take to Project Media…".into();
         Task::perform(
-            finalize_audio_input_take(
+            finalize_audio_take(FinalizeAudioTake {
                 track_id,
                 start_position_samples,
                 sample_rate,
                 frames,
+                recording_source: source,
+                completion_label,
                 truncated,
                 underrun_frames,
-            ),
+            }),
             Message::AudioRecordingFinalized,
         )
     }
@@ -321,8 +375,8 @@ impl App {
                 self.state.audio_recording.finish();
                 self.sync_audio_input_target();
                 let completed = format!(
-                    "Recorded {} · {:.2} s · one undo step",
-                    outcome.clip_name,
+                    "{} · {:.2} s · one undo step",
+                    outcome.completion_label,
                     duration as f64 / self.state.transport.sample_rate as f64,
                 );
                 self.state.status_text = quality_warning
@@ -349,6 +403,16 @@ impl App {
                 "Audio recording stopped — its target Track was removed. No Clip was created.",
             ));
         }
+        let source_missing = matches!(
+            self.state.audio_recording.source,
+            Some(AudioRecordingSource::TrackOutput(source_id))
+                if !self.state.find_track(source_id).is_some_and(ProjectTrack::is_playable_midi_target)
+        );
+        if self.state.audio_recording.is_busy() && source_missing {
+            return Some(self.abort_audio_recording(
+                "Resample stopped because its source MIDI Track was removed or became unavailable. No Clip was created.",
+            ));
+        }
         if !self.state.audio_recording.is_busy() && target_missing {
             self.state.audio_recording.armed_track = None;
             self.state.audio_recording.monitor_track = None;
@@ -370,7 +434,16 @@ impl App {
                 self.state.audio_recording.mark_truncated();
                 if self.state.audio_recording.is_recording() {
                     let task = self.stop_audio_recording();
-                    self.state.status_text = "Audio clock drift filled the bounded input buffer — salvaging the valid part of this take…".into();
+                    self.state.status_text = if matches!(
+                        self.state.audio_recording.source,
+                        Some(AudioRecordingSource::TrackOutput(_))
+                    ) {
+                        "The bounded Resample buffer filled — salvaging the valid part of this take…"
+                            .into()
+                    } else {
+                        "Audio clock drift filled the bounded input buffer — salvaging the valid part of this take…"
+                            .into()
+                    };
                     return Some(task);
                 }
             }
@@ -384,7 +457,9 @@ impl App {
         }
         if let Some(error) = errors.into_iter().next() {
             self._input_stream = None;
-            if self.state.audio_recording.is_capturing() {
+            if self.state.audio_recording.is_capturing()
+                && self.state.audio_recording.source == Some(AudioRecordingSource::HardwareInput)
+            {
                 return Some(self.abort_audio_recording(&format!(
                     "Audio Input disconnected — {error}. No Clip was created."
                 )));
@@ -413,6 +488,14 @@ impl App {
         self.sync_audio_input_target();
         let target = self.active_audio_input_target();
         if target.is_none() {
+            self._input_stream = None;
+            return Ok(());
+        }
+        let route = self
+            .state
+            .find_track(target.expect("checked target"))
+            .map(|track| track.audio_input_route);
+        if route.is_some_and(|route| route.resample_source().is_some()) {
             self._input_stream = None;
             return Ok(());
         }
@@ -466,20 +549,31 @@ impl App {
             .tracks
             .iter()
             .find(|track| {
-                track.kind == TrackKind::Audio && track.input_monitoring == InputMonitoring::On
+                track.kind == TrackKind::Audio
+                    && track.audio_input_route.is_hardware()
+                    && track.input_monitoring == InputMonitoring::On
             })
             .map(|track| track.id)
     }
 
     fn sync_audio_input_target(&self) {
+        self.input_bridge.set_target(None, false);
+        self.input_bridge.set_resample_source(None);
         let Some(track_id) = self.active_audio_input_target() else {
-            self.input_bridge.set_target(None, false);
             return;
         };
         let Some(track) = self.state.find_track(track_id) else {
-            self.input_bridge.set_target(None, false);
             return;
         };
+        if let Some(source_id) = track.audio_input_route.resample_source() {
+            self.input_bridge.set_resample_source(
+                self.state
+                    .find_track(source_id)
+                    .is_some_and(ProjectTrack::is_playable_midi_target)
+                    .then_some(source_id),
+            );
+            return;
+        }
         let monitoring = match track.input_monitoring {
             InputMonitoring::Off => false,
             InputMonitoring::Auto => self.state.audio_recording.armed_track == Some(track_id),
@@ -489,8 +583,31 @@ impl App {
         self.input_bridge.set_target(Some(track_id), monitoring);
     }
 
-    fn input_route_is_available(&self, route: AudioInputRoute) -> bool {
-        route_fits_channels(route, self.state.audio_settings.input_channel_count())
+    fn input_route_is_available(&self, target_id: TrackId, route: AudioInputRoute) -> bool {
+        match route {
+            AudioInputRoute::Mono { .. } | AudioInputRoute::Stereo { .. } => {
+                route_fits_channels(route, self.state.audio_settings.input_channel_count())
+            }
+            AudioInputRoute::Resample { track_id } => {
+                track_id != target_id
+                    && self
+                        .state
+                        .find_track(track_id)
+                        .is_some_and(ProjectTrack::is_playable_midi_target)
+            }
+        }
+    }
+
+    fn recording_source_for_target(&self, target_id: TrackId) -> Option<AudioRecordingSource> {
+        let route = self.state.find_track(target_id)?.audio_input_route;
+        match route {
+            AudioInputRoute::Mono { .. } | AudioInputRoute::Stereo { .. } => self
+                .input_route_is_available(target_id, route)
+                .then_some(AudioRecordingSource::HardwareInput),
+            AudioInputRoute::Resample { track_id } => self
+                .input_route_is_available(target_id, route)
+                .then_some(AudioRecordingSource::TrackOutput(track_id)),
+        }
     }
 
     fn abort_audio_recording(&mut self, status: &str) -> Task<Message> {
@@ -518,6 +635,19 @@ fn route_fits_channels(route: AudioInputRoute, channels: u16) -> bool {
     match route {
         AudioInputRoute::Mono { channel } => channel < channels,
         AudioInputRoute::Stereo { left } => left.saturating_add(1) < channels,
+        AudioInputRoute::Resample { .. } => false,
+    }
+}
+
+fn track_recording_source_label(
+    route: Option<AudioInputRoute>,
+    state: &crate::state::AppState,
+) -> Option<String> {
+    match route? {
+        AudioInputRoute::Mono { .. } | AudioInputRoute::Stereo { .. } => Some("Audio Input".into()),
+        AudioInputRoute::Resample { track_id } => state
+            .find_track(track_id)
+            .map(|track| format!("Resample · {}", track.name)),
     }
 }
 
@@ -541,19 +671,36 @@ fn recording_target_accepts_finalizer(
     phase == AudioRecordingPhase::Finalizing && armed_track == Some(outcome_track) && target_exists
 }
 
-async fn finalize_audio_input_take(
+struct FinalizeAudioTake {
     track_id: TrackId,
     start_position_samples: u64,
     sample_rate: u32,
     frames: Vec<[f32; 2]>,
+    recording_source: AudioRecordingSource,
+    completion_label: String,
     truncated: bool,
     underrun_frames: u64,
-) -> Result<AudioRecordingOutcome, String> {
+}
+
+async fn finalize_audio_take(request: FinalizeAudioTake) -> Result<AudioRecordingOutcome, String> {
+    let FinalizeAudioTake {
+        track_id,
+        start_position_samples,
+        sample_rate,
+        frames,
+        recording_source,
+        completion_label,
+        truncated,
+        underrun_frames,
+    } = request;
     tokio::task::spawn_blocking(move || {
         if frames.is_empty() {
-            return Err("the take contained no Audio Input frames".into());
+            return Err("the take contained no recorded audio frames".into());
         }
-        let clip_name = format!("Recording {}", start_position_samples);
+        let clip_name = match recording_source {
+            AudioRecordingSource::HardwareInput => format!("Recording {start_position_samples}"),
+            AudioRecordingSource::TrackOutput(_) => format!("Resample {start_position_samples}"),
+        };
         let audio = Arc::new(DecodedAudio {
             channels: vec![
                 frames.iter().map(|frame| frame[0]).collect(),
@@ -570,9 +717,10 @@ async fn finalize_audio_input_take(
         .map_err(|error| format!("Project Media staging failed: {error}"))?;
         let mut warnings = Vec::new();
         if truncated {
-            warnings.push("input overflow truncated the take to its valid captured frames".into());
+            warnings
+                .push("capture overflow truncated the take to its valid captured frames".into());
         }
-        if underrun_frames > 0 {
+        if recording_source == AudioRecordingSource::HardwareInput && underrun_frames > 0 {
             warnings.push(format!(
                 "{underrun_frames} input frame(s) were unavailable and replaced with silence"
             ));
@@ -583,6 +731,7 @@ async fn finalize_audio_input_take(
             clip_name,
             audio,
             source,
+            completion_label,
             quality_warning: (!warnings.is_empty()).then(|| warnings.join("; ")),
         })
     })
@@ -597,14 +746,16 @@ mod tests {
 
     #[tokio::test]
     async fn completed_take_is_staged_before_it_can_become_project_content() {
-        let outcome = finalize_audio_input_take(
-            TrackId::new(),
-            9_600,
-            48_000,
-            vec![[0.25, -0.25]; 480],
-            false,
-            0,
-        )
+        let outcome = finalize_audio_take(FinalizeAudioTake {
+            track_id: TrackId::new(),
+            start_position_samples: 9_600,
+            sample_rate: 48_000,
+            frames: vec![[0.25, -0.25]; 480],
+            recording_source: AudioRecordingSource::HardwareInput,
+            completion_label: "Recorded Audio Input".into(),
+            truncated: false,
+            underrun_frames: 0,
+        })
         .await
         .unwrap();
 
@@ -662,13 +813,46 @@ mod tests {
 
     #[tokio::test]
     async fn drift_damage_is_preserved_as_an_explicit_salvage_warning() {
-        let outcome =
-            finalize_audio_input_take(TrackId::new(), 0, 48_000, vec![[0.1, -0.1]; 32], true, 7)
-                .await
-                .unwrap();
+        let outcome = finalize_audio_take(FinalizeAudioTake {
+            track_id: TrackId::new(),
+            start_position_samples: 0,
+            sample_rate: 48_000,
+            frames: vec![[0.1, -0.1]; 32],
+            recording_source: AudioRecordingSource::HardwareInput,
+            completion_label: "Recorded Audio Input".into(),
+            truncated: true,
+            underrun_frames: 7,
+        })
+        .await
+        .unwrap();
         let warning = outcome.quality_warning.unwrap();
         assert!(warning.contains("overflow truncated"));
         assert!(warning.contains("7 input frame(s)"));
+    }
+
+    #[tokio::test]
+    async fn resample_take_uses_recorded_audio_staging_without_hardware_drift_warnings() {
+        let outcome = finalize_audio_take(FinalizeAudioTake {
+            track_id: TrackId::new(),
+            start_position_samples: 24_000,
+            sample_rate: 48_000,
+            frames: vec![[0.3, -0.2]; 128],
+            recording_source: AudioRecordingSource::TrackOutput(TrackId::new()),
+            completion_label: "Resampled MIDI 2".into(),
+            truncated: false,
+            underrun_frames: 99,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.clip_name, "Resample 24000");
+        assert_eq!(outcome.completion_label, "Resampled MIDI 2");
+        assert_eq!(outcome.audio.num_frames(), 128);
+        assert!(outcome.quality_warning.is_none());
+        assert!(matches!(
+            outcome.source,
+            MediaSourceRef::StagedProjectMedia { .. }
+        ));
     }
 
     #[tokio::test]
@@ -676,10 +860,18 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let project_path = directory.path().join("recording-roundtrip.vzp");
         let track = vibez_core::track::TrackInfo::new("Vocal");
-        let outcome =
-            finalize_audio_input_take(track.id, 12_345, 48_000, vec![[0.4, -0.2]; 960], false, 0)
-                .await
-                .unwrap();
+        let outcome = finalize_audio_take(FinalizeAudioTake {
+            track_id: track.id,
+            start_position_samples: 12_345,
+            sample_rate: 48_000,
+            frames: vec![[0.4, -0.2]; 960],
+            recording_source: AudioRecordingSource::HardwareInput,
+            completion_label: "Recorded Audio Input".into(),
+            truncated: false,
+            underrun_frames: 0,
+        })
+        .await
+        .unwrap();
         let project = vibez_project::Project {
             tracks: vec![track.clone()],
             arrange: vibez_project::TimelineInfo {

--- a/crates/vibez-ui/src/app/audio_recording.rs
+++ b/crates/vibez-ui/src/app/audio_recording.rs
@@ -219,6 +219,10 @@ impl App {
             self.discard_audio_recording_transaction();
             return Task::none();
         }
+        // A take is allowed to extend Arrange beyond the last existing Clip.
+        // This must precede Play in the ordered engine queue so the first
+        // output callback cannot immediately auto-stop at the old content end.
+        self.send_command(EngineCommand::SetArrangementRecording(true));
         self.input_bridge.begin_recording();
         self.sync_audio_input_target();
         let track_name = self
@@ -428,8 +432,15 @@ impl App {
         self.state.audio_recording.input_peak_l = peak_l;
         self.state.audio_recording.input_peak_r = peak_r;
         if self.state.audio_recording.is_capturing() {
+            let previous_len = self.state.audio_recording.captured_frames.len();
             self.input_bridge
                 .drain_recorded(&mut self.state.audio_recording.captured_frames);
+            self.state
+                .audio_recording
+                .captured_frames_appended(previous_len);
+            if let Some(position) = self.input_bridge.record_start_position() {
+                self.state.audio_recording.start_position_samples = position;
+            }
             if self.input_bridge.overflowed() {
                 self.state.audio_recording.mark_truncated();
                 if self.state.audio_recording.is_recording() {

--- a/crates/vibez-ui/src/app/capture.rs
+++ b/crates/vibez-ui/src/app/capture.rs
@@ -539,6 +539,7 @@ mod tests {
     use vibez_core::id::{ClipId, TrackId};
     use vibez_core::midi::{InstrumentKind, MidiNote};
     use vibez_core::perform::GrooveGrid;
+    use vibez_engine::engine::AudioProcessBlock;
 
     struct NoteLogInstrument(Arc<Mutex<Vec<u8>>>);
 
@@ -835,7 +836,7 @@ mod tests {
                 instrument: Box::new(NoteLogInstrument(Arc::clone(&heard))),
             })
             .unwrap();
-        audio_engine.process(&mut [0.0; 2], 2);
+        audio_engine.process_block(AudioProcessBlock::new(&mut [0.0; 2], 2));
 
         let note_clip = |pitch, note_count| UiNoteClip {
             id: ClipId::new(),
@@ -877,13 +878,13 @@ mod tests {
         apply_capture_to_arrangement(&mut timeline, captured, &mut commands);
         assert_eq!(commands.pending_len(), 2);
 
-        audio_engine.process(&mut [0.0; 2], 2);
+        audio_engine.process_block(AudioProcessBlock::new(&mut [0.0; 2], 2));
         commands.flush();
         assert_eq!(commands.pending_len(), 0);
-        audio_engine.process(&mut [0.0; 2], 2);
+        audio_engine.process_block(AudioProcessBlock::new(&mut [0.0; 2], 2));
         commands.send(EngineCommand::Seek(0));
         commands.send(EngineCommand::Play);
-        audio_engine.process(&mut [0.0; 512], 2);
+        audio_engine.process_block(AudioProcessBlock::new(&mut [0.0; 512], 2));
 
         assert!(
             heard.lock().unwrap().contains(&72),

--- a/crates/vibez-ui/src/app/project_format_v1_tests.rs
+++ b/crates/vibez-ui/src/app/project_format_v1_tests.rs
@@ -6,6 +6,7 @@ use vibez_core::id::ClipId;
 use vibez_core::midi::{InstrumentKind, TrackKind};
 use vibez_core::track::{InstrumentStateInfo, TrackInfo};
 use vibez_engine::commands::{AuditionSync, EngineCommand};
+use vibez_engine::engine::AudioProcessBlock;
 
 fn one_second_audio() -> Arc<DecodedAudio> {
     Arc::new(DecodedAudio {
@@ -30,7 +31,7 @@ fn assert_audible(audio: Arc<DecodedAudio>, label: &str) {
         })
         .unwrap();
     let mut output = vec![0.0_f32; 8_192];
-    engine.process(&mut output, 2);
+    engine.process_block(AudioProcessBlock::new(&mut output, 2));
     assert!(
         output.iter().any(|sample| sample.abs() > 1.0e-5),
         "{label} produced no Audition output"

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -61,6 +61,7 @@ impl App {
         self.stop_browser_audition();
         self.input_bridge.end_recording();
         self.input_bridge.set_target(None, false);
+        self.input_bridge.set_resample_source(None);
         self._input_stream = None;
         self.state.audio_recording = Default::default();
         self.state.transport.playing = false;

--- a/crates/vibez-ui/src/app/views_arrangement.rs
+++ b/crates/vibez-ui/src/app/views_arrangement.rs
@@ -277,6 +277,7 @@ impl App {
                         self.state.audio_recording.input_peak_l,
                         self.state.audio_recording.input_peak_r,
                     )),
+                    source_tracks: &self.state.project_tracks.tracks,
                 },
             );
 

--- a/crates/vibez-ui/src/app/views_arrangement.rs
+++ b/crates/vibez-ui/src/app/views_arrangement.rs
@@ -20,7 +20,7 @@ use crate::state::{ArrangementSelection, ContextMenuTarget, TrackTimelineContent
 use crate::theme as th;
 use crate::timeline_geometry::TimelineGeometry;
 use crate::widgets::timeline::{
-    build_row_spans, ArrangementMinimap, MinimapTrack, RulerWidget, TrackClipCanvas,
+    build_row_spans, ArrangementMinimap, MinimapTrack, RulerWidget, TimelineClip, TrackClipCanvas,
     TRACK_ROW_HEIGHT,
 };
 use crate::widgets::track_header::{
@@ -282,7 +282,7 @@ impl App {
             );
 
             // Clip canvas for this track
-            let clip_canvas_widget = TrackClipCanvas::from_track(
+            let mut clip_canvas_widget = TrackClipCanvas::from_track(
                 track,
                 content,
                 playhead_beats,
@@ -318,6 +318,32 @@ impl App {
                 row_spans.clone(),
                 timeline.marquee.as_ref().map(|marquee| marquee.rect),
             );
+            if let Some(preview) = self.state.audio_recording.preview_for_track(track.id) {
+                let name = match preview.source {
+                    crate::domains::audio_recording::AudioRecordingSource::HardwareInput => {
+                        "● RECORDING INPUT".into()
+                    }
+                    crate::domains::audio_recording::AudioRecordingSource::TrackOutput(source) => {
+                        let source_name = self
+                            .state
+                            .find_track(source)
+                            .map_or("MIDI TRACK", |track| track.name.as_str());
+                        format!("● RESAMPLING {source_name}")
+                    }
+                };
+                clip_canvas_widget =
+                    clip_canvas_widget.with_audio_recording_preview(TimelineClip {
+                        clip_id: preview.clip_id,
+                        position: preview.position,
+                        duration: preview.duration,
+                        name,
+                        peaks: preview.peaks,
+                        loop_enabled: false,
+                        loop_start: 0,
+                        loop_end: 0,
+                        warp_stale: false,
+                    });
+            }
             let track_id = track.id;
             let compatible = !track.kind.is_midi();
             let grid = self.state.view.grid_config();

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::TrackKind;
+use vibez_core::track::{AudioInputRoute, InputMonitoring};
 use vibez_engine::commands::EngineCommand;
 
 use super::timeline_editor::TimelineEditorAdapter;
@@ -116,6 +117,12 @@ impl ArrangementState {
             .unwrap_or_else(|| format!("{track_id}"));
         engine.send(EngineCommand::RemoveTrack(track_id));
         project_tracks.tracks.retain(|track| track.id != track_id);
+        for track in &mut project_tracks.tracks {
+            if track.audio_input_route.resample_source() == Some(track_id) {
+                track.audio_input_route = AudioInputRoute::default();
+                track.input_monitoring = InputMonitoring::Off;
+            }
+        }
         Arc::make_mut(&mut self.timeline).remove(track_id);
         if self.selected_track == Some(track_id) {
             self.selected_track = project_tracks.tracks.first().map(|track| track.id);

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -6,6 +6,7 @@ use crate::domains::test_support::RecordingEngine;
 use crate::state::UiClip;
 use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
 use vibez_core::midi::MidiNote;
+use vibez_core::track::AudioInputRoute;
 
 #[test]
 fn add_track_selects_it_and_names_uniquely() {
@@ -82,6 +83,30 @@ fn immediate_track_removal_reuses_the_confirmed_deletion_operation() {
     assert_eq!(action.close_track_guis, Some(victim));
     assert_eq!(action.remove_track_from_sections, Some(victim));
     assert!(ArrangementMsg::RemoveTrack(victim).marks_dirty());
+}
+
+#[test]
+fn removing_a_resample_source_resets_dependent_audio_track_routes() {
+    let mut a = arrangement_with_tracks(2);
+    let source = a.tracks[0].id;
+    let target = a.tracks[1].id;
+    a.tracks[1].audio_input_route = AudioInputRoute::Resample { track_id: source };
+    let mut engine = RecordingEngine::default();
+
+    a.update(
+        ArrangementMsg::RemoveTrack(source),
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    assert_eq!(
+        a.tracks
+            .iter()
+            .find(|track| track.id == target)
+            .unwrap()
+            .audio_input_route,
+        AudioInputRoute::default(),
+    );
 }
 
 #[test]

--- a/crates/vibez-ui/src/domains/audio_recording.rs
+++ b/crates/vibez-ui/src/domains/audio_recording.rs
@@ -1,9 +1,12 @@
-//! Runtime lifecycle for one Arrange hardware-input recording target.
+//! Runtime lifecycle and live preview for one Arrange Audio Track take.
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
-use vibez_core::id::TrackId;
+use vibez_core::id::{ClipId, TrackId};
 
 pub const STOP_ACK_TIMEOUT: Duration = Duration::from_secs(2);
+const LIVE_WAVEFORM_FRAMES_PER_PEAK: usize = 64;
+const LIVE_WAVEFORM_MAX_PEAKS: usize = 4_096;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum AudioRecordingPhase {
@@ -20,6 +23,70 @@ pub enum AudioRecordingSource {
     TrackOutput(TrackId),
 }
 
+#[derive(Debug)]
+struct LiveWaveformPreview {
+    peaks: Arc<Vec<(f32, f32)>>,
+    pending_min: f32,
+    pending_max: f32,
+    pending_frames: usize,
+    frames_per_peak: usize,
+}
+
+impl Default for LiveWaveformPreview {
+    fn default() -> Self {
+        Self {
+            peaks: Arc::new(Vec::new()),
+            pending_min: 0.0,
+            pending_max: 0.0,
+            pending_frames: 0,
+            frames_per_peak: LIVE_WAVEFORM_FRAMES_PER_PEAK,
+        }
+    }
+}
+
+impl LiveWaveformPreview {
+    fn clear(&mut self) {
+        self.peaks = Arc::new(Vec::new());
+        self.pending_min = 0.0;
+        self.pending_max = 0.0;
+        self.pending_frames = 0;
+        self.frames_per_peak = LIVE_WAVEFORM_FRAMES_PER_PEAK;
+    }
+
+    fn extend(&mut self, frames: &[[f32; 2]]) {
+        let peaks = Arc::make_mut(&mut self.peaks);
+        for frame in frames {
+            self.pending_min = self.pending_min.min(frame[0]).min(frame[1]);
+            self.pending_max = self.pending_max.max(frame[0]).max(frame[1]);
+            self.pending_frames += 1;
+            if self.pending_frames == self.frames_per_peak {
+                peaks.push((self.pending_min, self.pending_max));
+                self.pending_min = 0.0;
+                self.pending_max = 0.0;
+                self.pending_frames = 0;
+                if peaks.len() >= LIVE_WAVEFORM_MAX_PEAKS {
+                    for index in 0..peaks.len() / 2 {
+                        let left = peaks[index * 2];
+                        let right = peaks[index * 2 + 1];
+                        peaks[index] = (left.0.min(right.0), left.1.max(right.1));
+                    }
+                    peaks.truncate(peaks.len() / 2);
+                    self.frames_per_peak = self.frames_per_peak.saturating_mul(2);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioRecordingPreview {
+    pub clip_id: ClipId,
+    pub position: u64,
+    pub duration: u64,
+    pub peaks: Arc<Vec<(f32, f32)>>,
+    pub source: AudioRecordingSource,
+}
+
 #[derive(Debug, Default)]
 pub struct AudioRecordingState {
     pub armed_track: Option<TrackId>,
@@ -28,6 +95,8 @@ pub struct AudioRecordingState {
     pub source: Option<AudioRecordingSource>,
     pub start_position_samples: u64,
     pub captured_frames: Vec<[f32; 2]>,
+    preview_clip_id: Option<ClipId>,
+    live_waveform: LiveWaveformPreview,
     pub input_peak_l: f32,
     pub input_peak_r: f32,
     pub truncated: bool,
@@ -64,10 +133,34 @@ impl AudioRecordingState {
         self.captured_frames.clear();
         self.start_position_samples = position_samples;
         self.source = Some(source);
+        self.preview_clip_id = Some(ClipId::new());
+        self.live_waveform.clear();
         self.truncated = false;
         self.stop_requested_at = None;
         self.phase = AudioRecordingPhase::Recording;
         true
+    }
+
+    pub fn captured_frames_appended(&mut self, previous_len: usize) {
+        let first_new = previous_len.min(self.captured_frames.len());
+        self.live_waveform
+            .extend(&self.captured_frames[first_new..]);
+    }
+
+    pub fn preview_for_track(&self, track_id: TrackId) -> Option<AudioRecordingPreview> {
+        if !self.is_capturing()
+            || self.armed_track != Some(track_id)
+            || self.captured_frames.is_empty()
+        {
+            return None;
+        }
+        Some(AudioRecordingPreview {
+            clip_id: self.preview_clip_id?,
+            position: self.start_position_samples,
+            duration: self.captured_frames.len() as u64,
+            peaks: Arc::clone(&self.live_waveform.peaks),
+            source: self.source?,
+        })
     }
 
     pub fn request_stop(&mut self) -> bool {
@@ -105,6 +198,8 @@ impl AudioRecordingState {
     pub fn finish(&mut self) {
         self.phase = AudioRecordingPhase::Idle;
         self.source = None;
+        self.preview_clip_id = None;
+        self.live_waveform.clear();
         self.stop_requested_at = None;
     }
 }
@@ -136,5 +231,41 @@ mod tests {
         assert!(state.request_stop());
         state.stop_requested_at = Some(Instant::now() - STOP_ACK_TIMEOUT);
         assert!(state.stop_ack_timed_out(Instant::now()));
+    }
+
+    #[test]
+    fn captured_frames_build_a_live_waveform_preview_across_ui_drains() {
+        let track = TrackId::new();
+        let mut state = AudioRecordingState::default();
+        state.arm(track);
+        assert!(state.begin(9_600, AudioRecordingSource::HardwareInput));
+
+        state.captured_frames.extend([[0.25, -0.5]; 40]);
+        state.captured_frames_appended(0);
+        state.captured_frames.extend([[0.75, -0.2]; 40]);
+        state.captured_frames_appended(40);
+
+        let preview = state.preview_for_track(track).unwrap();
+        assert_eq!(preview.position, 9_600);
+        assert_eq!(preview.duration, 80);
+        assert_eq!(preview.peaks.as_slice(), &[(-0.5, 0.75)]);
+        assert!(state.preview_for_track(TrackId::new()).is_none());
+    }
+
+    #[test]
+    fn long_live_waveforms_compact_without_losing_extrema() {
+        let track = TrackId::new();
+        let mut state = AudioRecordingState::default();
+        state.arm(track);
+        assert!(state.begin(0, AudioRecordingSource::HardwareInput));
+        state.captured_frames.resize(
+            LIVE_WAVEFORM_MAX_PEAKS * LIVE_WAVEFORM_FRAMES_PER_PEAK,
+            [0.9, -0.7],
+        );
+        state.captured_frames_appended(0);
+
+        let preview = state.preview_for_track(track).unwrap();
+        assert_eq!(preview.peaks.len(), LIVE_WAVEFORM_MAX_PEAKS / 2);
+        assert!(preview.peaks.iter().all(|peak| *peak == (-0.7, 0.9)));
     }
 }

--- a/crates/vibez-ui/src/domains/audio_recording.rs
+++ b/crates/vibez-ui/src/domains/audio_recording.rs
@@ -14,11 +14,18 @@ pub enum AudioRecordingPhase {
     Finalizing,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioRecordingSource {
+    HardwareInput,
+    TrackOutput(TrackId),
+}
+
 #[derive(Debug, Default)]
 pub struct AudioRecordingState {
     pub armed_track: Option<TrackId>,
     pub monitor_track: Option<TrackId>,
     pub phase: AudioRecordingPhase,
+    pub source: Option<AudioRecordingSource>,
     pub start_position_samples: u64,
     pub captured_frames: Vec<[f32; 2]>,
     pub input_peak_l: f32,
@@ -50,12 +57,13 @@ impl AudioRecordingState {
         }
     }
 
-    pub fn begin(&mut self, position_samples: u64) -> bool {
+    pub fn begin(&mut self, position_samples: u64, source: AudioRecordingSource) -> bool {
         if self.armed_track.is_none() || self.phase != AudioRecordingPhase::Idle {
             return false;
         }
         self.captured_frames.clear();
         self.start_position_samples = position_samples;
+        self.source = Some(source);
         self.truncated = false;
         self.stop_requested_at = None;
         self.phase = AudioRecordingPhase::Recording;
@@ -96,6 +104,7 @@ impl AudioRecordingState {
 
     pub fn finish(&mut self) {
         self.phase = AudioRecordingPhase::Idle;
+        self.source = None;
         self.stop_requested_at = None;
     }
 }
@@ -109,7 +118,7 @@ mod tests {
         let track = TrackId::new();
         let mut state = AudioRecordingState::default();
         state.arm(track);
-        assert!(state.begin(4_800));
+        assert!(state.begin(4_800, AudioRecordingSource::HardwareInput));
         state.captured_frames.push([0.2, -0.2]);
         assert!(state.request_stop());
         let (target, start, take) = state.begin_finalizing().unwrap();
@@ -123,7 +132,7 @@ mod tests {
     fn a_missing_output_callback_cannot_leave_stop_pending_forever() {
         let mut state = AudioRecordingState::default();
         state.arm(TrackId::new());
-        assert!(state.begin(0));
+        assert!(state.begin(0, AudioRecordingSource::TrackOutput(TrackId::new())));
         assert!(state.request_stop());
         state.stop_requested_at = Some(Instant::now() - STOP_ACK_TIMEOUT);
         assert!(state.stop_ack_timed_out(Instant::now()));

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -161,6 +161,7 @@ pub struct AudioRecordingOutcome {
     pub clip_name: String,
     pub audio: Arc<DecodedAudio>,
     pub source: MediaSourceRef,
+    pub completion_label: String,
     pub quality_warning: Option<String>,
 }
 

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -93,6 +93,9 @@ pub struct TrackClipCanvas {
     /// Transient Section Record visualization. It is deliberately excluded
     /// from hit testing and edit messages.
     pub recording_preview: Option<TimelineNoteClip>,
+    /// Transient Audio Track Recording waveform. Like Section Record, it is
+    /// display-only until Stop commits one canonical Clip.
+    pub audio_recording_preview: Option<TimelineClip>,
     /// Primary edit cursor (or Arrange's shared transport/edit cursor).
     pub playhead_beats: f64,
     /// Section playback truth, rendered independently from the edit cursor.
@@ -230,6 +233,7 @@ impl TrackClipCanvas {
             clips,
             note_clips,
             recording_preview: None,
+            audio_recording_preview: None,
             playhead_beats,
             playback_playhead_beats: None,
             zoom_level,
@@ -270,6 +274,11 @@ impl TrackClipCanvas {
 
     pub fn with_recording_preview(mut self, preview: TimelineNoteClip) -> Self {
         self.recording_preview = Some(preview);
+        self
+    }
+
+    pub fn with_audio_recording_preview(mut self, preview: TimelineClip) -> Self {
+        self.audio_recording_preview = Some(preview);
         self
     }
 

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -127,11 +127,27 @@ impl TrackClipCanvas {
         // Draw audio clips
         if self.bpm > 0.0 {
             let spb = self.sample_rate as f64 * 60.0 / self.bpm;
-            let clip_color = theme::with_alpha(self.track_color, 0.5);
-            let clip_border_color = theme::darken(self.track_color, 0.7);
-            let waveform_color = theme::with_alpha(self.track_color, 0.6);
-
-            for clip in &self.clips {
+            for (clip, is_recording_preview) in self
+                .clips
+                .iter()
+                .map(|clip| (clip, false))
+                .chain(self.audio_recording_preview.iter().map(|clip| (clip, true)))
+            {
+                let clip_color = if is_recording_preview {
+                    theme::with_alpha(theme::danger(), 0.28)
+                } else {
+                    theme::with_alpha(self.track_color, 0.5)
+                };
+                let clip_border_color = if is_recording_preview {
+                    theme::danger()
+                } else {
+                    theme::darken(self.track_color, 0.7)
+                };
+                let waveform_color = if is_recording_preview {
+                    theme::with_alpha(theme::danger(), 0.92)
+                } else {
+                    theme::with_alpha(self.track_color, 0.6)
+                };
                 let clip_start_beat = clip.position as f64 / spb;
                 let clip_dur_beats = clip.duration as f64 / spb;
 
@@ -213,7 +229,8 @@ impl TrackClipCanvas {
                 }
 
                 // Selection highlight
-                let is_selected = self.selected_clips.contains(&clip.clip_id);
+                let is_selected =
+                    !is_recording_preview && self.selected_clips.contains(&clip.clip_id);
                 let border_color = if is_selected {
                     theme::accent()
                 } else {

--- a/crates/vibez-ui/src/widgets/timeline/clips_tests.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_tests.rs
@@ -345,3 +345,25 @@ fn recording_preview_is_visible_but_not_hit_testable() {
     );
     assert!(canvas.hit_test(10.0).is_none());
 }
+
+#[test]
+fn audio_recording_waveform_is_visible_but_not_hit_testable() {
+    let preview_id = ClipId::new();
+    let canvas = empty_track_canvas().with_audio_recording_preview(TimelineClip {
+        clip_id: preview_id,
+        position: 0,
+        duration: 44_100,
+        name: "● RECORDING INPUT".into(),
+        peaks: Arc::new(vec![(-0.8, 0.6); 32]),
+        loop_enabled: false,
+        loop_start: 0,
+        loop_end: 0,
+        warp_stale: false,
+    });
+
+    assert_eq!(
+        canvas.audio_recording_preview.as_ref().unwrap().clip_id,
+        preview_id
+    );
+    assert!(canvas.hit_test(10.0).is_none());
+}

--- a/crates/vibez-ui/src/widgets/track_header.rs
+++ b/crates/vibez-ui/src/widgets/track_header.rs
@@ -24,11 +24,24 @@ pub const TRACK_HEADER_WIDTH: f32 = 220.0;
 /// Total width including the 3px color bar on the left edge.
 pub const TRACK_HEADER_TOTAL_WIDTH: f32 = TRACK_HEADER_WIDTH + 3.0;
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct TrackHeaderRecordingView {
+#[derive(Debug, Clone, Copy)]
+pub struct TrackHeaderRecordingView<'a> {
     pub input_channels: u16,
     pub armed: bool,
     pub input_peaks: Option<(f32, f32)>,
+    pub source_tracks: &'a [ProjectTrack],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AudioInputChoice {
+    route: AudioInputRoute,
+    label: String,
+}
+
+impl std::fmt::Display for AudioInputChoice {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.label)
+    }
 }
 
 fn compact_input_pick_list<'a, T>(
@@ -128,12 +141,13 @@ pub fn view_track_header<'a>(
     editing_name: bool,
     edit_text: &'a str,
     automation_open: bool,
-    recording: TrackHeaderRecordingView,
+    recording: TrackHeaderRecordingView<'a>,
 ) -> Element<'a, Message> {
     let TrackHeaderRecordingView {
         input_channels: audio_input_channels,
         armed,
         input_peaks,
+        source_tracks,
     } = recording;
     let track_color = th::track_color(track.color_index);
 
@@ -321,34 +335,72 @@ pub fn view_track_header<'a>(
             });
         let mut routes = Vec::new();
         for channel in 0..audio_input_channels {
-            routes.push(AudioInputRoute::Mono { channel });
+            let route = AudioInputRoute::Mono { channel };
+            routes.push(AudioInputChoice {
+                route,
+                label: route.to_string(),
+            });
         }
         for left in (0..audio_input_channels.saturating_sub(1)).step_by(2) {
-            routes.push(AudioInputRoute::Stereo { left });
+            let route = AudioInputRoute::Stereo { left };
+            routes.push(AudioInputChoice {
+                route,
+                label: route.to_string(),
+            });
         }
+        routes.extend(
+            source_tracks
+                .iter()
+                .filter(|source| source.id != track.id && source.is_playable_midi_target())
+                .map(|source| AudioInputChoice {
+                    route: AudioInputRoute::Resample {
+                        track_id: source.id,
+                    },
+                    label: format!("RS · {}", source.name),
+                }),
+        );
+        let selected_route = routes
+            .iter()
+            .find(|choice| choice.route == track.audio_input_route)
+            .cloned()
+            .unwrap_or_else(|| AudioInputChoice {
+                route: track.audio_input_route,
+                label: match track.audio_input_route {
+                    AudioInputRoute::Resample { .. } => "RS · Missing Track".into(),
+                    route => route.to_string(),
+                },
+            });
         if routes.is_empty() {
-            routes.push(track.audio_input_route);
+            routes.push(selected_route.clone());
         }
+        let is_resample = track.audio_input_route.resample_source().is_some();
         let track_id = track.id;
         let route = compact_input_pick_list(
             routes,
-            track.audio_input_route,
-            move |value| Message::SetAudioTrackInputRoute(track_id, value),
-            58.0,
-            false,
+            selected_route,
+            move |choice| Message::SetAudioTrackInputRoute(track_id, choice.route),
+            if is_resample { 119.0 } else { 78.0 },
+            is_resample,
         );
-        let track_id = track.id;
-        let monitor = compact_input_pick_list(
-            InputMonitoring::ALL,
-            track.input_monitoring,
-            move |value| Message::SetAudioTrackMonitoring(track_id, value),
-            52.0,
-            track.input_monitoring != InputMonitoring::Off,
-        );
-        row![mute_btn, solo_btn, arm_btn, route, monitor]
-            .spacing(3)
-            .align_y(iced::Alignment::Center)
-            .into()
+        if is_resample {
+            row![mute_btn, solo_btn, arm_btn, route]
+                .spacing(3)
+                .align_y(iced::Alignment::Center)
+                .into()
+        } else {
+            let track_id = track.id;
+            let monitor = compact_input_pick_list(
+                InputMonitoring::ALL,
+                track.input_monitoring,
+                move |value| Message::SetAudioTrackMonitoring(track_id, value),
+                42.0,
+                track.input_monitoring != InputMonitoring::Off,
+            );
+            row![mute_btn, solo_btn, arm_btn, route, monitor]
+                .spacing(3)
+                .align_y(iced::Alignment::Center)
+                .into()
+        }
     } else {
         row![mute_btn, solo_btn].spacing(4).into()
     };

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -467,6 +467,38 @@ temporary-file/read-back copy, but very long takes still scale linearly in
 memory. Streaming long-form capture into a recoverable project-owned staging
 file is a future durability optimisation.
 
+Live **Resample** reuses that recording lifecycle without opening hardware
+Audio Input. An Audio Track may persistently choose one playable MIDI/
+instrument Project Track as its input. The output callback gives the engine a
+preallocated scratch slice, and the ordinary channel renderer copies only the
+selected source Track's direct output into it after the instrument, insert
+effects, mute envelope, automated/manual gain, and pan have run. The callback
+then feeds those stereo frames into the same bounded recording bridge used by
+hardware capture.
+
+```mermaid
+flowchart LR
+    MIDI["MIDI/instrument Track source"] --> DEV["instrument + inserts"]
+    DEV --> CH["mute + gain/pan"]
+    CH --> TAP["bounded Resample tap"]
+    TAP --> REC["shared recording finalizer<br/>+ Project Media"]
+    CH --> MIX["project mix"]
+    CH --> SEND["post-fader sends"]
+    SEND --> RET["returns"]
+    MIX --> MASTER["master"]
+    RET --> MASTER
+    AUD["Browser Audition"] -->|"post-master, excluded"| OUT["device output"]
+    MASTER --> OUT
+```
+
+The Track-output tap is deliberately pre-send and pre-master: it records the
+source Project Track's audible direct output, but not return buses, master
+processing, other Tracks, or the dedicated Browser Audition Bus. Source mute
+and solo audibility therefore become silence in the take. The source remains
+audible through the normal project mix while recording; Resample never injects
+it into the target Audio Track and cannot create a feedback edge. This is live
+Resample, distinct from the existing offline Bounce renderer.
+
 `EngineTrack` is the shared project channel strip: it owns the instrument,
 effects, sends, gain/pan, mute/solo, meters, and preallocated render scratch.
 Time-based content is a separate `PreparedPlaybackSource` behind an owned


### PR DESCRIPTION
## Summary

- add a persisted Resample input route to Audio Tracks, sourced from eligible MIDI/instrument Project Tracks
- capture the source post-instrument, post-inserts, post-mute and post-fader/pan, while excluding sends, returns, master processing, other Tracks and Browser Audition
- reuse the hardware-recording output-clock lifecycle, bounded bridge, Project Media staging, Clip insertion and one-step Undo without opening a hardware input stream
- add compact `RS · Track` routing UI, invalid/source-removal recovery, documentation and regression coverage

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

## Native QA

Created an Audio Track and instrument MIDI Track, selected `RS · MIDI 2`, armed with the recording glyph, recorded a non-silent take, stopped with Space, confirmed playback, undid/redid the take, saved, restarted Vibez and reopened with both the route and project-owned audio intact. A second take completed with `Resampled MIDI 2 · 1.11 s · one undo step`.

## Scope

Live Arrange resampling only. Audio Track/bus/master/Browser Audition/Perform sources, multi-source recording and offline Bounce/Freeze remain out of scope.