### PR TITLE
Fix deterministic Section split and delete

### DIFF
--- a/crates/vibez-ui/src/domains/arrangement/clipboard.rs
+++ b/crates/vibez-ui/src/domains/arrangement/clipboard.rs
@@ -404,7 +404,7 @@ impl TimelineEditorState {
         let count = selected.len();
         self.selected_clips = selected;
         self.selected_track = Some(anchor_track);
-        self.time_selection_active = false;
+        self.clear_time_selection();
         ArrangementAction {
             status: Some(if count == 1 {
                 "Pasted clip".to_string()

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -82,6 +82,12 @@ impl ProjectTracksState {
 }
 
 impl TimelineEditorState {
+    pub(super) fn clear_time_selection(&mut self) {
+        self.time_selection_active = false;
+        self.time_selection_track = None;
+        self.marquee = None;
+    }
+
     fn find_content(&self, track_id: TrackId) -> Option<&TrackTimelineContent> {
         self.timeline.get(track_id)
     }
@@ -414,9 +420,7 @@ impl TimelineEditorState {
                 // Leaving an older time range active makes split/cut commands
                 // silently operate on that range instead of the visible clip
                 // selection.
-                self.time_selection_active = false;
-                self.time_selection_track = None;
-                self.marquee = None;
+                self.clear_time_selection();
                 if shift_held {
                     // Toggle in/out of selection set
                     if !self.selected_clips.remove(&selection) {
@@ -793,9 +797,10 @@ impl TimelineEditorState {
                 action.focus_clip_tab = !self.selected_clips.is_empty();
             }
             ArrangementMsg::SetTimeSelectionActive(active) => {
-                self.time_selection_active = active;
-                if !active {
-                    self.time_selection_track = None;
+                if active {
+                    self.time_selection_active = true;
+                } else {
+                    self.clear_time_selection();
                 }
             }
             ArrangementMsg::DuplicateNoteClip(track_id, clip_id) => {

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -410,6 +410,13 @@ impl TimelineEditorState {
                 selection,
                 shift_held,
             } => {
+                // Clicking a clip switches the editor back to clip selection.
+                // Leaving an older time range active makes split/cut commands
+                // silently operate on that range instead of the visible clip
+                // selection.
+                self.time_selection_active = false;
+                self.time_selection_track = None;
+                self.marquee = None;
                 if shift_held {
                     // Toggle in/out of selection set
                     if !self.selected_clips.remove(&selection) {

--- a/crates/vibez-ui/src/domains/arrangement/ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/ops.rs
@@ -148,7 +148,7 @@ impl TimelineEditorState {
         }
         self.selected_clips.clear();
         self.selected_note_clip = None;
-        self.time_selection_active = false;
+        self.clear_time_selection();
         let count = audio_removals.len() + note_removals.len();
         action.status = Some(format!("Deleted {count} clips in region"));
         action

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -1323,6 +1323,42 @@ fn ending_the_drag_drops_the_box_but_keeps_the_selection() {
 }
 
 #[test]
+fn selecting_a_clip_replaces_a_stale_time_range_before_split_and_delete() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut a, 0, 0, 800);
+    let mut engine = RecordingEngine::default();
+    let ctx = ArrangementCtx {
+        samples_per_beat: 100.0,
+        playhead_samples: 300,
+        playhead_beats: 3.0,
+    };
+
+    a.time_selection_active = true;
+    a.selection_start_beats = 2.0;
+    a.selection_end_beats = 5.0;
+    a.time_selection_track = Some(track_id);
+
+    a.update(
+        ArrangementMsg::SelectArrangementClip {
+            selection: ArrangementSelection::AudioClip { track_id, clip_id },
+            shift_held: false,
+        },
+        &mut engine,
+        ctx,
+    );
+    a.update(ArrangementMsg::SplitSelectedAtPlayhead, &mut engine, ctx);
+
+    assert!(!a.time_selection_active);
+    assert_eq!(a.tracks[0].clips.len(), 2);
+
+    a.update(ArrangementMsg::DeleteSelectedClip, &mut engine, ctx);
+
+    assert_eq!(a.tracks[0].clips.len(), 1);
+    assert_eq!(a.tracks[0].clips[0].position, 300);
+    assert!(a.selected_clips.is_empty());
+}
+
+#[test]
 fn select_all_clips_takes_every_clip_on_every_track() {
     let mut a = arrangement_with_tracks(2);
     let (t0, first) = add_audio_clip(&mut a, 0, 0, 100);

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -1349,6 +1349,7 @@ fn selecting_a_clip_replaces_a_stale_time_range_before_split_and_delete() {
     a.update(ArrangementMsg::SplitSelectedAtPlayhead, &mut engine, ctx);
 
     assert!(!a.time_selection_active);
+    assert_eq!(a.time_selection_track, None);
     assert_eq!(a.tracks[0].clips.len(), 2);
 
     a.update(ArrangementMsg::DeleteSelectedClip, &mut engine, ctx);


### PR DESCRIPTION
## Outcome

Delete and Backspace now act on the fragment the producer visibly selected after splitting a Section clip, even when the previous edit was a time-range selection.

## Root cause

A normal clip click replaced `selected_clips` but left `time_selection_active` set. `SplitSelectedAtPlayhead` gives an active time range priority, so the same shortcut could perform either a direct clip split or a region split depending on hidden selection history. The resulting selection made the following Delete/Backspace appear intermittent.

## Change

- treat any clip click as an explicit return to clip-selection mode
- retire the stale time range, range track, and transient marquee before applying the clip selection
- cover the complete range → clip select → split → delete sequence with a regression test

## Verification

- native QA on a temporary copy of `test-perform-clips.vzp`: set edit cursor, drag a range, select the audio clip, split, Delete the left fragment, Backspace the remaining fragment
- source project was not modified
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace` (539 UI tests)
