### PR TITLE
Keep Browser WARP audition continuous

### DIFF
--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -67,7 +67,10 @@ impl App {
                         self.state.browser.stop_audition_state();
                         if matches!(
                             self.state.status_text.as_str(),
-                            "RAW Audition playing" | "WARP Audition playing"
+                            "RAW Audition playing"
+                                | "WARP Audition playing"
+                                | "RAW Audition playing while WARP awaits source BPM"
+                                | "RAW Audition continues; confirm the edited BPM to hear WARP"
                         ) {
                             self.state.status_text = "Audition finished".into();
                         }
@@ -81,7 +84,17 @@ impl App {
                         self.state.browser.audition_loading = false;
                         self.state.browser.audition_queued = false;
                         self.state.browser.audition_playing = true;
-                        self.state.status_text = match self.state.browser.audition_mode {
+                        let playback_mode = self
+                            .state
+                            .browser
+                            .audition_playback_mode
+                            .unwrap_or(self.state.browser.audition_mode);
+                        self.state.status_text = match playback_mode {
+                            AuditionMode::Raw
+                                if self.state.browser.audition_mode == AuditionMode::Warp =>
+                            {
+                                "RAW Audition playing while WARP awaits source BPM".into()
+                            }
                             AuditionMode::Raw => "RAW Audition playing".into(),
                             AuditionMode::Warp => "WARP Audition playing".into(),
                         };

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -27,6 +27,16 @@ fn apply_track_mute_event(
     pending
 }
 
+fn active_audition_status(status: &str) -> bool {
+    matches!(
+        status,
+        RAW_AUDITION_PLAYING
+            | WARP_AUDITION_PLAYING
+            | RAW_AUDITION_AWAITING_BPM
+            | RAW_AUDITION_CONTINUES_FOR_BPM_EDIT
+    )
+}
+
 impl App {
     pub(super) fn poll_engine_events(&mut self) {
         let mut completed_section_recordings = Vec::new();
@@ -65,13 +75,7 @@ impl App {
                     }
                     EngineEvent::AuditionStopped => {
                         self.state.browser.stop_audition_state();
-                        if matches!(
-                            self.state.status_text.as_str(),
-                            "RAW Audition playing"
-                                | "WARP Audition playing"
-                                | "RAW Audition playing while WARP awaits source BPM"
-                                | "RAW Audition continues; confirm the edited BPM to hear WARP"
-                        ) {
+                        if active_audition_status(&self.state.status_text) {
                             self.state.status_text = "Audition finished".into();
                         }
                     }
@@ -93,10 +97,10 @@ impl App {
                             AuditionMode::Raw
                                 if self.state.browser.audition_mode == AuditionMode::Warp =>
                             {
-                                "RAW Audition playing while WARP awaits source BPM".into()
+                                RAW_AUDITION_AWAITING_BPM.into()
                             }
-                            AuditionMode::Raw => "RAW Audition playing".into(),
-                            AuditionMode::Warp => "WARP Audition playing".into(),
+                            AuditionMode::Raw => RAW_AUDITION_PLAYING.into(),
+                            AuditionMode::Warp => WARP_AUDITION_PLAYING.into(),
                         };
                     }
                     EngineEvent::TrackMeter {
@@ -393,6 +397,19 @@ mod tests {
     use crate::domains::perform::PendingTrackMute;
     use crate::state::ProjectTrack;
     use vibez_core::id::TrackId;
+
+    #[test]
+    fn audition_completion_recognizes_every_canonical_playing_status() {
+        for status in [
+            RAW_AUDITION_PLAYING,
+            WARP_AUDITION_PLAYING,
+            RAW_AUDITION_AWAITING_BPM,
+            RAW_AUDITION_CONTINUES_FOR_BPM_EDIT,
+        ] {
+            assert!(active_audition_status(status));
+        }
+        assert!(!active_audition_status(WARP_BPM_EDIT_NEEDS_CONFIRMATION));
+    }
 
     #[test]
     fn effective_quantized_mute_commits_one_undoable_project_edit() {

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -236,7 +236,11 @@ impl App {
         self.state.browser.cancel_audition_requests();
     }
 
-    pub(super) fn start_browser_audition(&mut self, audio: Arc<DecodedAudio>) {
+    pub(super) fn start_browser_audition(
+        &mut self,
+        audio: Arc<DecodedAudio>,
+        playback_mode: AuditionMode,
+    ) {
         let queued =
             self.state.transport.playing && self.state.browser.audition_sync != AuditionSync::Off;
         // Retain a UI-side clone (never cleared on stop) so the engine
@@ -259,16 +263,36 @@ impl App {
             sync: self.state.browser.audition_sync,
             looped: self.state.browser.audition_loop,
         });
-        self.state.browser.mark_audition_requested(queued);
-        let mode = match self.state.browser.audition_mode {
-            AuditionMode::Raw => "RAW",
-            AuditionMode::Warp => "WARP",
-        };
+        self.state
+            .browser
+            .mark_audition_requested(queued, playback_mode);
+        let mode = playback_mode.label();
         self.state.status_text = if queued {
             format!("{mode} Audition queued")
+        } else if playback_mode == AuditionMode::Raw
+            && self.state.browser.audition_mode == AuditionMode::Warp
+        {
+            "RAW Audition playing while WARP awaits source BPM".into()
         } else {
             format!("{mode} Audition playing")
         };
+    }
+
+    /// Keep a truthful RAW voice underneath BPM editing and WARP preparation.
+    /// Repeated calls are idempotent so UI state changes do not restart a loop.
+    pub(super) fn ensure_raw_browser_audition(&mut self) {
+        if self.state.browser.audition_playback_mode == Some(AuditionMode::Raw)
+            && (self.state.browser.audition_playing || self.state.browser.audition_queued)
+        {
+            return;
+        }
+        let Some(source) = self.state.browser.selected_source.clone() else {
+            return;
+        };
+        let Some(raw) = self.state.browser.waveform_for_source(&source) else {
+            return;
+        };
+        self.start_browser_audition(raw, AuditionMode::Raw);
     }
 
     pub(super) fn schedule_browser_bpm_detection(
@@ -295,7 +319,7 @@ impl App {
         source_bpm: f64,
     ) -> Task<Message> {
         let project_bpm = self.state.transport.bpm;
-        let generation = self.state.browser.begin_audition_load(&source);
+        let generation = self.state.browser.begin_audition_preparation(&source);
         self.state.status_text = format!("Preparing WARP at {source_bpm:.1} BPM...");
         Task::perform(
             warp_browser_audition_async(raw, source_bpm, project_bpm),
@@ -315,26 +339,17 @@ impl App {
         raw: Arc<DecodedAudio>,
     ) -> Task<Message> {
         let detection = self.schedule_browser_bpm_detection(source.clone(), Arc::clone(&raw));
-        match self.state.browser.audition_mode {
-            AuditionMode::Raw => {
-                self.start_browser_audition(raw);
+        match self.state.browser.audition_playback_plan() {
+            crate::state::BrowserAuditionPlan::Raw => {
+                self.start_browser_audition(raw, AuditionMode::Raw);
                 detection
             }
-            AuditionMode::Warp => {
-                self.stop_browser_audition();
-                if let Some(source_bpm) = self.state.browser.audition_bpm_confirmed {
-                    Task::batch([
-                        detection,
-                        self.prepare_browser_warp(source, raw, source_bpm),
-                    ])
-                } else {
-                    self.state.status_text = if self.state.browser.audition_bpm_detecting {
-                        "Detecting source BPM; WARP awaits confirmation".into()
-                    } else {
-                        "Confirm or enter a positive source BPM for WARP".into()
-                    };
-                    detection
-                }
+            crate::state::BrowserAuditionPlan::Warp { source_bpm } => {
+                self.ensure_raw_browser_audition();
+                Task::batch([
+                    detection,
+                    self.prepare_browser_warp(source, raw, source_bpm),
+                ])
             }
         }
     }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -272,27 +272,32 @@ impl App {
         } else if playback_mode == AuditionMode::Raw
             && self.state.browser.audition_mode == AuditionMode::Warp
         {
-            "RAW Audition playing while WARP awaits source BPM".into()
+            RAW_AUDITION_AWAITING_BPM.into()
         } else {
-            format!("{mode} Audition playing")
+            match playback_mode {
+                AuditionMode::Raw => RAW_AUDITION_PLAYING.into(),
+                AuditionMode::Warp => WARP_AUDITION_PLAYING.into(),
+            }
         };
     }
 
     /// Keep a truthful RAW voice underneath BPM editing and WARP preparation.
     /// Repeated calls are idempotent so UI state changes do not restart a loop.
-    pub(super) fn ensure_raw_browser_audition(&mut self) {
+    /// Returns whether a RAW voice is active or was successfully requested.
+    pub(super) fn ensure_raw_browser_audition(&mut self) -> bool {
         if self.state.browser.audition_playback_mode == Some(AuditionMode::Raw)
             && (self.state.browser.audition_playing || self.state.browser.audition_queued)
         {
-            return;
+            return true;
         }
         let Some(source) = self.state.browser.selected_source.clone() else {
-            return;
+            return false;
         };
         let Some(raw) = self.state.browser.waveform_for_source(&source) else {
-            return;
+            return false;
         };
         self.start_browser_audition(raw, AuditionMode::Raw);
+        true
     }
 
     pub(super) fn schedule_browser_bpm_detection(
@@ -345,7 +350,7 @@ impl App {
                 detection
             }
             crate::state::BrowserAuditionPlan::Warp { source_bpm } => {
-                self.ensure_raw_browser_audition();
+                let _ = self.ensure_raw_browser_audition();
                 Task::batch([
                     detection,
                     self.prepare_browser_warp(source, raw, source_bpm),

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -34,6 +34,15 @@ use crate::state::{AppState, AudioStreamHealth};
 use crate::theme as th;
 use crate::ui_settings::UiSettings;
 
+pub(super) const RAW_AUDITION_PLAYING: &str = "RAW Audition playing";
+pub(super) const WARP_AUDITION_PLAYING: &str = "WARP Audition playing";
+pub(super) const RAW_AUDITION_AWAITING_BPM: &str =
+    "RAW Audition playing while WARP awaits source BPM";
+pub(super) const RAW_AUDITION_CONTINUES_FOR_BPM_EDIT: &str =
+    "RAW Audition continues; confirm the edited BPM to hear WARP";
+pub(super) const WARP_BPM_EDIT_NEEDS_CONFIRMATION: &str =
+    "Confirm the edited BPM before preparing WARP Audition";
+
 struct App {
     state: AppState,
     edge_shortcuts: EdgeShortcutState,

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -426,11 +426,13 @@ impl App {
         self.state.browser.audition_bpm_confirmed = None;
         if self.state.browser.audition_mode == crate::state::AuditionMode::Warp {
             self.state.browser.cancel_audition_preparation();
-            if self.state.browser.audition_enabled {
-                self.ensure_raw_browser_audition();
-            }
-            self.state.status_text =
-                "RAW Audition continues; confirm the edited BPM to hear WARP".into();
+            let raw_audition_active =
+                self.state.browser.audition_enabled && self.ensure_raw_browser_audition();
+            self.state.status_text = if raw_audition_active {
+                RAW_AUDITION_CONTINUES_FOR_BPM_EDIT.into()
+            } else {
+                WARP_BPM_EDIT_NEEDS_CONFIRMATION.into()
+            };
         }
         Task::none()
     }

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -316,12 +316,19 @@ impl App {
                     Message::BrowserWaveformReady(source.clone(), result)
                 });
             }
+        } else if self.state.browser.audition_enabled {
+            if let Some(raw) = self.state.browser.waveform_for_source(&source) {
+                return self.play_browser_mode(source, raw);
+            }
         }
         Task::none()
     }
 
     pub(super) fn on_preview_local_entry(&mut self, source: MediaSourceRef) -> Task<Message> {
         self.state.browser.select_source(source.clone());
+        if let Some(raw) = self.state.browser.waveform_for_source(&source) {
+            return self.play_browser_mode(source, raw);
+        }
         let generation = self.state.browser.begin_audition_load(&source);
         if let MediaSourceRef::LocalFile { path } = source.clone() {
             self.state.status_text = "Preparing Audition...".to_string();
@@ -417,11 +424,13 @@ impl App {
     pub(super) fn on_audition_bpm_edit_changed(&mut self, value: String) -> Task<Message> {
         self.state.browser.audition_bpm_edit = value;
         self.state.browser.audition_bpm_confirmed = None;
-        if self.state.browser.audition_mode == crate::state::AuditionMode::Warp
-            && (self.state.browser.audition_playing || self.state.browser.audition_queued)
-        {
-            self.stop_browser_audition();
-            self.state.status_text = "Confirm the edited source BPM for WARP".into();
+        if self.state.browser.audition_mode == crate::state::AuditionMode::Warp {
+            self.state.browser.cancel_audition_preparation();
+            if self.state.browser.audition_enabled {
+                self.ensure_raw_browser_audition();
+            }
+            self.state.status_text =
+                "RAW Audition continues; confirm the edited BPM to hear WARP".into();
         }
         Task::none()
     }
@@ -442,7 +451,6 @@ impl App {
             let Some(raw) = self.state.browser.waveform_audio.clone() else {
                 return Task::none();
             };
-            self.stop_browser_audition();
             return self.prepare_browser_warp(source, raw, source_bpm);
         }
         Task::none()
@@ -606,7 +614,6 @@ impl App {
                 );
                 if self.state.browser.audition_enabled {
                     if let Some(raw) = self.state.browser.waveform_audio.clone() {
-                        self.stop_browser_audition();
                         return self.prepare_browser_warp(source_for_warp, raw, source_bpm);
                     }
                 }
@@ -645,7 +652,7 @@ impl App {
         }
         self.state.browser.audition_loading = false;
         match result {
-            Ok(audio) => self.start_browser_audition(audio),
+            Ok(audio) => self.start_browser_audition(audio, crate::state::AuditionMode::Warp),
             Err(error) => {
                 self.state.browser.stop_audition_state();
                 self.state.status_text = format!("WARP Audition error: {error}");

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -452,18 +452,22 @@ impl App {
         self.state
             .browser
             .update(BrowserMsg::SelectRemoteEntry(entry.clone()));
+        let audition_entry = DropboxEntry {
+            path_lower: entry.provider_item_id,
+            path_display: entry.path,
+            name: entry.name,
+            is_folder: false,
+            rev: entry.revision,
+            size: entry.size,
+        };
         if changed {
-            return self.start_remote_audition(
-                DropboxEntry {
-                    path_lower: entry.provider_item_id,
-                    path_display: entry.path,
-                    name: entry.name,
-                    is_folder: false,
-                    rev: entry.revision,
-                    size: entry.size,
-                },
-                true,
-            );
+            return self.start_remote_audition(audition_entry, true);
+        }
+        if self.state.browser.audition_enabled {
+            if let Some(raw) = self.state.browser.waveform_for_source(&source) {
+                return self.play_browser_mode(source, raw);
+            }
+            return self.start_remote_audition(audition_entry, true);
         }
         Task::none()
     }

--- a/crates/vibez-ui/src/app/views_browser_audition.rs
+++ b/crates/vibez-ui/src/app/views_browser_audition.rs
@@ -102,7 +102,7 @@ impl App {
             .padding([3, 5])
             .width(Length::Fixed(if compact { 54.0 } else { 62.0 }))
             .style(browser_compact_input_style);
-        let confirm_bpm = button(text(if compact { "USE" } else { "USE SOURCE" }).size(9))
+        let confirm_bpm = button(text(if compact { "USE" } else { "CONFIRM BPM" }).size(9))
             .on_press(Message::ConfirmAuditionBpm)
             .padding([3, 5])
             .style(browser_utility_action_style);
@@ -170,12 +170,25 @@ impl App {
             stop,
             text(if self.state.browser.remote.preview_in_progress {
                 "FETCHING"
+            } else if self.state.browser.audition_loading
+                && self.state.browser.audition_playing
+                && self.state.browser.audition_playback_mode == Some(AuditionMode::Raw)
+            {
+                "RAW · WARPING"
             } else if self.state.browser.audition_loading {
                 "PREPARING"
             } else if self.state.browser.audition_queued {
                 "QUEUED"
             } else if self.state.browser.audition_playing {
-                "PLAYING"
+                match self.state.browser.audition_playback_mode {
+                    Some(AuditionMode::Raw)
+                        if self.state.browser.audition_mode == AuditionMode::Warp =>
+                    {
+                        "RAW · BPM NEEDED"
+                    }
+                    Some(mode) => mode.label(),
+                    None => "PLAYING",
+                }
             } else if self.state.browser.waveform_error.is_some() {
                 "UNAVAILABLE"
             } else if self.state.browser.waveform_audio.is_some() {

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -208,6 +208,79 @@ fn trustworthy_detected_source_bpm_is_ready_without_manual_entry() {
 }
 
 #[test]
+fn warp_intent_without_confirmed_bpm_falls_back_to_raw_audition() {
+    let mut browser = BrowserState {
+        audition_mode: crate::state::AuditionMode::Warp,
+        ..BrowserState::default()
+    };
+
+    assert_eq!(
+        browser.audition_playback_plan(),
+        crate::state::BrowserAuditionPlan::Raw
+    );
+    assert!(browser.audition_import_input().is_none());
+
+    browser.audition_bpm_edit = "128".into();
+    browser.confirm_audition_bpm().unwrap();
+    assert_eq!(
+        browser.audition_playback_plan(),
+        crate::state::BrowserAuditionPlan::Warp { source_bpm: 128.0 }
+    );
+}
+
+#[test]
+fn selected_source_can_reuse_its_decoded_waveform_for_retriggering() {
+    let source = MediaSourceRef::LocalFile {
+        path: PathBuf::from("/samples/loop.wav"),
+    };
+    let other = MediaSourceRef::LocalFile {
+        path: PathBuf::from("/samples/other.wav"),
+    };
+    let audio = std::sync::Arc::new(vibez_core::audio_buffer::DecodedAudio {
+        channels: vec![vec![0.0, 0.8, -0.4]],
+        sample_rate: 44_100,
+    });
+    let mut browser = BrowserState::default();
+    browser.select_source(source.clone());
+    assert!(browser.install_waveform(source.clone(), std::sync::Arc::clone(&audio)));
+
+    assert!(std::sync::Arc::ptr_eq(
+        &browser.waveform_for_source(&source).unwrap(),
+        &audio
+    ));
+    assert!(browser.waveform_for_source(&other).is_none());
+}
+
+#[test]
+fn warp_preparation_keeps_the_loaded_waveform_and_raw_voice_live() {
+    let source = MediaSourceRef::LocalFile {
+        path: PathBuf::from("/samples/loop.wav"),
+    };
+    let audio = std::sync::Arc::new(vibez_core::audio_buffer::DecodedAudio {
+        channels: vec![vec![0.0, 0.8, -0.4]],
+        sample_rate: 44_100,
+    });
+    let mut browser = BrowserState::default();
+    browser.select_source(source.clone());
+    assert!(browser.install_waveform(source.clone(), audio));
+    browser.mark_audition_requested(false, crate::state::AuditionMode::Raw);
+
+    let preparation = browser.begin_audition_preparation(&source);
+    assert!(browser.audition_loading);
+    assert!(!browser.waveform_loading);
+    assert!(browser.audition_playing);
+
+    browser.cancel_audition_preparation();
+    assert!(!browser.audition_request_is_current(preparation));
+    assert!(!browser.audition_loading);
+    assert!(browser.audition_playing);
+    assert_eq!(
+        browser.audition_playback_mode,
+        Some(crate::state::AuditionMode::Raw)
+    );
+}
+
+#[test]
 fn manual_confirmation_during_detection_wins_over_late_estimate() {
     let source = MediaSourceRef::LocalFile {
         path: PathBuf::from("/samples/loop.wav"),

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -21,6 +21,12 @@ pub const BROWSER_RESULTS_PAGE_SIZE: usize = 200;
 pub const AUDITION_BPM_MIN: f64 = 20.0;
 pub const AUDITION_BPM_MAX: f64 = 999.0;
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BrowserAuditionPlan {
+    Raw,
+    Warp { source_bpm: f64 },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BrowserSearchScope {
     #[default]
@@ -93,6 +99,9 @@ pub struct BrowserState {
     pub audition_loading: bool,
     pub audition_playing: bool,
     pub audition_queued: bool,
+    /// Treatment currently handed to the Audition Bus. This can be RAW while
+    /// the selected intent remains WARP and its source BPM is unresolved.
+    pub audition_playback_mode: Option<AuditionMode>,
     /// Monotonic token minted by [`Self::begin_audition_load`] and
     /// invalidated by [`Self::cancel_audition_requests`]; async decode
     /// and WARP completions carry it so stale results never start
@@ -158,6 +167,7 @@ impl Default for BrowserState {
             audition_loading: false,
             audition_playing: false,
             audition_queued: false,
+            audition_playback_mode: None,
             audition_generation: 0,
             audition_audio: None,
             audition_audio_retired: [None, None, None, None],
@@ -416,8 +426,26 @@ impl BrowserState {
         self.audition_generation
     }
 
+    /// Start preparing an alternate treatment for an already decoded source.
+    /// Unlike [`Self::begin_audition_load`], this does not mark the selected
+    /// waveform as loading again.
+    pub fn begin_audition_preparation(&mut self, source: &MediaSourceRef) -> u64 {
+        if self.selected_source.as_ref() == Some(source) {
+            self.audition_loading = true;
+        }
+        self.audition_generation = self.audition_generation.wrapping_add(1);
+        self.audition_generation
+    }
+
     pub fn audition_request_is_current(&self, generation: u64) -> bool {
         self.audition_generation == generation
+    }
+
+    /// Invalidate only background decode/WARP preparation. Unlike an explicit
+    /// Stop this deliberately leaves the currently audible voice alone.
+    pub fn cancel_audition_preparation(&mut self) {
+        self.audition_generation = self.audition_generation.wrapping_add(1);
+        self.audition_loading = false;
     }
 
     /// Explicit user cancellation: clears audition state and
@@ -448,6 +476,7 @@ impl BrowserState {
         self.audition_loading = false;
         self.audition_playing = false;
         self.audition_queued = false;
+        self.audition_playback_mode = None;
     }
 
     pub fn toggle_audition_enabled(&mut self) -> bool {
@@ -459,10 +488,11 @@ impl BrowserState {
         self.audition_gain = gain.clamp(0.0, 2.0);
     }
 
-    pub fn mark_audition_requested(&mut self, queued: bool) {
+    pub fn mark_audition_requested(&mut self, queued: bool, mode: AuditionMode) {
         self.audition_loading = false;
         self.audition_queued = queued;
         self.audition_playing = !queued;
+        self.audition_playback_mode = Some(mode);
     }
 
     pub fn begin_bpm_detection(&mut self, source: &MediaSourceRef) -> bool {
@@ -546,6 +576,24 @@ impl BrowserState {
                     })
             }
         }
+    }
+
+    /// Choose a safe Audition plan without weakening WARP's confirmed-BPM
+    /// requirement. An unconfirmed WARP selection remains a WARP import
+    /// intent, but Audition falls back to the truthful RAW source instead of
+    /// going silent.
+    pub fn audition_playback_plan(&self) -> BrowserAuditionPlan {
+        match (self.audition_mode, self.audition_bpm_confirmed) {
+            (AuditionMode::Warp, Some(source_bpm)) => BrowserAuditionPlan::Warp { source_bpm },
+            _ => BrowserAuditionPlan::Raw,
+        }
+    }
+
+    pub fn waveform_for_source(&self, source: &MediaSourceRef) -> Option<Arc<DecodedAudio>> {
+        if self.waveform_source.as_ref() != Some(source) {
+            return None;
+        }
+        self.waveform_audio.clone()
     }
 
     pub fn begin_pending_drag(


### PR DESCRIPTION
## What changed
- play the truthful RAW source immediately while WARP awaits BPM detection or confirmation
- keep RAW audible while WARP is prepared, then crossfade through the existing Audition Bus
- distinguish `RAW · BPM NEEDED`, `RAW · WARPING`, and WARP playback in the footer
- make re-click and Play reuse decoded Local/Remote audio instead of silently doing nothing or decoding again
- rename `USE SOURCE` to the clearer `CONFIRM BPM`

WARP import remains blocked until source BPM is confirmed; this changes audition continuity, not the safety rule.

## Root cause
The WARP branch stopped the Audition Bus before checking whether a confirmed BPM existed. Low-confidence detections therefore left Browser silent until manual confirmation. Selecting an already-selected result was also a no-op.

## Verification
- red/green plan regression for unresolved WARP -> RAW Audition while import stays blocked
- regressions for decoded-source reuse and preparation that preserves the RAW voice/waveform
- native QA with `/home/alexander/Music/Samples/Synths/DD CHO 033.wav`: WARP + Loop progressed `RAW · BPM NEEDED` -> `RAW · WARPING` -> WARP after confirming its low-confidence 135.3 BPM suggestion
- test Local Root removed after QA
- full formatting, diff, strict workspace Clippy, and workspace test gate passed (541 UI tests)