### PR TITLE
fix: keep Section record controls legible

### DIFF
--- a/crates/vibez-ui/src/app/views_perform_record.rs
+++ b/crates/vibez-ui/src/app/views_perform_record.rs
@@ -14,6 +14,9 @@ use crate::typography::{PERFORM_LABEL, PERFORM_TECH, PERFORM_TECH_STRONG};
 
 use super::*;
 
+const SECTION_RECORD_INLINE_MIN_WIDTH: f32 = 1_120.0;
+const SECTION_RECORD_STATUS_BELOW_MIN_WIDTH: f32 = 680.0;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SectionRecordBarLayout {
     Inline,
@@ -22,9 +25,9 @@ enum SectionRecordBarLayout {
 }
 
 fn section_record_bar_layout(workspace_width: f32) -> SectionRecordBarLayout {
-    if workspace_width >= 1_120.0 {
+    if workspace_width >= SECTION_RECORD_INLINE_MIN_WIDTH {
         SectionRecordBarLayout::Inline
-    } else if workspace_width >= 680.0 {
+    } else if workspace_width >= SECTION_RECORD_STATUS_BELOW_MIN_WIDTH {
         SectionRecordBarLayout::StatusBelow
     } else {
         SectionRecordBarLayout::StackedControls
@@ -202,52 +205,39 @@ impl App {
             }
         };
         let layout = section_record_bar_layout(self.perform_workspace_width());
-        let (content, height): (Element<'_, Message>, f32) = match layout {
-            SectionRecordBarLayout::Inline => (
-                row![
-                    record_button,
-                    count_in,
-                    mode,
-                    quantization,
-                    capture_button,
-                    container(horizontal_space()).width(Length::Fill),
-                    status(false),
-                ]
-                .spacing(7)
-                .align_y(iced::Alignment::Center)
-                .into(),
-                42.0,
-            ),
-            SectionRecordBarLayout::StatusBelow => (
-                column![
-                    row![record_button, count_in, mode, quantization, capture_button]
-                        .spacing(7)
-                        .align_y(iced::Alignment::Center),
-                    status(false),
-                ]
-                .spacing(6)
-                .into(),
-                64.0,
-            ),
-            SectionRecordBarLayout::StackedControls => (
-                column![
-                    row![record_button, count_in, mode]
-                        .spacing(7)
-                        .align_y(iced::Alignment::Center),
-                    row![quantization, capture_button]
-                        .spacing(7)
-                        .align_y(iced::Alignment::Center),
-                    status(true),
-                ]
-                .spacing(6)
-                .into(),
-                104.0,
-            ),
+        let content: Element<'_, Message> = match layout {
+            SectionRecordBarLayout::Inline | SectionRecordBarLayout::StatusBelow => {
+                let controls = row![record_button, count_in, mode, quantization, capture_button]
+                    .spacing(7)
+                    .align_y(iced::Alignment::Center);
+                if layout == SectionRecordBarLayout::Inline {
+                    row![
+                        controls,
+                        container(horizontal_space()).width(Length::Fill),
+                        status(false),
+                    ]
+                    .align_y(iced::Alignment::Center)
+                    .into()
+                } else {
+                    column![controls, status(false)].spacing(6).into()
+                }
+            }
+            SectionRecordBarLayout::StackedControls => column![
+                row![record_button, count_in, mode]
+                    .spacing(7)
+                    .align_y(iced::Alignment::Center),
+                row![quantization, capture_button]
+                    .spacing(7)
+                    .align_y(iced::Alignment::Center),
+                status(true),
+            ]
+            .spacing(6)
+            .into(),
         };
 
         container(content)
             .width(Length::Fill)
-            .height(Length::Fixed(height))
+            .height(Length::Shrink)
             .padding([5, 12])
             .style(|_theme: &Theme| container::Style {
                 background: Some(th::bg_surface().into()),
@@ -415,7 +405,8 @@ fn record_pick_list<'a, T: Copy + Eq + std::fmt::Display + 'static>(
 mod tests {
     use super::{
         capture_destination_label, count_in_beats_remaining, section_record_bar_layout,
-        SectionRecordBarLayout,
+        SectionRecordBarLayout, SECTION_RECORD_INLINE_MIN_WIDTH,
+        SECTION_RECORD_STATUS_BELOW_MIN_WIDTH,
     };
     use crate::domains::perform::CapturePhase;
 
@@ -451,15 +442,19 @@ mod tests {
     #[test]
     fn record_bar_adapts_before_controls_or_status_can_be_squashed() {
         assert_eq!(
-            section_record_bar_layout(1400.0),
+            section_record_bar_layout(SECTION_RECORD_INLINE_MIN_WIDTH),
             SectionRecordBarLayout::Inline
         );
         assert_eq!(
-            section_record_bar_layout(970.0),
+            section_record_bar_layout(SECTION_RECORD_INLINE_MIN_WIDTH - 1.0),
             SectionRecordBarLayout::StatusBelow
         );
         assert_eq!(
-            section_record_bar_layout(480.0),
+            section_record_bar_layout(SECTION_RECORD_STATUS_BELOW_MIN_WIDTH),
+            SectionRecordBarLayout::StatusBelow
+        );
+        assert_eq!(
+            section_record_bar_layout(SECTION_RECORD_STATUS_BELOW_MIN_WIDTH - 1.0),
             SectionRecordBarLayout::StackedControls
         );
     }

--- a/crates/vibez-ui/src/app/views_perform_record.rs
+++ b/crates/vibez-ui/src/app/views_perform_record.rs
@@ -1,6 +1,6 @@
 //! Compact Section Record and Capture strip shared by every Perform mode.
 
-use iced::widget::{button, container, horizontal_space, pick_list, row, text};
+use iced::widget::{button, column, container, horizontal_space, pick_list, row, text};
 use iced::{Element, Length, Theme};
 
 use crate::domains::perform::{
@@ -13,6 +13,23 @@ use crate::theme as th;
 use crate::typography::{PERFORM_LABEL, PERFORM_TECH, PERFORM_TECH_STRONG};
 
 use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SectionRecordBarLayout {
+    Inline,
+    StatusBelow,
+    StackedControls,
+}
+
+fn section_record_bar_layout(workspace_width: f32) -> SectionRecordBarLayout {
+    if workspace_width >= 1_120.0 {
+        SectionRecordBarLayout::Inline
+    } else if workspace_width >= 680.0 {
+        SectionRecordBarLayout::StatusBelow
+    } else {
+        SectionRecordBarLayout::StackedControls
+    }
+}
 
 impl App {
     pub(super) fn view_section_record_bar(&self) -> Element<'_, Message> {
@@ -156,48 +173,92 @@ impl App {
             th::text_dim()
         };
 
-        container(
-            row![
-                record_button,
-                count_in,
-                mode,
-                quantization,
-                capture_button,
-                container(horizontal_space()).width(Length::Fill),
+        let status = |narrow: bool| -> Element<'_, Message> {
+            let target = text(target.clone())
+                .font(PERFORM_TECH)
+                .size(9)
+                .color(th::text_dim());
+            let phase = text(phase.clone())
+                .font(PERFORM_LABEL)
+                .size(9)
+                .color(state_color);
+            let destination = text(capture_phase.clone())
+                .font(PERFORM_LABEL)
+                .size(9)
+                .color(if capturing {
+                    th::danger()
+                } else {
+                    th::accent()
+                });
+            if narrow {
+                column![target, row![phase, destination].spacing(12)]
+                    .spacing(3)
+                    .into()
+            } else {
+                row![target, phase, destination]
+                    .spacing(12)
+                    .align_y(iced::Alignment::Center)
+                    .into()
+            }
+        };
+        let layout = section_record_bar_layout(self.perform_workspace_width());
+        let (content, height): (Element<'_, Message>, f32) = match layout {
+            SectionRecordBarLayout::Inline => (
                 row![
-                    text(target)
-                        .font(PERFORM_TECH)
-                        .size(9)
-                        .color(th::text_dim()),
-                    text(phase).font(PERFORM_LABEL).size(9).color(state_color),
-                    text(capture_phase)
-                        .font(PERFORM_LABEL)
-                        .size(9)
-                        .color(if capturing {
-                            th::danger()
-                        } else {
-                            th::accent()
-                        }),
+                    record_button,
+                    count_in,
+                    mode,
+                    quantization,
+                    capture_button,
+                    container(horizontal_space()).width(Length::Fill),
+                    status(false),
                 ]
-                .spacing(12)
-                .align_y(iced::Alignment::Center),
-            ]
-            .spacing(7)
-            .align_y(iced::Alignment::Center),
-        )
-        .width(Length::Fill)
-        .height(Length::Fixed(42.0))
-        .padding([5, 12])
-        .style(|_theme: &Theme| container::Style {
-            background: Some(th::bg_surface().into()),
-            border: iced::Border {
-                color: th::divider(),
-                width: 1.0,
-                radius: 0.0.into(),
-            },
-            ..Default::default()
-        })
-        .into()
+                .spacing(7)
+                .align_y(iced::Alignment::Center)
+                .into(),
+                42.0,
+            ),
+            SectionRecordBarLayout::StatusBelow => (
+                column![
+                    row![record_button, count_in, mode, quantization, capture_button]
+                        .spacing(7)
+                        .align_y(iced::Alignment::Center),
+                    status(false),
+                ]
+                .spacing(6)
+                .into(),
+                64.0,
+            ),
+            SectionRecordBarLayout::StackedControls => (
+                column![
+                    row![record_button, count_in, mode]
+                        .spacing(7)
+                        .align_y(iced::Alignment::Center),
+                    row![quantization, capture_button]
+                        .spacing(7)
+                        .align_y(iced::Alignment::Center),
+                    status(true),
+                ]
+                .spacing(6)
+                .into(),
+                104.0,
+            ),
+        };
+
+        container(content)
+            .width(Length::Fill)
+            .height(Length::Fixed(height))
+            .padding([5, 12])
+            .style(|_theme: &Theme| container::Style {
+                background: Some(th::bg_surface().into()),
+                border: iced::Border {
+                    color: th::divider(),
+                    width: 1.0,
+                    radius: 0.0.into(),
+                },
+                ..Default::default()
+            })
+            .into()
     }
 }
 
@@ -352,7 +413,10 @@ fn record_pick_list<'a, T: Copy + Eq + std::fmt::Display + 'static>(
 
 #[cfg(test)]
 mod tests {
-    use super::{capture_destination_label, count_in_beats_remaining};
+    use super::{
+        capture_destination_label, count_in_beats_remaining, section_record_bar_layout,
+        SectionRecordBarLayout,
+    };
     use crate::domains::perform::CapturePhase;
 
     #[test]
@@ -381,6 +445,22 @@ mod tests {
         assert_eq!(
             capture_destination_label(240_000, 48_000, CapturePhase::Recording),
             "ARRANGE @ 00:05.00 · CAPTURING"
+        );
+    }
+
+    #[test]
+    fn record_bar_adapts_before_controls_or_status_can_be_squashed() {
+        assert_eq!(
+            section_record_bar_layout(1400.0),
+            SectionRecordBarLayout::Inline
+        );
+        assert_eq!(
+            section_record_bar_layout(970.0),
+            SectionRecordBarLayout::StatusBelow
+        );
+        assert_eq!(
+            section_record_bar_layout(480.0),
+            SectionRecordBarLayout::StackedControls
         );
     }
 }


### PR DESCRIPTION
## Outcome

The shared Section Record/Capture strip now adapts before its controls or status text can be compressed.

## Root cause

The strip was permanently one 42 px-high row. Its fixed pickers/buttons consumed roughly 650 px before the flexible spacer, so opening the Browser in the reported 1400 px window left the target, phase, and Arrange destination to wrap into a squashed cluster.

## Fix

- `>= 1120 px`: retain the compact inline strip.
- `680–1119 px`: keep all controls on row one and move the complete status group to row two.
- `< 680 px`: split controls across two intentional rows and stack the status detail.

The width is the real Perform workspace after the Browser reservation, not the raw application window.

## Regression evidence

`record_bar_adapts_before_controls_or_status_can_be_squashed` failed against the old always-inline policy and now locks all three layout modes at 1400, 970, and 480 px.

Native QA reproduced the reported 1400 px window with Browser open: every control remains full-sized and all status text is visible on the second row.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace` (539 UI tests)
