### PR TITLE
Fix Select All stale time-range routing

### DIFF
--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -772,6 +772,7 @@ impl TimelineEditorState {
                 self.marquee = None;
             }
             ArrangementMsg::SelectAllClips => {
+                self.clear_time_selection();
                 self.selected_clips =
                     self.timeline
                         .by_track

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -1382,6 +1382,31 @@ fn select_all_clips_takes_every_clip_on_every_track() {
 }
 
 #[test]
+fn select_all_replaces_a_stale_time_range_before_split() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, _) = add_audio_clip(&mut a, 0, 0, 800);
+    let mut engine = RecordingEngine::default();
+    let ctx = ArrangementCtx {
+        samples_per_beat: 100.0,
+        playhead_samples: 300,
+        playhead_beats: 3.0,
+    };
+    a.time_selection_active = true;
+    a.selection_start_beats = 2.0;
+    a.selection_end_beats = 5.0;
+    a.time_selection_track = Some(track_id);
+
+    a.update(ArrangementMsg::SelectAllClips, &mut engine, ctx);
+    a.update(ArrangementMsg::SplitSelectedAtPlayhead, &mut engine, ctx);
+
+    assert!(!a.time_selection_active);
+    assert_eq!(a.time_selection_track, None);
+    assert_eq!(a.tracks[0].clips.len(), 2);
+    assert_eq!(a.tracks[0].clips[0].duration, 300);
+    assert_eq!(a.tracks[0].clips[1].position, 300);
+}
+
+#[test]
 fn select_all_clips_on_an_empty_timeline_selects_nothing() {
     let mut a = arrangement_with_tracks(2);
     let stale_track = a.tracks[0].id;


### PR DESCRIPTION
## Summary

- clear a stale arrangement time selection when Ctrl+A switches to clip selection
- keep subsequent split/delete commands routed through the visible clip selection
- add a regression covering Ctrl+A followed by split at the playhead

## Verification

- `cargo test -p vibez-ui select_all_replaces_a_stale_time_range_before_split -- --nocapture`
- `cargo test -p vibez-ui domains::arrangement::tests`
- `cargo clippy -p vibez-ui --all-targets --all-features -- -D warnings`
- `git diff --check`

## Stack

This is a focused follow-up stacked on #173, as requested in review. Merge #173 first, then retarget this PR to `dev` before merging.