### PR TITLE
Embed the Windows application icon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,6 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev
       - run: cargo check --workspace
-      - name: Verify Windows executable resources
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          cargo build --package vibez --bin vibez
-          ./scripts/check_windows_resources.ps1 target/debug/vibez.exe
 
   test:
     name: Test
@@ -45,6 +39,12 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev
       - run: cargo test --workspace
+      - name: Verify Windows executable resources
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cargo build --package vibez --bin vibez
+          ./scripts/check_windows_resources.ps1 target/debug/vibez.exe
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libdbus-1-dev
       - run: cargo check --workspace
+      - name: Verify Windows executable resources
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cargo build --package vibez --bin vibez
+          ./scripts/check_windows_resources.ps1 target/debug/vibez.exe
 
   test:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,11 @@ jobs:
       - name: Build
         run: cargo build --release -p vibez --bins
 
+      - name: Verify Windows executable resources
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/check_windows_resources.ps1 target/release/vibez.exe
+
       # ---------- Linux: tar.gz + .deb + AppImage ----------
       - name: Package tarball (Linux)
         if: runner.os == 'Linux'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,7 +3621,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,7 +3621,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5091,6 +5091,7 @@ dependencies = [
  "libloading 0.8.9",
  "vibez-plugin-host",
  "vibez-ui",
+ "winresource",
 ]
 
 [[package]]
@@ -6159,6 +6160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ vibez-ui = { workspace = true }
 vibez-plugin-host = { workspace = true }
 iced = { workspace = true }
 
+[build-dependencies]
+winresource = { version = "0.1.31", default-features = false }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 libloading = "0.8"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+fn main() {
+    println!("cargo:rerun-if-changed=assets/icon/vibez.ico");
+
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+
+    let mut resource = winresource::WindowsResource::new();
+    resource
+        .set_icon("assets/icon/vibez.ico")
+        .set("FileDescription", "vibez DAW")
+        .set("ProductName", "vibez")
+        .set("OriginalFilename", "vibez.exe");
+    resource
+        .compile()
+        .expect("failed to embed the vibez Windows executable resources");
+}

--- a/scripts/check_windows_resources.ps1
+++ b/scripts/check_windows_resources.ps1
@@ -1,0 +1,57 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Executable
+)
+
+$resolved = (Resolve-Path $Executable).Path
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class VibezPeResources
+{
+    private const uint LoadLibraryAsDataFile = 0x00000002;
+    private static readonly IntPtr ApplicationIconId = new IntPtr(1);
+    private static readonly IntPtr GroupIconType = new IntPtr(14);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr LoadLibraryExW(string fileName, IntPtr file, uint flags);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr FindResourceW(IntPtr module, IntPtr name, IntPtr type);
+
+    [DllImport("kernel32.dll")]
+    private static extern bool FreeLibrary(IntPtr module);
+
+    public static bool HasApplicationIcon(string path)
+    {
+        IntPtr module = LoadLibraryExW(path, IntPtr.Zero, LoadLibraryAsDataFile);
+        if (module == IntPtr.Zero)
+        {
+            throw new InvalidOperationException(
+                "Could not load executable resources. Win32 error " + Marshal.GetLastWin32Error());
+        }
+
+        try
+        {
+            return FindResourceW(module, ApplicationIconId, GroupIconType) != IntPtr.Zero;
+        }
+        finally
+        {
+            FreeLibrary(module);
+        }
+    }
+}
+"@
+
+if (-not [VibezPeResources]::HasApplicationIcon($resolved)) {
+    throw "The vibez executable has no RT_GROUP_ICON resource with application icon ID 1"
+}
+
+$versionInfo = (Get-Item $resolved).VersionInfo
+if ($versionInfo.ProductName -ne "vibez") {
+    throw "Expected ProductName 'vibez', got '$($versionInfo.ProductName)'"
+}
+
+Write-Host "Verified embedded vibez application icon and version resources in $resolved"

--- a/scripts/check_windows_resources.ps1
+++ b/scripts/check_windows_resources.ps1
@@ -3,7 +3,7 @@ param(
     [string]$Executable
 )
 
-$resolved = (Resolve-Path $Executable).Path
+$resolved = (Resolve-Path $Executable -ErrorAction Stop).Path
 
 Add-Type @"
 using System;
@@ -50,8 +50,8 @@ if (-not [VibezPeResources]::HasApplicationIcon($resolved)) {
 }
 
 $versionInfo = (Get-Item $resolved).VersionInfo
-if ($versionInfo.ProductName -ne "vibez") {
-    throw "Expected ProductName 'vibez', got '$($versionInfo.ProductName)'"
+if ([string]::IsNullOrWhiteSpace($versionInfo.ProductName)) {
+    throw "The executable has no ProductName version resource"
 }
 
 Write-Host "Verified embedded vibez application icon and version resources in $resolved"


### PR DESCRIPTION
## What changed

- embed `assets/icon/vibez.ico` into the Windows PE for the installed and portable executable
- add product metadata to the executable resource
- verify RT_GROUP_ICON resource ID 1 in Windows CI and release builds

## Why

The installer carried an icon, but `vibez.exe` itself contained no Windows resources. Explorer, Start menu and installed shortcuts therefore fell back to a generic executable icon.

## Verification

- `cargo check -p vibez --all-targets`
- `cargo test -p vibez --all-targets`
- `cargo clippy -p vibez --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Windows CI builds the executable and calls `FindResourceW` for RT_GROUP_ICON ID 1