### PR TITLE
fix: start Vibez maximized

### DIFF
--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -478,6 +478,12 @@ impl App {
             .filter(|p| p.is_file())
             .map(|p| Task::done(Message::ProjectOpenPathSelected(Some(p))))
             .unwrap_or_else(Task::none);
+        // `window::Settings` has no maximized field in iced 0.13. The
+        // initial task runs after the first window exists, so ask the window
+        // manager to maximize that concrete window instead of merely opening
+        // at a large hard-coded size.
+        let maximize_window_task =
+            iced::window::get_latest().and_then(|id| iced::window::maximize(id, true));
 
         (
             app,
@@ -487,6 +493,7 @@ impl App {
                 plugin_catalog_startup_task,
                 update_check_task,
                 open_task,
+                maximize_window_task,
             ]),
         )
     }


### PR DESCRIPTION
## Outcome

Vibez now asks the window manager to maximize the concrete main window during startup instead of only opening at a fixed 1400×900 size.

## Root cause

iced 0.13's `window::Settings` has an initial size but no maximized field. Vibez configured `.window_size((1400.0, 900.0))` and never sent the runtime maximize action, so larger desktops always opened with unused space.

## Verification

- Native before: 1400×900 window with no maximized flags on a 1920×1040 work area.
- Native after: 1920×1008 at `(0, 64)` with `_NET_WM_STATE_MAXIMIZED_HORZ` and `_NET_WM_STATE_MAXIMIZED_VERT`.
- Manual restore/resize remains owned by the window manager.
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

The window-manager acknowledgement is the correct regression seam; iced startup tasks are opaque, so a duplicated boolean unit test would not prove native maximization.
