### PR TITLE
Add Windows ASIO backend selection

### DIFF
--- a/.github/actions/setup-asio-sdk/action.yml
+++ b/.github/actions/setup-asio-sdk/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: .asio-sdk
-        key: asio-sdk-d5ebf0c20dd2c5f43771fd0c1418f4b361bf52434ee670097cfa6b3a335e2eca
+        key: asio-sdk-${{ hashFiles('scripts/setup_asio_sdk.ps1') }}
     - name: Download and verify ASIO SDK
       shell: pwsh
       run: ./scripts/setup_asio_sdk.ps1

--- a/.github/actions/setup-asio-sdk/action.yml
+++ b/.github/actions/setup-asio-sdk/action.yml
@@ -1,0 +1,14 @@
+name: Set up pinned ASIO SDK
+description: Restore or verify the GPLv3-compatible Steinberg ASIO SDK used by CPAL
+
+runs:
+  using: composite
+  steps:
+    - name: Restore ASIO SDK cache
+      uses: actions/cache@v4
+      with:
+        path: .asio-sdk
+        key: asio-sdk-d5ebf0c20dd2c5f43771fd0c1418f4b361bf52434ee670097cfa6b3a335e2eca
+    - name: Download and verify ASIO SDK
+      shell: pwsh
+      run: ./scripts/setup_asio_sdk.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Configure Windows ASIO build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '"LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Append'
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev
@@ -35,6 +39,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Configure Windows ASIO build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '"LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Append'
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Configure Windows ASIO build
+      - uses: ./.github/actions/setup-asio-sdk
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: '"LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Append'
+      - uses: Swatinem/rust-cache@v2
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev
@@ -38,11 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Configure Windows ASIO build
+      - uses: ./.github/actions/setup-asio-sdk
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: '"LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Append'
+      - uses: Swatinem/rust-cache@v2
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Configure Windows ASIO build
+      - uses: ./.github/actions/setup-asio-sdk
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: '"LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Append'
+      - uses: Swatinem/rust-cache@v2
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Configure Windows ASIO build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '"LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Append'
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/.asio-sdk
 *.swp
 *.swo
 *~

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.11.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
  "bitflags 2.11.0",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
 dependencies = [
  "libc",
  "pkg-config",
@@ -104,15 +104,6 @@ dependencies = [
  "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "android-build"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fc9904ad2ad097c3c1cfe2eacaaf0fc24710936fa9ed941cb310b7c6ed2ab7"
-dependencies = [
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -814,11 +805,11 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.14.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 1.3.2",
  "libc",
  "objc2-audio-toolbox",
  "objc2-core-audio",
@@ -872,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.17.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
+checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
 dependencies = [
  "alsa",
  "asio-sys",
@@ -888,17 +879,13 @@ dependencies = [
  "ndk-context",
  "num-derive",
  "num-traits",
- "objc2 0.6.3",
  "objc2-audio-toolbox",
- "objc2-avf-audio",
  "objc2-core-audio",
  "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.62.2",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -1230,16 +1217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlopen2"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60768c353d76ba6dd1b6332a5dbbdd3bc2dddadc2935f4cc6a9d0f17ca8ecb6a"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,7 +1329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2384,15 +2361,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "java-locator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c46c1fe465c59b1474e665e85e1256c3893dd00927b8d55f63b09044c1e64f"
-dependencies = [
- "glob",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,28 +2369,11 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "java-locator",
  "jni-sys",
- "libloading 0.7.4",
  "log",
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-min-helper"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913370a00ba1851b0f3369b49d0f3e745da2d20d3f15ecc296a64234ccda45f7"
-dependencies = [
- "android-build",
- "dlopen2",
- "jni",
- "libc",
- "log",
- "ndk-context",
- "process_path",
 ]
 
 [[package]]
@@ -2512,9 +2463,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.189"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libdbus-sys"
@@ -2687,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.5.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
@@ -2744,23 +2695,19 @@ dependencies = [
 
 [[package]]
 name = "midir"
-version = "0.11.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c12e74a8604bc07f9a3fcf3d5889a81bc96ca6e07d6a114d63fc0371f3e5a4"
+checksum = "56542e359bb7e4bd1a77cb79042be32d4af0713a9ce58160355eaf72df9db87c"
 dependencies = [
  "alsa",
- "cc",
+ "bitflags 1.3.2",
  "coremidi",
- "jni",
- "jni-min-helper",
  "js-sys",
  "libc",
- "log",
- "ndk-context",
  "parking_lot 0.12.5",
  "wasm-bindgen",
  "web-sys",
- "windows 0.62.2",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -3040,16 +2987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-avf-audio"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
-dependencies = [
- "objc2 0.6.3",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3083,7 +3020,6 @@ dependencies = [
  "objc2 0.6.3",
  "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3115,9 +3051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.6.2",
  "dispatch2",
- "libc",
  "objc2 0.6.3",
 ]
 
@@ -3184,8 +3118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.6.2",
- "libc",
  "objc2 0.6.3",
  "objc2-core-foundation",
 ]
@@ -3667,16 +3599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "process_path"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f676f11eb0b3e2ea0fbaee218fa6b806689e2297b8c8adc5bf73df465c4f6171"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,7 +3665,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4132,7 +4054,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4482,7 +4404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4781,7 +4703,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5674,7 +5596,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.5",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -5702,7 +5624,7 @@ dependencies = [
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.5",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
@@ -5744,7 +5666,7 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.5",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -5797,7 +5719,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5832,23 +5754,22 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.62.2"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
- "windows-collections",
- "windows-core 0.62.2",
- "windows-future",
- "windows-numerics",
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "windows-collections"
-version = "0.3.2"
+name = "windows"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5862,33 +5783,31 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.2"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
  "windows-result",
- "windows-strings",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "windows-future"
-version = "0.3.2"
+name = "windows-core"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link",
- "windows-threading",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.2"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5897,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.3"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5913,31 +5832,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link",
-]
-
-[[package]]
 name = "windows-result"
-version = "0.4.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6055,15 +5955,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "asio-sys"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826194e1612938c9be09b78b58323fbb2e326de3d491b4230186cf6e832d8ded"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "num-derive",
+ "num-traits",
+ "parse_cfg",
+ "walkdir",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +400,26 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.117",
 ]
@@ -834,6 +868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
 dependencies = [
  "alsa",
+ "asio-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
@@ -3352,6 +3387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse_cfg"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905787a434a2c721408e7c9a252e85f3d93ca0f118a5283022636c0e05a7ea49"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4233,7 +4277,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51dae6f10b5532510f65c309c4d868babe3aecf6ce0782678081338311f176fd"
 dependencies = [
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "dasp",
 ]
@@ -5101,6 +5145,8 @@ dependencies = [
  "cpal",
  "midir",
  "rubato",
+ "serde",
+ "serde_json",
  "symphonia",
  "tempfile",
  "vibez-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
  "bitflags 2.11.0",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
@@ -104,6 +104,15 @@ dependencies = [
  "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "android-build"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fc9904ad2ad097c3c1cfe2eacaaf0fc24710936fa9ed941cb310b7c6ed2ab7"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -805,11 +814,11 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "libc",
  "objc2-audio-toolbox",
  "objc2-core-audio",
@@ -863,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.16.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
 dependencies = [
  "alsa",
  "asio-sys",
@@ -879,13 +888,17 @@ dependencies = [
  "ndk-context",
  "num-derive",
  "num-traits",
+ "objc2 0.6.3",
  "objc2-audio-toolbox",
+ "objc2-avf-audio",
  "objc2-core-audio",
  "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.54.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -1217,6 +1230,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlopen2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60768c353d76ba6dd1b6332a5dbbdd3bc2dddadc2935f4cc6a9d0f17ca8ecb6a"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,7 +1352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2361,6 +2384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "java-locator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c46c1fe465c59b1474e665e85e1256c3893dd00927b8d55f63b09044c1e64f"
+dependencies = [
+ "glob",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,11 +2401,28 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
+ "java-locator",
  "jni-sys",
+ "libloading 0.7.4",
  "log",
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-min-helper"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913370a00ba1851b0f3369b49d0f3e745da2d20d3f15ecc296a64234ccda45f7"
+dependencies = [
+ "android-build",
+ "dlopen2",
+ "jni",
+ "libc",
+ "log",
+ "ndk-context",
+ "process_path",
 ]
 
 [[package]]
@@ -2463,9 +2512,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
@@ -2638,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -2695,19 +2744,23 @@ dependencies = [
 
 [[package]]
 name = "midir"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56542e359bb7e4bd1a77cb79042be32d4af0713a9ce58160355eaf72df9db87c"
+checksum = "77c12e74a8604bc07f9a3fcf3d5889a81bc96ca6e07d6a114d63fc0371f3e5a4"
 dependencies = [
  "alsa",
- "bitflags 1.3.2",
+ "cc",
  "coremidi",
+ "jni",
+ "jni-min-helper",
  "js-sys",
  "libc",
+ "log",
+ "ndk-context",
  "parking_lot 0.12.5",
  "wasm-bindgen",
  "web-sys",
- "windows 0.56.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2987,6 +3040,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,6 +3083,7 @@ dependencies = [
  "objc2 0.6.3",
  "objc2-core-audio-types",
  "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3051,7 +3115,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.3",
 ]
 
@@ -3118,6 +3184,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
  "objc2-core-foundation",
 ]
@@ -3599,6 +3667,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "process_path"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f676f11eb0b3e2ea0fbaee218fa6b806689e2297b8c8adc5bf73df465c4f6171"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3665,7 +3743,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4054,7 +4132,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4404,7 +4482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4703,7 +4781,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5596,7 +5674,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.12.5",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -5624,7 +5702,7 @@ dependencies = [
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.12.5",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
@@ -5666,7 +5744,7 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
- "parking_lot 0.12.5",
+ "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -5719,7 +5797,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5754,22 +5832,23 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows"
-version = "0.56.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.56.0",
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5783,31 +5862,33 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.54.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
+ "windows-link",
  "windows-result",
- "windows-targets 0.52.6",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.56.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5816,9 +5897,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.56.0"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5832,12 +5913,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5955,6 +6055,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,12 @@ vibez-dropbox = { path = "crates/vibez-dropbox" }
 vibez-ui = { path = "crates/vibez-ui" }
 
 # Audio
-cpal = "0.16"
+cpal = "0.17.3"
 symphonia = { version = "0.5", default-features = false, features = ["mp3", "flac", "ogg", "vorbis", "wav", "aiff", "isomp4", "aac", "pcm"] }
 rubato = "0.16"
 rtrb = "0.3"
 audio_thread_priority = "0.32"
-midir = "0.10"
+midir = "0.11"
 
 # GUI
 iced = { version = "0.13", features = ["canvas", "tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,14 @@ vibez-dropbox = { path = "crates/vibez-dropbox" }
 vibez-ui = { path = "crates/vibez-ui" }
 
 # Audio
-cpal = "0.17.3"
+# Host upgrades change ALSA, CoreAudio and WASAPI behaviour together. Keep them
+# in a dedicated hardware-regression PR; CPAL 0.16 already provides ASIO.
+cpal = "0.16"
 symphonia = { version = "0.5", default-features = false, features = ["mp3", "flac", "ogg", "vorbis", "wav", "aiff", "isomp4", "aac", "pcm"] }
 rubato = "0.16"
 rtrb = "0.3"
 audio_thread_priority = "0.32"
-midir = "0.11"
+midir = "0.10"
 
 # GUI
 iced = { version = "0.13", features = ["canvas", "tokio"] }

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ of Arrange applies to it unchanged:
   drag/resize/split/join, time selection, looping, and an overview minimap
 - **Audio recording** from a soundcard input or the output of an instrument
   track, with the waveform drawn while the take is recorded
-- **Soundcard settings** for choosing the input device, output device, sample
-  rate and buffer size
+- **Soundcard settings** for choosing the audio backend, input/output device,
+  sample rate and buffer size. Windows builds support WASAPI and ASIO;
+  macOS uses CoreAudio and Linux uses ALSA
 - **Warping** with automatic BPM detection and high-quality time stretching
   through Signalsmith Stretch. Warped clips follow the project BPM
 - **Piano roll** with draw and select modes, multi-note editing, velocity,
@@ -150,6 +151,8 @@ where a redundant-looking cast can be load-bearing on another target.
 ## License
 
 GPL-3.0-or-later. See [LICENSE](LICENSE).
+
+ASIO is a trademark and software of Steinberg Media Technologies GmbH.
 
 ## For Mum
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ Linux additionally needs:
 sudo apt install libasound2-dev libudev-dev libdbus-1-dev
 ```
 
+Windows ASIO builds use a checksum-pinned copy of Steinberg's SDK. Set it up
+in the same PowerShell session before running Cargo:
+
+```powershell
+./scripts/setup_asio_sdk.ps1
+```
+
 Then:
 
 ```sh
@@ -152,7 +159,10 @@ where a redundant-looking cast can be load-bearing on another target.
 
 GPL-3.0-or-later. See [LICENSE](LICENSE).
 
-ASIO is a trademark and software of Steinberg Media Technologies GmbH.
+Windows ASIO builds link Steinberg's ASIO SDK under its GPLv3 option, which is
+compatible with Vibez's GPL-3.0-or-later licence. The release build downloads
+one checksum-pinned copy from Steinberg's official SDK endpoint. ASIO is a
+trademark of Steinberg Media Technologies GmbH.
 
 ## For Mum
 

--- a/crates/vibez-audio-io/Cargo.toml
+++ b/crates/vibez-audio-io/Cargo.toml
@@ -7,11 +7,18 @@ license.workspace = true
 [dependencies]
 vibez-core = { workspace = true }
 vibez-engine = { workspace = true }
-cpal = { workspace = true }
 symphonia = { workspace = true }
 rubato = { workspace = true }
 audio_thread_priority = { workspace = true }
 midir = { workspace = true }
+serde = { workspace = true }
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+cpal = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+cpal = { workspace = true, features = ["asio"] }
 
 [dev-dependencies]
 tempfile = "3"
+serde_json = { workspace = true }

--- a/crates/vibez-audio-io/src/audio_host.rs
+++ b/crates/vibez-audio-io/src/audio_host.rs
@@ -262,11 +262,11 @@ impl AudioHost {
         let default_input_name = self
             .host
             .default_input_device()
-            .and_then(|device| cpal_device_name(&device).ok());
+            .and_then(|device| device.name().ok());
         let default_output_name = self
             .host
             .default_output_device()
-            .and_then(|device| cpal_device_name(&device).ok());
+            .and_then(|device| device.name().ok());
         Ok(AudioDeviceCatalog {
             default_input_name,
             default_output_name,
@@ -318,7 +318,7 @@ fn device_info(
     device: &cpal::Device,
     direction: StreamDirection,
 ) -> Result<DeviceInfo, AudioHostError> {
-    let name = cpal_device_name(device)?;
+    let name = device.name()?;
     let default_config = match direction {
         StreamDirection::Input => device.default_input_config(),
         StreamDirection::Output => device.default_output_config(),
@@ -340,10 +340,6 @@ fn device_info(
         default_config,
         supported_configs,
     })
-}
-
-pub(crate) fn cpal_device_name(device: &cpal::Device) -> Result<String, cpal::DeviceNameError> {
-    device.name()
 }
 
 fn output_device_info(device: &cpal::Device) -> Result<DeviceInfo, AudioHostError> {

--- a/crates/vibez-audio-io/src/audio_host.rs
+++ b/crates/vibez-audio-io/src/audio_host.rs
@@ -282,15 +282,6 @@ impl AudioHost {
     }
 }
 
-impl Default for AudioHost {
-    fn default() -> Self {
-        Self {
-            backend: AudioBackend::System,
-            host: cpal::default_host(),
-        }
-    }
-}
-
 /// Extract [`DeviceInfo`] from a cpal device.
 fn buffer_size_range(size: &cpal::SupportedBufferSize) -> Option<(u32, u32)> {
     match size {
@@ -307,7 +298,7 @@ enum StreamDirection {
 
 fn stream_config_info(config: cpal::SupportedStreamConfig) -> StreamConfigInfo {
     StreamConfigInfo {
-        sample_rate: config.sample_rate(),
+        sample_rate: config.sample_rate().0,
         channels: config.channels(),
         sample_format: format!("{:?}", config.sample_format()),
     }
@@ -316,8 +307,8 @@ fn stream_config_info(config: cpal::SupportedStreamConfig) -> StreamConfigInfo {
 fn supported_config_info(range: cpal::SupportedStreamConfigRange) -> SupportedConfigRange {
     SupportedConfigRange {
         channels: range.channels(),
-        min_sample_rate: range.min_sample_rate(),
-        max_sample_rate: range.max_sample_rate(),
+        min_sample_rate: range.min_sample_rate().0,
+        max_sample_rate: range.max_sample_rate().0,
         sample_format: format!("{:?}", range.sample_format()),
         buffer_size_range: buffer_size_range(range.buffer_size()),
     }
@@ -352,9 +343,7 @@ fn device_info(
 }
 
 pub(crate) fn cpal_device_name(device: &cpal::Device) -> Result<String, cpal::DeviceNameError> {
-    device
-        .description()
-        .map(|description| description.name().to_owned())
+    device.name()
 }
 
 fn output_device_info(device: &cpal::Device) -> Result<DeviceInfo, AudioHostError> {

--- a/crates/vibez-audio-io/src/audio_host.rs
+++ b/crates/vibez-audio-io/src/audio_host.rs
@@ -4,6 +4,84 @@
 //! discovering input/output devices and their supported configurations.
 
 use cpal::traits::{DeviceTrait, HostTrait};
+use serde::{Deserialize, Serialize};
+
+/// Stable application-facing audio backend choice.
+///
+/// `System` maps to the native CPAL default on every platform. `Asio` remains
+/// serializable on non-Windows systems so a settings file copied between
+/// machines can be read and safely repaired by the application.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AudioBackend {
+    #[default]
+    System,
+    Asio,
+}
+
+impl AudioBackend {
+    /// Backends compiled into this Vibez build for the current platform.
+    pub const fn available() -> &'static [Self] {
+        #[cfg(target_os = "windows")]
+        {
+            &[Self::System, Self::Asio]
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            &[Self::System]
+        }
+    }
+
+    pub fn is_available(self) -> bool {
+        Self::available().contains(&self)
+    }
+
+    /// Construct the CPAL host represented by this stable backend choice.
+    pub fn create_host(self) -> Result<cpal::Host, AudioHostError> {
+        match self {
+            Self::System => Ok(cpal::default_host()),
+            Self::Asio => {
+                #[cfg(target_os = "windows")]
+                {
+                    cpal::host_from_id(cpal::HostId::Asio)
+                        .map_err(|_| AudioHostError::BackendUnavailable(self))
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
+                    Err(AudioHostError::BackendUnavailable(self))
+                }
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for AudioBackend {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::System => formatter.write_str(system_backend_name()),
+            Self::Asio => formatter.write_str("ASIO"),
+        }
+    }
+}
+
+const fn system_backend_name() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "WASAPI"
+    }
+    #[cfg(target_os = "macos")]
+    {
+        "CoreAudio"
+    }
+    #[cfg(target_os = "linux")]
+    {
+        "ALSA"
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        "System Audio"
+    }
+}
 
 /// Information about an available audio input or output device.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,6 +125,8 @@ pub struct AudioDeviceCatalog {
 /// Errors that can occur during host / device enumeration.
 #[derive(Debug)]
 pub enum AudioHostError {
+    /// The selected backend is not compiled in or cannot initialise.
+    BackendUnavailable(AudioBackend),
     /// Failed to enumerate devices.
     DevicesError(cpal::DevicesError),
     /// No default device found for the requested direction.
@@ -62,6 +142,9 @@ pub enum AudioHostError {
 impl std::fmt::Display for AudioHostError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::BackendUnavailable(backend) => {
+                write!(f, "{backend} audio backend is unavailable")
+            }
             Self::DevicesError(e) => write!(f, "failed to enumerate audio devices: {e}"),
             Self::NoDefaultDevice(direction) => {
                 write!(f, "no default audio {direction} device found")
@@ -78,6 +161,7 @@ impl std::fmt::Display for AudioHostError {
 impl std::error::Error for AudioHostError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::BackendUnavailable(_) => None,
             Self::DevicesError(e) => Some(e),
             Self::NoDefaultDevice(_) => None,
             Self::DeviceNameError(e) => Some(e),
@@ -113,15 +197,21 @@ impl From<cpal::DefaultStreamConfigError> for AudioHostError {
 
 /// Wrapper around [`cpal::Host`] that provides ergonomic device enumeration.
 pub struct AudioHost {
+    backend: AudioBackend,
     host: cpal::Host,
 }
 
 impl AudioHost {
-    /// Create a new `AudioHost` using the platform default host.
-    pub fn new() -> Self {
-        Self {
-            host: cpal::default_host(),
-        }
+    /// Create an `AudioHost` for one explicit application backend.
+    pub fn new(backend: AudioBackend) -> Result<Self, AudioHostError> {
+        Ok(Self {
+            backend,
+            host: backend.create_host()?,
+        })
+    }
+
+    pub fn backend(&self) -> AudioBackend {
+        self.backend
     }
 
     /// Return a reference to the inner [`cpal::Host`].
@@ -194,7 +284,10 @@ impl AudioHost {
 
 impl Default for AudioHost {
     fn default() -> Self {
-        Self::new()
+        Self {
+            backend: AudioBackend::System,
+            host: cpal::default_host(),
+        }
     }
 }
 
@@ -274,7 +367,36 @@ mod tests {
     /// hardware-dependent, so we only assert that construction succeeds.
     #[test]
     fn audio_host_construction() {
-        let _host = AudioHost::new();
+        let host = AudioHost::new(AudioBackend::System).unwrap();
+        assert_eq!(host.backend(), AudioBackend::System);
+    }
+
+    #[test]
+    fn backend_names_match_the_native_platform() {
+        assert!(AudioBackend::available().contains(&AudioBackend::System));
+        #[cfg(target_os = "windows")]
+        assert_eq!(AudioBackend::System.to_string(), "WASAPI");
+        #[cfg(target_os = "macos")]
+        assert_eq!(AudioBackend::System.to_string(), "CoreAudio");
+        #[cfg(target_os = "linux")]
+        assert_eq!(AudioBackend::System.to_string(), "ALSA");
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_build_includes_the_asio_host() {
+        let host = AudioHost::new(AudioBackend::Asio).unwrap();
+        assert_eq!(host.backend(), AudioBackend::Asio);
+    }
+
+    #[test]
+    fn backend_identity_roundtrips_for_cross_platform_settings() {
+        let encoded = serde_json::to_string(&AudioBackend::Asio).unwrap();
+        assert_eq!(encoded, "\"asio\"");
+        assert_eq!(
+            serde_json::from_str::<AudioBackend>(&encoded).unwrap(),
+            AudioBackend::Asio
+        );
     }
 
     /// Verify that `DeviceInfo`, `StreamConfigInfo`, and `SupportedConfigRange`

--- a/crates/vibez-audio-io/src/audio_host.rs
+++ b/crates/vibez-audio-io/src/audio_host.rs
@@ -262,11 +262,11 @@ impl AudioHost {
         let default_input_name = self
             .host
             .default_input_device()
-            .and_then(|device| device.name().ok());
+            .and_then(|device| cpal_device_name(&device).ok());
         let default_output_name = self
             .host
             .default_output_device()
-            .and_then(|device| device.name().ok());
+            .and_then(|device| cpal_device_name(&device).ok());
         Ok(AudioDeviceCatalog {
             default_input_name,
             default_output_name,
@@ -307,7 +307,7 @@ enum StreamDirection {
 
 fn stream_config_info(config: cpal::SupportedStreamConfig) -> StreamConfigInfo {
     StreamConfigInfo {
-        sample_rate: config.sample_rate().0,
+        sample_rate: config.sample_rate(),
         channels: config.channels(),
         sample_format: format!("{:?}", config.sample_format()),
     }
@@ -316,8 +316,8 @@ fn stream_config_info(config: cpal::SupportedStreamConfig) -> StreamConfigInfo {
 fn supported_config_info(range: cpal::SupportedStreamConfigRange) -> SupportedConfigRange {
     SupportedConfigRange {
         channels: range.channels(),
-        min_sample_rate: range.min_sample_rate().0,
-        max_sample_rate: range.max_sample_rate().0,
+        min_sample_rate: range.min_sample_rate(),
+        max_sample_rate: range.max_sample_rate(),
         sample_format: format!("{:?}", range.sample_format()),
         buffer_size_range: buffer_size_range(range.buffer_size()),
     }
@@ -327,7 +327,7 @@ fn device_info(
     device: &cpal::Device,
     direction: StreamDirection,
 ) -> Result<DeviceInfo, AudioHostError> {
-    let name = device.name()?;
+    let name = cpal_device_name(device)?;
     let default_config = match direction {
         StreamDirection::Input => device.default_input_config(),
         StreamDirection::Output => device.default_output_config(),
@@ -349,6 +349,12 @@ fn device_info(
         default_config,
         supported_configs,
     })
+}
+
+pub(crate) fn cpal_device_name(device: &cpal::Device) -> Result<String, cpal::DeviceNameError> {
+    device
+        .description()
+        .map(|description| description.name().to_owned())
 }
 
 fn output_device_info(device: &cpal::Device) -> Result<DeviceInfo, AudioHostError> {

--- a/crates/vibez-audio-io/src/audio_input.rs
+++ b/crates/vibez-audio-io/src/audio_input.rs
@@ -11,6 +11,7 @@ use cpal::{FromSample, Sample, SampleFormat, SampleRate, StreamConfig};
 use vibez_core::id::TrackId;
 use vibez_core::track::AudioInputRoute;
 
+use crate::audio_host::{AudioBackend, AudioHostError};
 use crate::stream_config::{select_stream_config, StreamDirection, StreamOpenError};
 
 const DEFAULT_BRIDGE_FRAMES: usize = 262_144;
@@ -23,6 +24,7 @@ pub enum AudioInputEvent {
 
 #[derive(Debug)]
 pub enum AudioInputError {
+    AudioHost(AudioHostError),
     NoInputDevice,
     InputDeviceNotFound(String),
     Devices(cpal::DevicesError),
@@ -32,6 +34,7 @@ pub enum AudioInputError {
 impl fmt::Display for AudioInputError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::AudioHost(error) => error.fmt(formatter),
             Self::NoInputDevice => formatter.write_str("no default Audio Input is available"),
             Self::InputDeviceNotFound(name) => {
                 write!(formatter, "Audio Input is unavailable: {name}")
@@ -47,6 +50,11 @@ impl std::error::Error for AudioInputError {}
 impl From<cpal::DevicesError> for AudioInputError {
     fn from(error: cpal::DevicesError) -> Self {
         Self::Devices(error)
+    }
+}
+impl From<AudioHostError> for AudioInputError {
+    fn from(error: AudioHostError) -> Self {
+        Self::AudioHost(error)
     }
 }
 impl From<cpal::BuildStreamError> for AudioInputError {
@@ -403,16 +411,18 @@ pub struct AudioInputStream {
     pub device_name: String,
     pub channels: usize,
     pub sample_rate: u32,
+    pub backend: AudioBackend,
 }
 
 impl AudioInputStream {
     pub fn open(
+        backend: AudioBackend,
         device_name: Option<&str>,
         sample_rate: u32,
         buffer_size: Option<u32>,
         bridge: Arc<AudioInputBridge>,
     ) -> Result<Self, AudioInputError> {
-        let host = cpal::default_host();
+        let host = backend.create_host()?;
         let device = match device_name {
             Some(name) => host
                 .input_devices()?
@@ -422,6 +432,18 @@ impl AudioInputStream {
                 .default_input_device()
                 .ok_or(AudioInputError::NoInputDevice)?,
         };
+        Self::open_on_device(backend, device, sample_rate, buffer_size, bridge)
+    }
+
+    /// Open input through a concrete device already owned by the output path.
+    /// ASIO uses this route so both directions share one driver and buffer set.
+    pub fn open_on_device(
+        backend: AudioBackend,
+        device: cpal::Device,
+        sample_rate: u32,
+        buffer_size: Option<u32>,
+        bridge: Arc<AudioInputBridge>,
+    ) -> Result<Self, AudioInputError> {
         let selected = select_stream_config(
             &device,
             StreamDirection::Input,
@@ -450,9 +472,10 @@ impl AudioInputStream {
             events,
             device_name: device
                 .name()
-                .unwrap_or_else(|_| device_name.unwrap_or("System Default").to_string()),
+                .unwrap_or_else(|_| "System Default".to_string()),
             channels,
             sample_rate,
+            backend,
         })
     }
 

--- a/crates/vibez-audio-io/src/audio_input.rs
+++ b/crates/vibez-audio-io/src/audio_input.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::Arc;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{FromSample, Sample, SampleFormat, StreamConfig};
+use cpal::{FromSample, Sample, SampleFormat, SampleRate, StreamConfig};
 use vibez_core::id::TrackId;
 use vibez_core::track::AudioInputRoute;
 
@@ -454,7 +454,7 @@ impl AudioInputStream {
         let channels = selected.channels() as usize;
         let config = StreamConfig {
             channels: selected.channels(),
-            sample_rate,
+            sample_rate: SampleRate(sample_rate),
             buffer_size: buffer_size.map_or(cpal::BufferSize::Default, cpal::BufferSize::Fixed),
         };
         let (event_tx, events) = mpsc::sync_channel(8);

--- a/crates/vibez-audio-io/src/audio_input.rs
+++ b/crates/vibez-audio-io/src/audio_input.rs
@@ -11,7 +11,7 @@ use cpal::{FromSample, Sample, SampleFormat, SampleRate, StreamConfig};
 use vibez_core::id::TrackId;
 use vibez_core::track::AudioInputRoute;
 
-use crate::audio_host::{cpal_device_name, AudioBackend, AudioHostError};
+use crate::audio_host::{AudioBackend, AudioHostError};
 use crate::stream_config::{select_stream_config, StreamDirection, StreamOpenError};
 
 const DEFAULT_BRIDGE_FRAMES: usize = 262_144;
@@ -426,7 +426,7 @@ impl AudioInputStream {
         let device = match device_name {
             Some(name) => host
                 .input_devices()?
-                .find(|device| cpal_device_name(device).is_ok_and(|candidate| candidate == name))
+                .find(|device| device.name().is_ok_and(|candidate| candidate == name))
                 .ok_or_else(|| AudioInputError::InputDeviceNotFound(name.to_string()))?,
             None => host
                 .default_input_device()
@@ -470,7 +470,9 @@ impl AudioInputStream {
         Ok(Self {
             stream,
             events,
-            device_name: cpal_device_name(&device).unwrap_or_else(|_| "System Default".to_string()),
+            device_name: device
+                .name()
+                .unwrap_or_else(|_| "System Default".to_string()),
             channels,
             sample_rate,
             backend,

--- a/crates/vibez-audio-io/src/audio_input.rs
+++ b/crates/vibez-audio-io/src/audio_input.rs
@@ -7,11 +7,11 @@ use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::Arc;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{FromSample, Sample, SampleFormat, SampleRate, StreamConfig};
+use cpal::{FromSample, Sample, SampleFormat, StreamConfig};
 use vibez_core::id::TrackId;
 use vibez_core::track::AudioInputRoute;
 
-use crate::audio_host::{AudioBackend, AudioHostError};
+use crate::audio_host::{cpal_device_name, AudioBackend, AudioHostError};
 use crate::stream_config::{select_stream_config, StreamDirection, StreamOpenError};
 
 const DEFAULT_BRIDGE_FRAMES: usize = 262_144;
@@ -426,7 +426,7 @@ impl AudioInputStream {
         let device = match device_name {
             Some(name) => host
                 .input_devices()?
-                .find(|device| device.name().is_ok_and(|candidate| candidate == name))
+                .find(|device| cpal_device_name(device).is_ok_and(|candidate| candidate == name))
                 .ok_or_else(|| AudioInputError::InputDeviceNotFound(name.to_string()))?,
             None => host
                 .default_input_device()
@@ -454,7 +454,7 @@ impl AudioInputStream {
         let channels = selected.channels() as usize;
         let config = StreamConfig {
             channels: selected.channels(),
-            sample_rate: SampleRate(sample_rate),
+            sample_rate,
             buffer_size: buffer_size.map_or(cpal::BufferSize::Default, cpal::BufferSize::Fixed),
         };
         let (event_tx, events) = mpsc::sync_channel(8);
@@ -470,9 +470,7 @@ impl AudioInputStream {
         Ok(Self {
             stream,
             events,
-            device_name: device
-                .name()
-                .unwrap_or_else(|_| "System Default".to_string()),
+            device_name: cpal_device_name(&device).unwrap_or_else(|_| "System Default".to_string()),
             channels,
             sample_rate,
             backend,

--- a/crates/vibez-audio-io/src/audio_stream.rs
+++ b/crates/vibez-audio-io/src/audio_stream.rs
@@ -8,10 +8,10 @@ use std::fmt;
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{DevicesError, PauseStreamError, SampleRate, StreamConfig};
+use cpal::traits::{HostTrait, StreamTrait};
+use cpal::{DevicesError, PauseStreamError, StreamConfig};
 
-use crate::audio_host::{AudioBackend, AudioHostError};
+use crate::audio_host::{cpal_device_name, AudioBackend, AudioHostError};
 use crate::audio_input::AudioInputBridge;
 use crate::stream_config::{select_stream_config, StreamDirection, StreamOpenError};
 use vibez_core::constants::DEFAULT_CHANNELS;
@@ -72,6 +72,12 @@ pub enum AudioStreamError {
     PauseError(PauseStreamError),
     /// There is no connected stream to start or pause.
     NoActiveStream,
+    /// An exclusive driver switch failed and the last working stream could
+    /// not be reopened either.
+    RollbackFailed {
+        requested: Box<AudioStreamError>,
+        rollback: Box<AudioStreamError>,
+    },
 }
 
 impl fmt::Display for AudioStreamError {
@@ -86,6 +92,13 @@ impl fmt::Display for AudioStreamError {
             Self::StreamOpen(error) => error.fmt(f),
             Self::PauseError(e) => write!(f, "failed to pause audio stream: {e}"),
             Self::NoActiveStream => write!(f, "no active audio output stream"),
+            Self::RollbackFailed {
+                requested,
+                rollback,
+            } => write!(
+                f,
+                "requested output failed: {requested}; restoring the previous output also failed: {rollback}"
+            ),
         }
     }
 }
@@ -98,6 +111,7 @@ impl std::error::Error for AudioStreamError {
             Self::DevicesError(e) => Some(e),
             Self::StreamOpen(error) => Some(error),
             Self::PauseError(e) => Some(e),
+            Self::RollbackFailed { requested, .. } => Some(requested),
         }
     }
 }
@@ -193,6 +207,7 @@ pub struct AudioOutputStream {
     active_device: Option<cpal::Device>,
     active_device_name: Option<String>,
     active_backend: Option<AudioBackend>,
+    active_config: Option<OutputStreamConfig>,
     /// Shared engine slot.  The audio callback `try_lock`s this each
     /// invocation and calls `engine.process_block()` if the lock is obtained.
     engine_slot: Arc<Mutex<Option<AudioEngine>>>,
@@ -212,6 +227,7 @@ impl AudioOutputStream {
             active_device: None,
             active_device_name: None,
             active_backend: None,
+            active_config: None,
             engine_slot: Arc::new(Mutex::new(Some(engine))),
             event_reporter,
             event_rx,
@@ -245,7 +261,7 @@ impl AudioOutputStream {
         buffer_size: Option<u32>,
     ) -> Result<Self, AudioStreamError> {
         let mut output = Self::idle(engine);
-        let device_name = device.name().ok();
+        let device_name = cpal_device_name(device).ok();
         let (stream, params) = Self::build_stream(
             Arc::clone(&output.engine_slot),
             device,
@@ -261,6 +277,12 @@ impl AudioOutputStream {
         output.active_device = Some(device.clone());
         output.active_device_name = device_name;
         output.active_backend = Some(AudioBackend::System);
+        output.active_config = Some(OutputStreamConfig {
+            backend: AudioBackend::System,
+            device_name: output.active_device_name.clone(),
+            sample_rate: output.sample_rate(),
+            buffer_size,
+        });
         output.event_reporter.report(AudioStreamEvent::Running);
         Ok(output)
     }
@@ -272,25 +294,84 @@ impl AudioOutputStream {
     /// or start fails, the previous stream remains (or is resumed) instead of
     /// leaving the session silent.
     pub fn reconfigure(&mut self, request: OutputStreamConfig) -> Result<(), AudioStreamError> {
+        self.reconfigure_candidates(&[request]).map(|_| ())
+    }
+
+    /// Try a preferred configuration followed by compatible fallbacks as one
+    /// transaction. If an exclusive ASIO driver must be released and every
+    /// candidate fails, Vibez reopens the exact configuration which was live
+    /// before the attempt.
+    ///
+    /// The returned index identifies the candidate that became active.
+    pub fn reconfigure_candidates(
+        &mut self,
+        requests: &[OutputStreamConfig],
+    ) -> Result<usize, AudioStreamError> {
+        assert!(
+            !requests.is_empty(),
+            "at least one output request is required"
+        );
         self.event_reporter.report(AudioStreamEvent::Rebuilding);
         let mut previous_stream_running = self.stream.is_some();
+        let previous_config = self.active_config.clone();
+        let requested_backend = requests[0].backend;
         // Most native hosts allow a replacement stream to be prepared while
         // the old one remains live. ASIO drivers commonly own one exclusive
         // buffer set, so attempting to load the same driver twice fails. Drop
         // that driver before rebuilding while the engine remains safely held
         // in `engine_slot`.
-        if requires_exclusive_reopen(self.active_backend, request.backend) {
-            self.stream = None;
-            self.active_device = None;
-            self.params = None;
-            self.active_device_name = None;
-            self.active_backend = None;
+        let exclusive_stream_released =
+            requires_exclusive_reopen(self.active_backend, requested_backend);
+        if exclusive_stream_released {
+            self.clear_active_stream();
             previous_stream_running = false;
         }
+        let mut last_error = None;
+        for (index, request) in requests.iter().enumerate() {
+            match self.try_reconfigure(request, &mut previous_stream_running) {
+                Ok(()) => {
+                    self.event_reporter.report(AudioStreamEvent::Recovered);
+                    return Ok(index);
+                }
+                Err(error) => last_error = Some(error),
+            }
+        }
+
+        let mut error = last_error.expect("a non-empty request list always produces a result");
+        if exclusive_stream_released {
+            let mut rollback_stream_running = false;
+            match previous_config.as_ref() {
+                Some(config) => match self.try_reconfigure(config, &mut rollback_stream_running) {
+                    Ok(()) => previous_stream_running = true,
+                    Err(rollback) => {
+                        error = AudioStreamError::RollbackFailed {
+                            requested: Box::new(error),
+                            rollback: Box::new(rollback),
+                        };
+                    }
+                },
+                None => previous_stream_running = false,
+            }
+        }
+
+        let event = if previous_stream_running {
+            AudioStreamEvent::ConfigurationRejected(error.to_string())
+        } else {
+            AudioStreamEvent::Error(error.to_string())
+        };
+        self.event_reporter.report(event);
+        Err(error)
+    }
+
+    fn try_reconfigure(
+        &mut self,
+        request: &OutputStreamConfig,
+        previous_stream_running: &mut bool,
+    ) -> Result<(), AudioStreamError> {
         let result: Result<(), AudioStreamError> = (|| {
             let host = request.backend.create_host()?;
             let device = resolve_output_device(&host, request.device_name.as_deref())?;
-            let device_name = device.name().unwrap_or_else(|_| {
+            let device_name = cpal_device_name(&device).unwrap_or_else(|_| {
                 request
                     .device_name
                     .clone()
@@ -311,11 +392,11 @@ impl AudioOutputStream {
 
             if let Some(current) = self.stream.as_ref() {
                 current.pause()?;
-                previous_stream_running = false;
+                *previous_stream_running = false;
             }
             if let Err(error) = stream.play() {
                 if let Some(current) = self.stream.as_ref() {
-                    previous_stream_running = current.play().is_ok();
+                    *previous_stream_running = current.play().is_ok();
                 }
                 return Err(error.into());
             }
@@ -325,24 +406,24 @@ impl AudioOutputStream {
             self.active_device = Some(device);
             self.active_device_name = Some(device_name);
             self.active_backend = Some(request.backend);
+            self.active_config = Some(OutputStreamConfig {
+                backend: request.backend,
+                device_name: self.active_device_name.clone(),
+                sample_rate: self.sample_rate(),
+                buffer_size: request.buffer_size,
+            });
             Ok(())
         })();
+        result
+    }
 
-        match result {
-            Ok(()) => {
-                self.event_reporter.report(AudioStreamEvent::Recovered);
-                Ok(())
-            }
-            Err(error) => {
-                let event = if previous_stream_running {
-                    AudioStreamEvent::ConfigurationRejected(error.to_string())
-                } else {
-                    AudioStreamEvent::Error(error.to_string())
-                };
-                self.event_reporter.report(event);
-                Err(error)
-            }
-        }
+    fn clear_active_stream(&mut self) {
+        self.stream = None;
+        self.params = None;
+        self.active_device = None;
+        self.active_device_name = None;
+        self.active_backend = None;
+        self.active_config = None;
     }
 
     /// Internal: build a cpal stream around an existing engine slot.
@@ -362,7 +443,7 @@ impl AudioOutputStream {
             buffer_size,
             Some(DEFAULT_CHANNELS as u16),
         )?;
-        let sample_rate = supported_config.sample_rate().0;
+        let sample_rate = supported_config.sample_rate();
         let channels = supported_config.channels() as usize;
 
         let buf_size = match buffer_size {
@@ -372,7 +453,7 @@ impl AudioOutputStream {
 
         let config = StreamConfig {
             channels: channels as u16,
-            sample_rate: SampleRate(sample_rate),
+            sample_rate,
             buffer_size: buf_size,
         };
 
@@ -504,7 +585,7 @@ fn resolve_output_device(
             .ok_or(AudioStreamError::NoOutputDevice);
     };
     host.output_devices()?
-        .find(|device| device.name().is_ok_and(|name| name == requested_name))
+        .find(|device| cpal_device_name(device).is_ok_and(|name| name == requested_name))
         .ok_or_else(|| AudioStreamError::OutputDeviceNotFound(requested_name.to_string()))
 }
 

--- a/crates/vibez-audio-io/src/audio_stream.rs
+++ b/crates/vibez-audio-io/src/audio_stream.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Mutex};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{DevicesError, PauseStreamError, SampleRate, StreamConfig};
 
+use crate::audio_host::{AudioBackend, AudioHostError};
 use crate::audio_input::AudioInputBridge;
 use crate::stream_config::{select_stream_config, StreamDirection, StreamOpenError};
 use vibez_core::constants::DEFAULT_CHANNELS;
@@ -57,6 +58,8 @@ impl StreamEventReporter {
 /// Errors from [`AudioOutputStream`].
 #[derive(Debug)]
 pub enum AudioStreamError {
+    /// The selected audio backend could not be created.
+    AudioHost(AudioHostError),
     /// No default output device found.
     NoOutputDevice,
     /// A persisted named output is not currently visible.
@@ -74,6 +77,7 @@ pub enum AudioStreamError {
 impl fmt::Display for AudioStreamError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::AudioHost(error) => error.fmt(f),
             Self::NoOutputDevice => write!(f, "no default audio output device available"),
             Self::OutputDeviceNotFound(name) => {
                 write!(f, "audio output device is unavailable: {name}")
@@ -89,6 +93,7 @@ impl fmt::Display for AudioStreamError {
 impl std::error::Error for AudioStreamError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::AudioHost(error) => Some(error),
             Self::NoOutputDevice | Self::OutputDeviceNotFound(_) | Self::NoActiveStream => None,
             Self::DevicesError(e) => Some(e),
             Self::StreamOpen(error) => Some(error),
@@ -100,6 +105,12 @@ impl std::error::Error for AudioStreamError {
 impl From<DevicesError> for AudioStreamError {
     fn from(e: DevicesError) -> Self {
         Self::DevicesError(e)
+    }
+}
+
+impl From<AudioHostError> for AudioStreamError {
+    fn from(error: AudioHostError) -> Self {
+        Self::AudioHost(error)
     }
 }
 
@@ -137,6 +148,8 @@ pub struct StreamParams {
 /// The complete hardware request used to build an output stream.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutputStreamConfig {
+    /// Audio API used to enumerate and open the requested device.
+    pub backend: AudioBackend,
     /// `None` follows the platform's System Default output.
     pub device_name: Option<String>,
     /// `None` uses the selected device's default sample rate.
@@ -148,6 +161,7 @@ pub struct OutputStreamConfig {
 impl Default for OutputStreamConfig {
     fn default() -> Self {
         Self {
+            backend: AudioBackend::System,
             device_name: None,
             sample_rate: None,
             buffer_size: Some(512),
@@ -176,7 +190,9 @@ impl Default for OutputStreamConfig {
 pub struct AudioOutputStream {
     stream: Option<cpal::Stream>,
     params: Option<StreamParams>,
+    active_device: Option<cpal::Device>,
     active_device_name: Option<String>,
+    active_backend: Option<AudioBackend>,
     /// Shared engine slot.  The audio callback `try_lock`s this each
     /// invocation and calls `engine.process_block()` if the lock is obtained.
     engine_slot: Arc<Mutex<Option<AudioEngine>>>,
@@ -193,7 +209,9 @@ impl AudioOutputStream {
         Self {
             stream: None,
             params: None,
+            active_device: None,
             active_device_name: None,
+            active_backend: None,
             engine_slot: Arc::new(Mutex::new(Some(engine))),
             event_reporter,
             event_rx,
@@ -240,7 +258,9 @@ impl AudioOutputStream {
         stream.play()?;
         output.stream = Some(stream);
         output.params = Some(params);
+        output.active_device = Some(device.clone());
         output.active_device_name = device_name;
+        output.active_backend = Some(AudioBackend::System);
         output.event_reporter.report(AudioStreamEvent::Running);
         Ok(output)
     }
@@ -254,8 +274,21 @@ impl AudioOutputStream {
     pub fn reconfigure(&mut self, request: OutputStreamConfig) -> Result<(), AudioStreamError> {
         self.event_reporter.report(AudioStreamEvent::Rebuilding);
         let mut previous_stream_running = self.stream.is_some();
+        // Most native hosts allow a replacement stream to be prepared while
+        // the old one remains live. ASIO drivers commonly own one exclusive
+        // buffer set, so attempting to load the same driver twice fails. Drop
+        // that driver before rebuilding while the engine remains safely held
+        // in `engine_slot`.
+        if requires_exclusive_reopen(self.active_backend, request.backend) {
+            self.stream = None;
+            self.active_device = None;
+            self.params = None;
+            self.active_device_name = None;
+            self.active_backend = None;
+            previous_stream_running = false;
+        }
         let result: Result<(), AudioStreamError> = (|| {
-            let host = cpal::default_host();
+            let host = request.backend.create_host()?;
             let device = resolve_output_device(&host, request.device_name.as_deref())?;
             let device_name = device.name().unwrap_or_else(|_| {
                 request
@@ -289,7 +322,9 @@ impl AudioOutputStream {
 
             self.stream = Some(stream);
             self.params = Some(params);
+            self.active_device = Some(device);
             self.active_device_name = Some(device_name);
+            self.active_backend = Some(request.backend);
             Ok(())
         })();
 
@@ -417,6 +452,20 @@ impl AudioOutputStream {
         self.active_device_name.as_deref()
     }
 
+    /// Clone the concrete device which owns the active output stream.
+    ///
+    /// ASIO requires input and output buffers to be prepared through clones of
+    /// the same CPAL device object. Re-enumerating a matching driver name can
+    /// create an independent driver state which cannot join the live stream.
+    pub fn active_device(&self) -> Option<cpal::Device> {
+        self.active_device.clone()
+    }
+
+    /// Backend currently driving the output callback.
+    pub fn active_backend(&self) -> Option<AudioBackend> {
+        self.active_backend
+    }
+
     pub fn is_running(&self) -> bool {
         self.stream.is_some()
     }
@@ -436,6 +485,13 @@ impl AudioOutputStream {
     pub fn input_bridge(&self) -> Arc<AudioInputBridge> {
         Arc::clone(&self.input_bridge)
     }
+}
+
+fn requires_exclusive_reopen(
+    active_backend: Option<AudioBackend>,
+    requested_backend: AudioBackend,
+) -> bool {
+    active_backend == Some(AudioBackend::Asio) && requested_backend == AudioBackend::Asio
 }
 
 fn resolve_output_device(
@@ -496,6 +552,22 @@ mod tests {
             None => cpal::BufferSize::Default,
         };
         assert!(matches!(buf, cpal::BufferSize::Fixed(1024)));
+    }
+
+    #[test]
+    fn asio_releases_its_exclusive_driver_before_reconfiguration() {
+        assert!(requires_exclusive_reopen(
+            Some(AudioBackend::Asio),
+            AudioBackend::Asio
+        ));
+        assert!(!requires_exclusive_reopen(
+            Some(AudioBackend::System),
+            AudioBackend::Asio
+        ));
+        assert!(!requires_exclusive_reopen(
+            Some(AudioBackend::Asio),
+            AudioBackend::System
+        ));
     }
 
     #[test]

--- a/crates/vibez-audio-io/src/audio_stream.rs
+++ b/crates/vibez-audio-io/src/audio_stream.rs
@@ -9,7 +9,7 @@ use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 
 use cpal::traits::{HostTrait, StreamTrait};
-use cpal::{DevicesError, PauseStreamError, StreamConfig};
+use cpal::{DevicesError, PauseStreamError, SampleRate, StreamConfig};
 
 use crate::audio_host::{cpal_device_name, AudioBackend, AudioHostError};
 use crate::audio_input::AudioInputBridge;
@@ -443,7 +443,7 @@ impl AudioOutputStream {
             buffer_size,
             Some(DEFAULT_CHANNELS as u16),
         )?;
-        let sample_rate = supported_config.sample_rate();
+        let sample_rate = supported_config.sample_rate().0;
         let channels = supported_config.channels() as usize;
 
         let buf_size = match buffer_size {
@@ -453,7 +453,7 @@ impl AudioOutputStream {
 
         let config = StreamConfig {
             channels: channels as u16,
-            sample_rate,
+            sample_rate: SampleRate(sample_rate),
             buffer_size: buf_size,
         };
 

--- a/crates/vibez-audio-io/src/audio_stream.rs
+++ b/crates/vibez-audio-io/src/audio_stream.rs
@@ -8,10 +8,10 @@ use std::fmt;
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 
-use cpal::traits::{HostTrait, StreamTrait};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{DevicesError, PauseStreamError, SampleRate, StreamConfig};
 
-use crate::audio_host::{cpal_device_name, AudioBackend, AudioHostError};
+use crate::audio_host::{AudioBackend, AudioHostError};
 use crate::audio_input::AudioInputBridge;
 use crate::stream_config::{select_stream_config, StreamDirection, StreamOpenError};
 use vibez_core::constants::DEFAULT_CHANNELS;
@@ -261,7 +261,7 @@ impl AudioOutputStream {
         buffer_size: Option<u32>,
     ) -> Result<Self, AudioStreamError> {
         let mut output = Self::idle(engine);
-        let device_name = cpal_device_name(device).ok();
+        let device_name = device.name().ok();
         let (stream, params) = Self::build_stream(
             Arc::clone(&output.engine_slot),
             device,
@@ -371,7 +371,7 @@ impl AudioOutputStream {
         let result: Result<(), AudioStreamError> = (|| {
             let host = request.backend.create_host()?;
             let device = resolve_output_device(&host, request.device_name.as_deref())?;
-            let device_name = cpal_device_name(&device).unwrap_or_else(|_| {
+            let device_name = device.name().unwrap_or_else(|_| {
                 request
                     .device_name
                     .clone()
@@ -585,7 +585,7 @@ fn resolve_output_device(
             .ok_or(AudioStreamError::NoOutputDevice);
     };
     host.output_devices()?
-        .find(|device| cpal_device_name(device).is_ok_and(|name| name == requested_name))
+        .find(|device| device.name().is_ok_and(|name| name == requested_name))
         .ok_or_else(|| AudioStreamError::OutputDeviceNotFound(requested_name.to_string()))
 }
 

--- a/crates/vibez-audio-io/src/stream_config.rs
+++ b/crates/vibez-audio-io/src/stream_config.rs
@@ -104,7 +104,7 @@ pub(crate) fn select_stream_config(
         Err(error) => return Err(error.into()),
     };
     let sample_rate = requested_sample_rate
-        .or_else(|| default.as_ref().map(|config| config.sample_rate()))
+        .or_else(|| default.as_ref().map(|config| config.sample_rate().0))
         .expect("a requested or default sample rate is required");
     let preferred_channels =
         preferred_channels.or_else(|| default.as_ref().map(|config| config.channels()));
@@ -113,7 +113,7 @@ pub(crate) fn select_stream_config(
         StreamDirection::Output => device.supported_output_configs()?.collect(),
     };
     candidates.retain(|range| {
-        (range.min_sample_rate()..=range.max_sample_rate()).contains(&sample_rate)
+        (range.min_sample_rate().0..=range.max_sample_rate().0).contains(&sample_rate)
             && buffer_size_supported(buffer_size, range.buffer_size())
     });
     candidates.sort_by_key(|range| {
@@ -126,7 +126,7 @@ pub(crate) fn select_stream_config(
     candidates
         .into_iter()
         .next()
-        .and_then(|range| range.try_with_sample_rate(sample_rate))
+        .and_then(|range| range.try_with_sample_rate(cpal::SampleRate(sample_rate)))
         .ok_or_else(|| {
             StreamOpenError::Unsupported(format!(
                 "audio {} does not support {sample_rate} Hz with {} buffer",

--- a/crates/vibez-audio-io/src/stream_config.rs
+++ b/crates/vibez-audio-io/src/stream_config.rs
@@ -1,7 +1,7 @@
 //! Shared input/output CPAL stream selection and construction errors.
 
 use cpal::traits::DeviceTrait;
-use cpal::{SampleFormat, SampleRate};
+use cpal::SampleFormat;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum StreamDirection {
@@ -104,7 +104,7 @@ pub(crate) fn select_stream_config(
         Err(error) => return Err(error.into()),
     };
     let sample_rate = requested_sample_rate
-        .or_else(|| default.as_ref().map(|config| config.sample_rate().0))
+        .or_else(|| default.as_ref().map(|config| config.sample_rate()))
         .expect("a requested or default sample rate is required");
     let preferred_channels =
         preferred_channels.or_else(|| default.as_ref().map(|config| config.channels()));
@@ -113,7 +113,7 @@ pub(crate) fn select_stream_config(
         StreamDirection::Output => device.supported_output_configs()?.collect(),
     };
     candidates.retain(|range| {
-        (range.min_sample_rate().0..=range.max_sample_rate().0).contains(&sample_rate)
+        (range.min_sample_rate()..=range.max_sample_rate()).contains(&sample_rate)
             && buffer_size_supported(buffer_size, range.buffer_size())
     });
     candidates.sort_by_key(|range| {
@@ -126,7 +126,7 @@ pub(crate) fn select_stream_config(
     candidates
         .into_iter()
         .next()
-        .and_then(|range| range.try_with_sample_rate(SampleRate(sample_rate)))
+        .and_then(|range| range.try_with_sample_rate(sample_rate))
         .ok_or_else(|| {
             StreamOpenError::Unsupported(format!(
                 "audio {} does not support {sample_rate} Hz with {} buffer",

--- a/crates/vibez-ui/src/app/audio_recording.rs
+++ b/crates/vibez-ui/src/app/audio_recording.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use iced::Task;
+use vibez_audio_io::audio_host::AudioBackend;
 use vibez_audio_io::audio_input::{AudioInputEvent, AudioInputStream};
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::id::{ClipId, TrackId};
@@ -517,20 +518,42 @@ impl App {
             .selected_input_name()
             .map(str::to_owned);
         let must_reopen = input_stream_must_reopen(
-            self._input_stream
-                .as_ref()
-                .map(|stream| (stream.device_name.as_str(), stream.sample_rate)),
+            self._input_stream.as_ref().map(|stream| {
+                (
+                    stream.backend,
+                    stream.device_name.as_str(),
+                    stream.sample_rate,
+                )
+            }),
+            self.state.audio_settings.backend,
             expected_device_name.as_deref(),
             self.state.transport.sample_rate,
         );
         if must_reopen {
             self._input_stream = None;
-            let stream = AudioInputStream::open(
-                requested_name,
-                self.state.transport.sample_rate,
-                Some(self.state.audio_settings.buffer_size),
-                Arc::clone(&self.input_bridge),
-            )
+            let backend = self.state.audio_settings.backend;
+            let stream = if backend == AudioBackend::Asio {
+                let device = self
+                    ._stream
+                    .as_ref()
+                    .and_then(|output| output.active_device())
+                    .ok_or_else(|| "ASIO Audio Output is unavailable".to_string())?;
+                AudioInputStream::open_on_device(
+                    backend,
+                    device,
+                    self.state.transport.sample_rate,
+                    Some(self.state.audio_settings.buffer_size),
+                    Arc::clone(&self.input_bridge),
+                )
+            } else {
+                AudioInputStream::open(
+                    backend,
+                    requested_name,
+                    self.state.transport.sample_rate,
+                    Some(self.state.audio_settings.buffer_size),
+                    Arc::clone(&self.input_bridge),
+                )
+            }
             .map_err(|error| error.to_string())?;
             if !route_fits_channels(self.input_bridge.route(), stream.channels as u16) {
                 return Err(format!(
@@ -663,12 +686,14 @@ fn track_recording_source_label(
 }
 
 fn input_stream_must_reopen(
-    current: Option<(&str, u32)>,
+    current: Option<(AudioBackend, &str, u32)>,
+    expected_backend: AudioBackend,
     expected_device_name: Option<&str>,
     expected_sample_rate: u32,
 ) -> bool {
-    current.is_none_or(|(device_name, sample_rate)| {
-        sample_rate != expected_sample_rate
+    current.is_none_or(|(backend, device_name, sample_rate)| {
+        backend != expected_backend
+            || sample_rate != expected_sample_rate
             || expected_device_name.is_none_or(|expected| device_name != expected)
     })
 }
@@ -788,12 +813,20 @@ mod tests {
     #[test]
     fn switching_from_a_named_input_to_a_different_system_default_reopens() {
         assert!(input_stream_must_reopen(
-            Some(("USB Interface", 48_000)),
+            Some((AudioBackend::System, "USB Interface", 48_000)),
+            AudioBackend::System,
             Some("Built-in Audio"),
             48_000,
         ));
         assert!(!input_stream_must_reopen(
-            Some(("Built-in Audio", 48_000)),
+            Some((AudioBackend::System, "Built-in Audio", 48_000)),
+            AudioBackend::System,
+            Some("Built-in Audio"),
+            48_000,
+        ));
+        assert!(input_stream_must_reopen(
+            Some((AudioBackend::System, "Built-in Audio", 48_000)),
+            AudioBackend::Asio,
             Some("Built-in Audio"),
             48_000,
         ));

--- a/crates/vibez-ui/src/app/audio_recording.rs
+++ b/crates/vibez-ui/src/app/audio_recording.rs
@@ -1,13 +1,11 @@
 //! Arrange Audio Track Recording and live Resample lifecycle.
 
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
 use iced::Task;
 use vibez_audio_io::audio_host::AudioBackend;
 use vibez_audio_io::audio_input::{AudioInputEvent, AudioInputStream};
-use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::TrackKind;
 use vibez_core::track::{AudioInputRoute, InputMonitoring};
@@ -18,6 +16,9 @@ use crate::domains::transport::TransportMsg;
 use crate::message::{AudioRecordingOutcome, Message};
 use crate::state::{ArrangementSelection, ProjectTrack, UiClip, Workspace};
 
+use super::audio_take_finalization::{
+    finalize_audio_take, recording_target_accepts_finalizer, FinalizeAudioTake,
+};
 use super::*;
 
 impl App {
@@ -698,117 +699,9 @@ fn input_stream_must_reopen(
     })
 }
 
-fn recording_target_accepts_finalizer(
-    phase: AudioRecordingPhase,
-    armed_track: Option<TrackId>,
-    outcome_track: TrackId,
-    target_exists: bool,
-) -> bool {
-    phase == AudioRecordingPhase::Finalizing && armed_track == Some(outcome_track) && target_exists
-}
-
-struct FinalizeAudioTake {
-    track_id: TrackId,
-    start_position_samples: u64,
-    sample_rate: u32,
-    frames: Vec<[f32; 2]>,
-    recording_source: AudioRecordingSource,
-    completion_label: String,
-    truncated: bool,
-    underrun_frames: u64,
-}
-
-async fn finalize_audio_take(request: FinalizeAudioTake) -> Result<AudioRecordingOutcome, String> {
-    let FinalizeAudioTake {
-        track_id,
-        start_position_samples,
-        sample_rate,
-        frames,
-        recording_source,
-        completion_label,
-        truncated,
-        underrun_frames,
-    } = request;
-    tokio::task::spawn_blocking(move || {
-        if frames.is_empty() {
-            return Err("the take contained no recorded audio frames".into());
-        }
-        let clip_name = match recording_source {
-            AudioRecordingSource::HardwareInput => format!("Recording {start_position_samples}"),
-            AudioRecordingSource::TrackOutput(_) => format!("Resample {start_position_samples}"),
-        };
-        let audio = Arc::new(DecodedAudio {
-            channels: vec![
-                frames.iter().map(|frame| frame[0]).collect(),
-                frames.iter().map(|frame| frame[1]).collect(),
-            ],
-            sample_rate,
-        });
-        let bytes = vibez_audio_io::file_io::encode_wav(&audio);
-        let source = vibez_project::project_format_v1::stage_local_content(
-            Path::new("Recorded Audio"),
-            &format!("{clip_name}.wav"),
-            &bytes,
-        )
-        .map_err(|error| format!("Project Media staging failed: {error}"))?;
-        let mut warnings = Vec::new();
-        if truncated {
-            warnings
-                .push("capture overflow truncated the take to its valid captured frames".into());
-        }
-        if recording_source == AudioRecordingSource::HardwareInput && underrun_frames > 0 {
-            warnings.push(format!(
-                "{underrun_frames} input frame(s) were unavailable and replaced with silence"
-            ));
-        }
-        Ok(AudioRecordingOutcome {
-            track_id,
-            start_position_samples,
-            clip_name,
-            audio,
-            source,
-            completion_label,
-            quality_warning: (!warnings.is_empty()).then(|| warnings.join("; ")),
-        })
-    })
-    .await
-    .map_err(|error| format!("recording finalization task failed: {error}"))?
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vibez_core::track::MediaSourceRef;
-
-    #[tokio::test]
-    async fn completed_take_is_staged_before_it_can_become_project_content() {
-        let outcome = finalize_audio_take(FinalizeAudioTake {
-            track_id: TrackId::new(),
-            start_position_samples: 9_600,
-            sample_rate: 48_000,
-            frames: vec![[0.25, -0.25]; 480],
-            recording_source: AudioRecordingSource::HardwareInput,
-            completion_label: "Recorded Audio Input".into(),
-            truncated: false,
-            underrun_frames: 0,
-        })
-        .await
-        .unwrap();
-
-        assert_eq!(outcome.start_position_samples, 9_600);
-        assert_eq!(outcome.audio.num_frames(), 480);
-        match outcome.source {
-            MediaSourceRef::StagedProjectMedia {
-                staging_path,
-                file_name,
-                ..
-            } => {
-                assert!(staging_path.is_file());
-                assert!(file_name.ends_with(".wav"));
-            }
-            source => panic!("expected staged Project Media, got {source:?}"),
-        }
-    }
 
     #[test]
     fn switching_from_a_named_input_to_a_different_system_default_reopens() {
@@ -829,124 +722,6 @@ mod tests {
             AudioBackend::Asio,
             Some("Built-in Audio"),
             48_000,
-        ));
-    }
-
-    #[test]
-    fn a_stale_finalizer_cannot_land_in_a_new_project_or_ghost_track() {
-        let target = TrackId::new();
-        assert!(!recording_target_accepts_finalizer(
-            AudioRecordingPhase::Idle,
-            Some(target),
-            target,
-            true,
-        ));
-        assert!(!recording_target_accepts_finalizer(
-            AudioRecordingPhase::Finalizing,
-            Some(target),
-            target,
-            false,
-        ));
-        assert!(recording_target_accepts_finalizer(
-            AudioRecordingPhase::Finalizing,
-            Some(target),
-            target,
-            true,
-        ));
-    }
-
-    #[tokio::test]
-    async fn drift_damage_is_preserved_as_an_explicit_salvage_warning() {
-        let outcome = finalize_audio_take(FinalizeAudioTake {
-            track_id: TrackId::new(),
-            start_position_samples: 0,
-            sample_rate: 48_000,
-            frames: vec![[0.1, -0.1]; 32],
-            recording_source: AudioRecordingSource::HardwareInput,
-            completion_label: "Recorded Audio Input".into(),
-            truncated: true,
-            underrun_frames: 7,
-        })
-        .await
-        .unwrap();
-        let warning = outcome.quality_warning.unwrap();
-        assert!(warning.contains("overflow truncated"));
-        assert!(warning.contains("7 input frame(s)"));
-    }
-
-    #[tokio::test]
-    async fn resample_take_uses_recorded_audio_staging_without_hardware_drift_warnings() {
-        let outcome = finalize_audio_take(FinalizeAudioTake {
-            track_id: TrackId::new(),
-            start_position_samples: 24_000,
-            sample_rate: 48_000,
-            frames: vec![[0.3, -0.2]; 128],
-            recording_source: AudioRecordingSource::TrackOutput(TrackId::new()),
-            completion_label: "Resampled MIDI 2".into(),
-            truncated: false,
-            underrun_frames: 99,
-        })
-        .await
-        .unwrap();
-
-        assert_eq!(outcome.clip_name, "Resample 24000");
-        assert_eq!(outcome.completion_label, "Resampled MIDI 2");
-        assert_eq!(outcome.audio.num_frames(), 128);
-        assert!(outcome.quality_warning.is_none());
-        assert!(matches!(
-            outcome.source,
-            MediaSourceRef::StagedProjectMedia { .. }
-        ));
-    }
-
-    #[tokio::test]
-    async fn recorded_take_reopens_from_project_media_at_the_same_position() {
-        let directory = tempfile::tempdir().unwrap();
-        let project_path = directory.path().join("recording-roundtrip.vzp");
-        let track = vibez_core::track::TrackInfo::new("Vocal");
-        let outcome = finalize_audio_take(FinalizeAudioTake {
-            track_id: track.id,
-            start_position_samples: 12_345,
-            sample_rate: 48_000,
-            frames: vec![[0.4, -0.2]; 960],
-            recording_source: AudioRecordingSource::HardwareInput,
-            completion_label: "Recorded Audio Input".into(),
-            truncated: false,
-            underrun_frames: 0,
-        })
-        .await
-        .unwrap();
-        let project = vibez_project::Project {
-            tracks: vec![track.clone()],
-            arrange: vibez_project::TimelineInfo {
-                clips: vec![vibez_core::track::ClipInfo {
-                    id: ClipId::new(),
-                    track_id: track.id,
-                    name: outcome.clip_name,
-                    position: outcome.start_position_samples,
-                    source_offset: 0,
-                    duration: outcome.audio.num_frames() as u64,
-                    source: Some(outcome.source),
-                    file_path: None,
-                    loop_enabled: false,
-                    loop_start: 0,
-                    loop_end: outcome.audio.num_frames() as u64,
-                    original_bpm: None,
-                    warped: false,
-                    warped_to_bpm: None,
-                }],
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        vibez_project::project_format_v1::save_project_v1(&project_path, None, project).unwrap();
-
-        let reopened = super::load_project_async(project_path, None).await.unwrap();
-        assert_eq!(reopened.project.arrange.clips[0].position, 12_345);
-        assert_eq!(reopened.clips[0].audio.num_frames(), 960);
-        assert!(matches!(
-            reopened.project.arrange.clips[0].source,
-            Some(MediaSourceRef::ProjectMedia { .. })
         ));
     }
 }

--- a/crates/vibez-ui/src/app/audio_settings.rs
+++ b/crates/vibez-ui/src/app/audio_settings.rs
@@ -141,6 +141,24 @@ fn failed_initial_audio(error: impl std::fmt::Display) -> (AudioStreamHealth, Op
     )
 }
 
+fn rejected_output_status(
+    output_error: &str,
+    restored_output: Option<&str>,
+    input_error: Option<&str>,
+) -> String {
+    let output_status = match restored_output {
+        Some(active) => {
+            format!("Could not switch Audio Output — {output_error}. {active} restored")
+        }
+        None => format!("Audio Output failed and could not be restored — {output_error}"),
+    };
+
+    match input_error {
+        Some(error) => format!("{output_status}. Audio Input could not reopen — {error}"),
+        None => output_status,
+    }
+}
+
 fn live_output_requests(
     backend: AudioBackend,
     output_name: Option<String>,
@@ -189,13 +207,27 @@ impl App {
             }
         };
         let previous = self.state.audio_settings.clone();
+        self.state.audio_settings.remember_current_backend();
         self.state.audio_settings.backend = backend;
         self.state.audio_settings.catalog = catalog;
         self.state.audio_settings.catalog_error = None;
-        self.state.audio_settings.preferred_input_name = None;
-        self.state.audio_settings.preferred_output_name = None;
+        self.state
+            .audio_settings
+            .restore_backend_preferences(backend);
 
-        let choice = self.state.audio_settings.selected_output_choice();
+        let remembered_output = self.state.audio_settings.preferred_output_name.clone();
+        let remembered_choice = self.state.audio_settings.selected_output_choice();
+        let choice = if remembered_choice.available {
+            remembered_choice
+        } else {
+            AudioDeviceChoice::system_default(
+                self.state
+                    .audio_settings
+                    .catalog
+                    .default_output_name
+                    .is_some(),
+            )
+        };
         let Some((sample_rate, buffer_size)) = self
             .state
             .audio_settings
@@ -211,7 +243,12 @@ impl App {
             );
             return Task::none();
         };
-        if !self.apply_audio_output_configuration(None, sample_rate, buffer_size) {
+        if !self.apply_audio_output_configuration_with_preference(
+            choice.name,
+            remembered_output,
+            sample_rate,
+            buffer_size,
+        ) {
             self.state.audio_settings = previous;
         }
         Task::none()
@@ -301,6 +338,7 @@ impl App {
             return Task::none();
         }
         self.state.audio_settings.preferred_input_name = choice.name;
+        self.state.audio_settings.remember_current_backend();
         self.state.status_text = format!(
             "Audio Input selected — {}. Recording starts only when a track is armed",
             self.state.audio_settings.input_description()
@@ -351,6 +389,21 @@ impl App {
         sample_rate: u32,
         buffer_size: u32,
     ) -> bool {
+        self.apply_audio_output_configuration_with_preference(
+            preferred_output_name.clone(),
+            preferred_output_name,
+            sample_rate,
+            buffer_size,
+        )
+    }
+
+    fn apply_audio_output_configuration_with_preference(
+        &mut self,
+        requested_output_name: Option<String>,
+        preferred_output_name: Option<String>,
+        sample_rate: u32,
+        buffer_size: u32,
+    ) -> bool {
         if self.state.audio_recording.is_busy() {
             self.state.status_text = "Stop Audio Track Recording before changing hardware".into();
             return false;
@@ -363,12 +416,8 @@ impl App {
             // the successful path reopens it through the new output device.
             self._input_stream = None;
         }
-        let requests = live_output_requests(
-            backend,
-            preferred_output_name.clone(),
-            sample_rate,
-            buffer_size,
-        );
+        let requests =
+            live_output_requests(backend, requested_output_name, sample_rate, buffer_size);
         let result = self
             ._stream
             .as_mut()
@@ -403,12 +452,13 @@ impl App {
                 self.state.transport.sample_rate = actual_sample_rate;
                 self.state.audio_stream_health = AudioStreamHealth::Running;
                 self.send_command(EngineCommand::SetSampleRate(actual_sample_rate));
+                self.state.audio_settings.remember_current_backend();
+                self.persist_ui_settings();
                 if let Err(error) = self.sync_audio_input_runtime() {
                     self.state.status_text =
                         format!("Audio Output changed, but Audio Input could not reopen — {error}");
                     return true;
                 }
-                self.persist_ui_settings();
                 self.state.status_text = if applied_request == 0 {
                     format!(
                         "{backend} Audio Output running — {}, {} Hz, {buffer_size} frames",
@@ -425,6 +475,7 @@ impl App {
             }
             Err(error) => {
                 eprintln!("vibez: audio configuration rejected: {error}");
+                let mut restored_output = None;
                 if let Some(stream) = self._stream.as_ref() {
                     self.state.audio_settings.active_backend = stream.active_backend();
                     self.state.audio_settings.active_output_name =
@@ -433,19 +484,24 @@ impl App {
                         let active = stream
                             .active_device_name()
                             .unwrap_or("the previous Audio Output");
+                        restored_output = Some(active.to_string());
                         self.state.audio_stream_health = AudioStreamHealth::Running;
-                        self.state.status_text =
-                            format!("Could not switch Audio Output — {error}. {active} restored");
+                        self.state.status_text = rejected_output_status(&error, Some(active), None);
                     } else {
                         self.state.audio_stream_health = AudioStreamHealth::Error(error.clone());
-                        self.state.status_text =
-                            format!("Audio Output failed and could not be restored — {error}");
+                        self.state.status_text = rejected_output_status(&error, None, None);
                     }
                 }
                 if self._stream.is_none() {
                     self.state.status_text = format!("Audio configuration rejected: {error}");
                 }
-                let _ = self.sync_audio_input_runtime();
+                if let Err(input_error) = self.sync_audio_input_runtime() {
+                    self.state.status_text = rejected_output_status(
+                        &error,
+                        restored_output.as_deref(),
+                        Some(&input_error),
+                    );
+                }
                 false
             }
         }
@@ -454,7 +510,7 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::{initial_output_requests, live_output_requests};
+    use super::{initial_output_requests, live_output_requests, rejected_output_status};
     use vibez_audio_io::audio_host::AudioBackend;
     use vibez_audio_io::audio_stream::OutputStreamConfig;
 
@@ -539,6 +595,18 @@ mod tests {
                     buffer_size: None,
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn rejected_output_reports_when_restored_input_cannot_reopen() {
+        assert_eq!(
+            rejected_output_status(
+                "driver rejected the format",
+                Some("ASIO4ALL v2"),
+                Some("input driver is busy"),
+            ),
+            "Could not switch Audio Output — driver rejected the format. ASIO4ALL v2 restored. Audio Input could not reopen — input driver is busy"
         );
     }
 }

--- a/crates/vibez-ui/src/app/audio_settings.rs
+++ b/crates/vibez-ui/src/app/audio_settings.rs
@@ -1,7 +1,7 @@
 //! Settings → Audio hardware actions.
 
 use iced::Task;
-use vibez_audio_io::audio_host::AudioHost;
+use vibez_audio_io::audio_host::{AudioBackend, AudioHost};
 use vibez_audio_io::audio_stream::{AudioOutputStream, OutputStreamConfig};
 use vibez_engine::commands::EngineCommand;
 use vibez_engine::engine::AudioEngine;
@@ -16,18 +16,25 @@ pub(super) struct InitialAudioOutput {
     pub stream: AudioOutputStream,
     pub sample_rate: u32,
     pub active_output_name: Option<String>,
+    pub active_backend: Option<AudioBackend>,
     pub health: AudioStreamHealth,
     pub status: Option<String>,
 }
 
 pub(super) fn initialize_audio_output(
     engine: AudioEngine,
+    preferred_backend: AudioBackend,
     preferred_output_name: Option<String>,
     sample_rate: Option<u32>,
     buffer_size: u32,
 ) -> InitialAudioOutput {
     let mut stream = AudioOutputStream::idle(engine);
-    let requests = initial_output_requests(preferred_output_name.clone(), sample_rate, buffer_size);
+    let requests = initial_output_requests(
+        preferred_backend,
+        preferred_output_name.clone(),
+        sample_rate,
+        buffer_size,
+    );
     let mut errors = Vec::new();
     let mut successful_attempt = None;
     for (attempt, request) in requests.iter().cloned().enumerate() {
@@ -45,12 +52,14 @@ pub(super) fn initialize_audio_output(
     let (health, status) = match successful_attempt {
         Some(0) => (AudioStreamHealth::Running, None),
         Some(attempt) => {
-            let fallback = if requests[attempt].sample_rate.is_none()
+            let fallback = if requests[attempt].backend != preferred_backend {
+                format!("{} with device defaults", requests[attempt].backend)
+            } else if requests[attempt].sample_rate.is_none()
                 && requests[attempt].buffer_size.is_none()
             {
-                "System Default device settings"
+                format!("{preferred_backend} device defaults")
             } else {
-                "System Default"
+                format!("{preferred_backend} default device")
             };
             (
                 AudioStreamHealth::Running,
@@ -75,6 +84,7 @@ pub(super) fn initialize_audio_output(
     InitialAudioOutput {
         sample_rate: stream.sample_rate().unwrap_or(44_100),
         active_output_name: stream.active_device_name().map(str::to_owned),
+        active_backend: stream.active_backend(),
         stream,
         health,
         status,
@@ -82,11 +92,13 @@ pub(super) fn initialize_audio_output(
 }
 
 fn initial_output_requests(
+    backend: AudioBackend,
     preferred_output_name: Option<String>,
     sample_rate: Option<u32>,
     buffer_size: u32,
 ) -> Vec<OutputStreamConfig> {
     let saved_request = OutputStreamConfig {
+        backend,
         device_name: preferred_output_name.clone(),
         sample_rate,
         buffer_size: Some(buffer_size),
@@ -94,18 +106,28 @@ fn initial_output_requests(
     let mut requests = vec![saved_request];
     if preferred_output_name.is_some() {
         requests.push(OutputStreamConfig {
+            backend,
             device_name: None,
             sample_rate,
             buffer_size: Some(buffer_size),
         });
     }
     let device_defaults = OutputStreamConfig {
+        backend,
         device_name: None,
         sample_rate: None,
         buffer_size: None,
     };
     if requests.last() != Some(&device_defaults) {
         requests.push(device_defaults);
+    }
+    if backend != AudioBackend::System {
+        requests.push(OutputStreamConfig {
+            backend: AudioBackend::System,
+            device_name: None,
+            sample_rate: None,
+            buffer_size: None,
+        });
     }
     requests
 }
@@ -120,6 +142,54 @@ fn failed_initial_audio(error: impl std::fmt::Display) -> (AudioStreamHealth, Op
 }
 
 impl App {
+    pub(super) fn handle_select_audio_backend(&mut self, backend: AudioBackend) -> Task<Message> {
+        if self.state.audio_recording.is_busy() {
+            self.state.status_text = "Stop Audio Track Recording before changing hardware".into();
+            return Task::none();
+        }
+        if !backend.is_available() {
+            self.state.status_text = format!("{backend} is unavailable on this platform");
+            return Task::none();
+        }
+        if backend == self.state.audio_settings.backend {
+            return self.handle_rescan_audio_devices();
+        }
+        let catalog = match AudioHost::new(backend).and_then(|host| host.catalog()) {
+            Ok(catalog) => catalog,
+            Err(error) => {
+                self.state.status_text = format!("{backend} could not start — {error}");
+                return Task::none();
+            }
+        };
+        let previous = self.state.audio_settings.clone();
+        self.state.audio_settings.backend = backend;
+        self.state.audio_settings.catalog = catalog;
+        self.state.audio_settings.catalog_error = None;
+        self.state.audio_settings.preferred_input_name = None;
+        self.state.audio_settings.preferred_output_name = None;
+
+        let choice = self.state.audio_settings.selected_output_choice();
+        let Some((sample_rate, buffer_size)) = self
+            .state
+            .audio_settings
+            .compatible_output_configuration(&choice)
+        else {
+            self.state.audio_settings = previous.clone();
+            self.state.status_text = format!(
+                "No {backend} output driver found — {} remains active",
+                previous
+                    .active_backend
+                    .map(|active| active.to_string())
+                    .unwrap_or_else(|| "the current audio output".into())
+            );
+            return Task::none();
+        };
+        if !self.apply_audio_output_configuration(None, sample_rate, buffer_size) {
+            self.state.audio_settings = previous;
+        }
+        Task::none()
+    }
+
     pub(super) fn handle_set_buffer_size(&mut self, size: u32) -> Task<Message> {
         if !self
             .state
@@ -198,6 +268,11 @@ impl App {
                 format!("{} is unavailable — rescan after reconnecting it", choice);
             return Task::none();
         }
+        if self.state.audio_settings.backend == AudioBackend::Asio {
+            self.state.status_text =
+                "ASIO uses one driver for input and output — choose Audio Device".into();
+            return Task::none();
+        }
         self.state.audio_settings.preferred_input_name = choice.name;
         self.state.status_text = format!(
             "Audio Input selected — {}. Recording starts only when a track is armed",
@@ -211,14 +286,15 @@ impl App {
     }
 
     pub(super) fn handle_rescan_audio_devices(&mut self) -> Task<Message> {
-        match AudioHost::new().catalog() {
+        let backend = self.state.audio_settings.backend;
+        match AudioHost::new(backend).and_then(|host| host.catalog()) {
             Ok(catalog) => {
                 let inputs = catalog.input_devices.len();
                 let outputs = catalog.output_devices.len();
                 self.state.audio_settings.catalog = catalog;
                 self.state.audio_settings.catalog_error = None;
                 self.state.status_text =
-                    format!("Audio devices rescanned — {inputs} inputs, {outputs} outputs");
+                    format!("{backend} devices rescanned — {inputs} inputs, {outputs} outputs");
             }
             Err(error) => {
                 self.state.audio_settings.catalog_error = Some(error.to_string());
@@ -247,12 +323,21 @@ impl App {
         preferred_output_name: Option<String>,
         sample_rate: u32,
         buffer_size: u32,
-    ) {
+    ) -> bool {
         if self.state.audio_recording.is_busy() {
             self.state.status_text = "Stop Audio Track Recording before changing hardware".into();
-            return;
+            return false;
+        }
+        let backend = self.state.audio_settings.backend;
+        let active_backend = self.state.audio_settings.active_backend;
+        if backend == AudioBackend::Asio || active_backend == Some(AudioBackend::Asio) {
+            // ASIO input and output share one exclusive driver buffer set.
+            // Release on-demand monitoring before the output stream rebuilds;
+            // the successful path reopens it through the new output device.
+            self._input_stream = None;
         }
         let request = OutputStreamConfig {
+            backend,
             device_name: preferred_output_name.clone(),
             sample_rate: Some(sample_rate),
             buffer_size: Some(buffer_size),
@@ -278,6 +363,12 @@ impl App {
         match result {
             Ok((actual_sample_rate, active_output_name)) => {
                 self.state.audio_settings.preferred_output_name = preferred_output_name;
+                self.state.audio_settings.preferred_input_name = if backend == AudioBackend::Asio {
+                    self.state.audio_settings.preferred_output_name.clone()
+                } else {
+                    self.state.audio_settings.preferred_input_name.clone()
+                };
+                self.state.audio_settings.active_backend = Some(backend);
                 self.state.audio_settings.active_output_name = active_output_name.clone();
                 self.state.audio_settings.sample_rate = actual_sample_rate;
                 self.state.audio_settings.buffer_size = buffer_size;
@@ -287,20 +378,27 @@ impl App {
                 if let Err(error) = self.sync_audio_input_runtime() {
                     self.state.status_text =
                         format!("Audio Output changed, but Audio Input could not reopen — {error}");
-                    return;
+                    return true;
                 }
                 self.persist_ui_settings();
                 self.state.status_text = format!(
-                    "Audio Output running — {}, {} Hz, {buffer_size} frames",
+                    "{backend} Audio Output running — {}, {} Hz, {buffer_size} frames",
                     active_output_name.as_deref().unwrap_or("System Default"),
                     actual_sample_rate
                 );
+                true
             }
             Err(error) => {
                 eprintln!("vibez: audio configuration rejected: {error}");
+                if let Some(stream) = self._stream.as_ref() {
+                    self.state.audio_settings.active_backend = stream.active_backend();
+                    self.state.audio_settings.active_output_name =
+                        stream.active_device_name().map(str::to_owned);
+                }
                 if self._stream.is_none() {
                     self.state.status_text = format!("Audio configuration rejected: {error}");
                 }
+                false
             }
         }
     }
@@ -309,24 +407,28 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::initial_output_requests;
+    use vibez_audio_io::audio_host::AudioBackend;
     use vibez_audio_io::audio_stream::OutputStreamConfig;
 
     #[test]
     fn startup_fallbacks_progress_from_saved_device_to_device_defaults() {
         assert_eq!(
-            initial_output_requests(Some("Dock".into()), Some(96_000), 64),
+            initial_output_requests(AudioBackend::System, Some("Dock".into()), Some(96_000), 64,),
             vec![
                 OutputStreamConfig {
+                    backend: AudioBackend::System,
                     device_name: Some("Dock".into()),
                     sample_rate: Some(96_000),
                     buffer_size: Some(64),
                 },
                 OutputStreamConfig {
+                    backend: AudioBackend::System,
                     device_name: None,
                     sample_rate: Some(96_000),
                     buffer_size: Some(64),
                 },
                 OutputStreamConfig {
+                    backend: AudioBackend::System,
                     device_name: None,
                     sample_rate: None,
                     buffer_size: None,
@@ -338,19 +440,36 @@ mod tests {
     #[test]
     fn system_default_saved_configuration_still_falls_back_to_device_defaults() {
         assert_eq!(
-            initial_output_requests(None, Some(192_000), 64),
+            initial_output_requests(AudioBackend::System, None, Some(192_000), 64),
             vec![
                 OutputStreamConfig {
+                    backend: AudioBackend::System,
                     device_name: None,
                     sample_rate: Some(192_000),
                     buffer_size: Some(64),
                 },
                 OutputStreamConfig {
+                    backend: AudioBackend::System,
                     device_name: None,
                     sample_rate: None,
                     buffer_size: None,
                 },
             ]
         );
+    }
+
+    #[test]
+    fn asio_startup_falls_back_to_native_audio_when_the_driver_is_missing() {
+        let requests = initial_output_requests(
+            AudioBackend::Asio,
+            Some("Yamaha Steinberg USB ASIO".into()),
+            Some(48_000),
+            128,
+        );
+
+        assert_eq!(requests.last().unwrap().backend, AudioBackend::System);
+        assert_eq!(requests.last().unwrap().device_name, None);
+        assert_eq!(requests.last().unwrap().sample_rate, None);
+        assert_eq!(requests.last().unwrap().buffer_size, None);
     }
 }

--- a/crates/vibez-ui/src/app/audio_settings.rs
+++ b/crates/vibez-ui/src/app/audio_settings.rs
@@ -206,8 +206,10 @@ impl App {
                 return Task::none();
             }
         };
-        let previous = self.state.audio_settings.clone();
         self.state.audio_settings.remember_current_backend();
+        // Rollback must retain the current backend choices just captured
+        // above, including any unsaved in-memory selection.
+        let previous = self.state.audio_settings.clone();
         self.state.audio_settings.backend = backend;
         self.state.audio_settings.catalog = catalog;
         self.state.audio_settings.catalog_error = None;

--- a/crates/vibez-ui/src/app/audio_settings.rs
+++ b/crates/vibez-ui/src/app/audio_settings.rs
@@ -141,6 +141,33 @@ fn failed_initial_audio(error: impl std::fmt::Display) -> (AudioStreamHealth, Op
     )
 }
 
+fn live_output_requests(
+    backend: AudioBackend,
+    output_name: Option<String>,
+    sample_rate: u32,
+    buffer_size: u32,
+) -> Vec<OutputStreamConfig> {
+    let preferred = OutputStreamConfig {
+        backend,
+        device_name: output_name.clone(),
+        sample_rate: Some(sample_rate),
+        buffer_size: Some(buffer_size),
+    };
+    if backend == AudioBackend::Asio {
+        vec![
+            preferred,
+            OutputStreamConfig {
+                backend,
+                device_name: output_name,
+                sample_rate: None,
+                buffer_size: None,
+            },
+        ]
+    } else {
+        vec![preferred]
+    }
+}
+
 impl App {
     pub(super) fn handle_select_audio_backend(&mut self, backend: AudioBackend) -> Task<Message> {
         if self.state.audio_recording.is_busy() {
@@ -336,23 +363,24 @@ impl App {
             // the successful path reopens it through the new output device.
             self._input_stream = None;
         }
-        let request = OutputStreamConfig {
+        let requests = live_output_requests(
             backend,
-            device_name: preferred_output_name.clone(),
-            sample_rate: Some(sample_rate),
-            buffer_size: Some(buffer_size),
-        };
+            preferred_output_name.clone(),
+            sample_rate,
+            buffer_size,
+        );
         let result = self
             ._stream
             .as_mut()
             .ok_or_else(|| "audio engine is unavailable".to_string())
             .and_then(|stream| {
-                stream
-                    .reconfigure(request)
+                let applied_request = stream
+                    .reconfigure_candidates(&requests)
                     .map_err(|error| error.to_string())?;
                 Ok((
                     stream.sample_rate().unwrap_or(sample_rate),
                     stream.active_device_name().map(str::to_owned),
+                    applied_request,
                 ))
             });
         // Reconfiguration reports synchronously through the stream's lifecycle
@@ -361,7 +389,7 @@ impl App {
         // copy.
         self.poll_audio_stream_events();
         match result {
-            Ok((actual_sample_rate, active_output_name)) => {
+            Ok((actual_sample_rate, active_output_name, applied_request)) => {
                 self.state.audio_settings.preferred_output_name = preferred_output_name;
                 self.state.audio_settings.preferred_input_name = if backend == AudioBackend::Asio {
                     self.state.audio_settings.preferred_output_name.clone()
@@ -381,11 +409,18 @@ impl App {
                     return true;
                 }
                 self.persist_ui_settings();
-                self.state.status_text = format!(
-                    "{backend} Audio Output running — {}, {} Hz, {buffer_size} frames",
-                    active_output_name.as_deref().unwrap_or("System Default"),
-                    actual_sample_rate
-                );
+                self.state.status_text = if applied_request == 0 {
+                    format!(
+                        "{backend} Audio Output running — {}, {} Hz, {buffer_size} frames",
+                        active_output_name.as_deref().unwrap_or("System Default"),
+                        actual_sample_rate
+                    )
+                } else {
+                    format!(
+                        "{backend} Audio Output running — {} with driver defaults",
+                        active_output_name.as_deref().unwrap_or("System Default")
+                    )
+                };
                 true
             }
             Err(error) => {
@@ -394,10 +429,23 @@ impl App {
                     self.state.audio_settings.active_backend = stream.active_backend();
                     self.state.audio_settings.active_output_name =
                         stream.active_device_name().map(str::to_owned);
+                    if stream.is_running() {
+                        let active = stream
+                            .active_device_name()
+                            .unwrap_or("the previous Audio Output");
+                        self.state.audio_stream_health = AudioStreamHealth::Running;
+                        self.state.status_text =
+                            format!("Could not switch Audio Output — {error}. {active} restored");
+                    } else {
+                        self.state.audio_stream_health = AudioStreamHealth::Error(error.clone());
+                        self.state.status_text =
+                            format!("Audio Output failed and could not be restored — {error}");
+                    }
                 }
                 if self._stream.is_none() {
                     self.state.status_text = format!("Audio configuration rejected: {error}");
                 }
+                let _ = self.sync_audio_input_runtime();
                 false
             }
         }
@@ -406,7 +454,7 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::initial_output_requests;
+    use super::{initial_output_requests, live_output_requests};
     use vibez_audio_io::audio_host::AudioBackend;
     use vibez_audio_io::audio_stream::OutputStreamConfig;
 
@@ -471,5 +519,26 @@ mod tests {
         assert_eq!(requests.last().unwrap().device_name, None);
         assert_eq!(requests.last().unwrap().sample_rate, None);
         assert_eq!(requests.last().unwrap().buffer_size, None);
+    }
+
+    #[test]
+    fn asio_live_switch_retries_the_same_driver_with_its_defaults() {
+        assert_eq!(
+            live_output_requests(AudioBackend::Asio, Some("Realtek ASIO".into()), 48_000, 128,),
+            vec![
+                OutputStreamConfig {
+                    backend: AudioBackend::Asio,
+                    device_name: Some("Realtek ASIO".into()),
+                    sample_rate: Some(48_000),
+                    buffer_size: Some(128),
+                },
+                OutputStreamConfig {
+                    backend: AudioBackend::Asio,
+                    device_name: Some("Realtek ASIO".into()),
+                    sample_rate: None,
+                    buffer_size: None,
+                },
+            ]
+        );
     }
 }

--- a/crates/vibez-ui/src/app/audio_take_finalization.rs
+++ b/crates/vibez-ui/src/app/audio_take_finalization.rs
@@ -1,0 +1,245 @@
+//! Recorded take staging and validation outside the live recording lifecycle.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use vibez_core::audio_buffer::DecodedAudio;
+use vibez_core::id::TrackId;
+
+use crate::domains::audio_recording::{AudioRecordingPhase, AudioRecordingSource};
+use crate::message::AudioRecordingOutcome;
+
+pub(super) fn recording_target_accepts_finalizer(
+    phase: AudioRecordingPhase,
+    armed_track: Option<TrackId>,
+    outcome_track: TrackId,
+    target_exists: bool,
+) -> bool {
+    phase == AudioRecordingPhase::Finalizing && armed_track == Some(outcome_track) && target_exists
+}
+
+pub(super) struct FinalizeAudioTake {
+    pub track_id: TrackId,
+    pub start_position_samples: u64,
+    pub sample_rate: u32,
+    pub frames: Vec<[f32; 2]>,
+    pub recording_source: AudioRecordingSource,
+    pub completion_label: String,
+    pub truncated: bool,
+    pub underrun_frames: u64,
+}
+
+pub(super) async fn finalize_audio_take(
+    request: FinalizeAudioTake,
+) -> Result<AudioRecordingOutcome, String> {
+    let FinalizeAudioTake {
+        track_id,
+        start_position_samples,
+        sample_rate,
+        frames,
+        recording_source,
+        completion_label,
+        truncated,
+        underrun_frames,
+    } = request;
+    tokio::task::spawn_blocking(move || {
+        if frames.is_empty() {
+            return Err("the take contained no recorded audio frames".into());
+        }
+        let clip_name = match recording_source {
+            AudioRecordingSource::HardwareInput => format!("Recording {start_position_samples}"),
+            AudioRecordingSource::TrackOutput(_) => format!("Resample {start_position_samples}"),
+        };
+        let audio = Arc::new(DecodedAudio {
+            channels: vec![
+                frames.iter().map(|frame| frame[0]).collect(),
+                frames.iter().map(|frame| frame[1]).collect(),
+            ],
+            sample_rate,
+        });
+        let bytes = vibez_audio_io::file_io::encode_wav(&audio);
+        let source = vibez_project::project_format_v1::stage_local_content(
+            Path::new("Recorded Audio"),
+            &format!("{clip_name}.wav"),
+            &bytes,
+        )
+        .map_err(|error| format!("Project Media staging failed: {error}"))?;
+        let mut warnings = Vec::new();
+        if truncated {
+            warnings
+                .push("capture overflow truncated the take to its valid captured frames".into());
+        }
+        if recording_source == AudioRecordingSource::HardwareInput && underrun_frames > 0 {
+            warnings.push(format!(
+                "{underrun_frames} input frame(s) were unavailable and replaced with silence"
+            ));
+        }
+        Ok(AudioRecordingOutcome {
+            track_id,
+            start_position_samples,
+            clip_name,
+            audio,
+            source,
+            completion_label,
+            quality_warning: (!warnings.is_empty()).then(|| warnings.join("; ")),
+        })
+    })
+    .await
+    .map_err(|error| format!("recording finalization task failed: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::load_project_async;
+    use vibez_core::id::ClipId;
+    use vibez_core::track::MediaSourceRef;
+
+    #[tokio::test]
+    async fn completed_take_is_staged_before_it_can_become_project_content() {
+        let outcome = finalize_audio_take(FinalizeAudioTake {
+            track_id: TrackId::new(),
+            start_position_samples: 9_600,
+            sample_rate: 48_000,
+            frames: vec![[0.25, -0.25]; 480],
+            recording_source: AudioRecordingSource::HardwareInput,
+            completion_label: "Recorded Audio Input".into(),
+            truncated: false,
+            underrun_frames: 0,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.start_position_samples, 9_600);
+        assert_eq!(outcome.audio.num_frames(), 480);
+        match outcome.source {
+            MediaSourceRef::StagedProjectMedia {
+                staging_path,
+                file_name,
+                ..
+            } => {
+                assert!(staging_path.is_file());
+                assert!(file_name.ends_with(".wav"));
+            }
+            source => panic!("expected staged Project Media, got {source:?}"),
+        }
+    }
+
+    #[test]
+    fn a_stale_finalizer_cannot_land_in_a_new_project_or_ghost_track() {
+        let target = TrackId::new();
+        assert!(!recording_target_accepts_finalizer(
+            AudioRecordingPhase::Idle,
+            Some(target),
+            target,
+            true,
+        ));
+        assert!(!recording_target_accepts_finalizer(
+            AudioRecordingPhase::Finalizing,
+            Some(target),
+            target,
+            false,
+        ));
+        assert!(recording_target_accepts_finalizer(
+            AudioRecordingPhase::Finalizing,
+            Some(target),
+            target,
+            true,
+        ));
+    }
+
+    #[tokio::test]
+    async fn drift_damage_is_preserved_as_an_explicit_salvage_warning() {
+        let outcome = finalize_audio_take(FinalizeAudioTake {
+            track_id: TrackId::new(),
+            start_position_samples: 0,
+            sample_rate: 48_000,
+            frames: vec![[0.1, -0.1]; 32],
+            recording_source: AudioRecordingSource::HardwareInput,
+            completion_label: "Recorded Audio Input".into(),
+            truncated: true,
+            underrun_frames: 7,
+        })
+        .await
+        .unwrap();
+        let warning = outcome.quality_warning.unwrap();
+        assert!(warning.contains("overflow truncated"));
+        assert!(warning.contains("7 input frame(s)"));
+    }
+
+    #[tokio::test]
+    async fn resample_take_uses_recorded_audio_staging_without_hardware_drift_warnings() {
+        let outcome = finalize_audio_take(FinalizeAudioTake {
+            track_id: TrackId::new(),
+            start_position_samples: 24_000,
+            sample_rate: 48_000,
+            frames: vec![[0.3, -0.2]; 128],
+            recording_source: AudioRecordingSource::TrackOutput(TrackId::new()),
+            completion_label: "Resampled MIDI 2".into(),
+            truncated: false,
+            underrun_frames: 99,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.clip_name, "Resample 24000");
+        assert_eq!(outcome.completion_label, "Resampled MIDI 2");
+        assert_eq!(outcome.audio.num_frames(), 128);
+        assert!(outcome.quality_warning.is_none());
+        assert!(matches!(
+            outcome.source,
+            MediaSourceRef::StagedProjectMedia { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn recorded_take_reopens_from_project_media_at_the_same_position() {
+        let directory = tempfile::tempdir().unwrap();
+        let project_path = directory.path().join("recording-roundtrip.vzp");
+        let track = vibez_core::track::TrackInfo::new("Vocal");
+        let outcome = finalize_audio_take(FinalizeAudioTake {
+            track_id: track.id,
+            start_position_samples: 12_345,
+            sample_rate: 48_000,
+            frames: vec![[0.4, -0.2]; 960],
+            recording_source: AudioRecordingSource::HardwareInput,
+            completion_label: "Recorded Audio Input".into(),
+            truncated: false,
+            underrun_frames: 0,
+        })
+        .await
+        .unwrap();
+        let project = vibez_project::Project {
+            tracks: vec![track.clone()],
+            arrange: vibez_project::TimelineInfo {
+                clips: vec![vibez_core::track::ClipInfo {
+                    id: ClipId::new(),
+                    track_id: track.id,
+                    name: outcome.clip_name,
+                    position: outcome.start_position_samples,
+                    source_offset: 0,
+                    duration: outcome.audio.num_frames() as u64,
+                    source: Some(outcome.source),
+                    file_path: None,
+                    loop_enabled: false,
+                    loop_start: 0,
+                    loop_end: outcome.audio.num_frames() as u64,
+                    original_bpm: None,
+                    warped: false,
+                    warped_to_bpm: None,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        vibez_project::project_format_v1::save_project_v1(&project_path, None, project).unwrap();
+
+        let reopened = load_project_async(project_path, None).await.unwrap();
+        assert_eq!(reopened.project.arrange.clips[0].position, 12_345);
+        assert_eq!(reopened.clips[0].audio.num_frames(), 960);
+        assert!(matches!(
+            reopened.project.arrange.clips[0].source,
+            Some(MediaSourceRef::ProjectMedia { .. })
+        ));
+    }
+}

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -156,6 +156,7 @@ mod actions;
 mod async_helpers;
 mod audio_recording;
 mod audio_settings;
+mod audio_take_finalization;
 mod audio_tasks;
 mod bounce;
 mod capture;
@@ -236,7 +237,11 @@ impl App {
         } else {
             AudioBackend::System
         };
-        let preferred_audio_output = ui_settings.preferred_audio_output.clone();
+        let audio_backend_preferences = ui_settings.resolved_audio_device_preferences();
+        let preferred_audio_output = audio_backend_preferences
+            .for_backend(preferred_audio_backend)
+            .output_name
+            .clone();
         let requested_sample_rate = ui_settings.audio_sample_rate;
         let requested_buffer_size = ui_settings.audio_buffer_size;
         let audio_settings::InitialAudioOutput {
@@ -258,13 +263,9 @@ impl App {
         // that same active host instead of presenting one backend while the
         // engine silently runs another.
         let settings_audio_backend = active_backend.unwrap_or(preferred_audio_backend);
-        let stayed_on_preferred_backend = settings_audio_backend == preferred_audio_backend;
-        let preferred_audio_input = stayed_on_preferred_backend
-            .then(|| ui_settings.preferred_audio_input.clone())
-            .flatten();
-        let preferred_audio_output = stayed_on_preferred_backend
-            .then_some(preferred_audio_output)
-            .flatten();
+        let active_preferences = audio_backend_preferences.for_backend(settings_audio_backend);
+        let preferred_audio_input = active_preferences.input_name.clone();
+        let preferred_audio_output = active_preferences.output_name.clone();
         let (audio_catalog, catalog_error) =
             match AudioHost::new(settings_audio_backend).and_then(|host| host.catalog()) {
                 Ok(catalog) => (catalog, None),
@@ -308,6 +309,7 @@ impl App {
                 backend: settings_audio_backend,
                 active_backend,
                 catalog: audio_catalog,
+                backend_preferences: audio_backend_preferences,
                 preferred_input_name: preferred_audio_input,
                 preferred_output_name: preferred_audio_output,
                 active_output_name,

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -7,7 +7,7 @@ use crate::domains::browser::BrowserMsg;
 use crate::domains::perform::PerformMsg;
 use crate::domains::view::ViewMsg;
 use rtrb::Consumer;
-use vibez_audio_io::audio_host::AudioHost;
+use vibez_audio_io::audio_host::{AudioBackend, AudioHost};
 use vibez_audio_io::audio_stream::AudioOutputStream;
 use vibez_audio_io::file_io;
 use vibez_core::constants::UI_TICK_MS;
@@ -231,14 +231,11 @@ impl App {
         let recent_project_paths =
             crate::ui_settings::normalize_recent_projects(ui_settings.recent_project_paths.clone());
 
-        let (audio_catalog, catalog_error) = match AudioHost::new().catalog() {
-            Ok(catalog) => (catalog, None),
-            Err(error) => {
-                eprintln!("vibez: failed to scan audio devices: {error}");
-                (Default::default(), Some(error.to_string()))
-            }
+        let preferred_audio_backend = if ui_settings.audio_backend.is_available() {
+            ui_settings.audio_backend
+        } else {
+            AudioBackend::System
         };
-        let preferred_audio_input = ui_settings.preferred_audio_input.clone();
         let preferred_audio_output = ui_settings.preferred_audio_output.clone();
         let requested_sample_rate = ui_settings.audio_sample_rate;
         let requested_buffer_size = ui_settings.audio_buffer_size;
@@ -246,14 +243,36 @@ impl App {
             stream: output_stream,
             sample_rate,
             active_output_name,
+            active_backend,
             health: audio_stream_health,
             status: initial_audio_status,
         } = audio_settings::initialize_audio_output(
             engine,
+            preferred_audio_backend,
             preferred_audio_output.clone(),
             requested_sample_rate,
             requested_buffer_size,
         );
+        // If a saved backend cannot open any output, startup deliberately
+        // falls back to the native host. Keep Settings and on-demand input on
+        // that same active host instead of presenting one backend while the
+        // engine silently runs another.
+        let settings_audio_backend = active_backend.unwrap_or(preferred_audio_backend);
+        let stayed_on_preferred_backend = settings_audio_backend == preferred_audio_backend;
+        let preferred_audio_input = stayed_on_preferred_backend
+            .then(|| ui_settings.preferred_audio_input.clone())
+            .flatten();
+        let preferred_audio_output = stayed_on_preferred_backend
+            .then_some(preferred_audio_output)
+            .flatten();
+        let (audio_catalog, catalog_error) =
+            match AudioHost::new(settings_audio_backend).and_then(|host| host.catalog()) {
+                Ok(catalog) => (catalog, None),
+                Err(error) => {
+                    eprintln!("vibez: failed to scan audio devices: {error}");
+                    (Default::default(), Some(error.to_string()))
+                }
+            };
         let input_bridge = output_stream.input_bridge();
 
         let dropbox_settings = DropboxSettings::load();
@@ -286,6 +305,8 @@ impl App {
             },
             audio_stream_health,
             audio_settings: AudioSettingsState {
+                backend: settings_audio_backend,
+                active_backend,
                 catalog: audio_catalog,
                 preferred_input_name: preferred_audio_input,
                 preferred_output_name: preferred_audio_output,

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -279,6 +279,7 @@ impl App {
             preferred_audio_input: self.state.audio_settings.preferred_input_name.clone(),
             audio_backend: self.state.audio_settings.backend,
             preferred_audio_output: self.state.audio_settings.preferred_output_name.clone(),
+            audio_device_preferences: self.state.audio_settings.backend_preferences.clone(),
             audio_sample_rate: Some(self.state.audio_settings.sample_rate),
             audio_buffer_size: self.state.audio_settings.buffer_size,
             theme: Some(self.state.current_theme_name.clone()),

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -276,9 +276,11 @@ impl App {
             auto_warp_on_import: self.state.auto_warp_on_import,
             warp_confidence_threshold: self.state.warp_confidence_threshold,
             preferred_midi_input: self.midi_input.as_ref().map(|h| h.port_name.clone()),
-            preferred_audio_input: self.state.audio_settings.preferred_input_name.clone(),
+            // Legacy read-only migration fields. New saves use the per-backend
+            // map below and deliberately omit these values from JSON.
+            preferred_audio_input: None,
             audio_backend: self.state.audio_settings.backend,
-            preferred_audio_output: self.state.audio_settings.preferred_output_name.clone(),
+            preferred_audio_output: None,
             audio_device_preferences: self.state.audio_settings.backend_preferences.clone(),
             audio_sample_rate: Some(self.state.audio_settings.sample_rate),
             audio_buffer_size: self.state.audio_settings.buffer_size,

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -277,6 +277,7 @@ impl App {
             warp_confidence_threshold: self.state.warp_confidence_threshold,
             preferred_midi_input: self.midi_input.as_ref().map(|h| h.port_name.clone()),
             preferred_audio_input: self.state.audio_settings.preferred_input_name.clone(),
+            audio_backend: self.state.audio_settings.backend,
             preferred_audio_output: self.state.audio_settings.preferred_output_name.clone(),
             audio_sample_rate: Some(self.state.audio_settings.sample_rate),
             audio_buffer_size: self.state.audio_settings.buffer_size,

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -382,6 +382,9 @@ impl App {
             Message::ReconnectAudioOutput => {
                 return self.handle_reconnect_audio_output();
             }
+            Message::ShowAsioHardwareSetup => {
+                self.state.status_text = "Open the active ASIO driver's control panel to choose its hardware channels. ASIO4ALL exposes it from the Windows tray while the driver is running".into();
+            }
 
             // -- Plugin scanning --
             Message::ScanPlugins => {

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -361,6 +361,9 @@ impl App {
             Message::SelectSettingsTab(tab) => {
                 self.state.settings_tab = tab;
             }
+            Message::SelectAudioBackend(backend) => {
+                return self.handle_select_audio_backend(backend);
+            }
             Message::SetBufferSize(size) => {
                 return self.handle_set_buffer_size(size);
             }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -382,10 +382,6 @@ impl App {
             Message::ReconnectAudioOutput => {
                 return self.handle_reconnect_audio_output();
             }
-            Message::ShowAsioHardwareSetup => {
-                self.state.status_text = "Open the active ASIO driver's control panel to choose its hardware channels. ASIO4ALL exposes it from the Windows tray while the driver is running".into();
-            }
-
             // -- Plugin scanning --
             Message::ScanPlugins => {
                 return self.handle_scan_plugins();

--- a/crates/vibez-ui/src/app/views_settings_audio.rs
+++ b/crates/vibez-ui/src/app/views_settings_audio.rs
@@ -111,6 +111,12 @@ fn settings_divider<'a>() -> Element<'a, Message> {
 
 impl App {
     pub(super) fn view_settings_audio_tab(&self) -> Element<'_, Message> {
+        let backend_picker = settings_pick_list(
+            vibez_audio_io::audio_host::AudioBackend::available(),
+            Some(self.state.audio_settings.backend),
+            Message::SelectAudioBackend,
+            132.0,
+        );
         let output_picker = settings_pick_list(
             self.state.audio_settings.output_choices(),
             Some(self.state.audio_settings.selected_output_choice()),
@@ -132,9 +138,14 @@ impl App {
                     .active_output_name
                     .as_deref()
                     .unwrap_or("System Default");
+                let backend = self
+                    .state
+                    .audio_settings
+                    .active_backend
+                    .unwrap_or(self.state.audio_settings.backend);
                 row![
                     icons::icon(icons::CIRCLE_DOT).size(9).color(th::success()),
-                    text(format!("Running · {active}"))
+                    text(format!("Running · {backend} · {active}"))
                         .size(10)
                         .color(th::text_dim())
                 ]
@@ -201,8 +212,43 @@ impl App {
         ]
         .align_y(iced::Alignment::Center);
 
-        let device_group = container(
+        let backend_row = row![
             column![
+                text("Driver Type").size(12).color(th::text()),
+                text("The audio system used for input and output")
+                    .size(9)
+                    .color(th::text_muted())
+            ]
+            .spacing(1)
+            .width(Length::Fill),
+            backend_picker
+        ]
+        .spacing(18)
+        .align_y(iced::Alignment::Center);
+
+        let device_rows = if self.state.audio_settings.backend
+            == vibez_audio_io::audio_host::AudioBackend::Asio
+        {
+            column![
+                backend_row,
+                settings_divider(),
+                row![
+                    column![
+                        text("Audio Device").size(12).color(th::text()),
+                        output_status,
+                        input_status
+                    ]
+                    .spacing(3)
+                    .width(Length::Fill),
+                    output_picker
+                ]
+                .spacing(18)
+                .align_y(iced::Alignment::Center)
+            ]
+        } else {
+            column![
+                backend_row,
+                settings_divider(),
                 row![
                     column![
                         text("Output Device").size(12).color(th::text()),
@@ -225,20 +271,21 @@ impl App {
                     input_picker
                 ]
                 .spacing(18)
-                .align_y(iced::Alignment::Center),
+                .align_y(iced::Alignment::Center)
             ]
-            .spacing(9),
-        )
-        .padding([9, 10])
-        .style(|_theme: &Theme| container::Style {
-            background: Some(th::bg_dark().into()),
-            border: iced::Border {
-                color: th::border(),
-                width: 1.0,
-                radius: 4.0.into(),
-            },
-            ..Default::default()
-        });
+        };
+        let device_group =
+            container(device_rows.spacing(9))
+                .padding([9, 10])
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(th::bg_dark().into()),
+                    border: iced::Border {
+                        color: th::border(),
+                        width: 1.0,
+                        radius: 4.0.into(),
+                    },
+                    ..Default::default()
+                });
 
         let sizes = self.state.audio_settings.buffer_size_choices();
         let mut buf_row = row![].spacing(3);

--- a/crates/vibez-ui/src/app/views_settings_audio.rs
+++ b/crates/vibez-ui/src/app/views_settings_audio.rs
@@ -229,6 +229,8 @@ impl App {
         let device_rows = if self.state.audio_settings.backend
             == vibez_audio_io::audio_host::AudioBackend::Asio
         {
+            let hardware_setup =
+                settings_action_button("Hardware Setup", Message::ShowAsioHardwareSetup, false);
             column![
                 backend_row,
                 settings_divider(),
@@ -241,6 +243,20 @@ impl App {
                     .spacing(3)
                     .width(Length::Fill),
                     output_picker
+                ]
+                .spacing(18)
+                .align_y(iced::Alignment::Center),
+                settings_divider(),
+                row![
+                    column![
+                        text("ASIO Routing").size(12).color(th::text()),
+                        text("Choose speakers and headphones in the driver's control panel")
+                            .size(9)
+                            .color(th::text_muted())
+                    ]
+                    .spacing(1)
+                    .width(Length::Fill),
+                    hardware_setup
                 ]
                 .spacing(18)
                 .align_y(iced::Alignment::Center)

--- a/crates/vibez-ui/src/app/views_settings_audio.rs
+++ b/crates/vibez-ui/src/app/views_settings_audio.rs
@@ -225,15 +225,17 @@ impl App {
         ]
         .spacing(18)
         .align_y(iced::Alignment::Center);
+        let backend_section = if vibez_audio_io::audio_host::AudioBackend::available().len() > 1 {
+            column![backend_row, settings_divider()]
+        } else {
+            column![]
+        };
 
         let device_rows = if self.state.audio_settings.backend
             == vibez_audio_io::audio_host::AudioBackend::Asio
         {
-            let hardware_setup =
-                settings_action_button("Hardware Setup", Message::ShowAsioHardwareSetup, false);
             column![
-                backend_row,
-                settings_divider(),
+                backend_section,
                 row![
                     column![
                         text("Audio Device").size(12).color(th::text()),
@@ -247,24 +249,18 @@ impl App {
                 .spacing(18)
                 .align_y(iced::Alignment::Center),
                 settings_divider(),
-                row![
-                    column![
-                        text("ASIO Routing").size(12).color(th::text()),
-                        text("Choose speakers and headphones in the driver's control panel")
-                            .size(9)
-                            .color(th::text_muted())
-                    ]
-                    .spacing(1)
-                    .width(Length::Fill),
-                    hardware_setup
+                column![
+                    text("ASIO Routing").size(12).color(th::text()),
+                    text("Choose speakers and headphones in the driver's control panel. ASIO4ALL exposes it from the Windows tray while running")
+                        .size(9)
+                        .color(th::text_muted())
                 ]
-                .spacing(18)
-                .align_y(iced::Alignment::Center)
+                .spacing(1)
+                .width(Length::Fill)
             ]
         } else {
             column![
-                backend_row,
-                settings_divider(),
+                backend_section,
                 row![
                     column![
                         text("Output Device").size(12).color(th::text()),

--- a/crates/vibez-ui/src/domains/audio_settings.rs
+++ b/crates/vibez-ui/src/domains/audio_settings.rs
@@ -2,7 +2,9 @@
 
 use std::fmt;
 
-use vibez_audio_io::audio_host::{AudioDeviceCatalog, DeviceInfo, SupportedConfigRange};
+use vibez_audio_io::audio_host::{
+    AudioBackend, AudioDeviceCatalog, DeviceInfo, SupportedConfigRange,
+};
 
 pub const BUFFER_SIZE_CHOICES: [u32; 7] = [64, 128, 256, 512, 1024, 2048, 4096];
 const COMMON_SAMPLE_RATES: [u32; 6] = [44_100, 48_000, 88_200, 96_000, 176_400, 192_000];
@@ -55,6 +57,11 @@ impl fmt::Display for AudioSampleRate {
 
 #[derive(Debug, Clone)]
 pub struct AudioSettingsState {
+    /// Persisted backend whose devices are displayed in Settings.
+    pub backend: AudioBackend,
+    /// Backend currently driving the engine callback. This may remain the
+    /// previous backend when a requested driver is temporarily unavailable.
+    pub active_backend: Option<AudioBackend>,
     pub catalog: AudioDeviceCatalog,
     /// Persisted target. It remains named when that device is temporarily absent.
     pub preferred_input_name: Option<String>,
@@ -70,6 +77,8 @@ pub struct AudioSettingsState {
 impl Default for AudioSettingsState {
     fn default() -> Self {
         Self {
+            backend: AudioBackend::System,
+            active_backend: None,
             catalog: AudioDeviceCatalog::default(),
             preferred_input_name: None,
             preferred_output_name: None,

--- a/crates/vibez-ui/src/domains/audio_settings.rs
+++ b/crates/vibez-ui/src/domains/audio_settings.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
 use vibez_audio_io::audio_host::{
     AudioBackend, AudioDeviceCatalog, DeviceInfo, SupportedConfigRange,
 };
@@ -55,6 +56,38 @@ impl fmt::Display for AudioSampleRate {
     }
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AudioDevicePreferences {
+    #[serde(default)]
+    pub input_name: Option<String>,
+    #[serde(default)]
+    pub output_name: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AudioBackendPreferences {
+    #[serde(default)]
+    pub system: AudioDevicePreferences,
+    #[serde(default)]
+    pub asio: AudioDevicePreferences,
+}
+
+impl AudioBackendPreferences {
+    pub fn for_backend(&self, backend: AudioBackend) -> &AudioDevicePreferences {
+        match backend {
+            AudioBackend::System => &self.system,
+            AudioBackend::Asio => &self.asio,
+        }
+    }
+
+    pub fn for_backend_mut(&mut self, backend: AudioBackend) -> &mut AudioDevicePreferences {
+        match backend {
+            AudioBackend::System => &mut self.system,
+            AudioBackend::Asio => &mut self.asio,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AudioSettingsState {
     /// Persisted backend whose devices are displayed in Settings.
@@ -63,6 +96,8 @@ pub struct AudioSettingsState {
     /// previous backend when a requested driver is temporarily unavailable.
     pub active_backend: Option<AudioBackend>,
     pub catalog: AudioDeviceCatalog,
+    /// Remembered targets for every backend, including inactive backends.
+    pub backend_preferences: AudioBackendPreferences,
     /// Persisted target. It remains named when that device is temporarily absent.
     pub preferred_input_name: Option<String>,
     /// Persisted target. It remains named when fallback output is active.
@@ -80,6 +115,7 @@ impl Default for AudioSettingsState {
             backend: AudioBackend::System,
             active_backend: None,
             catalog: AudioDeviceCatalog::default(),
+            backend_preferences: AudioBackendPreferences::default(),
             preferred_input_name: None,
             preferred_output_name: None,
             active_output_name: None,
@@ -91,6 +127,24 @@ impl Default for AudioSettingsState {
 }
 
 impl AudioSettingsState {
+    pub fn remember_current_backend(&mut self) {
+        let preferences = self.backend_preferences.for_backend_mut(self.backend);
+        preferences
+            .input_name
+            .clone_from(&self.preferred_input_name);
+        preferences
+            .output_name
+            .clone_from(&self.preferred_output_name);
+    }
+
+    pub fn restore_backend_preferences(&mut self, backend: AudioBackend) {
+        let preferences = self.backend_preferences.for_backend(backend);
+        self.preferred_input_name
+            .clone_from(&preferences.input_name);
+        self.preferred_output_name
+            .clone_from(&preferences.output_name);
+    }
+
     pub fn output_choices(&self) -> Vec<AudioDeviceChoice> {
         device_choices(
             self.usable_output_devices(),
@@ -456,6 +510,42 @@ mod tests {
                 true
             )),
             Some((44_100, 512))
+        );
+    }
+
+    #[test]
+    fn backend_device_preferences_survive_round_trip_switching() {
+        let mut state = AudioSettingsState {
+            backend: AudioBackend::System,
+            preferred_input_name: Some("UR12 Input".into()),
+            preferred_output_name: Some("UR12 Speakers".into()),
+            ..Default::default()
+        };
+        state.remember_current_backend();
+
+        state.backend = AudioBackend::Asio;
+        state.restore_backend_preferences(AudioBackend::Asio);
+        assert_eq!(state.preferred_input_name, None);
+        assert_eq!(state.preferred_output_name, None);
+
+        state.preferred_input_name = Some("ASIO4ALL v2".into());
+        state.preferred_output_name = Some("ASIO4ALL v2".into());
+        state.remember_current_backend();
+
+        state.backend = AudioBackend::System;
+        state.restore_backend_preferences(AudioBackend::System);
+        assert_eq!(state.preferred_input_name.as_deref(), Some("UR12 Input"));
+        assert_eq!(
+            state.preferred_output_name.as_deref(),
+            Some("UR12 Speakers")
+        );
+        assert_eq!(
+            state
+                .backend_preferences
+                .for_backend(AudioBackend::Asio)
+                .output_name
+                .as_deref(),
+            Some("ASIO4ALL v2")
         );
     }
 }

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -651,7 +651,6 @@ pub enum Message {
     SelectAudioOutput(AudioDeviceChoice),
     RescanAudioDevices,
     ReconnectAudioOutput,
-    ShowAsioHardwareSetup,
 
     // Plugin scanning
     ScanPlugins,

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -651,6 +651,7 @@ pub enum Message {
     SelectAudioOutput(AudioDeviceChoice),
     RescanAudioDevices,
     ReconnectAudioOutput,
+    ShowAsioHardwareSetup,
 
     // Plugin scanning
     ScanPlugins,

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -644,6 +644,7 @@ pub enum Message {
     OpenSettings,
     CloseSettings,
     SelectSettingsTab(SettingsTab),
+    SelectAudioBackend(vibez_audio_io::audio_host::AudioBackend),
     SetBufferSize(u32),
     SetAudioSampleRate(AudioSampleRate),
     SelectAudioInput(AudioDeviceChoice),

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use vibez_audio_io::audio_host::AudioBackend;
 
+use crate::domains::audio_settings::AudioBackendPreferences;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiSettings {
     /// Most recently opened or successfully saved projects, newest first.
@@ -44,14 +46,18 @@ pub struct UiSettings {
     #[serde(default)]
     pub preferred_midi_input: Option<String>,
     /// `None` follows the platform's System Default Audio Input.
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     pub preferred_audio_input: Option<String>,
     /// Native audio API used to enumerate and open both input and output.
     #[serde(default)]
     pub audio_backend: AudioBackend,
     /// `None` follows the platform's System Default Audio Output.
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     pub preferred_audio_output: Option<String>,
+    /// Device targets are remembered separately because names from one host
+    /// (for example WASAPI) have no meaning to another host (ASIO).
+    #[serde(default)]
+    pub audio_device_preferences: AudioBackendPreferences,
     /// `None` uses the output device's default until the producer chooses one.
     #[serde(default)]
     pub audio_sample_rate: Option<u32>,
@@ -140,6 +146,7 @@ impl Default for UiSettings {
             preferred_audio_input: None,
             audio_backend: AudioBackend::default(),
             preferred_audio_output: None,
+            audio_device_preferences: AudioBackendPreferences::default(),
             audio_sample_rate: None,
             audio_buffer_size: default_audio_buffer_size(),
             theme: None,
@@ -182,6 +189,20 @@ pub fn forget_recent_project(paths: &mut Vec<PathBuf>, path: &Path) -> bool {
 }
 
 impl UiSettings {
+    pub fn resolved_audio_device_preferences(&self) -> AudioBackendPreferences {
+        let mut preferences = self.audio_device_preferences.clone();
+        let selected = preferences.for_backend_mut(self.audio_backend);
+        if selected.input_name.is_none() {
+            selected.input_name.clone_from(&self.preferred_audio_input);
+        }
+        if selected.output_name.is_none() {
+            selected
+                .output_name
+                .clone_from(&self.preferred_audio_output);
+        }
+        preferences
+    }
+
     pub fn settings_path() -> PathBuf {
         dirs::config_dir()
             .unwrap_or_else(|| PathBuf::from("."))
@@ -354,21 +375,49 @@ mod tests {
 
     #[test]
     fn audio_configuration_roundtrips_outside_project_state() {
+        let mut preferences = AudioBackendPreferences::default();
+        preferences.asio.input_name = Some("USB In".into());
+        preferences.asio.output_name = Some("USB Out".into());
         let settings = UiSettings {
-            preferred_audio_input: Some("USB In".into()),
             audio_backend: AudioBackend::Asio,
-            preferred_audio_output: Some("USB Out".into()),
+            audio_device_preferences: preferences,
             audio_sample_rate: Some(48_000),
             audio_buffer_size: 128,
             ..Default::default()
         };
         let loaded: UiSettings =
             serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
-        assert_eq!(loaded.preferred_audio_input.as_deref(), Some("USB In"));
         assert_eq!(loaded.audio_backend, AudioBackend::Asio);
-        assert_eq!(loaded.preferred_audio_output.as_deref(), Some("USB Out"));
+        assert_eq!(
+            loaded.audio_device_preferences.asio.input_name.as_deref(),
+            Some("USB In")
+        );
+        assert_eq!(
+            loaded.audio_device_preferences.asio.output_name.as_deref(),
+            Some("USB Out")
+        );
         assert_eq!(loaded.audio_sample_rate, Some(48_000));
         assert_eq!(loaded.audio_buffer_size, 128);
+    }
+
+    #[test]
+    fn legacy_audio_device_names_migrate_into_their_saved_backend() {
+        let loaded: UiSettings = serde_json::from_str(
+            r#"{
+                "audio_backend": "asio",
+                "preferred_audio_input": "ASIO4ALL v2",
+                "preferred_audio_output": "ASIO4ALL v2"
+            }"#,
+        )
+        .unwrap();
+        let preferences = loaded.resolved_audio_device_preferences();
+
+        assert_eq!(preferences.asio.input_name.as_deref(), Some("ASIO4ALL v2"));
+        assert_eq!(preferences.asio.output_name.as_deref(), Some("ASIO4ALL v2"));
+        assert_eq!(
+            preferences.system,
+            crate::domains::audio_settings::AudioDevicePreferences::default()
+        );
     }
 
     #[test]

--- a/crates/vibez-ui/src/ui_settings.rs
+++ b/crates/vibez-ui/src/ui_settings.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use vibez_audio_io::audio_host::AudioBackend;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiSettings {
@@ -45,6 +46,9 @@ pub struct UiSettings {
     /// `None` follows the platform's System Default Audio Input.
     #[serde(default)]
     pub preferred_audio_input: Option<String>,
+    /// Native audio API used to enumerate and open both input and output.
+    #[serde(default)]
+    pub audio_backend: AudioBackend,
     /// `None` follows the platform's System Default Audio Output.
     #[serde(default)]
     pub preferred_audio_output: Option<String>,
@@ -134,6 +138,7 @@ impl Default for UiSettings {
             warp_confidence_threshold: default_warp_confidence_threshold(),
             preferred_midi_input: None,
             preferred_audio_input: None,
+            audio_backend: AudioBackend::default(),
             preferred_audio_output: None,
             audio_sample_rate: None,
             audio_buffer_size: default_audio_buffer_size(),
@@ -344,12 +349,14 @@ mod tests {
         assert_eq!(loaded.audio_sample_rate, None);
         assert_eq!(loaded.preferred_audio_input, None);
         assert_eq!(loaded.preferred_audio_output, None);
+        assert_eq!(loaded.audio_backend, AudioBackend::System);
     }
 
     #[test]
     fn audio_configuration_roundtrips_outside_project_state() {
         let settings = UiSettings {
             preferred_audio_input: Some("USB In".into()),
+            audio_backend: AudioBackend::Asio,
             preferred_audio_output: Some("USB Out".into()),
             audio_sample_rate: Some(48_000),
             audio_buffer_size: 128,
@@ -358,6 +365,7 @@ mod tests {
         let loaded: UiSettings =
             serde_json::from_str(&serde_json::to_string(&settings).unwrap()).unwrap();
         assert_eq!(loaded.preferred_audio_input.as_deref(), Some("USB In"));
+        assert_eq!(loaded.audio_backend, AudioBackend::Asio);
         assert_eq!(loaded.preferred_audio_output.as_deref(), Some("USB Out"));
         assert_eq!(loaded.audio_sample_rate, Some(48_000));
         assert_eq!(loaded.audio_buffer_size, 128);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -454,7 +454,11 @@ audio backend, soundcard selection, sample rate, and buffer size remain global
 application settings. The same selected backend opens input and output:
 CoreAudio on macOS, ALSA on Linux, and selectable WASAPI or ASIO on Windows.
 ASIO presents one driver choice for both directions rather than allowing an
-invalid pair of independent ASIO drivers.
+invalid pair of independent ASIO drivers. Because ASIO permits only one loaded
+driver, a driver-to-driver switch releases the live stream, tries the requested
+configuration and its driver defaults, then reopens the exact previous
+configuration if both attempts fail. Settings always report the stream which
+is actually running.
 
 That exact position is the output-clock boundary, not calibrated acoustic
 alignment. V1 does not measure input/output round-trip latency or continuously

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -462,7 +462,9 @@ configuration and its driver defaults, then reopens the exact previous
 configuration if both attempts fail. Settings always report the stream which
 is actually running. Windows CI and release builds set `CPAL_ASIO_DIR` to a
 checksum-verified SDK cache before Cargo runs, so `asio-sys` never performs its
-own mutable build-time download.
+own mutable build-time download in distributed builds. Local Windows builds
+must run `scripts/setup_asio_sdk.ps1` in the same PowerShell session before
+Cargo, as documented in the README.
 
 That exact position is the output-clock boundary, not calibrated acoustic
 alignment. V1 does not measure input/output round-trip latency or continuously

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -453,12 +453,16 @@ as a visibly warned take. Input route and monitoring mode are project state;
 audio backend, soundcard selection, sample rate, and buffer size remain global
 application settings. The same selected backend opens input and output:
 CoreAudio on macOS, ALSA on Linux, and selectable WASAPI or ASIO on Windows.
+WASAPI and ASIO keep separate remembered device targets, so trying another
+driver type does not overwrite a producer's established routing.
 ASIO presents one driver choice for both directions rather than allowing an
 invalid pair of independent ASIO drivers. Because ASIO permits only one loaded
 driver, a driver-to-driver switch releases the live stream, tries the requested
 configuration and its driver defaults, then reopens the exact previous
 configuration if both attempts fail. Settings always report the stream which
-is actually running.
+is actually running. Windows CI and release builds set `CPAL_ASIO_DIR` to a
+checksum-verified SDK cache before Cargo runs, so `asio-sys` never performs its
+own mutable build-time download.
 
 That exact position is the output-clock boundary, not calibrated acoustic
 alignment. V1 does not measure input/output round-trip latency or continuously

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -450,8 +450,11 @@ a background thread, stages it in Project Media, and only then inserts the
 canonical clip. Device loss abandons the open project transaction, leaving no
 partial clip; bounded-buffer overflow stops capture and offers the valid prefix
 as a visibly warned take. Input route and monitoring mode are project state;
-soundcard selection, sample rate, and buffer size remain global application
-settings.
+audio backend, soundcard selection, sample rate, and buffer size remain global
+application settings. The same selected backend opens input and output:
+CoreAudio on macOS, ALSA on Linux, and selectable WASAPI or ASIO on Windows.
+ASIO presents one driver choice for both directions rather than allowing an
+invalid pair of independent ASIO drivers.
 
 That exact position is the output-clock boundary, not calibrated acoustic
 alignment. V1 does not measure input/output round-trip latency or continuously

--- a/scripts/setup_asio_sdk.ps1
+++ b/scripts/setup_asio_sdk.ps1
@@ -3,7 +3,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$SdkUrl = "https://www.steinberg.net/asiosdk"
+$SdkUrl = "https://download.steinberg.net/sdk_downloads/ASIO-SDK_2.3.4_2025-10-15.zip"
 $SdkSha256 = "d5ebf0c20dd2c5f43771fd0c1418f4b361bf52434ee670097cfa6b3a335e2eca"
 $Marker = Join-Path $Destination ".vibez-source-sha256"
 

--- a/scripts/setup_asio_sdk.ps1
+++ b/scripts/setup_asio_sdk.ps1
@@ -1,0 +1,63 @@
+param(
+    [string]$Destination = (Join-Path (Split-Path -Parent $PSScriptRoot) ".asio-sdk")
+)
+
+$ErrorActionPreference = "Stop"
+$SdkUrl = "https://www.steinberg.net/asiosdk"
+$SdkSha256 = "d5ebf0c20dd2c5f43771fd0c1418f4b361bf52434ee670097cfa6b3a335e2eca"
+$Marker = Join-Path $Destination ".vibez-source-sha256"
+
+function Test-PinnedSdk {
+    return (Test-Path (Join-Path $Destination "common/asio.h")) `
+        -and (Test-Path (Join-Path $Destination "host/asiodrivers.cpp")) `
+        -and (Test-Path (Join-Path $Destination "LICENSE.txt")) `
+        -and (Test-Path $Marker) `
+        -and ((Get-Content $Marker -Raw).Trim() -eq $SdkSha256)
+}
+
+if (-not (Test-PinnedSdk)) {
+    if (Test-Path $Destination) {
+        Remove-Item -LiteralPath $Destination -Recurse -Force
+    }
+
+    $Token = [Guid]::NewGuid().ToString("N")
+    $Archive = Join-Path ([IO.Path]::GetTempPath()) "vibez-asio-$Token.zip"
+    $Extracted = Join-Path ([IO.Path]::GetTempPath()) "vibez-asio-$Token"
+    try {
+        Invoke-WebRequest -Uri $SdkUrl -OutFile $Archive
+        $ActualSha256 = (Get-FileHash -Path $Archive -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($ActualSha256 -ne $SdkSha256) {
+            throw "ASIO SDK checksum mismatch. Expected $SdkSha256, received $ActualSha256."
+        }
+
+        Expand-Archive -Path $Archive -DestinationPath $Extracted -Force
+        $SdkRoot = Get-ChildItem -Path $Extracted -Directory |
+            Where-Object { Test-Path (Join-Path $_.FullName "common/asio.h") } |
+            Select-Object -First 1
+        if ($null -eq $SdkRoot) {
+            throw "The pinned ASIO SDK archive does not contain common/asio.h."
+        }
+
+        $License = Get-Content (Join-Path $SdkRoot.FullName "LICENSE.txt") -Raw
+        if ($License -notmatch "General Public License \(GPL\) Version 3") {
+            throw "The ASIO SDK archive does not contain the expected GPLv3 licence option."
+        }
+
+        Move-Item -LiteralPath $SdkRoot.FullName -Destination $Destination
+        Set-Content -Path $Marker -Value $SdkSha256 -NoNewline
+    }
+    finally {
+        Remove-Item -LiteralPath $Archive -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $Extracted -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$env:CPAL_ASIO_DIR = $Destination
+$env:LIBCLANG_PATH = "C:\Program Files\LLVM\bin"
+
+if ($env:GITHUB_ENV) {
+    "CPAL_ASIO_DIR=$env:CPAL_ASIO_DIR" | Out-File -FilePath $env:GITHUB_ENV -Append
+    "LIBCLANG_PATH=$env:LIBCLANG_PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
+}
+
+Write-Host "Using pinned Steinberg ASIO SDK at $Destination"


### PR DESCRIPTION
## What changed

- add a persisted audio backend choice to Soundcard Settings
- keep ALSA on Linux and CoreAudio on macOS while exposing WASAPI and ASIO on Windows
- remember System and ASIO devices separately, including migration from existing settings
- open ASIO input and output through the same duplex driver object
- release the exclusive ASIO driver before reconfiguration and restore the previous output after a rejected switch
- surface an input reopen failure after either a successful switch or an output rollback
- present one Audio Device choice for ASIO because one driver owns both directions
- hide Driver Type when the platform only has one backend
- replace the non-functional Hardware Setup button with clear ASIO routing guidance

## Dependency and SDK decision

CPAL stays on 0.16 and midir stays on 0.10. CPAL 0.16 already supports ASIO, so this PR does not need to replace the ALSA, CoreAudio, WASAPI and MIDI host layers at the same time. A CPAL upgrade needs a separate hardware regression pass.

Windows builds use the current Steinberg ASIO SDK under its GPLv3 licensing option. CI and release builds download it from Steinberg through one setup action, verify SHA-256 `d5ebf0c20dd2c5f43771fd0c1418f4b361bf52434ee670097cfa6b3a335e2eca`, cache that exact copy, and set `CPAL_ASIO_DIR` before Cargo runs. This prevents the mutable download inside `asio-sys` from deciding the release input.

The lockfile remains on the versions from `dev` apart from the ASIO feature dependencies and the serde dependencies used for audio backend settings.

## Why

A Windows producer using ASIO4ALL and a Yamaha or Steinberg UR12 could not see either ASIO driver in Vibez. The app only enumerated the default Windows host, WASAPI.

## Verification

- `cargo test --workspace --offline`
- `cargo check -p vibez-ui --offline`
- `cargo clippy --workspace --all-targets --exclude vibez-plugin-host --offline -- -D warnings`
- `cargo clippy -p vibez-plugin-host --offline -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Windows CI asserts that the ASIO host is compiled and builds through the pinned SDK setup
- ASIO4ALL output selection was dogfooded on Windows; real UR12 and ASIO recording still need hardware confirmation
