### PR TITLE
style(browser): slim tree and results scrollbars

### DIFF
--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -550,9 +550,7 @@ impl App {
                     SampleBrowserMode::Local,
                 ))
                 .height(Length::Fill)
-                .direction(scrollable::Direction::Vertical(
-                    scrollable::Scrollbar::default()
-                ))
+                .direction(scrollable::Direction::Vertical(browser_vertical_scrollbar()))
             ]
             .spacing(0)
             .padding(8)

--- a/crates/vibez-ui/src/app/views_browser_places.rs
+++ b/crates/vibez-ui/src/app/views_browser_places.rs
@@ -265,9 +265,8 @@ impl App {
         );
 
         container(
-            scrollable(container(places.padding(9)).width(Length::Fill)).direction(
-                scrollable::Direction::Vertical(scrollable::Scrollbar::default()),
-            ),
+            scrollable(container(places.padding(9)).width(Length::Fill))
+                .direction(scrollable::Direction::Vertical(browser_vertical_scrollbar())),
         )
         .width(Length::Fill)
         .height(Length::Fill)

--- a/crates/vibez-ui/src/app/views_browser_remote.rs
+++ b/crates/vibez-ui/src/app/views_browser_remote.rs
@@ -456,9 +456,7 @@ impl App {
                     SampleBrowserMode::Remote,
                 ))
                 .height(Length::Fill)
-                .direction(scrollable::Direction::Vertical(
-                    scrollable::Scrollbar::default()
-                ))
+                .direction(scrollable::Direction::Vertical(browser_vertical_scrollbar()))
             ]
             .spacing(0)
             .padding(8)

--- a/crates/vibez-ui/src/app/views_browser_style.rs
+++ b/crates/vibez-ui/src/app/views_browser_style.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 
-use iced::widget::{button, container, text};
+use iced::widget::{button, container, scrollable, text};
 use iced::{Element, Length, Theme};
 
 use crate::message::Message;
@@ -13,6 +13,16 @@ use crate::theme as th;
 pub(super) const REMOTE_CONNECTION_INDENT: f32 = 14.0;
 pub(super) const BROWSER_TREE_INDENT_STEP: f32 = 8.0;
 pub(super) const BROWSER_TREE_MAX_DEPTH: f32 = 5.0;
+pub(super) const BROWSER_SCROLLBAR_TRACK_WIDTH: f32 = 5.0;
+pub(super) const BROWSER_SCROLLBAR_HANDLE_WIDTH: f32 = 3.0;
+const _: () = assert!(BROWSER_SCROLLBAR_HANDLE_WIDTH < BROWSER_SCROLLBAR_TRACK_WIDTH);
+const _: () = assert!(BROWSER_SCROLLBAR_TRACK_WIDTH <= 5.0);
+
+pub(super) fn browser_vertical_scrollbar() -> scrollable::Scrollbar {
+    scrollable::Scrollbar::new()
+        .width(BROWSER_SCROLLBAR_TRACK_WIDTH)
+        .scroller_width(BROWSER_SCROLLBAR_HANDLE_WIDTH)
+}
 
 pub(super) fn remote_places_indent(depth: usize) -> f32 {
     REMOTE_CONNECTION_INDENT

--- a/crates/vibez-ui/src/app/views_browser_style.rs
+++ b/crates/vibez-ui/src/app/views_browser_style.rs
@@ -16,7 +16,6 @@ pub(super) const BROWSER_TREE_MAX_DEPTH: f32 = 5.0;
 pub(super) const BROWSER_SCROLLBAR_TRACK_WIDTH: f32 = 5.0;
 pub(super) const BROWSER_SCROLLBAR_HANDLE_WIDTH: f32 = 3.0;
 const _: () = assert!(BROWSER_SCROLLBAR_HANDLE_WIDTH < BROWSER_SCROLLBAR_TRACK_WIDTH);
-const _: () = assert!(BROWSER_SCROLLBAR_TRACK_WIDTH <= 5.0);
 
 pub(super) fn browser_vertical_scrollbar() -> scrollable::Scrollbar {
     scrollable::Scrollbar::new()


### PR DESCRIPTION
## Summary

- use a shared slim vertical scrollbar configuration in the Browser
- reduce Browser tracks to 5 px and handles to 3 px
- apply the styling consistently to Places, local results, and remote results

## Tests

- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

## Dependency

Stacked on #178.