### PR TITLE
refactor(clips): centralize playback timeline geometry

### DIFF
--- a/crates/vibez-core/src/clip_timeline.rs
+++ b/crates/vibez-core/src/clip_timeline.rs
@@ -1,0 +1,363 @@
+//! Clip-local playback geometry shared by audio, MIDI, engine, and UI.
+
+/// Playback geometry measured in source frames.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameClipTimeline {
+    pub start: u64,
+    pub loop_start: u64,
+    pub loop_end: u64,
+    pub duration: u64,
+    pub loop_enabled: bool,
+}
+
+impl FrameClipTimeline {
+    pub const MIN_START_GAP: u64 = 1;
+
+    pub const fn new(
+        start: u64,
+        loop_start: u64,
+        loop_end: u64,
+        duration: u64,
+        loop_enabled: bool,
+    ) -> Self {
+        Self {
+            start,
+            loop_start,
+            loop_end,
+            duration,
+            loop_enabled,
+        }
+    }
+
+    pub fn is_looping(self) -> bool {
+        self.has_loop_region() && self.start < self.loop_end
+    }
+
+    fn has_loop_region(self) -> bool {
+        self.loop_enabled && self.loop_end > self.loop_start
+    }
+
+    pub fn source_at(self, play_position: u64) -> u64 {
+        let raw = self.start.saturating_add(play_position);
+        if self.is_looping() && raw >= self.loop_end {
+            self.loop_start + (raw - self.loop_end) % (self.loop_end - self.loop_start)
+        } else {
+            raw
+        }
+    }
+
+    pub fn first_wrap(self) -> Option<u64> {
+        self.is_looping().then(|| self.loop_end - self.start)
+    }
+
+    pub fn wraps(self) -> FrameOccurrences {
+        FrameOccurrences {
+            initial: None,
+            next_repeat: self
+                .first_wrap()
+                .filter(|position| *position < self.duration),
+            repeat_length: self.loop_end.saturating_sub(self.loop_start),
+            duration: self.duration,
+        }
+    }
+
+    pub fn occurrences_of(self, source_position: u64) -> FrameOccurrences {
+        let initial = (source_position >= self.start
+            && (!self.is_looping() || source_position < self.loop_end))
+            .then(|| source_position - self.start)
+            .filter(|position| *position < self.duration);
+        let repeat = (self.is_looping()
+            && source_position >= self.loop_start
+            && source_position < self.loop_end)
+            .then(|| self.loop_end - self.start + source_position - self.loop_start)
+            .filter(|position| *position < self.duration);
+        FrameOccurrences {
+            initial,
+            next_repeat: repeat,
+            repeat_length: self.loop_end.saturating_sub(self.loop_start),
+            duration: self.duration,
+        }
+    }
+
+    pub fn clamp_start(self, candidate: u64, source_start: u64, source_end: u64) -> u64 {
+        self.clamp_start_with_gap(candidate, source_start, source_end, Self::MIN_START_GAP)
+    }
+
+    pub fn clamp_start_with_gap(
+        self,
+        candidate: u64,
+        source_start: u64,
+        source_end: u64,
+        minimum_gap: u64,
+    ) -> u64 {
+        let marker_end = if self.loop_enabled {
+            source_end.min(self.loop_end)
+        } else {
+            source_end
+        };
+        candidate.clamp(
+            source_start,
+            marker_end
+                .saturating_sub(minimum_gap.max(Self::MIN_START_GAP))
+                .max(source_start),
+        )
+    }
+
+    pub fn accepts_start(self, candidate: u64, source_start: u64, source_end: u64) -> bool {
+        candidate == self.clamp_start(candidate, source_start, source_end)
+            && candidate < source_end
+            && (!self.loop_enabled || candidate < self.loop_end)
+    }
+}
+
+pub struct FrameOccurrences {
+    initial: Option<u64>,
+    next_repeat: Option<u64>,
+    repeat_length: u64,
+    duration: u64,
+}
+
+impl FrameOccurrences {
+    pub fn starting_after(mut self, boundary: u64) -> Self {
+        if self.initial.is_some_and(|position| position <= boundary) {
+            self.initial = None;
+        }
+        if let Some(next) = self.next_repeat {
+            if next <= boundary && self.repeat_length > 0 {
+                let skipped = (boundary - next) / self.repeat_length + 1;
+                self.next_repeat = next.checked_add(skipped.saturating_mul(self.repeat_length));
+            }
+        }
+        self
+    }
+}
+
+impl Iterator for FrameOccurrences {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(initial) = self.initial.take() {
+            return Some(initial);
+        }
+        let current = self
+            .next_repeat
+            .filter(|position| *position < self.duration)?;
+        self.next_repeat = current.checked_add(self.repeat_length);
+        Some(current)
+    }
+}
+
+/// Playback geometry measured in musical beats.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BeatClipTimeline {
+    pub start: f64,
+    pub loop_start: f64,
+    pub loop_end: f64,
+    pub duration: f64,
+    pub loop_enabled: bool,
+}
+
+impl BeatClipTimeline {
+    pub const MIN_START_GAP: f64 = 0.01;
+
+    pub const fn new(
+        start: f64,
+        loop_start: f64,
+        loop_end: f64,
+        duration: f64,
+        loop_enabled: bool,
+    ) -> Self {
+        Self {
+            start,
+            loop_start,
+            loop_end,
+            duration,
+            loop_enabled,
+        }
+    }
+
+    pub fn is_looping(self) -> bool {
+        self.has_loop_region() && self.start.is_finite() && self.start < self.loop_end
+    }
+
+    fn has_loop_region(self) -> bool {
+        self.loop_enabled
+            && self.loop_end.is_finite()
+            && self.loop_start.is_finite()
+            && self.loop_end > self.loop_start
+    }
+
+    pub fn source_at(self, play_position: f64) -> f64 {
+        let raw = self.start + play_position;
+        if self.is_looping() && raw >= self.loop_end {
+            self.loop_start + (raw - self.loop_end) % (self.loop_end - self.loop_start)
+        } else {
+            raw
+        }
+    }
+
+    pub fn first_wrap(self) -> Option<f64> {
+        self.is_looping().then_some(self.loop_end - self.start)
+    }
+
+    pub fn wraps(self) -> BeatOccurrences {
+        BeatOccurrences {
+            initial: None,
+            next_repeat: self
+                .first_wrap()
+                .filter(|position| *position < self.duration),
+            repeat_length: self.loop_end - self.loop_start,
+            duration: self.duration,
+        }
+    }
+
+    pub fn occurrences_of(self, source_position: f64) -> BeatOccurrences {
+        let valid_source = source_position.is_finite() && source_position >= 0.0;
+        let initial = (valid_source
+            && source_position >= self.start
+            && (!self.is_looping() || source_position < self.loop_end))
+            .then_some(source_position - self.start)
+            .filter(|position| *position >= 0.0 && *position < self.duration);
+        let repeat = (valid_source
+            && self.is_looping()
+            && source_position >= self.loop_start
+            && source_position < self.loop_end)
+            .then_some(self.loop_end - self.start + source_position - self.loop_start)
+            .filter(|position| *position >= 0.0 && *position < self.duration);
+        BeatOccurrences {
+            initial,
+            next_repeat: repeat,
+            repeat_length: self.loop_end - self.loop_start,
+            duration: self.duration,
+        }
+    }
+
+    pub fn clamp_start(self, candidate: f64, source_start: f64, source_end: f64) -> f64 {
+        self.clamp_start_with_gap(candidate, source_start, source_end, Self::MIN_START_GAP)
+    }
+
+    pub fn clamp_start_with_gap(
+        self,
+        candidate: f64,
+        source_start: f64,
+        source_end: f64,
+        minimum_gap: f64,
+    ) -> f64 {
+        let marker_end = if self.loop_enabled && self.loop_end.is_finite() {
+            source_end.min(self.loop_end)
+        } else {
+            source_end
+        };
+        candidate.clamp(
+            source_start,
+            (marker_end - minimum_gap.max(Self::MIN_START_GAP)).max(source_start),
+        )
+    }
+
+    pub fn accepts_start(self, candidate: f64, source_start: f64, source_end: f64) -> bool {
+        candidate.is_finite()
+            && candidate == self.clamp_start(candidate, source_start, source_end)
+            && candidate < source_end
+            && (!self.loop_enabled || candidate < self.loop_end)
+    }
+}
+
+pub struct BeatOccurrences {
+    initial: Option<f64>,
+    next_repeat: Option<f64>,
+    repeat_length: f64,
+    duration: f64,
+}
+
+impl BeatOccurrences {
+    pub fn starting_after(mut self, boundary: f64) -> Self {
+        if self.initial.is_some_and(|position| position <= boundary) {
+            self.initial = None;
+        }
+        if let Some(next) = self.next_repeat {
+            if next <= boundary && self.repeat_length > 0.0 {
+                let skipped = ((boundary - next) / self.repeat_length).floor() + 1.0;
+                self.next_repeat = Some(next + skipped * self.repeat_length);
+            }
+        }
+        self
+    }
+}
+
+impl Iterator for BeatOccurrences {
+    type Item = f64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(initial) = self.initial.take() {
+            return Some(initial);
+        }
+        let current = self
+            .next_repeat
+            .filter(|position| *position < self.duration)?;
+        self.next_repeat = Some(current + self.repeat_length);
+        Some(current)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intro_plays_once_then_the_loop_repeats() {
+        let frames = FrameClipTimeline::new(20, 10, 30, 50, true);
+        assert_eq!(
+            (0..7).map(|i| frames.source_at(i * 10)).collect::<Vec<_>>(),
+            [20, 10, 20, 10, 20, 10, 20]
+        );
+        assert_eq!(frames.occurrences_of(10).collect::<Vec<_>>(), [10, 30]);
+
+        let beats = BeatClipTimeline::new(2.0, 1.0, 3.0, 5.0, true);
+        assert_eq!(beats.occurrences_of(1.0).collect::<Vec<_>>(), [1.0, 3.0]);
+        assert_eq!(
+            beats.occurrences_of(2.0).collect::<Vec<_>>(),
+            [0.0, 2.0, 4.0]
+        );
+    }
+
+    #[test]
+    fn frame_and_beat_flavours_share_the_same_integer_geometry() {
+        let frames = FrameClipTimeline::new(2, 1, 4, 12, true);
+        let beats = BeatClipTimeline::new(2.0, 1.0, 4.0, 12.0, true);
+        for play_position in 0..12 {
+            assert_eq!(
+                frames.source_at(play_position) as f64,
+                beats.source_at(play_position as f64)
+            );
+        }
+        for source_position in 0..4 {
+            let frame_occurrences = frames
+                .occurrences_of(source_position)
+                .map(|position| position as f64)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                frame_occurrences,
+                beats
+                    .occurrences_of(source_position as f64)
+                    .collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn ranged_occurrences_jump_without_scanning_previous_repeats() {
+        let beats = BeatClipTimeline::new(0.0, 0.0, 1.0, 1000.0, true);
+        assert_eq!(
+            beats.occurrences_of(0.25).starting_after(998.0).next(),
+            Some(998.25)
+        );
+    }
+
+    #[test]
+    fn clamp_start_uses_each_flavours_native_minimum_gap() {
+        let frames = FrameClipTimeline::new(0, 0, 100, 100, true);
+        assert_eq!(frames.clamp_start(100, 0, 100), 99);
+        let beats = BeatClipTimeline::new(0.0, 0.0, 4.0, 4.0, true);
+        assert_eq!(beats.clamp_start(4.0, 0.0, 4.0), 3.99);
+    }
+}

--- a/crates/vibez-core/src/lib.rs
+++ b/crates/vibez-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod audio_buffer;
 pub mod audio_format;
 pub mod automation;
+pub mod clip_timeline;
 pub mod constants;
 pub mod effect;
 pub mod id;

--- a/crates/vibez-core/src/midi.rs
+++ b/crates/vibez-core/src/midi.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::clip_timeline::BeatClipTimeline;
 use crate::id::{ClipId, TrackId};
 use crate::perform::GrooveGrid;
 
@@ -46,14 +47,15 @@ impl NoteClipInfo {
     /// Resolve the persisted Start marker into the playable clip window.
     /// Legacy projects begin at Loop Start, matching pre-marker playback.
     pub fn resolved_start_marker_beats(&self) -> f64 {
-        let marker_end = if self.loop_enabled {
-            self.duration_beats.min(self.loop_end_beats)
-        } else {
-            self.duration_beats
-        };
-        self.start_marker_beats
-            .unwrap_or(self.loop_start_beats)
-            .clamp(0.0, (marker_end - 0.01).max(0.0))
+        let start = self.start_marker_beats.unwrap_or(self.loop_start_beats);
+        BeatClipTimeline::new(
+            start,
+            self.loop_start_beats,
+            self.loop_end_beats,
+            self.duration_beats,
+            self.loop_enabled,
+        )
+        .clamp_start(start, 0.0, self.duration_beats)
     }
 }
 

--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::clip_timeline::FrameClipTimeline;
 use crate::effect::EffectInfo;
 use crate::id::{ClipId, TrackId};
 use crate::midi::{InstrumentKind, TrackKind};
@@ -408,14 +409,17 @@ impl ClipInfo {
             .source_offset
             .saturating_add(self.duration)
             .min(source_frames);
-        let marker_end = if self.loop_enabled {
-            source_end.min(self.loop_end)
-        } else {
-            source_end
-        };
-        self.start_marker.unwrap_or(self.source_offset).clamp(
+        FrameClipTimeline::new(
+            self.start_marker.unwrap_or(self.source_offset),
+            self.loop_start,
+            self.loop_end,
+            self.duration,
+            self.loop_enabled,
+        )
+        .clamp_start(
+            self.start_marker.unwrap_or(self.source_offset),
             self.source_offset,
-            marker_end.saturating_sub(1).max(self.source_offset),
+            source_end,
         )
     }
 

--- a/crates/vibez-engine/src/mixer/groove.rs
+++ b/crates/vibez-engine/src/mixer/groove.rs
@@ -54,18 +54,12 @@ pub(super) fn collect_timed_note_events(
         }
 
         let local_at_start = (first_beat - clip_start).max(0.0);
-        let looping = clip.loop_enabled && clip.loop_end_beats > clip.loop_start_beats;
-        let raw_at_start = clip.start_marker_beats + local_at_start;
-        let effective_at_start = if looping && raw_at_start >= clip.loop_end_beats {
-            let loop_len = clip.loop_end_beats - clip.loop_start_beats;
-            clip.loop_start_beats + (raw_at_start - clip.loop_end_beats) % loop_len
-        } else {
-            raw_at_start
-        };
+        let timeline = clip.timeline();
+        let effective_at_start = timeline.source_at(local_at_start);
         let entering_clip = previous_beat < clip_start;
         let clip_swing = clip.swing_for_pair(effective_at_start, swing, entering_clip);
 
-        if looping {
+        if timeline.is_looping() {
             collect_looping_clip_events(
                 clip,
                 previous_beat - clip_start,
@@ -79,8 +73,10 @@ pub(super) fn collect_timed_note_events(
             );
         } else {
             for (note_index, note) in clip.notes.iter().enumerate() {
-                let start = mapped_note_start(clip, note, clip_swing) - clip.start_marker_beats;
-                if start >= 0.0 && start < clip.duration_beats {
+                if let Some(start) = timeline
+                    .occurrences_of(mapped_note_start(clip, note, clip_swing))
+                    .next()
+                {
                     push_note_on(
                         clip_start + start,
                         note,
@@ -90,8 +86,10 @@ pub(super) fn collect_timed_note_events(
                         note_ons,
                     );
                 }
-                let end = mapped_note_end(clip, note_index, clip_swing) - clip.start_marker_beats;
-                if end >= 0.0 && end < clip.duration_beats {
+                if let Some(end) = timeline
+                    .occurrences_of(mapped_note_end(clip, note_index, clip_swing))
+                    .next()
+                {
                     push_note_off(
                         clip_start + end,
                         note.pitch,
@@ -129,125 +127,58 @@ fn collect_looping_clip_events(
     note_ons: &mut Vec<(u32, u8, u8)>,
     note_offs: &mut Vec<(u32, u8)>,
 ) {
-    let loop_start = clip.loop_start_beats;
-    let loop_end = clip.loop_end_beats;
-    let loop_len = loop_end - loop_start;
+    let timeline = clip.timeline();
 
     for (note_index, note) in clip.notes.iter().enumerate() {
         let start = mapped_note_start(clip, note, swing);
-        for_each_loop_occurrence(
-            start,
-            clip.duration_beats,
-            clip.start_marker_beats,
-            loop_start,
-            loop_end,
-            loop_len,
-            previous_local,
-            last_local,
-            |local| {
-                push_note_on(
+        for local in timeline
+            .occurrences_of(start)
+            .starting_after(previous_local)
+            .take_while(|local| *local <= last_local)
+        {
+            push_note_on(
+                clip.position_beats + local,
+                note,
+                pos,
+                frames,
+                samples_per_beat,
+                note_ons,
+            );
+        }
+
+        let end = mapped_note_end(clip, note_index, swing);
+        if end < timeline.loop_end {
+            for local in timeline
+                .occurrences_of(end)
+                .starting_after(previous_local)
+                .take_while(|local| *local <= last_local)
+            {
+                push_note_off(
                     clip.position_beats + local,
-                    note,
+                    note.pitch,
                     pos,
                     frames,
                     samples_per_beat,
-                    note_ons,
+                    note_offs,
                 );
-            },
-        );
-
-        let end = mapped_note_end(clip, note_index, swing);
-        if end < loop_end {
-            for_each_loop_occurrence(
-                end,
-                clip.duration_beats,
-                clip.start_marker_beats,
-                loop_start,
-                loop_end,
-                loop_len,
-                previous_local,
-                last_local,
-                |local| {
-                    push_note_off(
-                        clip.position_beats + local,
-                        note.pitch,
-                        pos,
-                        frames,
-                        samples_per_beat,
-                        note_offs,
-                    );
-                },
-            );
+            }
         }
     }
 
     // The previous renderer flushed all pitches at each loop wrap before
     // retriggering notes at loop_start on the same frame.
-    for_each_repetition(
-        loop_end - clip.start_marker_beats,
-        loop_len,
-        clip.duration_beats,
-        previous_local,
-        last_local,
-        |local| {
-            if let Some(frame) =
-                frame_for_beat(clip.position_beats + local, pos, frames, samples_per_beat)
-            {
-                for note in &clip.notes {
-                    note_offs.push((frame, note.pitch));
-                }
+    for local in timeline
+        .wraps()
+        .starting_after(previous_local)
+        .take_while(|local| *local <= last_local)
+    {
+        if let Some(frame) =
+            frame_for_beat(clip.position_beats + local, pos, frames, samples_per_beat)
+        {
+            for note in &clip.notes {
+                note_offs.push((frame, note.pitch));
             }
-        },
-    );
-}
-
-#[allow(clippy::too_many_arguments)]
-fn for_each_loop_occurrence(
-    event: f64,
-    clip_duration: f64,
-    start_marker: f64,
-    loop_start: f64,
-    loop_end: f64,
-    loop_len: f64,
-    previous_local: f64,
-    last_local: f64,
-    mut visit: impl FnMut(f64),
-) {
-    if event < 0.0 || event >= loop_end {
-        return;
-    }
-    if event >= start_marker {
-        let initial = event - start_marker;
-        if initial < clip_duration && previous_local < initial && initial <= last_local {
-            visit(initial);
         }
-    }
-    if event >= loop_start {
-        let first_repeat = loop_end - start_marker + event - loop_start;
-        for_each_repetition(
-            first_repeat,
-            loop_len,
-            clip_duration,
-            previous_local,
-            last_local,
-            visit,
-        );
-    }
-}
-
-fn for_each_repetition(
-    first: f64,
-    step: f64,
-    clip_duration: f64,
-    previous_local: f64,
-    last_local: f64,
-    mut visit: impl FnMut(f64),
-) {
-    let first_index = (((previous_local - first) / step).floor() as i64 + 1).max(0);
-    let mut event = first + first_index as f64 * step;
-    while event < clip_duration && event <= last_local {
-        visit(event);
-        event += step;
     }
 }
 

--- a/crates/vibez-engine/src/playback_source.rs
+++ b/crates/vibez-engine/src/playback_source.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::automation::AutomationLane;
+use vibez_core::clip_timeline::{BeatClipTimeline, FrameClipTimeline};
 use vibez_core::id::{ClipId, SectionId, TrackId};
 use vibez_core::midi::MidiNote;
 use vibez_core::perform::GrooveGrid;
@@ -44,6 +45,16 @@ pub struct EngineClip {
 }
 
 impl EngineClip {
+    pub fn timeline(&self) -> FrameClipTimeline {
+        FrameClipTimeline::new(
+            self.start_marker,
+            self.loop_start,
+            self.loop_end,
+            self.duration,
+            self.loop_enabled,
+        )
+    }
+
     pub fn end_position(&self) -> u64 {
         self.position.saturating_add(self.duration)
     }
@@ -96,6 +107,16 @@ impl EngineNoteClip {
             next_same_pitch_start_beats,
             groove_latch: Cell::new(None),
         }
+    }
+
+    pub fn timeline(&self) -> BeatClipTimeline {
+        BeatClipTimeline::new(
+            self.start_marker_beats,
+            self.loop_start_beats,
+            self.loop_end_beats,
+            self.duration_beats,
+            self.loop_enabled,
+        )
     }
 
     #[inline]
@@ -341,17 +362,7 @@ impl PreparedPlaybackSource {
                     continue;
                 }
                 let clip_frame = (global_frame - clip.position) as usize;
-                let source_frame = if clip.loop_enabled && clip.loop_end > clip.loop_start {
-                    let raw = clip.start_marker as usize + clip_frame;
-                    let loop_len = (clip.loop_end - clip.loop_start) as usize;
-                    if raw >= clip.loop_end as usize {
-                        clip.loop_start as usize + (raw - clip.loop_start as usize) % loop_len
-                    } else {
-                        raw
-                    }
-                } else {
-                    clip.start_marker as usize + clip_frame
-                };
+                let source_frame = clip.timeline().source_at(clip_frame as u64) as usize;
                 for ch in 0..channels {
                     let sample = if source_frame >= source_end {
                         0.0

--- a/crates/vibez-ui/src/domains/arrangement/audio_clip_inspector.rs
+++ b/crates/vibez-ui/src/domains/arrangement/audio_clip_inspector.rs
@@ -233,7 +233,7 @@ impl TimelineEditorState {
                 }
                 clip.source_offset = new_start;
                 clip.duration = new_end - new_start;
-                clip.start_marker = clip.start_marker.clamp(new_start, new_end - 1);
+                clip.clamp_start_to_source();
                 clip.loop_start = clip.loop_start.clamp(new_start, new_end);
                 clip.loop_end = clip.loop_end.clamp(clip.loop_start, new_end);
                 if clip.loop_enabled

--- a/crates/vibez-ui/src/domains/arrangement/clipboard.rs
+++ b/crates/vibez-ui/src/domains/arrangement/clipboard.rs
@@ -140,18 +140,7 @@ impl TimelineEditorState {
                     let mut fragment = clip.clone();
                     fragment.position = 0;
                     fragment.duration = duration.max(1);
-                    let raw_offset = clip.start_marker.saturating_add(delta);
-                    fragment.source_offset = if clip.loop_enabled && clip.loop_end > clip.loop_start
-                    {
-                        if raw_offset >= clip.loop_end {
-                            clip.loop_start
-                                + (raw_offset - clip.loop_start) % (clip.loop_end - clip.loop_start)
-                        } else {
-                            raw_offset
-                        }
-                    } else {
-                        raw_offset
-                    };
+                    fragment.source_offset = clip.timeline().source_at(delta);
                     fragment.start_marker = fragment.source_offset;
                     copied.push(ClipboardClip::Audio {
                         track_id: *track_id,

--- a/crates/vibez-ui/src/domains/arrangement/media_ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/media_ops.rs
@@ -20,13 +20,7 @@ use crate::state::{
 use super::*;
 
 fn audio_source_frame(clip: &UiClip, local_frame: u64) -> usize {
-    let raw = clip.start_marker.saturating_add(local_frame);
-    if clip.loop_enabled && clip.loop_end > clip.loop_start && raw >= clip.loop_end {
-        let loop_len = clip.loop_end - clip.loop_start;
-        (clip.loop_start + (raw - clip.loop_start) % loop_len) as usize
-    } else {
-        raw as usize
-    }
+    clip.timeline().source_at(local_frame) as usize
 }
 
 fn visible_notes(clip: &UiNoteClip, local_start: f64, local_end: f64) -> Vec<MidiNote> {
@@ -289,14 +283,7 @@ impl TimelineEditorState {
         if let Some(track) = self.find_content_mut(track_id) {
             if let Some(clip) = track.clips.iter_mut().find(|clip| clip.id == clip_id) {
                 clip.duration = new_duration;
-                let source_end = clip
-                    .source_offset
-                    .saturating_add(clip.duration)
-                    .min(clip.audio.num_frames() as u64);
-                clip.start_marker = clip.start_marker.clamp(
-                    clip.source_offset,
-                    source_end.saturating_sub(1).max(clip.source_offset),
-                );
+                clip.clamp_start_to_source();
                 if clip.loop_enabled {
                     clip.clamp_loop_to_clip();
                 }

--- a/crates/vibez-ui/src/domains/arrangement/ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/ops.rs
@@ -487,9 +487,7 @@ impl TimelineEditorState {
                         .and_then(|t| t.note_clips.iter_mut().find(|c| c.id == clip_id))
                     {
                         clip.duration_beats = (clip.duration_beats + delta).max(0.25);
-                        clip.start_marker_beats = clip
-                            .start_marker_beats
-                            .clamp(0.0, (clip.duration_beats - 0.01).max(0.0));
+                        clip.clamp_start_to_duration();
                         if clip.loop_enabled {
                             clip.clamp_loop_to_duration();
                         }

--- a/crates/vibez-ui/src/domains/perform/capture.rs
+++ b/crates/vibez-ui/src/domains/perform/capture.rs
@@ -659,12 +659,7 @@ fn append_timeline_window(
 }
 
 pub(crate) fn captured_audio_offset(clip: &UiClip, timeline_delta: u64) -> u64 {
-    let raw = clip.start_marker.saturating_add(timeline_delta);
-    if clip.loop_enabled && clip.loop_end > clip.loop_start && raw >= clip.loop_end {
-        clip.loop_start + (raw - clip.loop_start) % (clip.loop_end - clip.loop_start)
-    } else {
-        raw
-    }
+    clip.timeline().source_at(timeline_delta)
 }
 
 pub(crate) fn captured_visible_notes(

--- a/crates/vibez-ui/src/domains/piano_roll.rs
+++ b/crates/vibez-ui/src/domains/piano_roll.rs
@@ -659,9 +659,7 @@ impl PianoRollState {
                 if let Some(track) = find_track_mut(tracks, track_id) {
                     if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
                         clip.duration_beats = new_duration_beats;
-                        clip.start_marker_beats = clip
-                            .start_marker_beats
-                            .clamp(0.0, (new_duration_beats - 0.01).max(0.0));
+                        clip.clamp_start_to_duration();
 
                         // Keep the loop region inside the clip when
                         // shrinking. Extending leaves the region
@@ -728,9 +726,7 @@ impl PianoRollState {
                     if let Some(clip) = track.note_clips.iter_mut().find(|c| c.id == clip_id) {
                         let new_dur = (clip.duration_beats / 2.0).max(0.25);
                         clip.duration_beats = new_dur;
-                        clip.start_marker_beats = clip
-                            .start_marker_beats
-                            .clamp(0.0, (new_dur - 0.01).max(0.0));
+                        clip.clamp_start_to_duration();
                         if clip.loop_enabled {
                             clip.clamp_loop_to_duration();
                         }

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use vibez_core::audio_buffer::DecodedAudio;
+use vibez_core::clip_timeline::{BeatClipTimeline, FrameClipTimeline};
 use vibez_core::effect::{EffectType, ParamDescriptor};
 use vibez_core::id::{ClipId, EffectId, TrackId};
 use vibez_core::midi::{InstrumentKind, MidiNote, TrackKind};
@@ -53,6 +54,16 @@ pub struct UiClip {
 }
 
 impl UiClip {
+    pub(crate) fn timeline(&self) -> FrameClipTimeline {
+        FrameClipTimeline::new(
+            self.start_marker,
+            self.loop_start,
+            self.loop_end,
+            self.duration,
+            self.loop_enabled,
+        )
+    }
+
     pub(crate) fn reset_loop_region_to_clip(&mut self) {
         self.loop_start = self.start_marker;
         self.loop_end = self.source_offset.saturating_add(self.duration);
@@ -72,14 +83,24 @@ impl UiClip {
         }
     }
 
+    pub(crate) fn clamp_start_to_source(&mut self) {
+        let source_end = self
+            .source_offset
+            .saturating_add(self.duration)
+            .min(self.audio.num_frames() as u64);
+        self.start_marker =
+            self.timeline()
+                .clamp_start(self.start_marker, self.source_offset, source_end);
+    }
+
     pub(crate) fn set_start_marker(&mut self, start_marker: u64) -> bool {
         let source_end = self
             .source_offset
             .saturating_add(self.duration)
             .min(self.audio.num_frames() as u64);
-        let valid = start_marker >= self.source_offset
-            && start_marker < source_end
-            && (!self.loop_enabled || start_marker < self.loop_end);
+        let valid = self
+            .timeline()
+            .accepts_start(start_marker, self.source_offset, source_end);
         if !valid || start_marker == self.start_marker {
             return false;
         }
@@ -263,6 +284,16 @@ pub struct UiNoteClip {
 }
 
 impl UiNoteClip {
+    pub(crate) fn timeline(&self) -> BeatClipTimeline {
+        BeatClipTimeline::new(
+            self.start_marker_beats,
+            self.loop_start_beats,
+            self.loop_end_beats,
+            self.duration_beats,
+            self.loop_enabled,
+        )
+    }
+
     pub(crate) fn reset_loop_region_to_clip(&mut self) {
         self.loop_start_beats = self.start_marker_beats;
         self.loop_end_beats = self.duration_beats;
@@ -283,11 +314,16 @@ impl UiNoteClip {
         }
     }
 
+    pub(crate) fn clamp_start_to_duration(&mut self) {
+        self.start_marker_beats =
+            self.timeline()
+                .clamp_start(self.start_marker_beats, 0.0, self.duration_beats);
+    }
+
     pub(crate) fn set_start_marker(&mut self, start_marker_beats: f64) -> bool {
-        let valid = start_marker_beats.is_finite()
-            && start_marker_beats >= 0.0
-            && start_marker_beats < self.duration_beats
-            && (!self.loop_enabled || start_marker_beats < self.loop_end_beats);
+        let valid = self
+            .timeline()
+            .accepts_start(start_marker_beats, 0.0, self.duration_beats);
         if !valid || start_marker_beats == self.start_marker_beats {
             return false;
         }
@@ -312,27 +348,7 @@ impl UiNoteClip {
 
     /// Timeline-local occurrences of one source note onset, including repeats.
     pub(crate) fn note_occurrences(&self, source_beat: f64) -> Vec<f64> {
-        let mut occurrences = Vec::new();
-        let looping = self.loop_enabled && self.loop_end_beats > self.loop_start_beats;
-        if source_beat >= self.start_marker_beats {
-            let initial = source_beat - self.start_marker_beats;
-            if initial >= 0.0
-                && initial < self.duration_beats
-                && (!looping || source_beat < self.loop_end_beats)
-            {
-                occurrences.push(initial);
-            }
-        }
-        if looping && source_beat >= self.loop_start_beats && source_beat < self.loop_end_beats {
-            let loop_length = self.loop_end_beats - self.loop_start_beats;
-            let mut occurrence =
-                self.loop_end_beats - self.start_marker_beats + source_beat - self.loop_start_beats;
-            while occurrence < self.duration_beats {
-                occurrences.push(occurrence);
-                occurrence += loop_length;
-            }
-        }
-        occurrences
+        self.timeline().occurrences_of(source_beat).collect()
     }
 }
 

--- a/crates/vibez-ui/src/widgets/audio_clip_detail.rs
+++ b/crates/vibez-ui/src/widgets/audio_clip_detail.rs
@@ -5,6 +5,7 @@ use iced::widget::canvas;
 use iced::{Color, Point, Rectangle, Renderer, Theme};
 
 use vibez_core::audio_buffer::DecodedAudio;
+use vibez_core::clip_timeline::FrameClipTimeline;
 use vibez_core::id::{ClipId, TrackId};
 
 use crate::domains::arrangement::ArrangementMsg;
@@ -127,13 +128,14 @@ impl AudioClipDetailWidget {
             .source_offset
             .saturating_add(self.x_to_local_frame(x, bounds));
         let source_end = self.source_offset.saturating_add(self.loop_range_frames());
-        let last_source_frame = source_end.saturating_sub(1);
-        let latest = if self.loop_enabled {
-            last_source_frame.min(self.loop_end.saturating_sub(1))
-        } else {
-            last_source_frame
-        };
-        candidate.clamp(self.source_offset, latest.max(self.source_offset))
+        FrameClipTimeline::new(
+            self.start_marker,
+            self.loop_start,
+            self.loop_end,
+            self.duration_samples,
+            self.loop_enabled,
+        )
+        .clamp_start(candidate, self.source_offset, source_end)
     }
 }
 

--- a/crates/vibez-ui/src/widgets/piano_roll/loop_drag.rs
+++ b/crates/vibez-ui/src/widgets/piano_roll/loop_drag.rs
@@ -1,6 +1,7 @@
 //! Loop-brace interaction for the piano roll.
 
 use iced::{Point, Rectangle};
+use vibez_core::clip_timeline::BeatClipTimeline;
 
 use crate::domains::piano_roll::PianoRollMsg;
 use crate::message::Message;
@@ -78,12 +79,14 @@ impl PianoRollWidget {
                 undo_gesture,
             } => {
                 let marker_step = min_length.min(self.total_beats).max(0.01);
-                let latest = if clip.loop_enabled {
-                    self.total_beats.min(clip.loop_end_beats) - marker_step
-                } else {
-                    self.total_beats - marker_step
-                };
-                let start_marker_beats = pointer.clamp(0.0, latest.max(0.0));
+                let start_marker_beats = BeatClipTimeline::new(
+                    clip.start_marker_beats,
+                    clip.loop_start_beats,
+                    clip.loop_end_beats,
+                    self.total_beats,
+                    clip.loop_enabled,
+                )
+                .clamp_start_with_gap(pointer, 0.0, self.total_beats, marker_step);
                 (start_marker_beats != clip.start_marker_beats).then(|| {
                     Message::PianoRoll(PianoRollMsg::SetNoteClipStartMarker {
                         track_id: self.track_id,

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -225,7 +225,7 @@ impl TrackClipCanvas {
                     c.notes
                         .iter()
                         .flat_map(|note| {
-                            let first_repeat = c.loop_end_beats - c.start_marker_beats;
+                            let first_repeat = c.timeline().first_wrap().unwrap_or(f64::INFINITY);
                             c.note_occurrences(note.start_beat)
                                 .into_iter()
                                 .map(move |occurrence| {

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -406,8 +406,8 @@ impl TrackClipCanvas {
                 if looping {
                     let loop_len = note_clip.loop_end_beats - note_clip.loop_start_beats;
                     let repeat_color = theme::with_alpha(self.track_color, 0.2);
-                    let mut repeat_beat = note_clip.position_beats + note_clip.loop_end_beats
-                        - note_clip.start_marker_beats;
+                    let mut repeat_beat =
+                        note_clip.position_beats + note_clip.timeline().first_wrap().unwrap_or(0.0);
                     while repeat_beat < note_clip.position_beats + note_clip.duration_beats {
                         let rx = self.beat_to_x(repeat_beat);
                         let rw = geometry.width_for_beats(loop_len);

--- a/crates/vibez-ui/src/widgets/timeline/mod.rs
+++ b/crates/vibez-ui/src/widgets/timeline/mod.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Weak};
 
+use vibez_core::clip_timeline::BeatClipTimeline;
 use vibez_core::id::ClipId;
 
 // ── Lightweight data types for rendering ──
@@ -38,6 +39,18 @@ pub struct TimelineNoteClip {
     pub loop_enabled: bool,
     pub loop_start_beats: f64,
     pub loop_end_beats: f64,
+}
+
+impl TimelineNoteClip {
+    fn timeline(&self) -> BeatClipTimeline {
+        BeatClipTimeline::new(
+            self.start_marker_beats,
+            self.loop_start_beats,
+            self.loop_end_beats,
+            self.duration_beats,
+            self.loop_enabled,
+        )
+    }
 }
 
 /// Compute waveform peaks for a clip, with loop-aware wrapping.
@@ -83,9 +96,10 @@ pub fn compute_clip_peaks(clip: &crate::state::UiClip) -> Arc<Vec<(f32, f32)>> {
     }
 
     let num_peaks = (clip.duration as usize / 100).clamp(1, 1000);
-    let looping = clip.loop_enabled && clip.loop_end > clip.loop_start;
-    let loop_start = clip.loop_start as usize;
-    let loop_end = clip.loop_end as usize;
+    let timeline = clip.timeline();
+    let looping = timeline.is_looping();
+    let loop_start = timeline.loop_start as usize;
+    let loop_end = timeline.loop_end as usize;
     let loop_len = if looping { loop_end - loop_start } else { 0 };
     let channels = clip.audio.num_channels();
     if channels == 0 {
@@ -118,7 +132,7 @@ pub fn compute_clip_peaks(clip: &crate::state::UiClip) -> Arc<Vec<(f32, f32)>> {
                 let span = cf_end.saturating_sub(cf_start).max(1);
 
                 if !looping {
-                    let src_start = clip.start_marker as usize + cf_start;
+                    let src_start = timeline.source_at(cf_start as u64) as usize;
                     let source_end =
                         clip.source_offset
                             .saturating_add(clip.duration)
@@ -126,24 +140,14 @@ pub fn compute_clip_peaks(clip: &crate::state::UiClip) -> Arc<Vec<(f32, f32)>> {
                     if src_start >= source_end {
                         (0.0, 0.0)
                     } else {
-                        let src_end = (clip.start_marker as usize + cf_end).min(source_end);
+                        let src_end = (timeline.source_at(cf_end as u64) as usize).min(source_end);
                         peak_for_range(src_start, src_end)
                     }
                 } else if span >= loop_len {
                     full_loop_peak.unwrap()
                 } else {
-                    let raw_start = clip.start_marker as usize + cf_start;
-                    let raw_end = clip.start_marker as usize + cf_end;
-                    let src_start = if raw_start >= loop_end {
-                        loop_start + (raw_start - loop_start) % loop_len
-                    } else {
-                        raw_start
-                    };
-                    let src_end = if raw_end >= loop_end {
-                        loop_start + (raw_end - loop_start) % loop_len
-                    } else {
-                        raw_end
-                    };
+                    let src_start = timeline.source_at(cf_start as u64) as usize;
+                    let src_end = timeline.source_at(cf_end as u64) as usize;
 
                     if src_start <= src_end {
                         peak_for_range(src_start, src_end.max(src_start + 1))


### PR DESCRIPTION
## What changed

- adds shared frame and beat clip timeline value objects in `vibez-core`
- centralizes Start, Loop Start, Loop End, wrapping, occurrence placement and marker clamping
- routes audio playback, MIDI scheduling, waveform previews, capture, split and clipboard mapping through the shared geometry
- preserves real-time safety with allocation-free occurrence iterators that can jump directly to the current audio block
- removes the duplicated engine loop traversal helpers

## Why

This is the direct architectural follow-up from the review of #193. Clip timing rules should live in one domain abstraction rather than being repeated across engine and UI call sites.

## Verification

- `cargo test --workspace` (81 core, 230 engine, 609 UI tests passed)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Stacked on #193.