### PR TITLE
fix(browser): make warp audition automatic

### DIFF
--- a/crates/vibez-engine/src/commands.rs
+++ b/crates/vibez-engine/src/commands.rs
@@ -13,12 +13,11 @@ use vibez_instruments::Instrument;
 
 use crate::playback_source::PreparedSectionPlaybackSource;
 
-/// Quantization policy for the next Browser Audition start.
+/// Automatic start policy selected by the Browser audition treatment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AuditionSync {
-    Off,
-    Beat,
-    Bar,
+pub enum AuditionStart {
+    Immediate,
+    NextBar,
 }
 
 /// Commands sent from the UI thread to the audio engine (via rtrb).
@@ -309,18 +308,16 @@ pub enum EngineCommand {
 
     // -- Dedicated Audition Bus --
     /// Request Browser Audition playback after project master processing.
-    /// Beat/Bar quantization applies only while transport is already running.
+    /// Next-bar scheduling applies only while transport is already running.
     StartAudition {
         audio: Arc<DecodedAudio>,
-        sync: AuditionSync,
+        start: AuditionStart,
         looped: bool,
     },
     /// Stop the Audition Bus with a short click-safe fade.
     StopAudition,
     /// Set Audition Bus gain independently from project mixer state.
     SetAuditionGain(f32),
-    /// Change looping for the active or queued Browser Audition.
-    SetAuditionLoop(bool),
 
     // -- External MIDI input --
     /// Route a live note-on from an external MIDI source (hardware

--- a/crates/vibez-engine/src/engine.rs
+++ b/crates/vibez-engine/src/engine.rs
@@ -10,7 +10,7 @@ use vibez_core::time::TempoMap;
 use vibez_dsp::factory::create_effect;
 use vibez_instruments::create_instrument;
 
-use crate::commands::{AuditionSync, EngineCommand};
+use crate::commands::{AuditionStart, EngineCommand};
 use crate::engine_audition::{audition_fade_frames, next_audition_boundary, AuditionBus};
 use crate::events::EngineEvent;
 use crate::metering;

--- a/crates/vibez-engine/src/engine_audition.rs
+++ b/crates/vibez-engine/src/engine_audition.rs
@@ -101,15 +101,6 @@ impl AuditionBus {
         self.outgoing.iter().any(Option::is_some)
     }
 
-    pub(super) fn set_looped(&mut self, looped: bool) {
-        if let Some(active) = self.active.as_mut() {
-            active.looped = looped;
-        }
-        if let Some(queued) = self.queued.as_mut() {
-            queued.looped = looped;
-        }
-    }
-
     pub(super) fn process(
         &mut self,
         output: &mut [f32],

--- a/crates/vibez-engine/src/engine_audition.rs
+++ b/crates/vibez-engine/src/engine_audition.rs
@@ -27,12 +27,14 @@ pub(super) struct AuditionVoice {
     fade_in_frames: usize,
     fade_out_remaining: Option<usize>,
     looped: bool,
+    synchronized: bool,
 }
 
 pub(super) struct QueuedAudition {
     audio: Arc<DecodedAudio>,
-    target_position: u64,
+    frames_until_start: u64,
     looped: bool,
+    synchronized: bool,
 }
 
 impl AuditionBus {
@@ -45,7 +47,13 @@ impl AuditionBus {
         }
     }
 
-    pub(super) fn start(&mut self, audio: Arc<DecodedAudio>, fade_frames: usize, looped: bool) {
+    pub(super) fn start(
+        &mut self,
+        audio: Arc<DecodedAudio>,
+        fade_frames: usize,
+        looped: bool,
+        synchronized: bool,
+    ) {
         self.queued = None;
         self.stop_active(fade_frames);
         self.active = Some(AuditionVoice {
@@ -54,22 +62,48 @@ impl AuditionBus {
             fade_in_frames: fade_frames,
             fade_out_remaining: None,
             looped,
+            synchronized,
         });
     }
 
     pub(super) fn queue(
         &mut self,
         audio: Arc<DecodedAudio>,
-        target_position: u64,
+        frames_until_start: u64,
         fade_frames: usize,
         looped: bool,
+        synchronized: bool,
     ) {
         self.stop_active(fade_frames);
         self.queued = Some(QueuedAudition {
             audio,
-            target_position,
+            frames_until_start,
             looped,
+            synchronized,
         });
+    }
+
+    /// A synchronized preview may begin while the Project is stopped. When
+    /// playback later starts, restart it on the current bar boundary or queue
+    /// it to the next one so it cannot remain free-running beside the Project.
+    pub(super) fn resync_on_transport_start(
+        &mut self,
+        position: u64,
+        bpm: f64,
+        sample_rate: u32,
+        fade_frames: usize,
+    ) -> Option<bool> {
+        let active = self.active.as_ref().filter(|voice| voice.synchronized)?;
+        let audio = Arc::clone(&active.audio);
+        let looped = active.looped;
+        let frames_until_start = frames_until_audition_boundary(position, bpm, sample_rate, 4);
+        if frames_until_start == 0 {
+            self.start(audio, fade_frames, looped, true);
+            Some(false)
+        } else {
+            self.queue(audio, frames_until_start, fade_frames, looped, true);
+            Some(true)
+        }
     }
 
     pub(super) fn stop(&mut self, fade_frames: usize) {
@@ -116,24 +150,25 @@ impl AuditionBus {
             if !transport.is_playing() {
                 return true;
             }
-            let block_start = transport.position();
-            queued.target_position < block_start.saturating_add(frames as u64)
+            queued.frames_until_start < frames as u64
         });
         if queued_ready {
             let queued = self.queued.take().expect("queued audition exists");
             if transport.is_playing() {
-                start_offset = queued
-                    .target_position
-                    .saturating_sub(transport.position())
-                    .min(frames as u64) as usize;
+                start_offset = queued.frames_until_start.min(frames as u64) as usize;
             }
             self.start(
                 queued.audio,
                 audition_fade_frames(sample_rate),
                 queued.looped,
+                queued.synchronized,
             );
             had_voice = true;
             let _ = event_tx.push(EngineEvent::AuditionStarted);
+        } else if transport.is_playing() {
+            if let Some(queued) = self.queued.as_mut() {
+                queued.frames_until_start = queued.frames_until_start.saturating_sub(frames as u64);
+            }
         }
         let gain = self.gain;
         for slot in self.outgoing.iter_mut() {
@@ -167,7 +202,20 @@ pub(super) fn next_audition_boundary(position: u64, bpm: f64, sample_rate: u32, 
     (boundary_index * boundary_frames).round() as u64
 }
 
-/// Mix one RAW audition voice. Returns true once its source or fade is done.
+fn frames_until_audition_boundary(position: u64, bpm: f64, sample_rate: u32, beats: u64) -> u64 {
+    if bpm <= 0.0 || sample_rate == 0 {
+        return 0;
+    }
+    let boundary_frames = sample_rate as f64 * 60.0 / bpm * beats.max(1) as f64;
+    let nearest = ((position as f64 / boundary_frames).round() * boundary_frames).round() as u64;
+    if nearest == position {
+        0
+    } else {
+        next_audition_boundary(position, bpm, sample_rate, beats).saturating_sub(position)
+    }
+}
+
+/// Mix one audition voice. Returns true once its source or fade is done.
 fn render_audition_voice(
     voice: &mut AuditionVoice,
     output: &mut [f32],
@@ -189,9 +237,11 @@ fn render_audition_voice(
             if !voice.looped {
                 return true;
             }
-            let crossfade_frames = voice.fade_in_frames.min(audio_frames / 2);
-            source = crossfade_frames;
-            voice.position = source as u64;
+            // A loop voice must consume exactly one source-length of output
+            // per wrap or it will drift ahead of the Project transport. Fade
+            // the boundary in place instead of overlap-skipping head frames.
+            source = 0;
+            voice.position = 0;
         }
         let attack = if source < voice.fade_in_frames {
             (source + 1) as f32 / voice.fade_in_frames as f32
@@ -199,11 +249,8 @@ fn render_audition_voice(
             1.0
         };
         let remaining_source = audio_frames.saturating_sub(source + 1);
-        let natural_release = if voice.looped {
-            1.0
-        } else {
-            (remaining_source as f32 / voice.fade_in_frames as f32).clamp(0.0, 1.0)
-        };
+        let natural_release =
+            (remaining_source as f32 / voice.fade_in_frames as f32).clamp(0.0, 1.0);
         let commanded_release = match voice.fade_out_remaining {
             Some(remaining) => {
                 let envelope = remaining.saturating_sub(1) as f32 / voice.fade_in_frames as f32;
@@ -213,21 +260,9 @@ fn render_audition_voice(
             None => 1.0,
         };
         let envelope = attack.min(natural_release) * commanded_release * bus_gain;
-        let crossfade_frames = voice.fade_in_frames.min(audio_frames / 2);
-        let crossfade_offset = source.saturating_sub(audio_frames - crossfade_frames);
         for ch in 0..channels {
             let source_channel = ch.min(audio_channels - 1);
-            let sample = if voice.looped
-                && crossfade_frames > 0
-                && source >= audio_frames - crossfade_frames
-            {
-                let head_gain = crossfade_offset as f32 / crossfade_frames as f32;
-                let tail_gain = 1.0 - head_gain;
-                voice.audio.sample(source_channel, source) * tail_gain
-                    + voice.audio.sample(source_channel, crossfade_offset) * head_gain
-            } else {
-                voice.audio.sample(source_channel, source)
-            };
+            let sample = voice.audio.sample(source_channel, source);
             output[(output_frame_offset + frame) * channels + ch] += sample * envelope;
         }
         voice.position = voice.position.saturating_add(1);

--- a/crates/vibez-engine/src/engine_clock.rs
+++ b/crates/vibez-engine/src/engine_clock.rs
@@ -15,6 +15,19 @@ impl AudioEngine {
         }
         self.clock_domain = ClockDomain::Perform;
         self.performance_position = 0;
+        if let Some(queued) = self.audition.resync_on_transport_start(
+            0,
+            self.transport.bpm(),
+            self.sample_rate,
+            audition_fade_frames(self.sample_rate),
+        ) {
+            let event = if queued {
+                EngineEvent::AuditionQueued
+            } else {
+                EngineEvent::AuditionStarted
+            };
+            let _ = self.event_tx.push(event);
+        }
         let _ = self.event_tx.push(EngineEvent::PerformancePosition(0));
     }
 

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -743,17 +743,16 @@ impl AudioEngine {
                 // -- Dedicated Audition Bus --
                 EngineCommand::StartAudition {
                     audio,
-                    sync,
+                    start,
                     looped,
                 } => {
                     let fade_frames = audition_fade_frames(self.sample_rate);
-                    if self.transport.is_playing() && sync != AuditionSync::Off {
-                        let beats = if sync == AuditionSync::Bar { 4 } else { 1 };
+                    if self.transport.is_playing() && start == AuditionStart::NextBar {
                         let target = next_audition_boundary(
                             self.transport.position(),
                             self.transport.bpm(),
                             self.sample_rate,
-                            beats,
+                            4,
                         );
                         self.audition.queue(audio, target, fade_frames, looped);
                         let _ = self.event_tx.push(EngineEvent::AuditionQueued);
@@ -777,9 +776,6 @@ impl AudioEngine {
                 }
                 EngineCommand::SetAuditionGain(gain) => {
                     self.audition.gain = gain.clamp(0.0, 2.0);
-                }
-                EngineCommand::SetAuditionLoop(looped) => {
-                    self.audition.set_looped(looped);
                 }
 
                 // -- External MIDI input --

--- a/crates/vibez-engine/src/engine_drain_commands.rs
+++ b/crates/vibez-engine/src/engine_drain_commands.rs
@@ -11,6 +11,20 @@ impl AudioEngine {
                 EngineCommand::Play => {
                     self.clock_domain = ClockDomain::Arrange;
                     self.transport.play();
+                    let audition_queued = self.audition.resync_on_transport_start(
+                        self.transport.position(),
+                        self.transport.bpm(),
+                        self.sample_rate,
+                        audition_fade_frames(self.sample_rate),
+                    );
+                    if let Some(queued) = audition_queued {
+                        let event = if queued {
+                            EngineEvent::AuditionQueued
+                        } else {
+                            EngineEvent::AuditionStarted
+                        };
+                        let _ = self.event_tx.push(event);
+                    }
                     self.performance_position = self.transport.position();
                     self.stopped_note_repeat_anchor = None;
                     let anchor = self.playing_note_repeat_anchor();
@@ -748,16 +762,24 @@ impl AudioEngine {
                 } => {
                     let fade_frames = audition_fade_frames(self.sample_rate);
                     if self.transport.is_playing() && start == AuditionStart::NextBar {
+                        let clock_position = self.effective_position();
                         let target = next_audition_boundary(
-                            self.transport.position(),
+                            clock_position,
                             self.transport.bpm(),
                             self.sample_rate,
                             4,
                         );
-                        self.audition.queue(audio, target, fade_frames, looped);
+                        let frames_until_start = target.saturating_sub(clock_position);
+                        self.audition
+                            .queue(audio, frames_until_start, fade_frames, looped, true);
                         let _ = self.event_tx.push(EngineEvent::AuditionQueued);
                     } else {
-                        self.audition.start(audio, fade_frames, looped);
+                        self.audition.start(
+                            audio,
+                            fade_frames,
+                            looped,
+                            start == AuditionStart::NextBar,
+                        );
                         let _ = self.event_tx.push(EngineEvent::AuditionStarted);
                     }
                 }

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -26,7 +26,7 @@ fn make_constant_audio(frames: usize, value: f32) -> Arc<DecodedAudio> {
 fn start_audition(audio: Arc<DecodedAudio>) -> EngineCommand {
     EngineCommand::StartAudition {
         audio,
-        sync: AuditionSync::Off,
+        start: AuditionStart::Immediate,
         looped: false,
     }
 }
@@ -1078,7 +1078,7 @@ fn synced_audition_starts_immediately_when_transport_is_stopped() {
     cmd_tx
         .push(EngineCommand::StartAudition {
             audio: make_constant_audio(4_096, 0.4),
-            sync: AuditionSync::Bar,
+            start: AuditionStart::NextBar,
             looped: false,
         })
         .unwrap();
@@ -1091,7 +1091,7 @@ fn synced_audition_starts_immediately_when_transport_is_stopped() {
 }
 
 #[test]
-fn beat_synced_audition_queues_to_the_next_running_transport_boundary() {
+fn next_bar_audition_queues_to_the_next_running_transport_boundary() {
     let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
     cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
     cmd_tx.push(EngineCommand::Seek(10_000)).unwrap();
@@ -1099,15 +1099,15 @@ fn beat_synced_audition_queues_to_the_next_running_transport_boundary() {
     cmd_tx
         .push(EngineCommand::StartAudition {
             audio: make_constant_audio(4_096, 0.4),
-            sync: AuditionSync::Beat,
+            start: AuditionStart::NextBar,
             looped: false,
         })
         .unwrap();
 
-    let mut buf = vec![0.0f32; 28_000];
+    let boundary_offset = 88_200 - 10_000;
+    let mut buf = vec![0.0f32; (boundary_offset + 4_096) * 2];
     engine.process(&mut buf, 2);
 
-    let boundary_offset = 22_050 - 10_000;
     assert!(buf[..boundary_offset * 2]
         .iter()
         .all(|sample| sample.abs() < f32::EPSILON));
@@ -1132,7 +1132,7 @@ fn queued_audition_starts_immediately_if_transport_stops_before_boundary() {
     cmd_tx
         .push(EngineCommand::StartAudition {
             audio: make_constant_audio(4_096, 0.4),
-            sync: AuditionSync::Bar,
+            start: AuditionStart::NextBar,
             looped: false,
         })
         .unwrap();
@@ -1158,7 +1158,7 @@ fn stopping_a_queued_only_audition_emits_a_terminal_event() {
     cmd_tx
         .push(EngineCommand::StartAudition {
             audio: make_constant_audio(4_096, 0.4),
-            sync: AuditionSync::Bar,
+            start: AuditionStart::NextBar,
             looped: false,
         })
         .unwrap();
@@ -1213,7 +1213,7 @@ fn audition_loop_crossfades_the_source_boundary_without_silence_or_a_click() {
     cmd_tx
         .push(EngineCommand::StartAudition {
             audio,
-            sync: AuditionSync::Off,
+            start: AuditionStart::Immediate,
             looped: true,
         })
         .unwrap();

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -1124,6 +1124,116 @@ fn next_bar_audition_queues_to_the_next_running_transport_boundary() {
 }
 
 #[test]
+fn synced_audition_loop_keeps_every_wrap_on_the_transport_grid() {
+    const BAR_FRAMES: usize = 88_200;
+    const MARKER_FRAME: usize = 1_000;
+
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let mut marker = vec![0.0; BAR_FRAMES];
+    marker[MARKER_FRAME] = 1.0;
+    let audio = Arc::new(DecodedAudio {
+        channels: vec![marker.clone(), marker],
+        sample_rate: 44_100,
+    });
+
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx.push(EngineCommand::Seek(10_000)).unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    cmd_tx
+        .push(EngineCommand::StartAudition {
+            audio,
+            start: AuditionStart::NextBar,
+            looped: true,
+        })
+        .unwrap();
+
+    let launch_offset = BAR_FRAMES - 10_000;
+    let output_frames = launch_offset + BAR_FRAMES * 2 + MARKER_FRAME + 1;
+    let mut output = vec![0.0; output_frames * 2];
+    engine.process(&mut output, 2);
+
+    for loop_index in 0..=2 {
+        let expected = launch_offset + loop_index * BAR_FRAMES + MARKER_FRAME;
+        assert!(
+            output[expected * 2] > 0.9,
+            "loop {loop_index} marker must remain at transport frame {expected}"
+        );
+    }
+}
+
+#[test]
+fn starting_transport_rephases_an_already_playing_synced_audition() {
+    const BAR_FRAMES: usize = 88_200;
+    const MARKER_FRAME: usize = 1_000;
+
+    let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
+    let mut marker = vec![0.0; BAR_FRAMES];
+    marker[MARKER_FRAME] = 1.0;
+    let audio = Arc::new(DecodedAudio {
+        channels: vec![marker.clone(), marker],
+        sample_rate: 44_100,
+    });
+
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx
+        .push(EngineCommand::StartAudition {
+            audio,
+            start: AuditionStart::NextBar,
+            looped: true,
+        })
+        .unwrap();
+    let mut free_running = vec![0.0; 10_000 * 2];
+    engine.process(&mut free_running, 2);
+
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    let mut synchronized = vec![0.0; 2_000 * 2];
+    engine.process(&mut synchronized, 2);
+
+    assert!(
+        synchronized[MARKER_FRAME * 2] > 0.9,
+        "a WARP preview started while stopped must rejoin transport bar one"
+    );
+}
+
+#[test]
+fn next_bar_audition_survives_arrangement_loop_wraps() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
+    cmd_tx
+        .push(EngineCommand::SetArrangementLoopRegion {
+            start: 0,
+            end: 44_100,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::SetArrangementLoop(true))
+        .unwrap();
+    cmd_tx.push(EngineCommand::Seek(10_000)).unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    cmd_tx
+        .push(EngineCommand::StartAudition {
+            audio: make_constant_audio(88_200, 0.4),
+            start: AuditionStart::NextBar,
+            looped: true,
+        })
+        .unwrap();
+
+    let mut became_audible = false;
+    for _ in 0..200 {
+        let mut block = vec![0.0; 512 * 2];
+        engine.process(&mut block, 2);
+        became_audible |= block.iter().any(|sample| sample.abs() > 0.1);
+    }
+
+    assert!(
+        became_audible,
+        "transport wrapping must not strand a synchronized Browser audition"
+    );
+    assert!(std::iter::from_fn(|| event_rx.pop().ok())
+        .any(|event| matches!(event, EngineEvent::AuditionStarted)));
+}
+
+#[test]
 fn queued_audition_starts_immediately_if_transport_stops_before_boundary() {
     let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
     cmd_tx.push(EngineCommand::SetBpm(120.0)).unwrap();
@@ -1201,7 +1311,7 @@ fn beat_and_bar_boundaries_are_deterministic() {
 }
 
 #[test]
-fn audition_loop_crossfades_the_source_boundary_without_silence_or_a_click() {
+fn audition_loop_fades_the_source_boundary_without_silence_or_a_click() {
     let (mut engine, mut cmd_tx, _event_rx) = AudioEngine::new();
     let samples: Vec<f32> = (0..4_096)
         .map(|frame| -0.5 + frame as f32 / 4_095.0)

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -494,10 +494,7 @@ impl App {
         entry: DropboxEntry,
     ) -> Task<Message> {
         let target = BrowserImportTarget::ArrangementClip(self.state.arrangement.selected_track);
-        let Some(treatment) = self.state.browser.audition_import_input() else {
-            self.state.status_text = "Confirm source BPM before WARP import".into();
-            return Task::none();
-        };
+        let treatment = self.state.browser.audition_import_input();
         self.start_remote_import(entry, target, treatment)
     }
 
@@ -506,10 +503,7 @@ impl App {
             self.state.status_text = "Select a Sampler or Drum Pad track first".into();
             return Task::none();
         };
-        let Some(treatment) = self.state.browser.audition_import_input() else {
-            self.state.status_text = "Confirm source BPM before WARP import".into();
-            return Task::none();
-        };
+        let treatment = self.state.browser.audition_import_input();
         self.start_remote_import(entry, target, treatment)
     }
 }

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -30,10 +30,7 @@ fn apply_track_mute_event(
 fn active_audition_status(status: &str) -> bool {
     matches!(
         status,
-        RAW_AUDITION_PLAYING
-            | WARP_AUDITION_PLAYING
-            | RAW_AUDITION_AWAITING_BPM
-            | RAW_AUDITION_CONTINUES_FOR_BPM_EDIT
+        RAW_AUDITION_PLAYING | WARP_AUDITION_PLAYING | WARP_AUDITION_PREPARING
     )
 }
 
@@ -85,7 +82,6 @@ impl App {
                         self.state.browser.audition_queued = true;
                     }
                     EngineEvent::AuditionStarted => {
-                        self.state.browser.audition_loading = false;
                         self.state.browser.audition_queued = false;
                         self.state.browser.audition_playing = true;
                         let playback_mode = self
@@ -93,12 +89,13 @@ impl App {
                             .browser
                             .audition_playback_mode
                             .unwrap_or(self.state.browser.audition_mode);
+                        let preparing_warp = playback_mode == AuditionMode::Raw
+                            && self.state.browser.audition_mode == AuditionMode::Warp;
+                        if !preparing_warp {
+                            self.state.browser.audition_loading = false;
+                        }
                         self.state.status_text = match playback_mode {
-                            AuditionMode::Raw
-                                if self.state.browser.audition_mode == AuditionMode::Warp =>
-                            {
-                                RAW_AUDITION_AWAITING_BPM.into()
-                            }
+                            AuditionMode::Raw if preparing_warp => WARP_AUDITION_PREPARING.into(),
                             AuditionMode::Raw => RAW_AUDITION_PLAYING.into(),
                             AuditionMode::Warp => WARP_AUDITION_PLAYING.into(),
                         };
@@ -403,12 +400,11 @@ mod tests {
         for status in [
             RAW_AUDITION_PLAYING,
             WARP_AUDITION_PLAYING,
-            RAW_AUDITION_AWAITING_BPM,
-            RAW_AUDITION_CONTINUES_FOR_BPM_EDIT,
+            WARP_AUDITION_PREPARING,
         ] {
             assert!(active_audition_status(status));
         }
-        assert!(!active_audition_status(WARP_BPM_EDIT_NEEDS_CONFIRMATION));
+        assert!(!active_audition_status("Audition unavailable"));
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -281,25 +281,6 @@ impl App {
         };
     }
 
-    /// Keep a truthful RAW voice underneath BPM editing and WARP preparation.
-    /// Repeated calls are idempotent so UI state changes do not restart a loop.
-    /// Returns whether a RAW voice is active or was successfully requested.
-    pub(super) fn ensure_raw_browser_audition(&mut self) -> bool {
-        if self.state.browser.audition_playback_mode == Some(AuditionMode::Raw)
-            && (self.state.browser.audition_playing || self.state.browser.audition_queued)
-        {
-            return true;
-        }
-        let Some(source) = self.state.browser.selected_source.clone() else {
-            return false;
-        };
-        let Some(raw) = self.state.browser.waveform_for_source(&source) else {
-            return false;
-        };
-        self.start_browser_audition(raw, AuditionMode::Raw);
-        true
-    }
-
     pub(super) fn prepare_browser_warp(
         &mut self,
         source: MediaSourceRef,
@@ -336,7 +317,6 @@ impl App {
                 Task::none()
             }
             crate::state::BrowserAuditionPlan::Warp { source_bpm } => {
-                let _ = self.ensure_raw_browser_audition();
                 self.prepare_browser_warp(source, raw, source_bpm)
             }
         }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -9,7 +9,7 @@ use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::{InstrumentKind, TrackKind};
 use vibez_core::track::MediaSourceRef;
-use vibez_engine::commands::{AuditionSync, EngineCommand};
+use vibez_engine::commands::{AuditionStart, EngineCommand};
 
 use crate::message::{BrowserImportTarget, Message, PreparedBrowserImport};
 use crate::state::{AuditionMode, ProjectTrack, SampleBrowserEntry, UiClip, UiDrumPad};
@@ -241,8 +241,8 @@ impl App {
         audio: Arc<DecodedAudio>,
         playback_mode: AuditionMode,
     ) {
-        let queued =
-            self.state.transport.playing && self.state.browser.audition_sync != AuditionSync::Off;
+        let warped = playback_mode == AuditionMode::Warp;
+        let queued = self.state.transport.playing && warped;
         // Retain a UI-side clone (never cleared on stop) so the engine
         // voice can never drop the final Arc inside the RT callback.
         // A superseded buffer moves into the retired ring rather than
@@ -260,8 +260,12 @@ impl App {
         }
         self.send_command(EngineCommand::StartAudition {
             audio,
-            sync: self.state.browser.audition_sync,
-            looped: self.state.browser.audition_loop,
+            start: if warped {
+                AuditionStart::NextBar
+            } else {
+                AuditionStart::Immediate
+            },
+            looped: warped,
         });
         self.state
             .browser
@@ -269,10 +273,6 @@ impl App {
         let mode = playback_mode.label();
         self.state.status_text = if queued {
             format!("{mode} Audition queued")
-        } else if playback_mode == AuditionMode::Raw
-            && self.state.browser.audition_mode == AuditionMode::Warp
-        {
-            RAW_AUDITION_AWAITING_BPM.into()
         } else {
             match playback_mode {
                 AuditionMode::Raw => RAW_AUDITION_PLAYING.into(),
@@ -300,23 +300,6 @@ impl App {
         true
     }
 
-    pub(super) fn schedule_browser_bpm_detection(
-        &mut self,
-        source: MediaSourceRef,
-        audio: Arc<DecodedAudio>,
-    ) -> Task<Message> {
-        if !self.state.browser.begin_bpm_detection(&source) {
-            return Task::none();
-        }
-        let sample_rate = audio.sample_rate;
-        Task::perform(detect_clip_bpm_async(audio, sample_rate), move |estimate| {
-            Message::BrowserBpmDetected(
-                source.clone(),
-                estimate.map(|value| (value.bpm, value.confidence)),
-            )
-        })
-    }
-
     pub(super) fn prepare_browser_warp(
         &mut self,
         source: MediaSourceRef,
@@ -325,13 +308,13 @@ impl App {
     ) -> Task<Message> {
         let project_bpm = self.state.transport.bpm;
         let generation = self.state.browser.begin_audition_preparation(&source);
-        self.state.status_text = format!("Preparing WARP at {source_bpm:.1} BPM...");
+        self.state.status_text =
+            format!("Fitting {source_bpm:.1} BPM loop to project {project_bpm:.1} BPM...");
         Task::perform(
             warp_browser_audition_async(raw, source_bpm, project_bpm),
             move |result| Message::BrowserAuditionWarpReady {
                 source: source.clone(),
                 generation,
-                source_bpm,
                 project_bpm,
                 result,
             },
@@ -343,18 +326,18 @@ impl App {
         source: MediaSourceRef,
         raw: Arc<DecodedAudio>,
     ) -> Task<Message> {
-        let detection = self.schedule_browser_bpm_detection(source.clone(), Arc::clone(&raw));
-        match self.state.browser.audition_playback_plan() {
+        match self
+            .state
+            .browser
+            .audition_playback_plan(&raw, self.state.transport.bpm)
+        {
             crate::state::BrowserAuditionPlan::Raw => {
                 self.start_browser_audition(raw, AuditionMode::Raw);
-                detection
+                Task::none()
             }
             crate::state::BrowserAuditionPlan::Warp { source_bpm } => {
                 let _ = self.ensure_raw_browser_audition();
-                Task::batch([
-                    detection,
-                    self.prepare_browser_warp(source, raw, source_bpm),
-                ])
+                self.prepare_browser_warp(source, raw, source_bpm)
             }
         }
     }
@@ -481,6 +464,13 @@ impl App {
         source: MediaSourceRef,
     ) -> Task<Message> {
         let project_bpm = self.state.transport.bpm;
+        let treatment = match treatment.resolve_for_audio(&raw, project_bpm) {
+            Ok(treatment) => treatment,
+            Err(error) => {
+                self.state.status_text = format!("{error}: {name}");
+                return Task::none();
+            }
+        };
         self.state.status_text = match treatment.mode {
             AuditionMode::Raw => format!("Preparing RAW import: {name}"),
             AuditionMode::Warp => format!("Preparing WARP import: {name}"),

--- a/crates/vibez-ui/src/app/media_import.rs
+++ b/crates/vibez-ui/src/app/media_import.rs
@@ -10,10 +10,10 @@ use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::TrackKind;
 use vibez_core::track::MediaSourceRef;
 use vibez_dropbox::DropboxEntry;
-use vibez_engine::commands::{AuditionSync, EngineCommand};
+use vibez_engine::commands::{AuditionStart, EngineCommand};
 
 use crate::message::{BrowserImportTarget, Message};
-use crate::state::{AuditionMode, UiClip};
+use crate::state::UiClip;
 
 use super::*;
 
@@ -36,18 +36,7 @@ impl App {
         source: MediaSourceRef,
         target: BrowserImportTarget,
     ) -> Task<Message> {
-        let Some(treatment) = self.state.browser.audition_import_input() else {
-            self.state.status_text =
-                "Confirm a positive source BPM before importing in WARP mode".into();
-            return Task::none();
-        };
-        if treatment.mode == AuditionMode::Warp
-            && self.state.browser.selected_source.as_ref() != Some(&source)
-        {
-            self.state.status_text =
-                "Select this source and confirm its BPM before WARP import".into();
-            return Task::none();
-        }
+        let treatment = self.state.browser.audition_import_input();
         match source {
             MediaSourceRef::LocalFile { path } => {
                 let name = path
@@ -627,7 +616,7 @@ impl App {
                 if let Some((audio, name)) = audition {
                     self.send_command(EngineCommand::StartAudition {
                         audio,
-                        sync: AuditionSync::Off,
+                        start: AuditionStart::Immediate,
                         looped: false,
                     });
                     self.state.status_text = format!("Pad {}: {}", pad_index + 1, name);

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -36,12 +36,7 @@ use crate::ui_settings::UiSettings;
 
 pub(super) const RAW_AUDITION_PLAYING: &str = "RAW Audition playing";
 pub(super) const WARP_AUDITION_PLAYING: &str = "WARP Audition playing";
-pub(super) const RAW_AUDITION_AWAITING_BPM: &str =
-    "RAW Audition playing while WARP awaits source BPM";
-pub(super) const RAW_AUDITION_CONTINUES_FOR_BPM_EDIT: &str =
-    "RAW Audition continues; confirm the edited BPM to hear WARP";
-pub(super) const WARP_BPM_EDIT_NEEDS_CONFIRMATION: &str =
-    "Confirm the edited BPM before preparing WARP Audition";
+pub(super) const WARP_AUDITION_PREPARING: &str = "Preparing WARP Audition";
 
 struct App {
     state: AppState,
@@ -325,7 +320,6 @@ impl App {
                 ),
                 audition_enabled: ui_settings.audition_enabled,
                 audition_gain: ui_settings.audition_gain.clamp(0.0, 2.0),
-                audition_loop: ui_settings.audition_loop,
                 roots: ui_settings.sample_library_roots,
                 remote: remote_ui_state,
                 ..Default::default()
@@ -423,9 +417,6 @@ impl App {
         app.send_command(EngineCommand::SetBpm(app.state.transport.bpm));
         app.send_command(EngineCommand::SetAuditionGain(
             app.state.browser.audition_gain,
-        ));
-        app.send_command(EngineCommand::SetAuditionLoop(
-            app.state.browser.audition_loop,
         ));
 
         // Console model: the master bus carries its channel EQ from

--- a/crates/vibez-ui/src/app/project_format_v1_tests.rs
+++ b/crates/vibez-ui/src/app/project_format_v1_tests.rs
@@ -5,7 +5,7 @@ use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::id::ClipId;
 use vibez_core::midi::{InstrumentKind, TrackKind};
 use vibez_core::track::{InstrumentStateInfo, TrackInfo};
-use vibez_engine::commands::{AuditionSync, EngineCommand};
+use vibez_engine::commands::{AuditionStart, EngineCommand};
 use vibez_engine::engine::AudioProcessBlock;
 
 fn one_second_audio() -> Arc<DecodedAudio> {
@@ -26,7 +26,7 @@ fn assert_audible(audio: Arc<DecodedAudio>, label: &str) {
     commands
         .push(EngineCommand::StartAudition {
             audio,
-            sync: AuditionSync::Off,
+            start: AuditionStart::Immediate,
             looped: false,
         })
         .unwrap();

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -273,7 +273,6 @@ impl App {
             detail_panel_height: self.state.view.detail_panel_height,
             audition_enabled: self.state.browser.audition_enabled,
             audition_gain: self.state.browser.audition_gain,
-            audition_loop: self.state.browser.audition_loop,
             auto_warp_on_import: self.state.auto_warp_on_import,
             warp_confidence_threshold: self.state.warp_confidence_threshold,
             preferred_midi_input: self.midi_input.as_ref().map(|h| h.port_name.clone()),

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -848,12 +848,6 @@ impl App {
                 self.persist_ui_settings();
             }
             Message::SetAuditionMode(mode) => return self.on_set_audition_mode(mode),
-            Message::SetAuditionSync(sync) => return self.on_set_audition_sync(sync),
-            Message::ToggleAuditionLoop => return self.on_toggle_audition_loop(),
-            Message::AuditionBpmEditChanged(value) => {
-                return self.on_audition_bpm_edit_changed(value)
-            }
-            Message::ConfirmAuditionBpm => return self.on_confirm_audition_bpm(),
             Message::EscapePressed => return self.on_escape_pressed(),
 
             // -- Drag-and-drop from sample browser --
@@ -885,23 +879,13 @@ impl App {
             Message::BrowserWaveformReady(source, Err(err)) => {
                 self.state.browser.fail_waveform_load(&source, err);
             }
-            Message::BrowserBpmDetected(source, estimate) => {
-                return self.on_browser_bpm_detected(source, estimate)
-            }
             Message::BrowserAuditionWarpReady {
                 source,
                 generation,
-                source_bpm,
                 project_bpm,
                 result,
             } => {
-                return self.on_browser_audition_warp_ready(
-                    source,
-                    generation,
-                    source_bpm,
-                    project_bpm,
-                    result,
-                )
+                return self.on_browser_audition_warp_ready(source, generation, project_bpm, result)
             }
             Message::ImportSelectedBrowserSampleToArrangement => {
                 return self.handle_import_selected_browser_sample_to_arrangement();

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -12,7 +12,6 @@ use crate::domains::piano_roll::PianoRollMsg;
 use crate::domains::view::ViewMsg;
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::track::MediaSourceRef;
-use vibez_engine::commands::EngineCommand;
 
 use crate::message::{BrowserImportTarget, Message};
 
@@ -376,7 +375,10 @@ impl App {
         if self.state.browser.audition_mode == mode {
             return Task::none();
         }
-        self.stop_browser_audition();
+        // A mode switch supersedes only in-flight preparation. The current
+        // voice keeps playing until the Audition Bus crossfades the requested
+        // treatment, so RAW/WARP never introduces a needless gap.
+        self.state.browser.cancel_audition_preparation();
         self.state.browser.audition_mode = mode;
         let Some(source) = self.state.browser.selected_source.clone() else {
             return Task::none();
@@ -386,76 +388,6 @@ impl App {
             return Task::none();
         };
         self.play_browser_mode(source, raw)
-    }
-
-    pub(super) fn on_set_audition_sync(
-        &mut self,
-        sync: vibez_engine::commands::AuditionSync,
-    ) -> Task<Message> {
-        self.state.browser.audition_sync = sync;
-        self.state.status_text = match sync {
-            vibez_engine::commands::AuditionSync::Off => {
-                "Audition Sync Off: starts immediately".into()
-            }
-            vibez_engine::commands::AuditionSync::Beat => {
-                "Audition Sync Beat: queues only while transport runs".into()
-            }
-            vibez_engine::commands::AuditionSync::Bar => {
-                "Audition Sync Bar: queues only while transport runs".into()
-            }
-        };
-        Task::none()
-    }
-
-    pub(super) fn on_toggle_audition_loop(&mut self) -> Task<Message> {
-        self.state.browser.audition_loop = !self.state.browser.audition_loop;
-        self.send_command(EngineCommand::SetAuditionLoop(
-            self.state.browser.audition_loop,
-        ));
-        self.persist_ui_settings();
-        self.state.status_text = if self.state.browser.audition_loop {
-            "Audition Loop enabled".into()
-        } else {
-            "Audition Loop disabled".into()
-        };
-        Task::none()
-    }
-
-    pub(super) fn on_audition_bpm_edit_changed(&mut self, value: String) -> Task<Message> {
-        self.state.browser.audition_bpm_edit = value;
-        self.state.browser.audition_bpm_confirmed = None;
-        if self.state.browser.audition_mode == crate::state::AuditionMode::Warp {
-            self.state.browser.cancel_audition_preparation();
-            let raw_audition_active =
-                self.state.browser.audition_enabled && self.ensure_raw_browser_audition();
-            self.state.status_text = if raw_audition_active {
-                RAW_AUDITION_CONTINUES_FOR_BPM_EDIT.into()
-            } else {
-                WARP_BPM_EDIT_NEEDS_CONFIRMATION.into()
-            };
-        }
-        Task::none()
-    }
-
-    pub(super) fn on_confirm_audition_bpm(&mut self) -> Task<Message> {
-        let source_bpm = match self.state.browser.confirm_audition_bpm() {
-            Ok(value) => value,
-            Err(error) => {
-                self.state.status_text = error.into();
-                return Task::none();
-            }
-        };
-        self.state.status_text = format!("Confirmed {source_bpm:.1} source BPM");
-        if self.state.browser.audition_mode == crate::state::AuditionMode::Warp {
-            let Some(source) = self.state.browser.selected_source.clone() else {
-                return Task::none();
-            };
-            let Some(raw) = self.state.browser.waveform_audio.clone() else {
-                return Task::none();
-            };
-            return self.prepare_browser_warp(source, raw, source_bpm);
-        }
-        Task::none()
     }
 
     pub(super) fn on_escape_pressed(&mut self) -> Task<Message> {
@@ -582,56 +514,8 @@ impl App {
         source: MediaSourceRef,
         audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
     ) -> Task<Message> {
-        if self
-            .state
-            .browser
-            .install_waveform(source.clone(), Arc::clone(&audio))
-        {
-            return self.schedule_browser_bpm_detection(source, audio);
-        }
-        Task::none()
-    }
-
-    pub(super) fn on_browser_bpm_detected(
-        &mut self,
-        source: MediaSourceRef,
-        estimate: Option<(f64, f32)>,
-    ) -> Task<Message> {
-        let source_for_warp = source.clone();
-        // A BPM the user confirmed while detection was running
-        // already drives the audition; the late estimate must
-        // not restart it or rewrite the status line.
-        let already_confirmed = self.state.browser.audition_bpm_confirmed.is_some();
-        if self.state.browser.install_bpm_suggestion(
-            source,
-            estimate,
-            self.state.warp_confidence_threshold,
-        ) && self.state.browser.audition_mode == crate::state::AuditionMode::Warp
-            && !already_confirmed
-        {
-            if let Some(source_bpm) = self.state.browser.audition_bpm_confirmed {
-                let project_bpm = self.state.transport.bpm;
-                self.state.status_text = format!(
-                    "Detected {source_bpm:.1} source BPM; WARP targets project {project_bpm:.1} BPM"
-                );
-                if self.state.browser.audition_enabled {
-                    if let Some(raw) = self.state.browser.waveform_audio.clone() {
-                        return self.prepare_browser_warp(source_for_warp, raw, source_bpm);
-                    }
-                }
-            } else {
-                self.state.status_text = match estimate {
-                    Some((bpm, confidence))
-                        if confidence < self.state.warp_confidence_threshold =>
-                    {
-                        format!("Low-confidence suggestion {bpm:.1} BPM; confirm or edit for WARP")
-                    }
-                    Some((bpm, _)) => {
-                        format!("Suggested {bpm:.1} BPM; confirm for WARP")
-                    }
-                    None => "No BPM detected; enter a positive source BPM for WARP".into(),
-                };
-            }
+        if self.state.browser.install_waveform(source, audio) {
+            self.state.status_text = "Waveform ready".into();
         }
         Task::none()
     }
@@ -640,14 +524,12 @@ impl App {
         &mut self,
         source: MediaSourceRef,
         generation: u64,
-        source_bpm: f64,
         project_bpm: f64,
         result: Result<Arc<vibez_core::audio_buffer::DecodedAudio>, String>,
     ) -> Task<Message> {
         let current = self.state.browser.audition_request_is_current(generation)
             && self.state.browser.selected_source.as_ref() == Some(&source)
             && self.state.browser.audition_mode == crate::state::AuditionMode::Warp
-            && self.state.browser.audition_bpm_confirmed == Some(source_bpm)
             && (self.state.transport.bpm - project_bpm).abs() < f64::EPSILON;
         if !current {
             return Task::none();

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -376,9 +376,16 @@ impl App {
             let bpm = if selected {
                 self.state
                     .browser
-                    .audition_bpm_confirmed
-                    .or(self.state.browser.audition_bpm_suggestion)
-                    .map(|bpm| format!("{bpm:.0}"))
+                    .waveform_audio
+                    .as_ref()
+                    .and_then(|audio| {
+                        crate::warp::fit_loop_to_project(
+                            audio.num_frames(),
+                            audio.sample_rate as f64,
+                            self.state.transport.bpm,
+                        )
+                    })
+                    .map(|fit| format!("{:.0}", fit.source_bpm))
                     .unwrap_or_else(|| "—".into())
             } else {
                 "—".into()

--- a/crates/vibez-ui/src/app/views_browser_audition.rs
+++ b/crates/vibez-ui/src/app/views_browser_audition.rs
@@ -1,27 +1,18 @@
 //! Sample-browser audition footer rendering.
 //! Split from views_browser.rs; inherent methods on [`super::App`].
 
-use iced::widget::{
-    button, canvas, column, container, horizontal_space, row, slider, text, text_input,
-};
+use iced::widget::{button, canvas, column, container, row, slider, text};
 use iced::{Element, Length, Theme};
 
+use super::views_browser_style::*;
+use super::*;
 use crate::icons;
 use crate::message::Message;
 use crate::state::{AuditionMode, SampleBrowserMode};
 use crate::theme as th;
-use vibez_engine::commands::AuditionSync;
-
-use super::views_browser_style::*;
-use super::*;
 
 impl App {
     pub(super) fn view_browser_audition_footer(&self) -> Element<'_, Message> {
-        let compact = self
-            .state
-            .browser
-            .effective_dock_width(self.state.view.window_width)
-            < 360.0;
         let selected_local = self.selected_sample_browser_entry();
         let selected_dropbox = self.selected_dropbox_entry();
         let selected_label = match self.state.browser.mode {
@@ -66,11 +57,6 @@ impl App {
         .on_press(Message::ToggleAuditionEnabled)
         .padding([2, 4])
         .style(browser_utility_action_style);
-        let import_label = match self.state.browser.audition_import_input() {
-            Some(input) if input.mode == AuditionMode::Raw => "IMPORT RAW".to_string(),
-            Some(input) => format!("IMPORT WARP {:.1}", input.source_bpm.unwrap_or_default()),
-            None => "IMPORT BLOCKED".to_string(),
-        };
 
         let raw_active = self.state.browser.audition_mode == AuditionMode::Raw;
         let raw = button(text("RAW").size(9))
@@ -82,70 +68,6 @@ impl App {
             .on_press(Message::SetAuditionMode(AuditionMode::Warp))
             .padding([2, 5])
             .style(move |_theme: &Theme, status| browser_place_button_style(warp_active, status));
-        let sync_button = |label, value| {
-            let active = self.state.browser.audition_sync == value;
-            button(text(label).size(9))
-                .on_press(Message::SetAuditionSync(value))
-                .padding([2, 4])
-                .style(move |_theme: &Theme, status| browser_place_button_style(active, status))
-        };
-        let looped = self.state.browser.audition_loop;
-        let loop_toggle = button(text(if looped { "LOOP ON" } else { "LOOP OFF" }).size(9))
-            .on_press(Message::ToggleAuditionLoop)
-            .padding([2, 4])
-            .style(move |_theme: &Theme, status| browser_place_button_style(looped, status));
-
-        let bpm_input = text_input("BPM", &self.state.browser.audition_bpm_edit)
-            .on_input(Message::AuditionBpmEditChanged)
-            .on_submit(Message::ConfirmAuditionBpm)
-            .size(10)
-            .padding([3, 5])
-            .width(Length::Fixed(if compact { 54.0 } else { 62.0 }))
-            .style(browser_compact_input_style);
-        let confirm_bpm = button(text(if compact { "USE" } else { "CONFIRM BPM" }).size(9))
-            .on_press(Message::ConfirmAuditionBpm)
-            .padding([3, 5])
-            .style(browser_utility_action_style);
-        let automatic_bpm = self
-            .state
-            .browser
-            .audition_bpm_suggestion
-            .zip(self.state.browser.audition_bpm_confidence)
-            .is_some_and(|(suggestion, confidence)| {
-                confidence >= self.state.warp_confidence_threshold
-                    && self.state.browser.audition_bpm_confirmed == Some(suggestion)
-            });
-        let bpm_controls: Element<'_, Message> = if automatic_bpm {
-            text("AUTO").size(9).color(th::accent()).into()
-        } else {
-            row![bpm_input, confirm_bpm]
-                .spacing(4)
-                .align_y(iced::Alignment::Center)
-                .into()
-        };
-        let project_bpm = self.state.transport.bpm;
-        let bpm_state = if self.state.browser.audition_bpm_detecting {
-            format!("DETECTING SOURCE → {project_bpm:.0}")
-        } else if let Some(confirmed) = self.state.browser.audition_bpm_confirmed {
-            if compact {
-                format!("{confirmed:.1} → {project_bpm:.0}")
-            } else {
-                format!("SOURCE {confirmed:.1} → PROJECT {project_bpm:.0}")
-            }
-        } else if let Some(suggestion) = self.state.browser.audition_bpm_suggestion {
-            let low = self
-                .state
-                .browser
-                .audition_bpm_confidence
-                .is_some_and(|confidence| confidence < self.state.warp_confidence_threshold);
-            if low {
-                format!("LOW {suggestion:.1} → PROJECT {project_bpm:.0}")
-            } else {
-                format!("SOURCE {suggestion:.1} → PROJECT {project_bpm:.0}")
-            }
-        } else {
-            format!("SOURCE NEEDED → PROJECT {project_bpm:.0}")
-        };
 
         let waveform: Element<'_, Message> = container(
             canvas(crate::widgets::browser_waveform::BrowserWaveform {
@@ -174,7 +96,7 @@ impl App {
                 && self.state.browser.audition_playing
                 && self.state.browser.audition_playback_mode == Some(AuditionMode::Raw)
             {
-                "RAW · WARPING"
+                "WARPING"
             } else if self.state.browser.audition_loading {
                 "PREPARING"
             } else if self.state.browser.audition_queued {
@@ -184,7 +106,7 @@ impl App {
                     Some(AuditionMode::Raw)
                         if self.state.browser.audition_mode == AuditionMode::Warp =>
                     {
-                        "RAW · BPM NEEDED"
+                        "WARPING"
                     }
                     Some(mode) => mode.label(),
                     None => "PLAYING",
@@ -192,13 +114,7 @@ impl App {
             } else if self.state.browser.waveform_error.is_some() {
                 "UNAVAILABLE"
             } else if self.state.browser.waveform_audio.is_some() {
-                match self.state.browser.audition_mode {
-                    AuditionMode::Raw => "RAW",
-                    AuditionMode::Warp if self.state.browser.audition_bpm_confirmed.is_some() => {
-                        "WARP READY"
-                    }
-                    AuditionMode::Warp => "BPM NEEDED",
-                }
+                self.state.browser.audition_mode.label()
             } else {
                 "SELECT"
             })
@@ -246,7 +162,8 @@ impl App {
             row![
                 text("AUDITION").size(9).color(th::text_muted()),
                 follow_toggle,
-                text(import_label).size(9).color(th::text_dim()),
+                raw,
+                warp,
                 text(selected_label)
                     .size(10)
                     .color(th::text_dim())
@@ -255,37 +172,6 @@ impl App {
                     .wrapping(iced::widget::text::Wrapping::None)
             ]
             .spacing(5)
-            .align_y(iced::Alignment::Center),
-            row![
-                text("MODE").size(9).color(th::text_muted()),
-                raw,
-                warp,
-                text("SYNC").size(9).color(th::text_muted()),
-                sync_button("OFF", AuditionSync::Off),
-                sync_button("BEAT", AuditionSync::Beat),
-                sync_button("BAR", AuditionSync::Bar),
-                horizontal_space(),
-                loop_toggle,
-            ]
-            .spacing(3)
-            .align_y(iced::Alignment::Center),
-            row![
-                text(if compact { "SRC" } else { "SOURCE BPM" })
-                    .size(9)
-                    .color(th::text_muted()),
-                bpm_controls,
-                text(bpm_state)
-                    .size(9)
-                    .color(if self.state.browser.audition_bpm_confirmed.is_some() {
-                        th::accent()
-                    } else {
-                        th::text_dim()
-                    })
-                    .width(Length::Fill)
-                    .align_x(iced::alignment::Horizontal::Right)
-                    .wrapping(iced::widget::text::Wrapping::None),
-            ]
-            .spacing(4)
             .align_y(iced::Alignment::Center),
             controls,
             gain_row

--- a/crates/vibez-ui/src/app/views_browser_style.rs
+++ b/crates/vibez-ui/src/app/views_browser_style.rs
@@ -170,24 +170,6 @@ pub(super) fn browser_utility_action_style(
     }
 }
 
-pub(super) fn browser_compact_input_style(
-    _theme: &Theme,
-    _status: iced::widget::text_input::Status,
-) -> iced::widget::text_input::Style {
-    iced::widget::text_input::Style {
-        background: th::bg_dark().into(),
-        border: iced::Border {
-            color: th::border(),
-            width: 1.0,
-            radius: 0.0.into(),
-        },
-        icon: th::text_dim(),
-        placeholder: th::text_dim(),
-        value: th::text(),
-        selection: th::accent(),
-    }
-}
-
 pub(super) fn browser_transport_button_style(
     _theme: &Theme,
     status: button::Status,

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -148,7 +148,7 @@ fn audition_defaults_on_and_remembers_clamped_gain_state() {
     let mut browser = BrowserState::default();
     assert!(browser.audition_enabled);
     assert_eq!(browser.audition_gain, 1.0);
-    assert_eq!(browser.audition_mode, crate::state::AuditionMode::Raw);
+    assert_eq!(browser.audition_mode, crate::state::AuditionMode::Warp);
 
     assert!(!browser.toggle_audition_enabled());
     browser.set_audition_gain(3.0);

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -107,7 +107,7 @@ fn changing_selection_clears_waveform_and_rejects_stale_decode() {
     let generation = browser.begin_audition_load(&first);
     assert!(browser.install_audition(generation, first.clone(), std::sync::Arc::clone(&audio)));
     assert!(browser.waveform_audio.is_some());
-    assert!(browser.audition_playing);
+    assert!(!browser.audition_playing);
 
     browser.select_source(second);
     assert!(browser.waveform_audio.is_none());
@@ -140,7 +140,7 @@ fn stopping_or_superseding_an_audition_invalidates_in_flight_decodes() {
     let new = browser.begin_audition_load(&source);
     assert!(!browser.install_audition(old, source.clone(), std::sync::Arc::clone(&audio)));
     assert!(browser.install_audition(new, source, audio));
-    assert!(browser.audition_playing);
+    assert!(!browser.audition_playing);
 }
 
 #[test]
@@ -221,7 +221,7 @@ fn selected_source_can_reuse_its_decoded_waveform_for_retriggering() {
 }
 
 #[test]
-fn warp_preparation_keeps_the_loaded_waveform_and_raw_voice_live() {
+fn warp_preparation_keeps_the_loaded_waveform_without_claiming_playback() {
     let source = MediaSourceRef::LocalFile {
         path: PathBuf::from("/samples/loop.wav"),
     };
@@ -232,21 +232,17 @@ fn warp_preparation_keeps_the_loaded_waveform_and_raw_voice_live() {
     let mut browser = BrowserState::default();
     browser.select_source(source.clone());
     assert!(browser.install_waveform(source.clone(), audio));
-    browser.mark_audition_requested(false, crate::state::AuditionMode::Raw);
 
     let preparation = browser.begin_audition_preparation(&source);
     assert!(browser.audition_loading);
     assert!(!browser.waveform_loading);
-    assert!(browser.audition_playing);
+    assert!(!browser.audition_playing);
 
     browser.cancel_audition_preparation();
     assert!(!browser.audition_request_is_current(preparation));
     assert!(!browser.audition_loading);
-    assert!(browser.audition_playing);
-    assert_eq!(
-        browser.audition_playback_mode,
-        Some(crate::state::AuditionMode::Raw)
-    );
+    assert!(!browser.audition_playing);
+    assert_eq!(browser.audition_playback_mode, None);
 }
 
 #[test]

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -198,6 +198,33 @@ fn warp_audition_plan_always_grid_fits_valid_audio() {
 }
 
 #[test]
+fn warp_audition_and_import_keep_one_shots_raw() {
+    let browser = BrowserState {
+        audition_mode: crate::state::AuditionMode::Warp,
+        ..BrowserState::default()
+    };
+    let audio = vibez_core::audio_buffer::DecodedAudio {
+        channels: vec![vec![0.0; 2_205]],
+        sample_rate: 44_100,
+    };
+
+    assert_eq!(
+        browser.audition_playback_plan(&audio, 120.0),
+        crate::state::BrowserAuditionPlan::Raw
+    );
+    assert_eq!(
+        browser
+            .audition_import_input()
+            .resolve_for_audio(&audio, 120.0)
+            .unwrap(),
+        crate::state::AuditionImportInput {
+            mode: crate::state::AuditionMode::Raw,
+            source_bpm: None,
+        }
+    );
+}
+
+#[test]
 fn selected_source_can_reuse_its_decoded_waveform_for_retriggering() {
     let source = MediaSourceRef::LocalFile {
         path: PathBuf::from("/samples/loop.wav"),

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -149,11 +149,6 @@ fn audition_defaults_on_and_remembers_clamped_gain_state() {
     assert!(browser.audition_enabled);
     assert_eq!(browser.audition_gain, 1.0);
     assert_eq!(browser.audition_mode, crate::state::AuditionMode::Raw);
-    assert_eq!(
-        browser.audition_sync,
-        vibez_engine::commands::AuditionSync::Off
-    );
-    assert!(!browser.audition_loop);
 
     assert!(!browser.toggle_audition_enabled());
     browser.set_audition_gain(3.0);
@@ -163,67 +158,41 @@ fn audition_defaults_on_and_remembers_clamped_gain_state() {
 }
 
 #[test]
-fn warp_import_input_requires_positive_confirmed_bpm_for_the_current_source() {
-    let first = MediaSourceRef::LocalFile {
-        path: PathBuf::from("/samples/loop.wav"),
-    };
-    let second = MediaSourceRef::LocalFile {
-        path: PathBuf::from("/samples/other.wav"),
-    };
-    let mut browser = BrowserState::default();
-    browser.select_source(first.clone());
-    browser.audition_mode = crate::state::AuditionMode::Warp;
-    assert!(browser.audition_import_input().is_none());
-
-    assert!(browser.install_bpm_suggestion(first, Some((127.8, 0.42)), 0.6));
-    assert_eq!(browser.audition_bpm_edit, "127.8");
-    assert!(browser.audition_bpm_confirmed.is_none());
-    assert_eq!(browser.confirm_audition_bpm().unwrap(), 127.8);
-    let input = browser.audition_import_input().unwrap();
-    assert_eq!(input.mode, crate::state::AuditionMode::Warp);
-    assert_eq!(input.source_bpm, Some(127.8));
-
-    browser.select_source(second);
-    assert!(browser.audition_bpm_confirmed.is_none());
-    assert!(browser.audition_import_input().is_none());
-    browser.audition_bpm_edit = "0".into();
-    assert!(browser.confirm_audition_bpm().is_err());
-}
-
-#[test]
-fn trustworthy_detected_source_bpm_is_ready_without_manual_entry() {
-    let source = MediaSourceRef::LocalFile {
-        path: PathBuf::from("/samples/loop.wav"),
-    };
-    let mut browser = BrowserState::default();
-    browser.select_source(source.clone());
-    browser.audition_mode = crate::state::AuditionMode::Warp;
-
-    assert!(browser.install_bpm_suggestion(source, Some((124.0, 0.91)), 0.6));
-    assert_eq!(browser.audition_bpm_confirmed, Some(124.0));
-    assert_eq!(
-        browser.audition_import_input().unwrap().source_bpm,
-        Some(124.0)
-    );
-}
-
-#[test]
-fn warp_intent_without_confirmed_bpm_falls_back_to_raw_audition() {
-    let mut browser = BrowserState {
+fn warp_import_resolves_the_same_grid_fit_without_confirmation() {
+    let browser = BrowserState {
         audition_mode: crate::state::AuditionMode::Warp,
         ..BrowserState::default()
     };
 
-    assert_eq!(
-        browser.audition_playback_plan(),
-        crate::state::BrowserAuditionPlan::Raw
-    );
-    assert!(browser.audition_import_input().is_none());
+    let frames = (4.0 * 4.0 * 60.0 / 128.0 * 44_100.0) as usize;
+    let audio = vibez_core::audio_buffer::DecodedAudio {
+        channels: vec![vec![0.0; frames]],
+        sample_rate: 44_100,
+    };
 
-    browser.audition_bpm_edit = "128".into();
-    browser.confirm_audition_bpm().unwrap();
+    let input = browser.audition_import_input();
+    assert_eq!(input.mode, crate::state::AuditionMode::Warp);
+    assert_eq!(input.source_bpm, None);
     assert_eq!(
-        browser.audition_playback_plan(),
+        input.resolve_for_audio(&audio, 120.0).unwrap().source_bpm,
+        Some(128.0)
+    );
+}
+
+#[test]
+fn warp_audition_plan_always_grid_fits_valid_audio() {
+    let browser = BrowserState {
+        audition_mode: crate::state::AuditionMode::Warp,
+        ..BrowserState::default()
+    };
+    let frames = (4.0 * 4.0 * 60.0 / 128.0 * 44_100.0) as usize;
+    let audio = vibez_core::audio_buffer::DecodedAudio {
+        channels: vec![vec![0.0; frames]],
+        sample_rate: 44_100,
+    };
+
+    assert_eq!(
+        browser.audition_playback_plan(&audio, 120.0),
         crate::state::BrowserAuditionPlan::Warp { source_bpm: 128.0 }
     );
 }
@@ -278,51 +247,6 @@ fn warp_preparation_keeps_the_loaded_waveform_and_raw_voice_live() {
         browser.audition_playback_mode,
         Some(crate::state::AuditionMode::Raw)
     );
-}
-
-#[test]
-fn manual_confirmation_during_detection_wins_over_late_estimate() {
-    let source = MediaSourceRef::LocalFile {
-        path: PathBuf::from("/samples/loop.wav"),
-    };
-    let mut browser = BrowserState::default();
-    browser.select_source(source.clone());
-    browser.audition_mode = crate::state::AuditionMode::Warp;
-    assert!(browser.begin_bpm_detection(&source));
-
-    // The user types and confirms a known BPM while the detector
-    // is still running; the late estimate must not clobber it.
-    browser.audition_bpm_edit = "140".into();
-    assert_eq!(browser.confirm_audition_bpm().unwrap(), 140.0);
-
-    assert!(browser.install_bpm_suggestion(source.clone(), Some((124.0, 0.91)), 0.6));
-    assert_eq!(browser.audition_bpm_confirmed, Some(140.0));
-    assert_eq!(browser.audition_bpm_suggestion, Some(124.0));
-
-    // A late low-confidence estimate must not clear it either.
-    browser.audition_bpm_source = None;
-    assert!(browser.install_bpm_suggestion(source, Some((99.0, 0.1)), 0.6));
-    assert_eq!(browser.audition_bpm_confirmed, Some(140.0));
-}
-
-#[test]
-fn confirmed_audition_bpm_is_bounded_to_a_sane_daw_range() {
-    let mut browser = BrowserState::default();
-    for rejected in ["0", "-120", "19.9", "1000", "1e8", "1e308", "inf", "nan"] {
-        browser.audition_bpm_edit = rejected.into();
-        assert!(
-            browser.confirm_audition_bpm().is_err(),
-            "{rejected} must be rejected"
-        );
-        assert!(browser.audition_bpm_confirmed.is_none());
-    }
-    for accepted in ["20", "174", "999"] {
-        browser.audition_bpm_edit = accepted.into();
-        assert!(
-            browser.confirm_audition_bpm().is_ok(),
-            "{accepted} must be accepted"
-        );
-    }
 }
 
 #[test]
@@ -387,18 +311,17 @@ fn drag_preview_reports_exact_raw_and_warp_musical_lengths() {
         waveform_source: Some(source.clone()),
         waveform_audio: Some(std::sync::Arc::new(
             vibez_core::audio_buffer::DecodedAudio {
-                channels: vec![vec![0.25; 44_100]],
+                channels: vec![vec![0.25; 88_200]],
                 sample_rate: 44_100,
             },
         )),
         ..BrowserState::default()
     };
-    assert_eq!(browser.drag_preview_beats(120.0), Some(2.0));
+    assert_eq!(browser.drag_preview_beats(120.0), Some(4.0));
 
     browser.selected_source = Some(source);
     browser.audition_mode = crate::state::AuditionMode::Warp;
-    browser.audition_bpm_confirmed = Some(120.0);
-    assert_eq!(browser.drag_preview_beats(60.0), Some(2.0));
+    assert_eq!(browser.drag_preview_beats(60.0), Some(4.0));
 }
 
 #[test]

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -589,21 +589,15 @@ pub enum Message {
     ToggleAuditionEnabled,
     SetAuditionGain(f32),
     SetAuditionMode(AuditionMode),
-    SetAuditionSync(vibez_engine::commands::AuditionSync),
-    ToggleAuditionLoop,
-    AuditionBpmEditChanged(String),
-    ConfirmAuditionBpm,
     EscapePressed,
     /// The `u64` is the audition request generation minted at spawn
     /// time; stale completions (stopped or superseded requests) are
     /// dropped instead of starting playback.
     LocalSamplePreviewReady(MediaSourceRef, u64, Result<Arc<DecodedAudio>, String>),
     BrowserWaveformReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
-    BrowserBpmDetected(MediaSourceRef, Option<(f64, f32)>),
     BrowserAuditionWarpReady {
         source: MediaSourceRef,
         generation: u64,
-        source_bpm: f64,
         project_bpm: f64,
         result: Result<Arc<DecodedAudio>, String>,
     },

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -17,10 +17,6 @@ pub const ARRANGE_MIN_WIDTH_WITH_BROWSER: f32 = 560.0;
 pub const BROWSER_PLACES_MIN_WIDTH: f32 = 124.0;
 pub const BROWSER_PLACES_MAX_WIDTH: f32 = 176.0;
 pub const BROWSER_RESULTS_PAGE_SIZE: usize = 200;
-/// Sane DAW range for a manually confirmed audition source BPM.
-pub const AUDITION_BPM_MIN: f64 = 20.0;
-pub const AUDITION_BPM_MAX: f64 = 999.0;
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BrowserAuditionPlan {
     Raw,
@@ -119,14 +115,6 @@ pub struct BrowserState {
     /// with the final reference either.
     pub audition_audio_retired: [Option<Arc<DecodedAudio>>; 4],
     pub audition_mode: AuditionMode,
-    pub audition_sync: AuditionSync,
-    pub audition_loop: bool,
-    pub audition_bpm_source: Option<MediaSourceRef>,
-    pub audition_bpm_suggestion: Option<f64>,
-    pub audition_bpm_confidence: Option<f32>,
-    pub audition_bpm_confirmed: Option<f64>,
-    pub audition_bpm_edit: String,
-    pub audition_bpm_detecting: bool,
     pub scan_in_progress: bool,
     pub mode: SampleBrowserMode,
     pub remote: RemoteUiState,
@@ -172,14 +160,6 @@ impl Default for BrowserState {
             audition_audio: None,
             audition_audio_retired: [None, None, None, None],
             audition_mode: AuditionMode::default(),
-            audition_sync: AuditionSync::Off,
-            audition_loop: false,
-            audition_bpm_source: None,
-            audition_bpm_suggestion: None,
-            audition_bpm_confidence: None,
-            audition_bpm_confirmed: None,
-            audition_bpm_edit: String::new(),
-            audition_bpm_detecting: false,
             scan_in_progress: false,
             mode: SampleBrowserMode::default(),
             remote: RemoteUiState::default(),
@@ -398,7 +378,6 @@ impl BrowserState {
         self.selected_source = Some(source);
         if changed {
             self.clear_waveform();
-            self.clear_audition_bpm();
         }
         changed
     }
@@ -406,7 +385,6 @@ impl BrowserState {
     pub fn clear_selection(&mut self) {
         self.selected_source = None;
         self.clear_waveform();
-        self.clear_audition_bpm();
     }
 
     pub fn begin_waveform_load(&mut self, source: &MediaSourceRef) {
@@ -495,97 +473,31 @@ impl BrowserState {
         self.audition_playback_mode = Some(mode);
     }
 
-    pub fn begin_bpm_detection(&mut self, source: &MediaSourceRef) -> bool {
-        if self.selected_source.as_ref() != Some(source)
-            || self.audition_bpm_source.as_ref() == Some(source)
-            || self.audition_bpm_detecting
-        {
-            return false;
+    pub fn audition_import_input(&self) -> AuditionImportInput {
+        AuditionImportInput {
+            mode: self.audition_mode,
+            // WARP resolves this from the decoded loop boundary and Project
+            // tempo immediately before rendering the import.
+            source_bpm: None,
         }
-        self.audition_bpm_detecting = true;
-        true
     }
 
-    pub fn install_bpm_suggestion(
-        &mut self,
-        source: MediaSourceRef,
-        estimate: Option<(f64, f32)>,
-        auto_confirm_threshold: f32,
-    ) -> bool {
-        if self.selected_source.as_ref() != Some(&source) {
-            return false;
-        }
-        self.audition_bpm_source = Some(source);
-        self.audition_bpm_detecting = false;
-        self.audition_bpm_suggestion = estimate.map(|value| value.0);
-        self.audition_bpm_confidence = estimate.map(|value| value.1);
-        // A BPM the user confirmed while detection was in flight wins
-        // over the late estimate; only auto-confirm into an empty slot.
-        if self.audition_bpm_confirmed.is_none() {
-            self.audition_bpm_confirmed = estimate
-                .filter(|(bpm, confidence)| {
-                    bpm.is_finite()
-                        && *bpm > 0.0
-                        && *confidence >= auto_confirm_threshold.clamp(0.0, 1.0)
-                })
-                .map(|(bpm, _)| bpm);
-        }
-        if self.audition_bpm_edit.is_empty() {
-            self.audition_bpm_edit = estimate
-                .map(|value| format!("{:.1}", value.0))
-                .unwrap_or_default();
-        }
-        true
-    }
-
-    pub fn confirm_audition_bpm(&mut self) -> Result<f64, &'static str> {
-        let bpm = self
-            .audition_bpm_edit
-            .trim()
-            .parse::<f64>()
-            .map_err(|_| "Enter a source BPM between 20 and 999")?;
-        // An unbounded BPM would request an effectively unbounded WARP
-        // allocation; keep manual entry inside a sane DAW range.
-        if !bpm.is_finite() || !(AUDITION_BPM_MIN..=AUDITION_BPM_MAX).contains(&bpm) {
-            return Err("Enter a source BPM between 20 and 999");
-        }
-        self.audition_bpm_confirmed = Some(bpm);
-        Ok(bpm)
-    }
-
-    pub fn clear_audition_bpm(&mut self) {
-        self.audition_bpm_source = None;
-        self.audition_bpm_suggestion = None;
-        self.audition_bpm_confidence = None;
-        self.audition_bpm_confirmed = None;
-        self.audition_bpm_edit.clear();
-        self.audition_bpm_detecting = false;
-    }
-
-    pub fn audition_import_input(&self) -> Option<AuditionImportInput> {
+    pub fn audition_playback_plan(
+        &self,
+        audio: &DecodedAudio,
+        project_bpm: f64,
+    ) -> BrowserAuditionPlan {
         match self.audition_mode {
-            AuditionMode::Raw => Some(AuditionImportInput {
-                mode: AuditionMode::Raw,
-                source_bpm: None,
-            }),
-            AuditionMode::Warp => {
-                self.audition_bpm_confirmed
-                    .map(|source_bpm| AuditionImportInput {
-                        mode: AuditionMode::Warp,
-                        source_bpm: Some(source_bpm),
-                    })
-            }
-        }
-    }
-
-    /// Choose a safe Audition plan without weakening WARP's confirmed-BPM
-    /// requirement. An unconfirmed WARP selection remains a WARP import
-    /// intent, but Audition falls back to the truthful RAW source instead of
-    /// going silent.
-    pub fn audition_playback_plan(&self) -> BrowserAuditionPlan {
-        match (self.audition_mode, self.audition_bpm_confirmed) {
-            (AuditionMode::Warp, Some(source_bpm)) => BrowserAuditionPlan::Warp { source_bpm },
-            _ => BrowserAuditionPlan::Raw,
+            AuditionMode::Raw => BrowserAuditionPlan::Raw,
+            AuditionMode::Warp => crate::warp::fit_loop_to_project(
+                audio.num_frames(),
+                audio.sample_rate as f64,
+                project_bpm,
+            )
+            .map(|fit| BrowserAuditionPlan::Warp {
+                source_bpm: fit.source_bpm,
+            })
+            .unwrap_or(BrowserAuditionPlan::Raw),
         }
     }
 
@@ -649,24 +561,14 @@ impl BrowserState {
             return None;
         }
         let seconds = audio.num_frames() as f64 / audio.sample_rate as f64;
-        match self.audition_import_input()? {
-            AuditionImportInput {
-                mode: AuditionMode::Raw,
-                ..
-            } => (project_bpm > 0.0).then_some(seconds * project_bpm / 60.0),
-            AuditionImportInput {
-                mode: AuditionMode::Warp,
-                source_bpm: Some(source_bpm),
-            } if project_bpm > 0.0 => {
-                let target_frames = crate::warp::warp_target_frames(
-                    audio.num_frames(),
-                    audio.sample_rate as f64,
-                    source_bpm,
-                    project_bpm,
-                );
-                Some(target_frames as f64 * project_bpm / (audio.sample_rate as f64 * 60.0))
-            }
-            _ => None,
+        match self.audition_mode {
+            AuditionMode::Raw => (project_bpm > 0.0).then_some(seconds * project_bpm / 60.0),
+            AuditionMode::Warp => crate::warp::fit_loop_to_project(
+                audio.num_frames(),
+                audio.sample_rate as f64,
+                project_bpm,
+            )
+            .map(|fit| fit.bars as f64 * 4.0),
         }
     }
 

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -446,7 +446,6 @@ impl BrowserState {
             return false;
         }
         self.audition_loading = false;
-        self.audition_playing = true;
         true
     }
 

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -567,7 +567,8 @@ impl BrowserState {
                 audio.sample_rate as f64,
                 project_bpm,
             )
-            .map(|fit| fit.bars as f64 * 4.0),
+            .map(|fit| fit.bars as f64 * 4.0)
+            .or_else(|| (project_bpm > 0.0).then_some(seconds * project_bpm / 60.0)),
         }
     }
 

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -17,7 +17,6 @@ use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::constants::DEFAULT_BPM;
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::track::MediaSourceRef;
-use vibez_engine::commands::AuditionSync;
 use vibez_plugin_host::PluginSettings;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -40,6 +39,29 @@ pub struct AuditionImportInput {
     pub mode: AuditionMode,
     pub source_bpm: Option<f64>,
 }
+
+impl AuditionImportInput {
+    /// Resolve Browser WARP from the same complete-loop grid fit used by
+    /// Audition. RAW remains untouched.
+    pub fn resolve_for_audio(
+        mut self,
+        audio: &DecodedAudio,
+        project_bpm: f64,
+    ) -> Result<Self, String> {
+        if self.mode == AuditionMode::Raw {
+            return Ok(self);
+        }
+        let fit = crate::warp::fit_loop_to_project(
+            audio.num_frames(),
+            audio.sample_rate as f64,
+            project_bpm,
+        )
+        .ok_or_else(|| "Cannot grid-fit empty or invalid audio".to_string())?;
+        self.source_bpm = Some(fit.source_bpm);
+        Ok(self)
+    }
+}
+
 pub const MEDIA_DRAG_THRESHOLD_PX: f32 = 6.0;
 pub const PERFORM_SURFACE_DEFAULT_WIDTH: f32 = 560.0;
 pub const DETAIL_PANEL_DEFAULT_HEIGHT: f32 = 280.0;

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -21,8 +21,8 @@ use vibez_plugin_host::PluginSettings;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AuditionMode {
-    #[default]
     Raw,
+    #[default]
     Warp,
 }
 

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -42,7 +42,8 @@ pub struct AuditionImportInput {
 
 impl AuditionImportInput {
     /// Resolve Browser WARP from the same complete-loop grid fit used by
-    /// Audition. RAW remains untouched.
+    /// Audition. Sources with no plausible loop interpretation fall back to
+    /// RAW so one-shots are never stretched into arbitrary bar lengths.
     pub fn resolve_for_audio(
         mut self,
         audio: &DecodedAudio,
@@ -51,12 +52,22 @@ impl AuditionImportInput {
         if self.mode == AuditionMode::Raw {
             return Ok(self);
         }
-        let fit = crate::warp::fit_loop_to_project(
+        if audio.num_frames() == 0
+            || audio.sample_rate == 0
+            || !project_bpm.is_finite()
+            || project_bpm <= 0.0
+        {
+            return Err("Cannot prepare empty or invalid audio".into());
+        }
+        let Some(fit) = crate::warp::fit_loop_to_project(
             audio.num_frames(),
             audio.sample_rate as f64,
             project_bpm,
-        )
-        .ok_or_else(|| "Cannot grid-fit empty or invalid audio".to_string())?;
+        ) else {
+            self.mode = AuditionMode::Raw;
+            self.source_bpm = None;
+            return Ok(self);
+        };
         self.source_bpm = Some(fit.source_bpm);
         Ok(self)
     }

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -27,8 +27,6 @@ pub struct UiSettings {
     pub audition_enabled: bool,
     #[serde(default = "default_audition_gain")]
     pub audition_gain: f32,
-    #[serde(default)]
-    pub audition_loop: bool,
     /// Automatically detect each dropped sample's BPM and warp it to
     /// the project tempo on import. Off by default; users opt in from
     /// Settings → Warping.
@@ -132,7 +130,6 @@ impl Default for UiSettings {
             detail_panel_height: default_detail_panel_height(),
             audition_enabled: default_audition_enabled(),
             audition_gain: default_audition_gain(),
-            audition_loop: false,
             auto_warp_on_import: false,
             warp_confidence_threshold: default_warp_confidence_threshold(),
             preferred_midi_input: None,
@@ -428,7 +425,6 @@ mod tests {
         let loaded: UiSettings = serde_json::from_str(r#"{"sample_library_roots":[]}"#).unwrap();
         assert!(loaded.audition_enabled);
         assert_eq!(loaded.audition_gain, 1.0);
-        assert!(!loaded.audition_loop);
     }
 
     #[test]
@@ -436,14 +432,12 @@ mod tests {
         let settings = UiSettings {
             audition_enabled: false,
             audition_gain: 0.42,
-            audition_loop: true,
             ..Default::default()
         };
         let loaded: UiSettings =
             serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
         assert!(!loaded.audition_enabled);
         assert_eq!(loaded.audition_gain, 0.42);
-        assert!(loaded.audition_loop);
     }
 
     #[test]

--- a/crates/vibez-ui/src/warp.rs
+++ b/crates/vibez-ui/src/warp.rs
@@ -43,6 +43,76 @@ pub struct WarpClipInput {
     pub project_bpm: f64,
 }
 
+/// Deterministic mapping from a clean production loop to the Project grid.
+///
+/// Browser WARP treats the complete source boundary as musical truth: the
+/// loop is assumed to span one of the conventional 1/2/4/8/16 bar lengths,
+/// and the source BPM is derived from that span. This avoids asking a generic
+/// beat detector to choose between rhythmic subdivisions before the producer
+/// can hear or import the loop.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LoopGridFit {
+    pub bars: u32,
+    pub source_bpm: f64,
+    pub target_frames: usize,
+}
+
+const LOOP_GRID_BARS: [u32; 5] = [1, 2, 4, 8, 16];
+const PLAUSIBLE_LOOP_BPM_MIN: f64 = 60.0;
+const PLAUSIBLE_LOOP_BPM_MAX: f64 = 200.0;
+
+/// Fit a complete source loop to the conventional Project bar span that
+/// requires the least time stretching. Candidates in a practical production
+/// tempo range win over half/double-time interpretations outside that range.
+/// If every interpretation is outside the range, the least-stretched result
+/// still wins: selecting WARP must always produce a deterministic treatment.
+pub fn fit_loop_to_project(
+    source_frames: usize,
+    sample_rate: f64,
+    project_bpm: f64,
+) -> Option<LoopGridFit> {
+    if source_frames == 0
+        || !sample_rate.is_finite()
+        || sample_rate <= 0.0
+        || !project_bpm.is_finite()
+        || project_bpm <= 0.0
+    {
+        return None;
+    }
+
+    let source_seconds = source_frames as f64 / sample_rate;
+    let candidates = LOOP_GRID_BARS.map(|bars| {
+        let beats = bars as f64 * 4.0;
+        let source_bpm = beats * 60.0 / source_seconds;
+        let target_frames = (beats * 60.0 / project_bpm * sample_rate).round() as usize;
+        let stretch_distance = (target_frames as f64 / source_frames as f64).ln().abs();
+        (
+            LoopGridFit {
+                bars,
+                source_bpm,
+                target_frames,
+            },
+            stretch_distance,
+        )
+    });
+    let has_plausible = candidates.iter().any(|(fit, _)| {
+        (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(&fit.source_bpm)
+    });
+
+    candidates
+        .into_iter()
+        .filter(|(fit, _)| {
+            !has_plausible
+                || (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(&fit.source_bpm)
+        })
+        .min_by(|left, right| {
+            left.1
+                .partial_cmp(&right.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|(fit, _)| fit)
+}
+
 /// Deterministic warped length for a clip: the naive proportional
 /// length snapped to the nearest whole bar at the project tempo when
 /// the naive result lands close to an integer bar count.
@@ -178,6 +248,47 @@ mod tests {
             channels: vec![vec![0.25; frames]],
             sample_rate: SR,
         })
+    }
+
+    #[test]
+    fn grid_fit_derives_clean_loop_tempo_from_its_project_bar_span() {
+        let cases = [
+            (2.0, 120.0, 120.0),
+            (1.0, 122.0, 122.0),
+            (4.0, 128.0, 128.0),
+            (2.0, 130.0, 130.0),
+            (1.0, 133.0, 133.0),
+            (1.0, 140.0, 140.0),
+            (8.0, 150.0, 150.0),
+        ];
+
+        for (bars, source_bpm, expected_bpm) in cases {
+            let audio = exact_loop(bars, source_bpm);
+            let fit = fit_loop_to_project(audio.num_frames(), audio.sample_rate as f64, 120.0)
+                .expect("valid audio and project tempo must always produce a grid fit");
+
+            assert_eq!(fit.bars, bars as u32);
+            assert!((fit.source_bpm - expected_bpm).abs() < 0.01);
+            let expected_frames = (bars * 4.0 * 60.0 / 120.0 * SR as f64).round() as usize;
+            assert_eq!(fit.target_frames, expected_frames);
+        }
+    }
+
+    #[test]
+    fn grid_fit_uses_a_plausible_source_octave_when_project_tempo_is_far_away() {
+        let audio = exact_loop(4.0, 120.0);
+        let fit = fit_loop_to_project(audio.num_frames(), audio.sample_rate as f64, 174.0).unwrap();
+
+        assert_eq!(fit.bars, 4);
+        assert!((fit.source_bpm - 120.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn grid_fit_still_returns_a_deterministic_result_outside_the_plausible_range() {
+        let fit = fit_loop_to_project(SR as usize / 20, SR as f64, 120.0).unwrap();
+        assert!(fit.source_bpm.is_finite());
+        assert!(fit.source_bpm > 0.0);
+        assert!(fit.target_frames > 0);
     }
 
     fn first_warp_input(

--- a/crates/vibez-ui/src/warp.rs
+++ b/crates/vibez-ui/src/warp.rs
@@ -64,8 +64,8 @@ const PLAUSIBLE_LOOP_BPM_MAX: f64 = 200.0;
 /// Fit a complete source loop to the conventional Project bar span that
 /// requires the least time stretching. Candidates in a practical production
 /// tempo range win over half/double-time interpretations outside that range.
-/// If every interpretation is outside the range, the least-stretched result
-/// still wins: selecting WARP must always produce a deterministic treatment.
+/// Audio with no plausible interpretation is treated as a one-shot rather
+/// than being stretched into an arbitrary bar length.
 pub fn fit_loop_to_project(
     source_frames: usize,
     sample_rate: f64,
@@ -95,15 +95,10 @@ pub fn fit_loop_to_project(
             stretch_distance,
         )
     });
-    let has_plausible = candidates.iter().any(|(fit, _)| {
-        (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(&fit.source_bpm)
-    });
-
     candidates
         .into_iter()
         .filter(|(fit, _)| {
-            !has_plausible
-                || (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(&fit.source_bpm)
+            (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(&fit.source_bpm)
         })
         .min_by(|left, right| {
             left.1
@@ -284,11 +279,11 @@ mod tests {
     }
 
     #[test]
-    fn grid_fit_still_returns_a_deterministic_result_outside_the_plausible_range() {
-        let fit = fit_loop_to_project(SR as usize / 20, SR as f64, 120.0).unwrap();
-        assert!(fit.source_bpm.is_finite());
-        assert!(fit.source_bpm > 0.0);
-        assert!(fit.target_frames > 0);
+    fn grid_fit_rejects_a_one_shot_with_no_plausible_loop_tempo() {
+        assert_eq!(
+            fit_loop_to_project(SR as usize / 20, SR as f64, 120.0),
+            None
+        );
     }
 
     fn first_warp_input(


### PR DESCRIPTION
## Summary

- replace Browser BPM detection and confirmation with deterministic complete-loop grid fitting across 1, 2, 4, 8, and 16 bars
- make WARP automatically target Project BPM, start on the next bar while transport runs, and loop; RAW stays immediate and one-shot
- use the exact same grid-fit treatment for audition, drag previews, local imports, and remote imports
- simplify the Audition footer to on/off, RAW/WARP, transport/waveform, and gain

## Root cause

Browser WARP exposed implementation uncertainty as a required producer workflow. Onset-derived BPM confidence gated both playback and import, while separate sync and loop controls allowed contradictory states. A valid loop could therefore be selected but remain silent until USE SOURCE or BPM confirmation was pressed.

## Verification

- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- native application smoke test at the maximized Browser layout