### PR TITLE
feat(browser): show audition waveform playhead

### DIFF
--- a/crates/vibez-engine/src/engine_audition.rs
+++ b/crates/vibez-engine/src/engine_audition.rs
@@ -183,6 +183,9 @@ impl AuditionBus {
         }) {
             self.active = None;
         }
+        if let Some(active) = self.active.as_ref() {
+            let _ = event_tx.push(EngineEvent::AuditionPosition(active.position));
+        }
         if had_voice && self.active.is_none() && !self.has_outgoing() && self.queued.is_none() {
             let _ = event_tx.push(EngineEvent::AuditionStopped);
         }

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -1341,6 +1341,24 @@ fn audition_loop_fades_the_source_boundary_without_silence_or_a_click() {
 }
 
 #[test]
+fn audition_reports_the_active_source_position_after_rendering() {
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    cmd_tx
+        .push(EngineCommand::StartAudition {
+            audio: make_constant_audio(4_096, 0.4),
+            start: AuditionStart::Immediate,
+            looped: true,
+        })
+        .unwrap();
+
+    let mut output = vec![0.0; 1_024 * 2];
+    engine.process(&mut output, 2);
+
+    assert!(std::iter::from_fn(|| event_rx.pop().ok())
+        .any(|event| event == EngineEvent::AuditionPosition(1_024)));
+}
+
+#[test]
 fn note_clip_loop_renders() {
     use vibez_core::midi::{InstrumentKind, MidiNote};
 

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -231,6 +231,8 @@ pub enum EngineEvent {
     AuditionQueued,
     /// Audition crossed its requested boundary and began rendering.
     AuditionStarted,
+    /// Current frame inside the active Browser Audition source.
+    AuditionPosition(u64),
 }
 
 impl PartialEq for EngineEvent {
@@ -541,6 +543,7 @@ impl PartialEq for EngineEvent {
             | (Self::AuditionStopped, Self::AuditionStopped)
             | (Self::AuditionQueued, Self::AuditionQueued)
             | (Self::AuditionStarted, Self::AuditionStarted) => true,
+            (Self::AuditionPosition(left), Self::AuditionPosition(right)) => left == right,
             _ => false,
         }
     }
@@ -587,6 +590,7 @@ mod tests {
         let _audition_stopped = EngineEvent::AuditionStopped;
         let _audition_queued = EngineEvent::AuditionQueued;
         let _audition_started = EngineEvent::AuditionStarted;
+        let _audition_position = EngineEvent::AuditionPosition(256);
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -82,6 +82,7 @@ impl App {
                         self.state.browser.audition_queued = true;
                     }
                     EngineEvent::AuditionStarted => {
+                        self.state.browser.audition_position_frames = 0;
                         self.state.browser.audition_queued = false;
                         self.state.browser.audition_playing = true;
                         let playback_mode = self
@@ -99,6 +100,9 @@ impl App {
                             AuditionMode::Raw => RAW_AUDITION_PLAYING.into(),
                             AuditionMode::Warp => WARP_AUDITION_PLAYING.into(),
                         };
+                    }
+                    EngineEvent::AuditionPosition(position_frames) => {
+                        self.state.browser.audition_position_frames = position_frames;
                     }
                     EngineEvent::TrackMeter {
                         track_id,

--- a/crates/vibez-ui/src/app/views_browser_audition.rs
+++ b/crates/vibez-ui/src/app/views_browser_audition.rs
@@ -72,6 +72,7 @@ impl App {
         let waveform: Element<'_, Message> = container(
             canvas(crate::widgets::browser_waveform::BrowserWaveform {
                 audio: self.state.browser.waveform_audio.clone(),
+                playhead_fraction: self.state.browser.audition_playhead_fraction(),
             })
             .width(Length::Fill)
             .height(Length::Fixed(26.0)),

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -158,6 +158,24 @@ fn audition_defaults_on_and_remembers_clamped_gain_state() {
 }
 
 #[test]
+fn audition_playhead_tracks_the_active_buffer_and_hides_when_stopped() {
+    let audio = std::sync::Arc::new(vibez_core::audio_buffer::DecodedAudio {
+        channels: vec![vec![0.0; 1_000]],
+        sample_rate: 44_100,
+    });
+    let mut browser = BrowserState {
+        audition_audio: Some(audio),
+        audition_playing: true,
+        audition_position_frames: 250,
+        ..BrowserState::default()
+    };
+
+    assert_eq!(browser.audition_playhead_fraction(), Some(0.25));
+    browser.stop_audition_state();
+    assert_eq!(browser.audition_playhead_fraction(), None);
+}
+
+#[test]
 fn warp_import_resolves_the_same_grid_fit_without_confirmation() {
     let browser = BrowserState {
         audition_mode: crate::state::AuditionMode::Warp,

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -95,6 +95,7 @@ pub struct BrowserState {
     pub audition_loading: bool,
     pub audition_playing: bool,
     pub audition_queued: bool,
+    pub audition_position_frames: u64,
     /// Treatment currently handed to the Audition Bus. This can be RAW while
     /// the selected intent remains WARP and its source BPM is unresolved.
     pub audition_playback_mode: Option<AuditionMode>,
@@ -155,6 +156,7 @@ impl Default for BrowserState {
             audition_loading: false,
             audition_playing: false,
             audition_queued: false,
+            audition_position_frames: 0,
             audition_playback_mode: None,
             audition_generation: 0,
             audition_audio: None,
@@ -453,6 +455,7 @@ impl BrowserState {
         self.audition_loading = false;
         self.audition_playing = false;
         self.audition_queued = false;
+        self.audition_position_frames = 0;
         self.audition_playback_mode = None;
     }
 
@@ -469,7 +472,14 @@ impl BrowserState {
         self.audition_loading = false;
         self.audition_queued = queued;
         self.audition_playing = !queued;
+        self.audition_position_frames = 0;
         self.audition_playback_mode = Some(mode);
+    }
+
+    pub fn audition_playhead_fraction(&self) -> Option<f32> {
+        let frames = self.audition_audio.as_ref()?.num_frames();
+        (self.audition_playing && frames > 0)
+            .then(|| (self.audition_position_frames as f64 / frames as f64).clamp(0.0, 1.0) as f32)
     }
 
     pub fn audition_import_input(&self) -> AuditionImportInput {

--- a/crates/vibez-ui/src/widgets/browser_waveform.rs
+++ b/crates/vibez-ui/src/widgets/browser_waveform.rs
@@ -13,6 +13,7 @@ use crate::theme;
 
 pub struct BrowserWaveform {
     pub audio: Option<Arc<DecodedAudio>>,
+    pub playhead_fraction: Option<f32>,
 }
 
 pub struct BrowserWaveformState {
@@ -91,7 +92,25 @@ impl canvas::Program<Message> for BrowserWaveform {
             }
         });
 
-        vec![geometry]
+        let playhead = {
+            let mut frame = canvas::Frame::new(renderer, bounds.size());
+            if let Some(fraction) = self.playhead_fraction {
+                let x = fraction.clamp(0.0, 1.0) * bounds.width;
+                let line = canvas::Path::line(
+                    iced::Point::new(x, 0.0),
+                    iced::Point::new(x, bounds.height),
+                );
+                frame.stroke(
+                    &line,
+                    canvas::Stroke::default()
+                        .with_color(theme::playhead())
+                        .with_width(1.5),
+                );
+            }
+            frame.into_geometry()
+        };
+
+        vec![geometry, playhead]
     }
 }
 

--- a/crates/vibez-ui/src/widgets/browser_waveform.rs
+++ b/crates/vibez-ui/src/widgets/browser_waveform.rs
@@ -11,6 +11,8 @@ use vibez_core::audio_buffer::DecodedAudio;
 use crate::message::Message;
 use crate::theme;
 
+use super::playhead::playhead_geometry;
+
 pub struct BrowserWaveform {
     pub audio: Option<Arc<DecodedAudio>>,
     pub playhead_fraction: Option<f32>,
@@ -92,25 +94,12 @@ impl canvas::Program<Message> for BrowserWaveform {
             }
         });
 
-        let playhead = {
-            let mut frame = canvas::Frame::new(renderer, bounds.size());
-            if let Some(fraction) = self.playhead_fraction {
-                let x = fraction.clamp(0.0, 1.0) * bounds.width;
-                let line = canvas::Path::line(
-                    iced::Point::new(x, 0.0),
-                    iced::Point::new(x, bounds.height),
-                );
-                frame.stroke(
-                    &line,
-                    canvas::Stroke::default()
-                        .with_color(theme::playhead())
-                        .with_width(1.5),
-                );
-            }
-            frame.into_geometry()
-        };
-
-        vec![geometry, playhead]
+        let playhead_x = self
+            .playhead_fraction
+            .map(|fraction| fraction.clamp(0.0, 1.0) * bounds.width);
+        let mut geometry = vec![geometry];
+        geometry.extend(playhead_geometry(renderer, bounds, playhead_x));
+        geometry
     }
 }
 

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -13,6 +13,7 @@ pub mod local_drag;
 pub mod mini_waveform;
 pub mod mixer_strip;
 pub mod piano_roll;
+mod playhead;
 pub mod swing_knob;
 pub mod timeline;
 pub mod track_header;

--- a/crates/vibez-ui/src/widgets/playhead.rs
+++ b/crates/vibez-ui/src/widgets/playhead.rs
@@ -1,0 +1,22 @@
+use iced::widget::canvas;
+use iced::{Rectangle, Renderer};
+
+use crate::theme;
+
+/// Draw an uncached playhead overlay only when a position is visible.
+pub(super) fn playhead_geometry(
+    renderer: &Renderer,
+    bounds: Rectangle,
+    x: Option<f32>,
+) -> Option<canvas::Geometry> {
+    let x = x?.clamp(0.0, bounds.width);
+    let mut frame = canvas::Frame::new(renderer, bounds.size());
+    let line = canvas::Path::line(iced::Point::new(x, 0.0), iced::Point::new(x, bounds.height));
+    frame.stroke(
+        &line,
+        canvas::Stroke::default()
+            .with_color(theme::playhead())
+            .with_width(1.5),
+    );
+    Some(frame.into_geometry())
+}

--- a/crates/vibez-ui/src/widgets/waveform.rs
+++ b/crates/vibez-ui/src/widgets/waveform.rs
@@ -10,6 +10,8 @@ use vibez_core::audio_buffer::DecodedAudio;
 use crate::domains::transport::TransportMsg;
 use crate::theme;
 
+use super::playhead::playhead_geometry;
+
 pub struct WaveformWidget {
     pub audio: Option<Arc<DecodedAudio>>,
     pub playhead_position: f64, // 0.0..1.0
@@ -130,26 +132,13 @@ impl canvas::Program<crate::message::Message> for WaveformWidget {
             }
         });
 
-        // Playhead (drawn every frame, not cached)
-        let playhead = {
-            let mut frame = canvas::Frame::new(renderer, bounds.size());
-            if self.audio.is_some() {
-                let x = (self.playhead_position as f32) * bounds.width;
-                let playhead_line = canvas::Path::line(
-                    iced::Point::new(x, 0.0),
-                    iced::Point::new(x, bounds.height),
-                );
-                frame.stroke(
-                    &playhead_line,
-                    canvas::Stroke::default()
-                        .with_color(theme::playhead())
-                        .with_width(1.5),
-                );
-            }
-            frame.into_geometry()
-        };
-
-        vec![waveform, playhead]
+        let playhead_x = self
+            .audio
+            .as_ref()
+            .map(|_| self.playhead_position.clamp(0.0, 1.0) as f32 * bounds.width);
+        let mut geometry = vec![waveform];
+        geometry.extend(playhead_geometry(renderer, bounds, playhead_x));
+        geometry
     }
 
     fn mouse_interaction(


### PR DESCRIPTION
## Summary

- report the active audition source position from the audio engine
- render a live playhead over the Browser waveform while auditioning
- reset and hide the playhead when an audition stops or changes

## Tests

- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

## Dependency

Stacked on #178.