### PR TITLE
Fix Browser warp tempo analysis

### DIFF
--- a/crates/vibez-core/src/onset.rs
+++ b/crates/vibez-core/src/onset.rs
@@ -168,6 +168,8 @@ const BPM_MIN: f64 = 40.0;
 const BPM_MAX: f64 = 280.0;
 // Target octave for folded output (dance-music conventional range).
 const BPM_FOLD_LO: f64 = 60.0;
+// Keep aligned with vibez-ui's PLAUSIBLE_LOOP_BPM_MAX so Browser fitting does
+// not accept a source tempo which onset analysis has already folded in half.
 const BPM_FOLD_HI: f64 = 200.0;
 const BPM_FOLD_PREF: f64 = 120.0;
 // Working sample rate for the autocorrelation. 500 Hz gives a lag

--- a/crates/vibez-core/src/onset.rs
+++ b/crates/vibez-core/src/onset.rs
@@ -11,7 +11,7 @@
 //!   Drives slice-and-snap audio quantize.
 //! - `detect_bpm` returns an `Option<BpmEstimate>`. Autocorrelates the
 //!   onset flux (so it works on sustained melodic material, not just
-//!   percussion), octave-folds into [60, 180] BPM using Parncutt's
+//!   percussion), octave-folds into [60, 200] BPM using Parncutt's
 //!   preference curve, and gates on confidence so sparse or silent
 //!   clips return `None` rather than guessing.
 
@@ -168,7 +168,7 @@ const BPM_MIN: f64 = 40.0;
 const BPM_MAX: f64 = 280.0;
 // Target octave for folded output (dance-music conventional range).
 const BPM_FOLD_LO: f64 = 60.0;
-const BPM_FOLD_HI: f64 = 180.0;
+const BPM_FOLD_HI: f64 = 200.0;
 const BPM_FOLD_PREF: f64 = 120.0;
 // Working sample rate for the autocorrelation. 500 Hz gives a lag
 // precision of ~0.5 BPM at 120 BPM, further refined by parabolic
@@ -186,7 +186,7 @@ const MIN_SECONDS_FOR_BPM_F64: f64 = 1.0;
 
 /// Detect the tempo of `audio`. Returns `None` when the audio is too
 /// short, too sparse, or the autocorrelation is not strong enough to
-/// commit to a tempo. Output BPM is always in `[60, 180]` after
+/// commit to a tempo. Output BPM is always in `[60, 200]` after
 /// Parncutt octave folding.
 pub fn detect_bpm(audio: &DecodedAudio, sample_rate: u32) -> Option<BpmEstimate> {
     let frames = audio.num_frames();
@@ -616,6 +616,17 @@ mod tests {
         assert!(
             (est.bpm - 174.0).abs() < 1.5,
             "expected ~174 BPM, got {}",
+            est.bpm
+        );
+    }
+
+    #[test]
+    fn detects_190_bpm_without_folding_to_half_time() {
+        let audio = synthetic_kick_track(44_100, 190.0, 8.0);
+        let est = detect_bpm(&audio, 44_100).expect("expected detection");
+        assert!(
+            (est.bpm - 190.0).abs() < 2.0,
+            "expected ~190 BPM, got {}",
             est.bpm
         );
     }

--- a/crates/vibez-ui/src/app/async_helpers.rs
+++ b/crates/vibez-ui/src/app/async_helpers.rs
@@ -36,8 +36,24 @@ pub(super) async fn analyse_browser_audio_async(
     audio: vibez_core::audio_buffer::DecodedAudio,
     source_name: String,
 ) -> Result<crate::message::AnalysedBrowserAudio, String> {
+    analyse_browser_audio_with_cached_metadata_async(audio, source_name, None).await
+}
+
+async fn analyse_browser_audio_with_cached_metadata_async(
+    audio: vibez_core::audio_buffer::DecodedAudio,
+    source_name: String,
+    cached_metadata: Option<vibez_dropbox::DerivedMetadata>,
+) -> Result<crate::message::AnalysedBrowserAudio, String> {
     tokio::task::spawn_blocking(move || {
-        let loop_fit = crate::warp::analyse_loop_tempo(&audio, &source_name);
+        let loop_fit = match cached_metadata {
+            Some(metadata) => crate::warp::fit_loop_tempo(
+                audio.num_frames(),
+                audio.sample_rate as f64,
+                &source_name,
+                metadata.bpm,
+            ),
+            None => crate::warp::analyse_loop_tempo(&audio, &source_name),
+        };
         crate::message::AnalysedBrowserAudio {
             audio: Arc::new(audio),
             loop_fit,
@@ -45,6 +61,14 @@ pub(super) async fn analyse_browser_audio_async(
     })
     .await
     .map_err(|error| format!("Browser analysis task failed: {error}"))
+}
+
+pub(super) async fn decode_and_analyse_async(
+    path: PathBuf,
+    source_name: String,
+) -> Result<crate::message::AnalysedBrowserAudio, String> {
+    let audio = decode_file_async(path).await?;
+    analyse_browser_audio_async(audio, source_name).await
 }
 
 pub(super) async fn decode_analyse_and_stage_local_async(
@@ -374,6 +398,15 @@ pub(super) async fn fetch_dropbox_sample_async(
             write_cache_blocking(&cache, &entry, bytes).await?
         }
     };
+    let metadata_cache = cache.clone();
+    let metadata_path = entry.path_lower.clone();
+    let metadata_revision = entry.rev.clone();
+    let cached_metadata = tokio::task::spawn_blocking(move || {
+        metadata_cache.derived_metadata(&metadata_path, metadata_revision.as_deref())
+    })
+    .await
+    .map_err(|error| format!("Derived Metadata lookup task failed: {error}"))?
+    .map_err(|error| format!("Derived Metadata lookup failed: {error}"))?;
     let decode_path = local.clone();
     let decoded = tokio::task::spawn_blocking(move || {
         vibez_audio_io::file_io::decode_audio_file(&decode_path).map_err(|e| e.to_string())
@@ -398,7 +431,12 @@ pub(super) async fn fetch_dropbox_sample_async(
     })
     .await
     .map_err(|error| format!("Remote Project Media staging task failed: {error}"))??;
-    let analysed = analyse_browser_audio_async(decoded, entry.name.clone()).await?;
+    let analysed = analyse_browser_audio_with_cached_metadata_async(
+        decoded,
+        entry.name.clone(),
+        cached_metadata,
+    )
+    .await?;
     Ok((analysed, entry.name, source))
 }
 

--- a/crates/vibez-ui/src/app/async_helpers.rs
+++ b/crates/vibez-ui/src/app/async_helpers.rs
@@ -32,6 +32,33 @@ pub(super) async fn decode_file_async(
     .map_err(|e| format!("decode task failed: {e}"))?
 }
 
+pub(super) async fn analyse_browser_audio_async(
+    audio: vibez_core::audio_buffer::DecodedAudio,
+    source_name: String,
+) -> Result<crate::message::AnalysedBrowserAudio, String> {
+    tokio::task::spawn_blocking(move || {
+        let loop_fit = crate::warp::analyse_loop_tempo(&audio, &source_name);
+        crate::message::AnalysedBrowserAudio {
+            audio: Arc::new(audio),
+            loop_fit,
+        }
+    })
+    .await
+    .map_err(|error| format!("Browser analysis task failed: {error}"))
+}
+
+pub(super) async fn decode_analyse_and_stage_local_async(
+    path: PathBuf,
+) -> Result<(crate::message::AnalysedBrowserAudio, MediaSourceRef), String> {
+    let name = path
+        .file_name()
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let (audio, source) = decode_and_stage_local_async(path).await?;
+    let analysed = analyse_browser_audio_async(audio, name).await?;
+    Ok((analysed, source))
+}
+
 pub(super) async fn decode_and_stage_local_async(
     path: PathBuf,
 ) -> Result<(vibez_core::audio_buffer::DecodedAudio, MediaSourceRef), String> {
@@ -330,14 +357,7 @@ pub(super) async fn fetch_dropbox_sample_async(
     client: Option<Arc<DropboxClient>>,
     cache: DropboxCache,
     entry: DropboxEntry,
-) -> Result<
-    (
-        Arc<vibez_core::audio_buffer::DecodedAudio>,
-        String,
-        MediaSourceRef,
-    ),
-    String,
-> {
+) -> Result<(crate::message::AnalysedBrowserAudio, String, MediaSourceRef), String> {
     let _lease = cache.protect(&entry.path_lower, entry.rev.as_deref());
     let local = match cache
         .lookup(&entry.path_lower, entry.rev.as_deref())
@@ -378,7 +398,8 @@ pub(super) async fn fetch_dropbox_sample_async(
     })
     .await
     .map_err(|error| format!("Remote Project Media staging task failed: {error}"))??;
-    Ok((Arc::new(decoded), entry.name, source))
+    let analysed = analyse_browser_audio_async(decoded, entry.name.clone()).await?;
+    Ok((analysed, entry.name, source))
 }
 
 pub(super) async fn materialize_remote_sample_async(

--- a/crates/vibez-ui/src/app/async_helpers.rs
+++ b/crates/vibez-ui/src/app/async_helpers.rs
@@ -5,9 +5,21 @@ use super::*;
 
 pub(super) async fn decode_local_for_preview_async(
     path: PathBuf,
-) -> Result<Arc<vibez_core::audio_buffer::DecodedAudio>, String> {
-    let audio = decode_file_async(path).await?;
-    Ok(Arc::new(audio))
+) -> Result<crate::message::AnalysedBrowserAudio, String> {
+    tokio::task::spawn_blocking(move || {
+        let name = path
+            .file_name()
+            .map(|value| value.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let audio = file_io::decode_audio_file(&path).map_err(|error| error.to_string())?;
+        let loop_fit = crate::warp::analyse_loop_tempo(&audio, &name);
+        Ok(crate::message::AnalysedBrowserAudio {
+            audio: Arc::new(audio),
+            loop_fit,
+        })
+    })
+    .await
+    .map_err(|error| format!("preview decode task failed: {error}"))?
 }
 
 pub(super) async fn decode_file_async(

--- a/crates/vibez-ui/src/app/dropbox_io.rs
+++ b/crates/vibez-ui/src/app/dropbox_io.rs
@@ -494,7 +494,12 @@ impl App {
         entry: DropboxEntry,
     ) -> Task<Message> {
         let target = BrowserImportTarget::ArrangementClip(self.state.arrangement.selected_track);
-        let treatment = self.state.browser.audition_import_input();
+        let source = MediaSourceRef::DropboxFile {
+            path_lower: entry.path_lower.clone(),
+            display_path: entry.path_display.clone(),
+            rev: entry.rev.clone(),
+        };
+        let treatment = self.state.browser.import_input_for_source(&source);
         self.start_remote_import(entry, target, treatment)
     }
 
@@ -503,7 +508,12 @@ impl App {
             self.state.status_text = "Select a Sampler or Drum Pad track first".into();
             return Task::none();
         };
-        let treatment = self.state.browser.audition_import_input();
+        let source = MediaSourceRef::DropboxFile {
+            path_lower: entry.path_lower.clone(),
+            display_path: entry.path_display.clone(),
+            rev: entry.rev.clone(),
+        };
+        let treatment = self.state.browser.import_input_for_source(&source);
         self.start_remote_import(entry, target, treatment)
     }
 }

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -435,12 +435,12 @@ impl App {
         &mut self,
         target: BrowserImportTarget,
         treatment: crate::state::AuditionImportInput,
-        raw: Arc<vibez_core::audio_buffer::DecodedAudio>,
+        analysed: crate::message::AnalysedBrowserAudio,
         name: String,
         source: MediaSourceRef,
     ) -> Task<Message> {
         let project_bpm = self.state.transport.bpm;
-        let treatment = match treatment.resolve_for_audio(&raw, &name) {
+        let treatment = match treatment.resolve_for_analysis(&analysed) {
             Ok(treatment) => treatment,
             Err(error) => {
                 self.state.status_text = format!("{error}: {name}");
@@ -453,6 +453,7 @@ impl App {
         };
         let retained_target = target.clone();
         let generation = self.browser_import_request.begin();
+        let raw = analysed.audio;
         let task = Task::perform(
             prepare_browser_import_audio_async(target, treatment, raw, source, project_bpm),
             move |result| match result {

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -307,11 +307,7 @@ impl App {
         source: MediaSourceRef,
         raw: Arc<DecodedAudio>,
     ) -> Task<Message> {
-        match self
-            .state
-            .browser
-            .audition_playback_plan(&raw, self.state.transport.bpm)
-        {
+        match self.state.browser.audition_playback_plan(&source) {
             crate::state::BrowserAuditionPlan::Raw => {
                 self.start_browser_audition(raw, AuditionMode::Raw);
                 Task::none()
@@ -444,7 +440,7 @@ impl App {
         source: MediaSourceRef,
     ) -> Task<Message> {
         let project_bpm = self.state.transport.bpm;
-        let treatment = match treatment.resolve_for_audio(&raw, project_bpm) {
+        let treatment = match treatment.resolve_for_audio(&raw, &name) {
             Ok(treatment) => treatment,
             Err(error) => {
                 self.state.status_text = format!("{error}: {name}");

--- a/crates/vibez-ui/src/app/media_import.rs
+++ b/crates/vibez-ui/src/app/media_import.rs
@@ -73,10 +73,7 @@ impl App {
                 };
                 let analysis_name = name.clone();
                 Task::perform(
-                    async move {
-                        let audio = decode_file_async(staging_path).await?;
-                        analyse_browser_audio_async(audio, analysis_name).await
-                    },
+                    decode_and_analyse_async(staging_path, analysis_name),
                     move |result| match result {
                         Ok(analysed) => Message::BrowserSampleDecoded(
                             target.clone(),
@@ -104,10 +101,7 @@ impl App {
                 };
                 let analysis_name = name.clone();
                 Task::perform(
-                    async move {
-                        let audio = decode_file_async(staging_path).await?;
-                        analyse_browser_audio_async(audio, analysis_name).await
-                    },
+                    decode_and_analyse_async(staging_path, analysis_name),
                     move |result| match result {
                         Ok(analysed) => Message::BrowserSampleDecoded(
                             target.clone(),

--- a/crates/vibez-ui/src/app/media_import.rs
+++ b/crates/vibez-ui/src/app/media_import.rs
@@ -36,7 +36,7 @@ impl App {
         source: MediaSourceRef,
         target: BrowserImportTarget,
     ) -> Task<Message> {
-        let treatment = self.state.browser.audition_import_input();
+        let treatment = self.state.browser.import_input_for_source(&source);
         match source {
             MediaSourceRef::LocalFile { path } => {
                 let name = path
@@ -45,12 +45,12 @@ impl App {
                     .unwrap_or_default();
                 self.state.status_text = format!("Dropping {name}...");
                 Task::perform(
-                    decode_and_stage_local_async(path),
+                    decode_analyse_and_stage_local_async(path),
                     move |result| match result {
-                        Ok((audio, source)) => Message::BrowserSampleDecoded(
+                        Ok((analysed, source)) => Message::BrowserSampleDecoded(
                             target.clone(),
                             treatment,
-                            Arc::new(audio),
+                            analysed,
                             name.clone(),
                             source,
                         ),
@@ -71,13 +71,17 @@ impl App {
                     staging_path: staging_path.clone(),
                     source_path,
                 };
+                let analysis_name = name.clone();
                 Task::perform(
-                    decode_file_async(staging_path),
+                    async move {
+                        let audio = decode_file_async(staging_path).await?;
+                        analyse_browser_audio_async(audio, analysis_name).await
+                    },
                     move |result| match result {
-                        Ok(audio) => Message::BrowserSampleDecoded(
+                        Ok(analysed) => Message::BrowserSampleDecoded(
                             target.clone(),
                             treatment,
-                            Arc::new(audio),
+                            analysed,
                             name.clone(),
                             retained_source.clone(),
                         ),
@@ -98,13 +102,17 @@ impl App {
                     staging_path: staging_path.clone(),
                     provenance,
                 };
+                let analysis_name = name.clone();
                 Task::perform(
-                    decode_file_async(staging_path),
+                    async move {
+                        let audio = decode_file_async(staging_path).await?;
+                        analyse_browser_audio_async(audio, analysis_name).await
+                    },
                     move |result| match result {
-                        Ok(audio) => Message::BrowserSampleDecoded(
+                        Ok(analysed) => Message::BrowserSampleDecoded(
                             target.clone(),
                             treatment,
-                            Arc::new(audio),
+                            analysed,
                             name.clone(),
                             retained_source.clone(),
                         ),
@@ -126,15 +134,21 @@ impl App {
                 let container_path = self.state.project.current_path.clone();
                 Task::perform(
                     async move {
-                        hydrate_saved_source(container_path.as_ref(), None, &retained_source, &name)
-                            .await
-                            .map(|audio| (audio, retained_source, name))
+                        let audio = hydrate_saved_source(
+                            container_path.as_ref(),
+                            None,
+                            &retained_source,
+                            &name,
+                        )
+                        .await?;
+                        let analysed = analyse_browser_audio_async(audio, name.clone()).await?;
+                        Ok((analysed, retained_source, name))
                     },
                     move |result| match result {
-                        Ok((audio, source, name)) => Message::BrowserSampleDecoded(
+                        Ok((analysed, source, name)) => Message::BrowserSampleDecoded(
                             target.clone(),
                             treatment,
-                            Arc::new(audio),
+                            analysed,
                             name,
                             source,
                         ),

--- a/crates/vibez-ui/src/app/project_format_v1_tests.rs
+++ b/crates/vibez-ui/src/app/project_format_v1_tests.rs
@@ -539,6 +539,64 @@ async fn cached_remote_media_materializes_without_a_client_and_persists_metadata
 }
 
 #[tokio::test]
+async fn remote_import_reuses_the_cached_audition_tempo() {
+    let directory = tempfile::tempdir().unwrap();
+    let source_path = directory.path().join("fast-loop.wav");
+    let sample_rate = 44_100_u32;
+    let source_bpm = 190.0;
+    let frames = (4.0 * 4.0 * 60.0 / source_bpm * sample_rate as f64).round() as usize;
+    let beat_frames = (60.0 / source_bpm * sample_rate as f64).round() as usize;
+    let mut channel = vec![0.0_f32; frames];
+    for beat in (0..frames).step_by(beat_frames) {
+        for offset in 0..256.min(frames - beat) {
+            channel[beat + offset] = 0.9 * (1.0 - offset as f32 / 256.0);
+        }
+    }
+    let audio = DecodedAudio {
+        channels: vec![channel],
+        sample_rate,
+    };
+    vibez_audio_io::file_io::write_wav_file(&source_path, &audio).unwrap();
+    let cache = DropboxCache::with_root(directory.path().join("media-cache"));
+    cache
+        .write(
+            "/megalodon/fast-loop.wav",
+            Some("rev-old-analysis"),
+            &std::fs::read(&source_path).unwrap(),
+        )
+        .unwrap();
+    cache
+        .store_derived_metadata(
+            "/megalodon/fast-loop.wav",
+            Some("rev-old-analysis"),
+            vibez_dropbox::DerivedMetadata {
+                provider_revision: Some("rev-old-analysis".into()),
+                duration_seconds: audio.duration_seconds(),
+                channels: 1,
+                sample_rate,
+                bpm: Some(95.0),
+                bpm_confidence: Some(0.9),
+                waveform_peaks: vec![],
+            },
+        )
+        .unwrap();
+    let entry = DropboxEntry {
+        path_lower: "/megalodon/fast-loop.wav".into(),
+        path_display: "/Megalodon/Fast Loop.wav".into(),
+        name: "Fast Loop.wav".into(),
+        is_folder: false,
+        rev: Some("rev-old-analysis".into()),
+        size: None,
+    };
+
+    let (analysed, _, _) = fetch_dropbox_sample_async(None, cache, entry)
+        .await
+        .unwrap();
+
+    assert!((analysed.loop_fit.unwrap().source_bpm - 95.0).abs() < 0.01);
+}
+
+#[tokio::test]
 async fn remote_warp_import_reopens_after_cache_clear_without_dropbox() {
     let directory = tempfile::tempdir().unwrap();
     let source_path = directory.path().join("remote-loop.wav");

--- a/crates/vibez-ui/src/app/project_format_v1_tests.rs
+++ b/crates/vibez-ui/src/app/project_format_v1_tests.rs
@@ -63,9 +63,9 @@ async fn supported_format_matrix_catalogs_auditions_imports_and_reopens() {
         let audition = decode_local_for_preview_async(source_path.clone())
             .await
             .unwrap();
-        assert_eq!(audition.num_channels(), channels, "{file_name}");
-        assert_eq!(audition.sample_rate, sample_rate, "{file_name}");
-        assert_audible(Arc::clone(&audition), file_name);
+        assert_eq!(audition.audio.num_channels(), channels, "{file_name}");
+        assert_eq!(audition.audio.sample_rate, sample_rate, "{file_name}");
+        assert_audible(Arc::clone(&audition.audio), file_name);
 
         let mut browser = crate::state::BrowserState {
             entries: catalog.entries,
@@ -76,7 +76,8 @@ async fn supported_format_matrix_catalogs_auditions_imports_and_reopens() {
         assert!(browser.install_audition(
             generation,
             browser.selected_source.clone().unwrap(),
-            Arc::clone(&audition)
+            Arc::clone(&audition.audio),
+            audition.loop_fit,
         ));
         let metadata = &browser.entries[0];
         assert_eq!(metadata.channels, Some(channels));
@@ -88,7 +89,11 @@ async fn supported_format_matrix_catalogs_auditions_imports_and_reopens() {
         let (imported, staged) = decode_and_stage_local_async(source_path.clone())
             .await
             .unwrap();
-        assert_eq!(imported.num_frames(), audition.num_frames(), "{file_name}");
+        assert_eq!(
+            imported.num_frames(),
+            audition.audio.num_frames(),
+            "{file_name}"
+        );
         let track = TrackInfo::new("Audio");
         let project_path = directory.path().join("format-roundtrip.vzp");
         let project = Project {

--- a/crates/vibez-ui/src/app/project_format_v1_tests.rs
+++ b/crates/vibez-ui/src/app/project_format_v1_tests.rs
@@ -76,8 +76,10 @@ async fn supported_format_matrix_catalogs_auditions_imports_and_reopens() {
         assert!(browser.install_audition(
             generation,
             browser.selected_source.clone().unwrap(),
-            Arc::clone(&audition.audio),
-            audition.loop_fit,
+            crate::message::AnalysedBrowserAudio {
+                audio: Arc::clone(&audition.audio),
+                loop_fit: audition.loop_fit,
+            },
         ));
         let metadata = &browser.entries[0];
         assert_eq!(metadata.channels, Some(channels));
@@ -559,7 +561,7 @@ async fn remote_warp_import_reopens_after_cache_clear_without_dropbox() {
         rev: Some("rev-9".into()),
         size: None,
     };
-    let (decoded, name, staged) = fetch_dropbox_sample_async(None, cache.clone(), entry)
+    let (analysed, name, staged) = fetch_dropbox_sample_async(None, cache.clone(), entry)
         .await
         .unwrap();
     assert!(matches!(
@@ -575,7 +577,7 @@ async fn remote_warp_import_reopens_after_cache_clear_without_dropbox() {
             position_samples: 0,
         },
         treatment,
-        decoded,
+        analysed.audio,
         staged,
         60.0,
     )

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -480,12 +480,13 @@ impl App {
         &mut self,
         source: MediaSourceRef,
         generation: u64,
-        audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
+        analysed: crate::message::AnalysedBrowserAudio,
     ) -> Task<Message> {
+        let crate::message::AnalysedBrowserAudio { audio, loop_fit } = analysed;
         if self
             .state
             .browser
-            .install_audition(generation, source, Arc::clone(&audio))
+            .install_audition(generation, source, Arc::clone(&audio), loop_fit)
         {
             let source = self.state.browser.selected_source.clone().unwrap();
             return self.play_browser_mode(source, audio);
@@ -512,9 +513,13 @@ impl App {
     pub(super) fn on_browser_waveform_ready(
         &mut self,
         source: MediaSourceRef,
-        audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
+        analysed: crate::message::AnalysedBrowserAudio,
     ) -> Task<Message> {
-        if self.state.browser.install_waveform(source, audio) {
+        if self
+            .state
+            .browser
+            .install_waveform(source, analysed.audio, analysed.loop_fit)
+        {
             self.state.status_text = "Waveform ready".into();
         }
         Task::none()

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -482,11 +482,11 @@ impl App {
         generation: u64,
         analysed: crate::message::AnalysedBrowserAudio,
     ) -> Task<Message> {
-        let crate::message::AnalysedBrowserAudio { audio, loop_fit } = analysed;
+        let audio = Arc::clone(&analysed.audio);
         if self
             .state
             .browser
-            .install_audition(generation, source, Arc::clone(&audio), loop_fit)
+            .install_audition(generation, source, analysed)
         {
             let source = self.state.browser.selected_source.clone().unwrap();
             return self.play_browser_mode(source, audio);
@@ -515,11 +515,7 @@ impl App {
         source: MediaSourceRef,
         analysed: crate::message::AnalysedBrowserAudio,
     ) -> Task<Message> {
-        if self
-            .state
-            .browser
-            .install_waveform(source, analysed.audio, analysed.loop_fit)
-        {
+        if self.state.browser.install_waveform(source, analysed) {
             self.state.status_text = "Waveform ready".into();
         }
         Task::none()
@@ -554,7 +550,7 @@ impl App {
         &mut self,
         target: BrowserImportTarget,
         treatment: crate::state::AuditionImportInput,
-        audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
+        analysed: crate::message::AnalysedBrowserAudio,
         name: String,
         source: MediaSourceRef,
     ) -> Task<Message> {
@@ -572,7 +568,7 @@ impl App {
         } else {
             Task::none()
         };
-        let import = self.prepare_browser_sample_import(target, treatment, audio, name, source);
+        let import = self.prepare_browser_sample_import(target, treatment, analysed, name, source);
         let pending_audition = if remote_import_finished {
             self.pending_remote_audition
                 .take()
@@ -589,14 +585,7 @@ impl App {
         request_id: u64,
         target: BrowserImportTarget,
         treatment: crate::state::AuditionImportInput,
-        result: Result<
-            (
-                Arc<vibez_core::audio_buffer::DecodedAudio>,
-                String,
-                MediaSourceRef,
-            ),
-            String,
-        >,
+        result: Result<(crate::message::AnalysedBrowserAudio, String, MediaSourceRef), String>,
     ) -> Task<Message> {
         if !self.remote_import_request.finish(request_id) {
             // Staging copies are content-addressed, so a superseding
@@ -606,8 +595,8 @@ impl App {
             return Task::none();
         }
         match result {
-            Ok((audio, name, source)) => self.update(Message::BrowserSampleDecoded(
-                target, treatment, audio, name, source,
+            Ok((analysed, name, source)) => self.update(Message::BrowserSampleDecoded(
+                target, treatment, analysed, name, source,
             )),
             Err(error) => Task::batch([
                 self.media_cache_maintenance_task(),

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -495,6 +495,10 @@ impl App {
                     &materialized.name,
                     materialized.metadata.bpm,
                 );
+                let analysed = crate::message::AnalysedBrowserAudio {
+                    audio: Arc::clone(&materialized.audio),
+                    loop_fit,
+                };
                 self.state
                     .browser
                     .remote
@@ -509,20 +513,17 @@ impl App {
                 let follow_up = if self.state.browser.selected_source.as_ref() != Some(&source) {
                     Task::none()
                 } else if self.state.browser.audition_enabled {
-                    if self.state.browser.install_audition(
-                        generation,
-                        source.clone(),
-                        Arc::clone(&materialized.audio),
-                        loop_fit,
-                    ) {
+                    if self
+                        .state
+                        .browser
+                        .install_audition(generation, source.clone(), analysed)
+                    {
                         self.play_browser_mode(source, materialized.audio)
                     } else {
                         Task::none()
                     }
                 } else {
-                    self.state
-                        .browser
-                        .install_waveform(source, materialized.audio, loop_fit);
+                    self.state.browser.install_waveform(source, analysed);
                     self.state.status_text = format!("Cached Remote media: {}", materialized.name);
                     Task::none()
                 };

--- a/crates/vibez-ui/src/app/update_remote.rs
+++ b/crates/vibez-ui/src/app/update_remote.rs
@@ -489,6 +489,12 @@ impl App {
         };
         match result {
             Ok(materialized) => {
+                let loop_fit = crate::warp::fit_loop_tempo(
+                    materialized.audio.num_frames(),
+                    materialized.audio.sample_rate as f64,
+                    &materialized.name,
+                    materialized.metadata.bpm,
+                );
                 self.state
                     .browser
                     .remote
@@ -507,6 +513,7 @@ impl App {
                         generation,
                         source.clone(),
                         Arc::clone(&materialized.audio),
+                        loop_fit,
                     ) {
                         self.play_browser_mode(source, materialized.audio)
                     } else {
@@ -515,7 +522,7 @@ impl App {
                 } else {
                     self.state
                         .browser
-                        .install_waveform(source, materialized.audio);
+                        .install_waveform(source, materialized.audio, loop_fit);
                     self.state.status_text = format!("Cached Remote media: {}", materialized.name);
                     Task::none()
                 };

--- a/crates/vibez-ui/src/app/views_browser.rs
+++ b/crates/vibez-ui/src/app/views_browser.rs
@@ -376,15 +376,7 @@ impl App {
             let bpm = if selected {
                 self.state
                     .browser
-                    .waveform_audio
-                    .as_ref()
-                    .and_then(|audio| {
-                        crate::warp::fit_loop_to_project(
-                            audio.num_frames(),
-                            audio.sample_rate as f64,
-                            self.state.transport.bpm,
-                        )
-                    })
+                    .waveform_loop_fit
                     .map(|fit| format!("{:.0}", fit.source_bpm))
                     .unwrap_or_else(|| "—".into())
             } else {

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -105,13 +105,18 @@ fn changing_selection_clears_waveform_and_rejects_stale_decode() {
 
     browser.select_source(first.clone());
     let generation = browser.begin_audition_load(&first);
-    assert!(browser.install_audition(generation, first.clone(), std::sync::Arc::clone(&audio)));
+    assert!(browser.install_audition(
+        generation,
+        first.clone(),
+        std::sync::Arc::clone(&audio),
+        None
+    ));
     assert!(browser.waveform_audio.is_some());
     assert!(!browser.audition_playing);
 
     browser.select_source(second);
     assert!(browser.waveform_audio.is_none());
-    assert!(!browser.install_audition(generation, first, audio));
+    assert!(!browser.install_audition(generation, first, audio, None));
     assert!(browser.waveform_audio.is_none());
 }
 
@@ -132,14 +137,19 @@ fn stopping_or_superseding_an_audition_invalidates_in_flight_decodes() {
     let stopped = browser.begin_audition_load(&source);
     browser.cancel_audition_requests();
     assert!(!browser.audition_request_is_current(stopped));
-    assert!(!browser.install_audition(stopped, source.clone(), std::sync::Arc::clone(&audio)));
+    assert!(!browser.install_audition(
+        stopped,
+        source.clone(),
+        std::sync::Arc::clone(&audio),
+        None
+    ));
     assert!(!browser.audition_playing);
 
     // A newer request supersedes an older one for the same source.
     let old = browser.begin_audition_load(&source);
     let new = browser.begin_audition_load(&source);
-    assert!(!browser.install_audition(old, source.clone(), std::sync::Arc::clone(&audio)));
-    assert!(browser.install_audition(new, source, audio));
+    assert!(!browser.install_audition(old, source.clone(), std::sync::Arc::clone(&audio), None));
+    assert!(browser.install_audition(new, source, audio, None));
     assert!(!browser.audition_playing);
 }
 
@@ -192,14 +202,20 @@ fn warp_import_resolves_the_same_grid_fit_without_confirmation() {
     assert_eq!(input.mode, crate::state::AuditionMode::Warp);
     assert_eq!(input.source_bpm, None);
     assert_eq!(
-        input.resolve_for_audio(&audio, 120.0).unwrap().source_bpm,
+        input
+            .resolve_for_audio(&audio, "loop_128_bpm.wav")
+            .unwrap()
+            .source_bpm,
         Some(128.0)
     );
 }
 
 #[test]
-fn warp_audition_plan_always_grid_fits_valid_audio() {
-    let browser = BrowserState {
+fn warp_audition_plan_uses_the_cached_source_analysis() {
+    let source = MediaSourceRef::LocalFile {
+        path: PathBuf::from("/samples/loop_128_bpm.wav"),
+    };
+    let mut browser = BrowserState {
         audition_mode: crate::state::AuditionMode::Warp,
         ..BrowserState::default()
     };
@@ -209,14 +225,26 @@ fn warp_audition_plan_always_grid_fits_valid_audio() {
         sample_rate: 44_100,
     };
 
+    browser.select_source(source.clone());
+    assert!(browser.install_waveform(
+        source.clone(),
+        std::sync::Arc::new(audio),
+        Some(crate::warp::LoopGridFit {
+            bars: 4,
+            source_bpm: 128.0,
+        })
+    ));
     assert_eq!(
-        browser.audition_playback_plan(&audio, 120.0),
+        browser.audition_playback_plan(&source),
         crate::state::BrowserAuditionPlan::Warp { source_bpm: 128.0 }
     );
 }
 
 #[test]
 fn warp_audition_and_import_keep_one_shots_raw() {
+    let source = MediaSourceRef::LocalFile {
+        path: PathBuf::from("/samples/hit.wav"),
+    };
     let browser = BrowserState {
         audition_mode: crate::state::AuditionMode::Warp,
         ..BrowserState::default()
@@ -227,13 +255,13 @@ fn warp_audition_and_import_keep_one_shots_raw() {
     };
 
     assert_eq!(
-        browser.audition_playback_plan(&audio, 120.0),
+        browser.audition_playback_plan(&source),
         crate::state::BrowserAuditionPlan::Raw
     );
     assert_eq!(
         browser
             .audition_import_input()
-            .resolve_for_audio(&audio, 120.0)
+            .resolve_for_audio(&audio, "hit.wav")
             .unwrap(),
         crate::state::AuditionImportInput {
             mode: crate::state::AuditionMode::Raw,
@@ -256,7 +284,7 @@ fn selected_source_can_reuse_its_decoded_waveform_for_retriggering() {
     });
     let mut browser = BrowserState::default();
     browser.select_source(source.clone());
-    assert!(browser.install_waveform(source.clone(), std::sync::Arc::clone(&audio)));
+    assert!(browser.install_waveform(source.clone(), std::sync::Arc::clone(&audio), None));
 
     assert!(std::sync::Arc::ptr_eq(
         &browser.waveform_for_source(&source).unwrap(),
@@ -276,7 +304,7 @@ fn warp_preparation_keeps_the_loaded_waveform_without_claiming_playback() {
     });
     let mut browser = BrowserState::default();
     browser.select_source(source.clone());
-    assert!(browser.install_waveform(source.clone(), audio));
+    assert!(browser.install_waveform(source.clone(), audio, None));
 
     let preparation = browser.begin_audition_preparation(&source);
     assert!(browser.audition_loading);
@@ -356,6 +384,10 @@ fn drag_preview_reports_exact_raw_and_warp_musical_lengths() {
                 sample_rate: 44_100,
             },
         )),
+        waveform_loop_fit: Some(crate::warp::LoopGridFit {
+            bars: 1,
+            source_bpm: 120.0,
+        }),
         ..BrowserState::default()
     };
     assert_eq!(browser.drag_preview_beats(120.0), Some(4.0));

--- a/crates/vibez-ui/src/domains/browser_tests.rs
+++ b/crates/vibez-ui/src/domains/browser_tests.rs
@@ -4,6 +4,13 @@ use std::sync::Arc;
 
 use super::*;
 
+fn analysed(
+    audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
+    loop_fit: Option<crate::warp::LoopGridFit>,
+) -> crate::message::AnalysedBrowserAudio {
+    crate::message::AnalysedBrowserAudio { audio, loop_fit }
+}
+
 #[test]
 fn toggle_persists_settings() {
     let mut b = BrowserState::default();
@@ -108,15 +115,14 @@ fn changing_selection_clears_waveform_and_rejects_stale_decode() {
     assert!(browser.install_audition(
         generation,
         first.clone(),
-        std::sync::Arc::clone(&audio),
-        None
+        analysed(std::sync::Arc::clone(&audio), None)
     ));
     assert!(browser.waveform_audio.is_some());
     assert!(!browser.audition_playing);
 
     browser.select_source(second);
     assert!(browser.waveform_audio.is_none());
-    assert!(!browser.install_audition(generation, first, audio, None));
+    assert!(!browser.install_audition(generation, first, analysed(audio, None)));
     assert!(browser.waveform_audio.is_none());
 }
 
@@ -140,16 +146,19 @@ fn stopping_or_superseding_an_audition_invalidates_in_flight_decodes() {
     assert!(!browser.install_audition(
         stopped,
         source.clone(),
-        std::sync::Arc::clone(&audio),
-        None
+        analysed(std::sync::Arc::clone(&audio), None)
     ));
     assert!(!browser.audition_playing);
 
     // A newer request supersedes an older one for the same source.
     let old = browser.begin_audition_load(&source);
     let new = browser.begin_audition_load(&source);
-    assert!(!browser.install_audition(old, source.clone(), std::sync::Arc::clone(&audio), None));
-    assert!(browser.install_audition(new, source, audio, None));
+    assert!(!browser.install_audition(
+        old,
+        source.clone(),
+        analysed(std::sync::Arc::clone(&audio), None)
+    ));
+    assert!(browser.install_audition(new, source, analysed(audio, None)));
     assert!(!browser.audition_playing);
 }
 
@@ -198,16 +207,80 @@ fn warp_import_resolves_the_same_grid_fit_without_confirmation() {
         sample_rate: 44_100,
     };
 
-    let input = browser.audition_import_input();
+    let source = MediaSourceRef::LocalFile {
+        path: PathBuf::from("/samples/loop_128_bpm.wav"),
+    };
+    let input = browser.import_input_for_source(&source);
     assert_eq!(input.mode, crate::state::AuditionMode::Warp);
     assert_eq!(input.source_bpm, None);
     assert_eq!(
         input
-            .resolve_for_audio(&audio, "loop_128_bpm.wav")
+            .resolve_for_analysis(&analysed(
+                std::sync::Arc::new(audio),
+                Some(crate::warp::LoopGridFit {
+                    bars: 4,
+                    source_bpm: 128.0,
+                }),
+            ))
             .unwrap()
             .source_bpm,
         Some(128.0)
     );
+}
+
+#[test]
+fn warp_import_uses_background_analysis_for_fast_loops() {
+    let analysed = analysed(
+        Arc::new(vibez_core::audio_buffer::DecodedAudio {
+            channels: vec![vec![0.0; 124_518]],
+            sample_rate: 44_100,
+        }),
+        Some(crate::warp::LoopGridFit {
+            bars: 2,
+            source_bpm: 170.0,
+        }),
+    );
+    let input = crate::state::AuditionImportInput {
+        mode: crate::state::AuditionMode::Warp,
+        source_bpm: None,
+    };
+
+    assert_eq!(
+        input.resolve_for_analysis(&analysed).unwrap().source_bpm,
+        Some(170.0)
+    );
+}
+
+#[test]
+fn dragged_source_does_not_inherit_the_selected_sources_tempo() {
+    let selected = MediaSourceRef::LocalFile {
+        path: PathBuf::from("/samples/selected_128.wav"),
+    };
+    let dragged = MediaSourceRef::LocalFile {
+        path: PathBuf::from("/samples/dragged_170.wav"),
+    };
+    let mut browser = BrowserState {
+        audition_mode: crate::state::AuditionMode::Warp,
+        ..BrowserState::default()
+    };
+    browser.select_source(selected.clone());
+    assert!(browser.install_waveform(
+        selected,
+        analysed(
+            std::sync::Arc::new(vibez_core::audio_buffer::DecodedAudio {
+                channels: vec![vec![0.0; 44_100]],
+                sample_rate: 44_100,
+            }),
+            Some(crate::warp::LoopGridFit {
+                bars: 4,
+                source_bpm: 128.0,
+            }),
+        )
+    ));
+    browser.begin_pending_drag(dragged.clone(), "dragged_170.wav".into(), 0.0, 0.0);
+    assert!(browser.move_pending_drag(10.0, 0.0));
+
+    assert_eq!(browser.import_input_for_source(&dragged).source_bpm, None);
 }
 
 #[test]
@@ -228,11 +301,13 @@ fn warp_audition_plan_uses_the_cached_source_analysis() {
     browser.select_source(source.clone());
     assert!(browser.install_waveform(
         source.clone(),
-        std::sync::Arc::new(audio),
-        Some(crate::warp::LoopGridFit {
-            bars: 4,
-            source_bpm: 128.0,
-        })
+        analysed(
+            std::sync::Arc::new(audio),
+            Some(crate::warp::LoopGridFit {
+                bars: 4,
+                source_bpm: 128.0,
+            }),
+        )
     ));
     assert_eq!(
         browser.audition_playback_plan(&source),
@@ -260,8 +335,8 @@ fn warp_audition_and_import_keep_one_shots_raw() {
     );
     assert_eq!(
         browser
-            .audition_import_input()
-            .resolve_for_audio(&audio, "hit.wav")
+            .import_input_for_source(&source)
+            .resolve_for_analysis(&analysed(std::sync::Arc::new(audio), None))
             .unwrap(),
         crate::state::AuditionImportInput {
             mode: crate::state::AuditionMode::Raw,
@@ -284,7 +359,10 @@ fn selected_source_can_reuse_its_decoded_waveform_for_retriggering() {
     });
     let mut browser = BrowserState::default();
     browser.select_source(source.clone());
-    assert!(browser.install_waveform(source.clone(), std::sync::Arc::clone(&audio), None));
+    assert!(browser.install_waveform(
+        source.clone(),
+        analysed(std::sync::Arc::clone(&audio), None)
+    ));
 
     assert!(std::sync::Arc::ptr_eq(
         &browser.waveform_for_source(&source).unwrap(),
@@ -304,7 +382,7 @@ fn warp_preparation_keeps_the_loaded_waveform_without_claiming_playback() {
     });
     let mut browser = BrowserState::default();
     browser.select_source(source.clone());
-    assert!(browser.install_waveform(source.clone(), audio, None));
+    assert!(browser.install_waveform(source.clone(), analysed(audio, None)));
 
     let preparation = browser.begin_audition_preparation(&source);
     assert!(browser.audition_loading);

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -625,7 +625,7 @@ pub enum Message {
     BrowserSampleDecoded(
         BrowserImportTarget,
         AuditionImportInput,
-        Arc<DecodedAudio>,
+        AnalysedBrowserAudio,
         String,
         MediaSourceRef,
     ),
@@ -787,7 +787,7 @@ pub enum Message {
         request_id: u64,
         target: BrowserImportTarget,
         treatment: AuditionImportInput,
-        result: Result<(Arc<DecodedAudio>, String, MediaSourceRef), String>,
+        result: Result<(AnalysedBrowserAudio, String, MediaSourceRef), String>,
     },
     DropboxPreview(DropboxEntry),
     DropboxImportToArrangement(DropboxEntry),

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -181,6 +181,12 @@ pub struct RemoteMaterializedSample {
     pub metadata: vibez_dropbox::DerivedMetadata,
 }
 
+#[derive(Debug, Clone)]
+pub struct AnalysedBrowserAudio {
+    pub audio: Arc<DecodedAudio>,
+    pub loop_fit: Option<crate::warp::LoopGridFit>,
+}
+
 #[derive(Debug)]
 pub struct RemoteCatalogStartupData {
     pub catalog: crate::remote_provider::RemoteCatalogSnapshot,
@@ -593,8 +599,8 @@ pub enum Message {
     /// The `u64` is the audition request generation minted at spawn
     /// time; stale completions (stopped or superseded requests) are
     /// dropped instead of starting playback.
-    LocalSamplePreviewReady(MediaSourceRef, u64, Result<Arc<DecodedAudio>, String>),
-    BrowserWaveformReady(MediaSourceRef, Result<Arc<DecodedAudio>, String>),
+    LocalSamplePreviewReady(MediaSourceRef, u64, Result<AnalysedBrowserAudio, String>),
+    BrowserWaveformReady(MediaSourceRef, Result<AnalysedBrowserAudio, String>),
     BrowserAuditionWarpReady {
         source: MediaSourceRef,
         generation: u64,

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -88,6 +88,7 @@ pub struct BrowserState {
     /// waveform. Audition still travels through the existing engine path.
     pub waveform_source: Option<MediaSourceRef>,
     pub waveform_audio: Option<Arc<DecodedAudio>>,
+    pub waveform_loop_fit: Option<crate::warp::LoopGridFit>,
     pub waveform_loading: bool,
     pub waveform_error: Option<String>,
     pub audition_enabled: bool,
@@ -149,6 +150,7 @@ impl Default for BrowserState {
             selected_source: None,
             waveform_source: None,
             waveform_audio: None,
+            waveform_loop_fit: None,
             waveform_loading: false,
             waveform_error: None,
             audition_enabled: true,
@@ -440,11 +442,12 @@ impl BrowserState {
         generation: u64,
         source: MediaSourceRef,
         audio: Arc<DecodedAudio>,
+        loop_fit: Option<crate::warp::LoopGridFit>,
     ) -> bool {
         if !self.audition_request_is_current(generation) {
             return false;
         }
-        if !self.install_waveform(source, audio) {
+        if !self.install_waveform(source, audio, loop_fit) {
             return false;
         }
         self.audition_loading = false;
@@ -485,28 +488,24 @@ impl BrowserState {
     pub fn audition_import_input(&self) -> AuditionImportInput {
         AuditionImportInput {
             mode: self.audition_mode,
-            // WARP resolves this from the decoded loop boundary and Project
-            // tempo immediately before rendering the import.
-            source_bpm: None,
+            source_bpm: if self.waveform_source == self.selected_source {
+                self.waveform_loop_fit.map(|fit| fit.source_bpm)
+            } else {
+                None
+            },
         }
     }
 
-    pub fn audition_playback_plan(
-        &self,
-        audio: &DecodedAudio,
-        project_bpm: f64,
-    ) -> BrowserAuditionPlan {
+    pub fn audition_playback_plan(&self, source: &MediaSourceRef) -> BrowserAuditionPlan {
         match self.audition_mode {
             AuditionMode::Raw => BrowserAuditionPlan::Raw,
-            AuditionMode::Warp => crate::warp::fit_loop_to_project(
-                audio.num_frames(),
-                audio.sample_rate as f64,
-                project_bpm,
-            )
-            .map(|fit| BrowserAuditionPlan::Warp {
-                source_bpm: fit.source_bpm,
-            })
-            .unwrap_or(BrowserAuditionPlan::Raw),
+            AuditionMode::Warp if self.waveform_source.as_ref() == Some(source) => self
+                .waveform_loop_fit
+                .map(|fit| BrowserAuditionPlan::Warp {
+                    source_bpm: fit.source_bpm,
+                })
+                .unwrap_or(BrowserAuditionPlan::Raw),
+            AuditionMode::Warp => BrowserAuditionPlan::Raw,
         }
     }
 
@@ -572,17 +571,19 @@ impl BrowserState {
         let seconds = audio.num_frames() as f64 / audio.sample_rate as f64;
         match self.audition_mode {
             AuditionMode::Raw => (project_bpm > 0.0).then_some(seconds * project_bpm / 60.0),
-            AuditionMode::Warp => crate::warp::fit_loop_to_project(
-                audio.num_frames(),
-                audio.sample_rate as f64,
-                project_bpm,
-            )
-            .map(|fit| fit.bars as f64 * 4.0)
-            .or_else(|| (project_bpm > 0.0).then_some(seconds * project_bpm / 60.0)),
+            AuditionMode::Warp => self
+                .waveform_loop_fit
+                .map(|fit| fit.bars as f64 * 4.0)
+                .or_else(|| (project_bpm > 0.0).then_some(seconds * project_bpm / 60.0)),
         }
     }
 
-    pub fn install_waveform(&mut self, source: MediaSourceRef, audio: Arc<DecodedAudio>) -> bool {
+    pub fn install_waveform(
+        &mut self,
+        source: MediaSourceRef,
+        audio: Arc<DecodedAudio>,
+        loop_fit: Option<crate::warp::LoopGridFit>,
+    ) -> bool {
         if self.selected_source.as_ref() != Some(&source) {
             return false;
         }
@@ -600,6 +601,7 @@ impl BrowserState {
         }
         self.waveform_source = Some(source);
         self.waveform_audio = Some(audio);
+        self.waveform_loop_fit = loop_fit;
         self.waveform_loading = false;
         self.waveform_error = None;
         true
@@ -615,6 +617,7 @@ impl BrowserState {
     fn clear_waveform(&mut self) {
         self.waveform_source = None;
         self.waveform_audio = None;
+        self.waveform_loop_fit = None;
         self.waveform_loading = false;
         self.waveform_error = None;
     }

--- a/crates/vibez-ui/src/state/browser_state.rs
+++ b/crates/vibez-ui/src/state/browser_state.rs
@@ -441,13 +441,12 @@ impl BrowserState {
         &mut self,
         generation: u64,
         source: MediaSourceRef,
-        audio: Arc<DecodedAudio>,
-        loop_fit: Option<crate::warp::LoopGridFit>,
+        analysed: crate::message::AnalysedBrowserAudio,
     ) -> bool {
         if !self.audition_request_is_current(generation) {
             return false;
         }
-        if !self.install_waveform(source, audio, loop_fit) {
+        if !self.install_waveform(source, analysed) {
             return false;
         }
         self.audition_loading = false;
@@ -485,10 +484,10 @@ impl BrowserState {
             .then(|| (self.audition_position_frames as f64 / frames as f64).clamp(0.0, 1.0) as f32)
     }
 
-    pub fn audition_import_input(&self) -> AuditionImportInput {
+    pub fn import_input_for_source(&self, source: &MediaSourceRef) -> AuditionImportInput {
         AuditionImportInput {
             mode: self.audition_mode,
-            source_bpm: if self.waveform_source == self.selected_source {
+            source_bpm: if self.waveform_source.as_ref() == Some(source) {
                 self.waveform_loop_fit.map(|fit| fit.source_bpm)
             } else {
                 None
@@ -581,16 +580,15 @@ impl BrowserState {
     pub fn install_waveform(
         &mut self,
         source: MediaSourceRef,
-        audio: Arc<DecodedAudio>,
-        loop_fit: Option<crate::warp::LoopGridFit>,
+        analysed: crate::message::AnalysedBrowserAudio,
     ) -> bool {
         if self.selected_source.as_ref() != Some(&source) {
             return false;
         }
-        let channels = audio.num_channels();
-        let sample_rate = audio.sample_rate;
+        let channels = analysed.audio.num_channels();
+        let sample_rate = analysed.audio.sample_rate;
         let duration_seconds = if sample_rate > 0 {
-            Some(audio.num_frames() as f64 / sample_rate as f64)
+            Some(analysed.audio.num_frames() as f64 / sample_rate as f64)
         } else {
             None
         };
@@ -600,8 +598,8 @@ impl BrowserState {
             entry.sample_rate = Some(sample_rate);
         }
         self.waveform_source = Some(source);
-        self.waveform_audio = Some(audio);
-        self.waveform_loop_fit = loop_fit;
+        self.waveform_audio = Some(analysed.audio);
+        self.waveform_loop_fit = analysed.loop_fit;
         self.waveform_loading = false;
         self.waveform_error = None;
         true

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -41,28 +41,27 @@ pub struct AuditionImportInput {
 }
 
 impl AuditionImportInput {
-    /// Resolve Browser WARP from the same complete-loop grid fit used by
-    /// Audition. Sources with no plausible loop interpretation fall back to
-    /// RAW so one-shots are never stretched into arbitrary bar lengths.
+    /// Resolve Browser WARP from source evidence only. Project tempo is not an
+    /// input because it must never change the identified source tempo.
     pub fn resolve_for_audio(
         mut self,
         audio: &DecodedAudio,
-        project_bpm: f64,
+        source_name: &str,
     ) -> Result<Self, String> {
         if self.mode == AuditionMode::Raw {
             return Ok(self);
         }
-        if audio.num_frames() == 0
-            || audio.sample_rate == 0
-            || !project_bpm.is_finite()
-            || project_bpm <= 0.0
-        {
+        if audio.num_frames() == 0 || audio.sample_rate == 0 {
             return Err("Cannot prepare empty or invalid audio".into());
         }
-        let Some(fit) = crate::warp::fit_loop_to_project(
+        if self.source_bpm.is_some() {
+            return Ok(self);
+        }
+        let Some(fit) = crate::warp::fit_loop_tempo(
             audio.num_frames(),
             audio.sample_rate as f64,
-            project_bpm,
+            source_name,
+            None,
         ) else {
             self.mode = AuditionMode::Raw;
             self.source_bpm = None;

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -43,26 +43,20 @@ pub struct AuditionImportInput {
 impl AuditionImportInput {
     /// Resolve Browser WARP from source evidence only. Project tempo is not an
     /// input because it must never change the identified source tempo.
-    pub fn resolve_for_audio(
+    pub fn resolve_for_analysis(
         mut self,
-        audio: &DecodedAudio,
-        source_name: &str,
+        analysed: &crate::message::AnalysedBrowserAudio,
     ) -> Result<Self, String> {
         if self.mode == AuditionMode::Raw {
             return Ok(self);
         }
-        if audio.num_frames() == 0 || audio.sample_rate == 0 {
+        if analysed.audio.num_frames() == 0 || analysed.audio.sample_rate == 0 {
             return Err("Cannot prepare empty or invalid audio".into());
         }
         if self.source_bpm.is_some() {
             return Ok(self);
         }
-        let Some(fit) = crate::warp::fit_loop_tempo(
-            audio.num_frames(),
-            audio.sample_rate as f64,
-            source_name,
-            None,
-        ) else {
+        let Some(fit) = analysed.loop_fit else {
             self.mode = AuditionMode::Raw;
             self.source_bpm = None;
             return Ok(self);

--- a/crates/vibez-ui/src/warp.rs
+++ b/crates/vibez-ui/src/warp.rs
@@ -55,8 +55,15 @@ pub struct LoopGridFit {
 
 const LOOP_GRID_BARS: [u32; 5] = [1, 2, 4, 8, 16];
 const PLAUSIBLE_LOOP_BPM_MIN: f64 = 60.0;
+// Keep aligned with vibez_core::onset::BPM_FOLD_HI. The detector must not
+// fold a tempo which this grid fitter treats as a valid source tempo.
 const PLAUSIBLE_LOOP_BPM_MAX: f64 = 200.0;
 const FILENAME_TEMPO_TOLERANCE: f64 = 1.10;
+
+struct LoopTempoDecision {
+    fit: LoopGridFit,
+    filename_hint_decided: bool,
+}
 
 /// Extract a conventional tempo token from a production-loop filename.
 /// Explicit `124bpm`/`bpm124` tokens win; otherwise a delimiter-separated
@@ -118,22 +125,34 @@ pub fn fit_loop_tempo(
     source_name: &str,
     detected_bpm: Option<f64>,
 ) -> Option<LoopGridFit> {
+    fit_loop_tempo_decision(source_frames, sample_rate, source_name, detected_bpm)
+        .map(|decision| decision.fit)
+}
+
+fn fit_loop_tempo_decision(
+    source_frames: usize,
+    sample_rate: f64,
+    source_name: &str,
+    detected_bpm: Option<f64>,
+) -> Option<LoopTempoDecision> {
     if source_frames == 0 || !sample_rate.is_finite() || sample_rate <= 0.0 {
         return None;
     }
 
     let source_seconds = source_frames as f64 / sample_rate;
-    let candidates: Vec<_> = LOOP_GRID_BARS
-        .into_iter()
-        .map(|bars| LoopGridFit {
+    let candidates = LOOP_GRID_BARS.map(|bars| {
+        let fit = LoopGridFit {
             bars,
             source_bpm: bars as f64 * 4.0 * 60.0 / source_seconds,
-        })
-        .filter(|fit| (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(&fit.source_bpm))
-        .collect();
+        };
+        (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX)
+            .contains(&fit.source_bpm)
+            .then_some(fit)
+    });
     let name_hint = bpm_hint_from_name(source_name).filter(|hint| {
         candidates
             .iter()
+            .flatten()
             .any(|fit| (fit.source_bpm / hint).ln().abs() <= FILENAME_TEMPO_TOLERANCE.ln())
     });
     let reference_bpm = name_hint
@@ -143,12 +162,16 @@ pub fn fit_loop_tempo(
             })
         })
         .unwrap_or(120.0);
-    candidates.into_iter().min_by(|left, right| {
+    let fit = candidates.into_iter().flatten().min_by(|left, right| {
         (left.source_bpm / reference_bpm)
             .ln()
             .abs()
             .partial_cmp(&(right.source_bpm / reference_bpm).ln().abs())
             .unwrap_or(std::cmp::Ordering::Equal)
+    })?;
+    Some(LoopTempoDecision {
+        fit,
+        filename_hint_decided: name_hint.is_some(),
     })
 }
 
@@ -163,17 +186,14 @@ fn analyse_loop_tempo_with(
     source_name: &str,
     detect: impl FnOnce() -> Option<f64>,
 ) -> Option<LoopGridFit> {
-    let cheap_fit = fit_loop_tempo(
+    let cheap_decision = fit_loop_tempo_decision(
         audio.num_frames(),
         audio.sample_rate as f64,
         source_name,
         None,
     )?;
-    let hint_decides = bpm_hint_from_name(source_name).is_some_and(|hint| {
-        (cheap_fit.source_bpm / hint).ln().abs() <= FILENAME_TEMPO_TOLERANCE.ln()
-    });
-    if hint_decides {
-        return Some(cheap_fit);
+    if cheap_decision.filename_hint_decided {
+        return Some(cheap_decision.fit);
     }
     fit_loop_tempo(
         audio.num_frames(),

--- a/crates/vibez-ui/src/warp.rs
+++ b/crates/vibez-ui/src/warp.rs
@@ -53,23 +53,10 @@ pub struct LoopGridFit {
     pub source_bpm: f64,
 }
 
-impl LoopGridFit {
-    pub fn target_frames(self, sample_rate: f64, project_bpm: f64) -> Option<usize> {
-        if !sample_rate.is_finite()
-            || sample_rate <= 0.0
-            || !project_bpm.is_finite()
-            || project_bpm <= 0.0
-        {
-            return None;
-        }
-        let beats = self.bars as f64 * 4.0;
-        Some((beats * 60.0 / project_bpm * sample_rate).round() as usize)
-    }
-}
-
 const LOOP_GRID_BARS: [u32; 5] = [1, 2, 4, 8, 16];
 const PLAUSIBLE_LOOP_BPM_MIN: f64 = 60.0;
 const PLAUSIBLE_LOOP_BPM_MAX: f64 = 200.0;
+const FILENAME_TEMPO_TOLERANCE: f64 = 1.10;
 
 /// Extract a conventional tempo token from a production-loop filename.
 /// Explicit `124bpm`/`bpm124` tokens win; otherwise a delimiter-separated
@@ -98,10 +85,16 @@ pub fn bpm_hint_from_name(name: &str) -> Option<f64> {
             return marked;
         }
         if token.eq_ignore_ascii_case("bpm") {
-            let adjacent = index
-                .checked_sub(1)
-                .and_then(|previous| tokens[previous].parse::<f64>().ok())
-                .or_else(|| tokens.get(index + 1)?.parse::<f64>().ok())
+            // `bpm 128` is explicit; prefer it to an unrelated number that
+            // happens to precede the marker (`Loop_90_bpm_128.wav`).
+            let adjacent = tokens
+                .get(index + 1)
+                .and_then(|next| next.parse::<f64>().ok())
+                .or_else(|| {
+                    index
+                        .checked_sub(1)
+                        .and_then(|previous| tokens[previous].parse::<f64>().ok())
+                })
                 .filter(|value| plausible(*value));
             if adjacent.is_some() {
                 return adjacent;
@@ -130,40 +123,63 @@ pub fn fit_loop_tempo(
     }
 
     let source_seconds = source_frames as f64 / sample_rate;
-    let name_hint = bpm_hint_from_name(source_name);
-    let reference_bpm = name_hint
-        .or_else(|| detected_bpm.filter(|bpm| bpm.is_finite() && *bpm > 0.0))
-        .unwrap_or(120.0);
-    let candidates = LOOP_GRID_BARS.map(|bars| LoopGridFit {
-        bars,
-        source_bpm: bars as f64 * 4.0 * 60.0 / source_seconds,
-    });
-    let fit = candidates
+    let candidates: Vec<_> = LOOP_GRID_BARS
         .into_iter()
+        .map(|bars| LoopGridFit {
+            bars,
+            source_bpm: bars as f64 * 4.0 * 60.0 / source_seconds,
+        })
         .filter(|fit| (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(&fit.source_bpm))
-        .min_by(|left, right| {
-            (left.source_bpm / reference_bpm)
-                .ln()
-                .abs()
-                .partial_cmp(&(right.source_bpm / reference_bpm).ln().abs())
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })?;
-    // A filename BPM is strong evidence only when the complete source length
-    // agrees with it. This rejects unrelated catalogue/take numbers instead
-    // of forcing them into the nearest musical bar count.
-    if name_hint.is_some_and(|hint| (fit.source_bpm / hint).ln().abs() > 1.05_f64.ln()) {
-        return None;
-    }
-    Some(fit)
+        .collect();
+    let name_hint = bpm_hint_from_name(source_name).filter(|hint| {
+        candidates
+            .iter()
+            .any(|fit| (fit.source_bpm / hint).ln().abs() <= FILENAME_TEMPO_TOLERANCE.ln())
+    });
+    let reference_bpm = name_hint
+        .or_else(|| {
+            detected_bpm.filter(|bpm| {
+                bpm.is_finite() && (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(bpm)
+            })
+        })
+        .unwrap_or(120.0);
+    candidates.into_iter().min_by(|left, right| {
+        (left.source_bpm / reference_bpm)
+            .ln()
+            .abs()
+            .partial_cmp(&(right.source_bpm / reference_bpm).ln().abs())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    })
 }
 
 pub fn analyse_loop_tempo(audio: &DecodedAudio, source_name: &str) -> Option<LoopGridFit> {
-    let detected = vibez_core::onset::detect_bpm(audio, audio.sample_rate).map(|value| value.bpm);
+    analyse_loop_tempo_with(audio, source_name, || {
+        vibez_core::onset::detect_bpm(audio, audio.sample_rate).map(|value| value.bpm)
+    })
+}
+
+fn analyse_loop_tempo_with(
+    audio: &DecodedAudio,
+    source_name: &str,
+    detect: impl FnOnce() -> Option<f64>,
+) -> Option<LoopGridFit> {
+    let cheap_fit = fit_loop_tempo(
+        audio.num_frames(),
+        audio.sample_rate as f64,
+        source_name,
+        None,
+    )?;
+    let hint_decides = bpm_hint_from_name(source_name).is_some_and(|hint| {
+        (cheap_fit.source_bpm / hint).ln().abs() <= FILENAME_TEMPO_TOLERANCE.ln()
+    });
+    if hint_decides {
+        return Some(cheap_fit);
+    }
     fit_loop_tempo(
         audio.num_frames(),
         audio.sample_rate as f64,
         source_name,
-        detected,
+        detect(),
     )
 }
 
@@ -324,8 +340,6 @@ mod tests {
 
             assert_eq!(fit.bars, bars as u32);
             assert!((fit.source_bpm - expected_bpm).abs() < 0.01);
-            let expected_frames = (bars * 4.0 * 60.0 / 120.0 * SR as f64).round() as usize;
-            assert_eq!(fit.target_frames(SR as f64, 120.0), Some(expected_frames));
         }
     }
 
@@ -342,8 +356,18 @@ mod tests {
 
         assert_eq!(fit.bars, 2);
         assert!((fit.source_bpm - 124.0).abs() < 0.01);
-        assert_eq!(fit.target_frames(SR as f64, 80.0), Some(264_600));
-        assert_eq!(fit.target_frames(SR as f64, 160.0), Some(132_300));
+    }
+
+    #[test]
+    fn filename_fit_skips_expensive_audio_detection() {
+        let audio = exact_loop(4.0, 128.0);
+        let fit = analyse_loop_tempo_with(&audio, "Warehouse_128_bpm.wav", || {
+            panic!("filename evidence should avoid onset analysis")
+        })
+        .unwrap();
+
+        assert_eq!(fit.bars, 4);
+        assert!((fit.source_bpm - 128.0).abs() < 0.01);
     }
 
     #[test]
@@ -363,20 +387,33 @@ mod tests {
         assert_eq!(bpm_hint_from_name("Warehouse 128bpm.wav"), Some(128.0));
         assert_eq!(bpm_hint_from_name("Warehouse_bpm_135.wav"), Some(135.0));
         assert_eq!(bpm_hint_from_name("recorded_2026_take_04.wav"), None);
+        assert_eq!(bpm_hint_from_name("Loop_90_bpm_128.wav"), Some(128.0));
     }
 
     #[test]
-    fn unrelated_filename_number_does_not_force_a_bad_grid_fit() {
+    fn unrelated_filename_number_does_not_discard_audio_evidence() {
         let audio = exact_loop(2.0, 124.0);
-        assert_eq!(
-            fit_loop_tempo(
-                audio.num_frames(),
-                audio.sample_rate as f64,
-                "catalogue_100_bass.wav",
-                Some(124.0),
-            ),
-            None
-        );
+        let fit = fit_loop_tempo(
+            audio.num_frames(),
+            audio.sample_rate as f64,
+            "catalogue_100_bass.wav",
+            Some(124.0),
+        )
+        .unwrap();
+
+        assert_eq!(fit.bars, 2);
+        assert!((fit.source_bpm - 124.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn production_loop_tail_does_not_invalidate_a_filename_tempo() {
+        let exact = exact_loop(4.0, 128.0);
+        let frames_with_tail = exact.num_frames() + (SR as usize * 60 / 128);
+        let fit =
+            fit_loop_tempo(frames_with_tail, SR as f64, "Warehouse_128_bpm.wav", None).unwrap();
+
+        assert_eq!(fit.bars, 4);
+        assert!((fit.source_bpm - 128.0).abs() < 8.0);
     }
 
     #[test]

--- a/crates/vibez-ui/src/warp.rs
+++ b/crates/vibez-ui/src/warp.rs
@@ -43,69 +43,128 @@ pub struct WarpClipInput {
     pub project_bpm: f64,
 }
 
-/// Deterministic mapping from a clean production loop to the Project grid.
+/// Intrinsic tempo analysis for a clean production loop.
 ///
-/// Browser WARP treats the complete source boundary as musical truth: the
-/// loop is assumed to span one of the conventional 1/2/4/8/16 bar lengths,
-/// and the source BPM is derived from that span. This avoids asking a generic
-/// beat detector to choose between rhythmic subdivisions before the producer
-/// can hear or import the loop.
+/// This deliberately contains no Project tempo. Browser WARP must identify
+/// the source before deciding how long its Project-tempo rendering should be.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LoopGridFit {
     pub bars: u32,
     pub source_bpm: f64,
-    pub target_frames: usize,
+}
+
+impl LoopGridFit {
+    pub fn target_frames(self, sample_rate: f64, project_bpm: f64) -> Option<usize> {
+        if !sample_rate.is_finite()
+            || sample_rate <= 0.0
+            || !project_bpm.is_finite()
+            || project_bpm <= 0.0
+        {
+            return None;
+        }
+        let beats = self.bars as f64 * 4.0;
+        Some((beats * 60.0 / project_bpm * sample_rate).round() as usize)
+    }
 }
 
 const LOOP_GRID_BARS: [u32; 5] = [1, 2, 4, 8, 16];
 const PLAUSIBLE_LOOP_BPM_MIN: f64 = 60.0;
 const PLAUSIBLE_LOOP_BPM_MAX: f64 = 200.0;
 
-/// Fit a complete source loop to the conventional Project bar span that
-/// requires the least time stretching. Candidates in a practical production
-/// tempo range win over half/double-time interpretations outside that range.
-/// Audio with no plausible interpretation is treated as a one-shot rather
-/// than being stretched into an arbitrary bar length.
-pub fn fit_loop_to_project(
+/// Extract a conventional tempo token from a production-loop filename.
+/// Explicit `124bpm`/`bpm124` tokens win; otherwise a delimiter-separated
+/// number in the supported loop range is accepted.
+pub fn bpm_hint_from_name(name: &str) -> Option<f64> {
+    let stem = std::path::Path::new(name)
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_ascii_lowercase();
+    let tokens: Vec<&str> = stem
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '.')
+        .filter(|token| !token.is_empty())
+        .collect();
+    let plausible = |value: f64| {
+        value.is_finite() && (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(&value)
+    };
+
+    for (index, token) in tokens.iter().enumerate() {
+        let marked = token
+            .strip_suffix("bpm")
+            .or_else(|| token.strip_prefix("bpm"))
+            .and_then(|number| number.parse::<f64>().ok())
+            .filter(|value| plausible(*value));
+        if marked.is_some() {
+            return marked;
+        }
+        if token.eq_ignore_ascii_case("bpm") {
+            let adjacent = index
+                .checked_sub(1)
+                .and_then(|previous| tokens[previous].parse::<f64>().ok())
+                .or_else(|| tokens.get(index + 1)?.parse::<f64>().ok())
+                .filter(|value| plausible(*value));
+            if adjacent.is_some() {
+                return adjacent;
+            }
+        }
+    }
+
+    tokens
+        .into_iter()
+        .filter_map(|token| token.parse::<f64>().ok())
+        .find(|value| plausible(*value))
+}
+
+/// Fit a complete source loop to a conventional 1/2/4/8/16 bar span.
+/// Filename and audio-analysis evidence resolve half/double-time ambiguity.
+/// The stable 120 BPM preference is only a final fallback, so the result can
+/// never change when the Project tempo changes.
+pub fn fit_loop_tempo(
     source_frames: usize,
     sample_rate: f64,
-    project_bpm: f64,
+    source_name: &str,
+    detected_bpm: Option<f64>,
 ) -> Option<LoopGridFit> {
-    if source_frames == 0
-        || !sample_rate.is_finite()
-        || sample_rate <= 0.0
-        || !project_bpm.is_finite()
-        || project_bpm <= 0.0
-    {
+    if source_frames == 0 || !sample_rate.is_finite() || sample_rate <= 0.0 {
         return None;
     }
 
     let source_seconds = source_frames as f64 / sample_rate;
-    let candidates = LOOP_GRID_BARS.map(|bars| {
-        let beats = bars as f64 * 4.0;
-        let source_bpm = beats * 60.0 / source_seconds;
-        let target_frames = (beats * 60.0 / project_bpm * sample_rate).round() as usize;
-        let stretch_distance = (target_frames as f64 / source_frames as f64).ln().abs();
-        (
-            LoopGridFit {
-                bars,
-                source_bpm,
-                target_frames,
-            },
-            stretch_distance,
-        )
+    let name_hint = bpm_hint_from_name(source_name);
+    let reference_bpm = name_hint
+        .or_else(|| detected_bpm.filter(|bpm| bpm.is_finite() && *bpm > 0.0))
+        .unwrap_or(120.0);
+    let candidates = LOOP_GRID_BARS.map(|bars| LoopGridFit {
+        bars,
+        source_bpm: bars as f64 * 4.0 * 60.0 / source_seconds,
     });
-    candidates
+    let fit = candidates
         .into_iter()
-        .filter(|(fit, _)| {
-            (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(&fit.source_bpm)
-        })
+        .filter(|fit| (PLAUSIBLE_LOOP_BPM_MIN..=PLAUSIBLE_LOOP_BPM_MAX).contains(&fit.source_bpm))
         .min_by(|left, right| {
-            left.1
-                .partial_cmp(&right.1)
+            (left.source_bpm / reference_bpm)
+                .ln()
+                .abs()
+                .partial_cmp(&(right.source_bpm / reference_bpm).ln().abs())
                 .unwrap_or(std::cmp::Ordering::Equal)
-        })
-        .map(|(fit, _)| fit)
+        })?;
+    // A filename BPM is strong evidence only when the complete source length
+    // agrees with it. This rejects unrelated catalogue/take numbers instead
+    // of forcing them into the nearest musical bar count.
+    if name_hint.is_some_and(|hint| (fit.source_bpm / hint).ln().abs() > 1.05_f64.ln()) {
+        return None;
+    }
+    Some(fit)
+}
+
+pub fn analyse_loop_tempo(audio: &DecodedAudio, source_name: &str) -> Option<LoopGridFit> {
+    let detected = vibez_core::onset::detect_bpm(audio, audio.sample_rate).map(|value| value.bpm);
+    fit_loop_tempo(
+        audio.num_frames(),
+        audio.sample_rate as f64,
+        source_name,
+        detected,
+    )
 }
 
 /// Deterministic warped length for a clip: the naive proportional
@@ -246,7 +305,7 @@ mod tests {
     }
 
     #[test]
-    fn grid_fit_derives_clean_loop_tempo_from_its_project_bar_span() {
+    fn grid_fit_derives_clean_loop_tempo_from_source_evidence() {
         let cases = [
             (2.0, 120.0, 120.0),
             (1.0, 122.0, 122.0),
@@ -259,31 +318,80 @@ mod tests {
 
         for (bars, source_bpm, expected_bpm) in cases {
             let audio = exact_loop(bars, source_bpm);
-            let fit = fit_loop_to_project(audio.num_frames(), audio.sample_rate as f64, 120.0)
+            let name = format!("loop_{source_bpm}_bpm.wav");
+            let fit = fit_loop_tempo(audio.num_frames(), audio.sample_rate as f64, &name, None)
                 .expect("valid audio and project tempo must always produce a grid fit");
 
             assert_eq!(fit.bars, bars as u32);
             assert!((fit.source_bpm - expected_bpm).abs() < 0.01);
             let expected_frames = (bars * 4.0 * 60.0 / 120.0 * SR as f64).round() as usize;
-            assert_eq!(fit.target_frames, expected_frames);
+            assert_eq!(fit.target_frames(SR as f64, 120.0), Some(expected_frames));
         }
     }
 
     #[test]
-    fn grid_fit_uses_a_plausible_source_octave_when_project_tempo_is_far_away() {
-        let audio = exact_loop(4.0, 120.0);
-        let fit = fit_loop_to_project(audio.num_frames(), audio.sample_rate as f64, 174.0).unwrap();
+    fn source_tempo_does_not_change_with_the_project_tempo() {
+        let audio = exact_loop(2.0, 124.0);
+        let fit = fit_loop_tempo(
+            audio.num_frames(),
+            audio.sample_rate as f64,
+            "US_DDH_Bass_124_Expectation_Fm.wav",
+            Some(160.0),
+        )
+        .unwrap();
 
-        assert_eq!(fit.bars, 4);
-        assert!((fit.source_bpm - 120.0).abs() < 0.01);
+        assert_eq!(fit.bars, 2);
+        assert!((fit.source_bpm - 124.0).abs() < 0.01);
+        assert_eq!(fit.target_frames(SR as f64, 80.0), Some(264_600));
+        assert_eq!(fit.target_frames(SR as f64, 160.0), Some(132_300));
     }
 
     #[test]
     fn grid_fit_rejects_a_one_shot_with_no_plausible_loop_tempo() {
         assert_eq!(
-            fit_loop_to_project(SR as usize / 20, SR as f64, 120.0),
+            fit_loop_tempo(SR as usize / 20, SR as f64, "hit.wav", None),
             None
         );
+    }
+
+    #[test]
+    fn filename_bpm_hint_understands_common_sample_pack_names() {
+        assert_eq!(
+            bpm_hint_from_name("US_DDH_Bass_124_Expectation_Fm.wav"),
+            Some(124.0)
+        );
+        assert_eq!(bpm_hint_from_name("Warehouse 128bpm.wav"), Some(128.0));
+        assert_eq!(bpm_hint_from_name("Warehouse_bpm_135.wav"), Some(135.0));
+        assert_eq!(bpm_hint_from_name("recorded_2026_take_04.wav"), None);
+    }
+
+    #[test]
+    fn unrelated_filename_number_does_not_force_a_bad_grid_fit() {
+        let audio = exact_loop(2.0, 124.0);
+        assert_eq!(
+            fit_loop_tempo(
+                audio.num_frames(),
+                audio.sample_rate as f64,
+                "catalogue_100_bass.wav",
+                Some(124.0),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn audio_estimate_resolves_the_grid_without_a_filename_hint() {
+        let audio = exact_loop(2.0, 124.0);
+        let fit = fit_loop_tempo(
+            audio.num_frames(),
+            audio.sample_rate as f64,
+            "Expectation_Fm.wav",
+            Some(160.0),
+        )
+        .unwrap();
+
+        assert_eq!(fit.bars, 2);
+        assert!((fit.source_bpm - 124.0).abs() < 0.01);
     }
 
     fn first_warp_input(


### PR DESCRIPTION
## What changed

- derive a loop tempo from its source boundary, filename BPM hint, and existing onset analysis
- remove Project BPM from the source-tempo fitting API
- analyse local previews off the UI thread and reuse revision-matched remote derived metadata for both audition and import
- cache one intrinsic loop fit for Audition, drag previews, BPM display, and imports
- ignore filename tempo hints that disagree with the complete source length and fall back to audio evidence
- align onset octave folding and loop fitting at a 200 BPM upper bound

## Why

The old fit selected whichever bar count required the least stretching toward the current Project tempo. A real two-bar 124 BPM UNDGRND loop was therefore interpreted as one bar at 62 BPM in an 80 BPM Project. Source identity must not change with Project tempo.

The onset fold upper bound moves from 180 to 200 BPM. Existing cached remote analysis at roughly 181 to 200 BPM can retain its previous half-time value until that provider revision is rematerialized. Audition and import intentionally share that revision-matched cached value, so a sample never changes tempo between preview and placement.

## Verification

- cargo test --workspace
- cargo clippy --workspace --all-targets --exclude vibez-plugin-host -- -D warnings
- cargo fmt --all -- --check
- regression covers the reproduced 170,710-frame, 44.1 kHz, two-bar 124 BPM sample shape at both 80 and 160 BPM Project tempos
- regression covers a cached 95 BPM remote audition importing at the same tempo even when fresh analysis detects 190 BPM