### PR TITLE
Fix vertical mouse-wheel scrolling in Section timelines

### DIFF
--- a/crates/vibez-ui/src/app/views_perform_sections.rs
+++ b/crates/vibez-ui/src/app/views_perform_sections.rs
@@ -497,7 +497,8 @@ impl App {
                 .with_marquee(
                     row_spans.clone(),
                     editor.marquee.as_ref().map(|marquee| marquee.rect),
-                );
+                )
+                .with_vertical_track_scrolling();
                 if let Some(preview) = recording_preview.as_ref().filter(|preview| {
                     preview.section_id == section_id && preview.track_id == track.id
                 }) {

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -66,6 +66,17 @@ const MARQUEE_MIN_PX: f32 = 4.0;
 /// horizontal drag near a row boundary would flicker between tracks.
 const CROSS_TRACK_MIN_PX: f32 = 20.0;
 
+/// Where an unmodified vertical wheel gesture should be handled.
+///
+/// Arrange treats it as timeline panning. Section construction lives inside
+/// a vertical track scroller, so its lanes must let the parent consume it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum VerticalWheelRouting {
+    #[default]
+    PanTimeline,
+    BubbleToTrackScroller,
+}
+
 /// Interaction state for clip canvas.
 #[derive(Debug, Default)]
 pub struct ClipInteractionState {
@@ -75,6 +86,7 @@ pub struct ClipInteractionState {
 
 /// Canvas for ONE track's clip area (waveforms, borders, names, playhead overlay).
 pub struct TrackClipCanvas {
+    vertical_wheel_routing: VerticalWheelRouting,
     pub track_id: TrackId,
     pub track_index: usize,
     pub total_tracks: usize,
@@ -222,6 +234,7 @@ impl TrackClipCanvas {
             })
             .collect();
         Self {
+            vertical_wheel_routing: VerticalWheelRouting::default(),
             track_id,
             track_index,
             total_tracks,
@@ -284,6 +297,14 @@ impl TrackClipCanvas {
 
     pub fn with_playback_playhead(mut self, playback_playhead_beats: Option<f64>) -> Self {
         self.playback_playhead_beats = playback_playhead_beats;
+        self
+    }
+
+    /// Let the surrounding track list handle ordinary vertical wheel input.
+    /// Horizontal wheel input and Shift+wheel remain lane-local timeline
+    /// navigation gestures.
+    pub fn with_vertical_track_scrolling(mut self) -> Self {
+        self.vertical_wheel_routing = VerticalWheelRouting::BubbleToTrackScroller;
         self
     }
 
@@ -907,6 +928,11 @@ impl canvas::Program<Message> for TrackClipCanvas {
                     }
                     // Plain scroll for horizontal panning
                     if dy.abs() > 0.0 {
+                        if self.vertical_wheel_routing
+                            == VerticalWheelRouting::BubbleToTrackScroller
+                        {
+                            return (canvas::event::Status::Ignored, None);
+                        }
                         return (
                             canvas::event::Status::Captured,
                             Some(Message::View(ViewMsg::ScrollArrangement(

--- a/crates/vibez-ui/src/widgets/timeline/clips_tests.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_tests.rs
@@ -168,7 +168,7 @@ fn section_lane_keeps_edit_cursor_and_playback_playhead_distinct() {
 
 #[test]
 fn one_pixel_shift_wheel_event_requests_continuous_cursor_anchored_zoom() {
-    let canvas = empty_track_canvas();
+    let canvas = empty_track_canvas().with_vertical_track_scrolling();
     let mut state = ClipInteractionState {
         shift_held: true,
         ..ClipInteractionState::default()
@@ -189,6 +189,47 @@ fn one_pixel_shift_wheel_event_requests_continuous_cursor_anchored_zoom() {
         message,
         Some(Message::View(ViewMsg::ZoomAround { factor, anchor_x }))
             if factor > 1.0 && factor < 1.01 && anchor_x == 320.0
+    ));
+}
+
+#[test]
+fn section_lane_bubbles_plain_vertical_wheel_to_its_track_scroller() {
+    let canvas = empty_track_canvas().with_vertical_track_scrolling();
+    let mut state = ClipInteractionState::default();
+    let bounds = Rectangle::new(Point::ORIGIN, Size::new(800.0, 80.0));
+    let (status, message) = <TrackClipCanvas as canvas::Program<Message>>::update(
+        &canvas,
+        &mut state,
+        canvas::Event::Mouse(iced::mouse::Event::WheelScrolled {
+            delta: iced::mouse::ScrollDelta::Pixels { x: 0.0, y: -12.0 },
+        }),
+        bounds,
+        mouse::Cursor::Available(Point::new(320.0, 20.0)),
+    );
+
+    assert_eq!(status, canvas::event::Status::Ignored);
+    assert!(message.is_none());
+}
+
+#[test]
+fn arrangement_lane_keeps_plain_vertical_wheel_timeline_panning() {
+    let canvas = empty_track_canvas();
+    let mut state = ClipInteractionState::default();
+    let bounds = Rectangle::new(Point::ORIGIN, Size::new(800.0, 80.0));
+    let (status, message) = <TrackClipCanvas as canvas::Program<Message>>::update(
+        &canvas,
+        &mut state,
+        canvas::Event::Mouse(iced::mouse::Event::WheelScrolled {
+            delta: iced::mouse::ScrollDelta::Pixels { x: 0.0, y: -12.0 },
+        }),
+        bounds,
+        mouse::Cursor::Available(Point::new(320.0, 20.0)),
+    );
+
+    assert_eq!(status, canvas::event::Status::Captured);
+    assert!(matches!(
+        message,
+        Some(Message::View(ViewMsg::ScrollArrangement(delta))) if delta < 0.0
     ));
 }
 


### PR DESCRIPTION
## What changed
- let plain vertical wheel gestures bubble from Section clip lanes to the existing track scroller
- preserve Arrangement vertical-wheel timeline panning, horizontal-wheel panning, and Section Shift+wheel zoom
- add focused event-routing regressions for the Section and Arrangement behaviors

## Root cause
`TrackClipCanvas` captured every plain vertical wheel event and emitted `ScrollArrangement`, so iced never delivered the event to the Section timeline's vertical `Scrollable` parent.

## Verification
- red/green regression: Section lane changed from `Captured` to `Ignored` for plain vertical wheel input
- native QA: created a 14-track Section and scrolled over the clip lanes from tracks 1-7 to tracks 8-14 with physical wheel events
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace` (540 UI tests)