### PR TITLE
feat: add timeline fade handles

### DIFF
--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -91,9 +91,7 @@ impl App {
         let owns_project_transaction = self.begin_project_track_deletion_transaction(&message);
         let deferred_arrangement_project_edit = matches!(
             &message,
-            Message::Arrangement(msg)
-                if msg.is_clipboard_project_edit()
-                    || matches!(msg, ArrangementMsg::SubmitAudioClipInspectorField { .. })
+            Message::Arrangement(msg) if msg.defers_project_edit()
         );
         let should_mark_dirty = matches!(
             &message,
@@ -210,9 +208,7 @@ impl App {
                 self.apply_devices_action(action);
             }
             Message::Arrangement(msg) => {
-                let deferred_snapshot = (msg.is_clipboard_project_edit()
-                    || matches!(msg, ArrangementMsg::SubmitAudioClipInspectorField { .. }))
-                .then(|| self.take_snapshot());
+                let deferred_snapshot = msg.defers_project_edit().then(|| self.take_snapshot());
                 let playhead_beats = self.focused_editor_playhead_beats();
                 let samples_per_beat = if self.state.transport.bpm > 0.0 {
                     60.0 * self.state.transport.sample_rate as f64 / self.state.transport.bpm

--- a/crates/vibez-ui/src/app/update_timeline.rs
+++ b/crates/vibez-ui/src/app/update_timeline.rs
@@ -179,6 +179,7 @@ impl App {
         ctx: ArrangementCtx,
     ) -> ArrangementAction {
         let clipboard_message = msg.is_clipboard_message();
+        let deferred_project_edit = msg.defers_project_edit();
         let section_content_changed = msg.marks_dirty();
         let editing_section = if clipboard_message {
             clipboard_targets_section(
@@ -255,7 +256,11 @@ impl App {
                 ctx,
             );
             self.state.perform.commit_selected_section_timeline();
-            if section_content_changed {
+            if if deferred_project_edit {
+                action.mark_dirty
+            } else {
+                section_content_changed
+            } {
                 if let Some(section_id) = self.state.perform.selected_section {
                     self.refresh_playing_section_after_edit(section_id);
                 }

--- a/crates/vibez-ui/src/app/views_arrangement.rs
+++ b/crates/vibez-ui/src/app/views_arrangement.rs
@@ -342,6 +342,8 @@ impl App {
                         loop_enabled: false,
                         loop_start: 0,
                         loop_end: 0,
+                        fade_in_frames: 0,
+                        fade_out_frames: 0,
                         warp_stale: false,
                     });
             }

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -105,6 +105,12 @@ pub enum ArrangementMsg {
         clip_id: ClipId,
         new_duration: u64,
     },
+    SetAudioClipFade {
+        track_id: TrackId,
+        clip_id: ClipId,
+        edge: crate::state::AudioClipFadeEdge,
+        frames: u64,
+    },
     MoveClipToTrack {
         source_track: TrackId,
         target_track: TrackId,
@@ -233,6 +239,7 @@ impl ArrangementMsg {
                 | Self::MoveAudioClip { .. }
                 | Self::MoveNoteClipPosition { .. }
                 | Self::ResizeAudioClip { .. }
+                | Self::SetAudioClipFade { .. }
                 | Self::MoveClipToTrack { .. }
                 | Self::ToggleClipLoop(..)
                 | Self::SetClipLoopRegion { .. }

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -309,6 +309,16 @@ impl ArrangementMsg {
     pub(crate) const fn is_clipboard_project_edit(&self) -> bool {
         matches!(self, Self::CutSelectedClips | Self::PasteClips)
     }
+
+    /// Edits whose domain result decides whether canonical state changed.
+    /// The app must defer its snapshot and dirty flag until after `update`.
+    pub(crate) const fn defers_project_edit(&self) -> bool {
+        self.is_clipboard_project_edit()
+            || matches!(
+                self,
+                Self::SubmitAudioClipInspectorField { .. } | Self::SetAudioClipFade { .. }
+            )
+    }
 }
 
 /// Cross-domain effects requested by an arrangement update.

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -521,7 +521,7 @@ impl TimelineEditorState {
                     .find_content_mut(track_id)
                     .and_then(|content| content.clips.iter_mut().find(|clip| clip.id == clip_id))
                 {
-                    clip.fades = match edge {
+                    let fades = match edge {
                         crate::state::AudioClipFadeEdge::In => {
                             clip.fades.with_fade_in(frames, clip.duration)
                         }
@@ -529,12 +529,17 @@ impl TimelineEditorState {
                             clip.fades.with_fade_out(frames, clip.duration)
                         }
                     };
+                    if fades == clip.fades {
+                        return ArrangementAction::default();
+                    }
+                    clip.fades = fades;
                     engine.send(EngineCommand::SetClipFades {
                         track_id,
                         clip_id,
-                        fades: clip.fades,
+                        fades,
                     });
                     self.discard_audio_clip_inspector_edits_for(clip_id);
+                    action.mark_dirty = true;
                 }
             }
             ArrangementMsg::MoveClipToTrack {

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -511,6 +511,32 @@ impl TimelineEditorState {
                 self.discard_audio_clip_inspector_edits_for(clip_id);
                 return self.op_resize_audio_clip(engine, ctx, track_id, clip_id, new_duration);
             }
+            ArrangementMsg::SetAudioClipFade {
+                track_id,
+                clip_id,
+                edge,
+                frames,
+            } => {
+                if let Some(clip) = self
+                    .find_content_mut(track_id)
+                    .and_then(|content| content.clips.iter_mut().find(|clip| clip.id == clip_id))
+                {
+                    clip.fades = match edge {
+                        crate::state::AudioClipFadeEdge::In => {
+                            clip.fades.with_fade_in(frames, clip.duration)
+                        }
+                        crate::state::AudioClipFadeEdge::Out => {
+                            clip.fades.with_fade_out(frames, clip.duration)
+                        }
+                    };
+                    engine.send(EngineCommand::SetClipFades {
+                        track_id,
+                        clip_id,
+                        fades: clip.fades,
+                    });
+                    self.discard_audio_clip_inspector_edits_for(clip_id);
+                }
+            }
             ArrangementMsg::MoveClipToTrack {
                 source_track,
                 target_track,

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -765,6 +765,35 @@ fn inspector_fades_commit_in_frames_and_clamp_as_one_pair() {
 }
 
 #[test]
+fn unchanged_timeline_fade_is_not_an_edit() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut a, 0, 0, 44_100);
+    a.tracks[0].clips[0].fades = vibez_core::track::ClipFades::new(11_025, 0, 44_100);
+    let mut engine = RecordingEngine::default();
+
+    let action = a.update(
+        ArrangementMsg::SetAudioClipFade {
+            track_id,
+            clip_id,
+            edge: crate::state::AudioClipFadeEdge::In,
+            frames: 11_025,
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    assert!(!action.mark_dirty);
+    assert!(engine.0.is_empty());
+    assert!(ArrangementMsg::SetAudioClipFade {
+        track_id,
+        clip_id,
+        edge: crate::state::AudioClipFadeEdge::In,
+        frames: 11_025,
+    }
+    .defers_project_edit());
+}
+
+#[test]
 fn inspector_knobs_commit_gain_and_rounded_transpose_values() {
     let mut a = arrangement_with_tracks(1);
     let (tid, cid) = add_audio_clip(&mut a, 0, 0, 44_100);

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -145,6 +145,12 @@ pub enum AudioClipInspectorField {
     Transpose,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioClipFadeEdge {
+    In,
+    Out,
+}
+
 /// Inspector fields that can be controlled by a rotary widget.
 ///
 /// Keeping this narrower than [`AudioClipInspectorField`] makes it impossible

--- a/crates/vibez-ui/src/widgets/timeline/clip_drag.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clip_drag.rs
@@ -1,0 +1,39 @@
+//! Pointer gestures that can own the per-track Clip canvas.
+
+use crate::state::UndoGestureId;
+use vibez_core::id::ClipId;
+
+use super::fade_drag::FadeClipDrag;
+
+#[derive(Debug, Clone)]
+pub enum ClipDragAction {
+    MoveClip {
+        undo_gesture: UndoGestureId,
+        clip_id: ClipId,
+        is_note_clip: bool,
+        start_local_x: f32,
+        start_scroll_beats: f64,
+        original_position_beats: f64,
+        start_y: f32,
+    },
+    ResizeClip {
+        undo_gesture: UndoGestureId,
+        clip_id: ClipId,
+        is_note_clip: bool,
+        clip_start_beat: f64,
+    },
+    FadeClip(FadeClipDrag),
+    PendingSeek {
+        beat: f64,
+        start_x: f32,
+        anchor_column_y: f32,
+    },
+    RegionSelect {
+        anchor_beat: f64,
+        anchor_column_y: f32,
+    },
+    PanViewport {
+        start_local_x: f32,
+        start_scroll_beats: f64,
+    },
+}

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -13,8 +13,8 @@ use crate::domains::transport::TransportMsg;
 use crate::domains::view::ViewMsg;
 use crate::message::Message;
 use crate::state::{
-    ArrangementMarqueeRect, ArrangementSelection, ContextMenuTarget, GridConfig, ProjectTrack,
-    TrackTimelineContent, UndoGestureId,
+    ArrangementMarqueeRect, ArrangementSelection, AudioClipFadeEdge, ContextMenuTarget, GridConfig,
+    ProjectTrack, TrackTimelineContent, UndoGestureId,
 };
 use crate::timeline_geometry::TimelineGeometry;
 use crate::widgets::local_drag::LocalDrag;
@@ -42,6 +42,13 @@ pub enum ClipDragAction {
         is_note_clip: bool,
         clip_start_beat: f64,
     },
+    FadeClip {
+        undo_gesture: UndoGestureId,
+        clip_id: ClipId,
+        edge: AudioClipFadeEdge,
+        clip_start_beat: f64,
+        duration_frames: u64,
+    },
     PendingSeek {
         beat: f64,
         start_x: f32,
@@ -65,6 +72,17 @@ const MARQUEE_MIN_PX: f32 = 4.0;
 /// Vertical travel before a clip drag may change lane. Without it a
 /// horizontal drag near a row boundary would flicker between tracks.
 const CROSS_TRACK_MIN_PX: f32 = 20.0;
+
+pub(super) fn fade_handle_xs(clip_x: f32, clip_width: f32, clip: &TimelineClip) -> (f32, f32) {
+    if clip.duration == 0 {
+        return (clip_x, clip_x + clip_width);
+    }
+    let pixels_per_frame = clip_width / clip.duration as f32;
+    (
+        clip_x + clip.fade_in_frames as f32 * pixels_per_frame,
+        clip_x + clip_width - clip.fade_out_frames as f32 * pixels_per_frame,
+    )
+}
 
 /// Where an unmodified vertical wheel gesture should be handled.
 ///
@@ -203,6 +221,8 @@ impl TrackClipCanvas {
                 loop_enabled: c.loop_enabled,
                 loop_start: c.loop_start,
                 loop_end: c.loop_end,
+                fade_in_frames: c.fades.fade_in_frames(),
+                fade_out_frames: c.fades.fade_out_frames(),
                 warp_stale: c.warped
                     && c.warped_to_bpm
                         .map(|b| (b - bpm).abs() > 0.01)
@@ -450,6 +470,41 @@ impl TrackClipCanvas {
 
         None
     }
+
+    fn fade_handle_hit(&self, pos: iced::Point) -> Option<(ClipId, AudioClipFadeEdge, f64, u64)> {
+        if (pos.y - FADE_HANDLE_Y).abs() > FADE_HANDLE_HIT_RADIUS {
+            return None;
+        }
+        let spb = self.spb();
+        for clip in &self.clips {
+            if !self.selected_clips.contains(&clip.clip_id) {
+                continue;
+            }
+            let start_beat = clip.position as f64 / spb;
+            let clip_x = self.beat_to_x(start_beat);
+            let clip_width = self.geometry().width_for_beats(clip.duration as f64 / spb);
+            if pos.x < clip_x || pos.x > clip_x + clip_width {
+                continue;
+            }
+            let (fade_in_x, fade_out_x) = fade_handle_xs(clip_x, clip_width, clip);
+            let in_distance = (pos.x - fade_in_x).abs();
+            let out_distance = (pos.x - fade_out_x).abs();
+            let edge = if in_distance <= FADE_HANDLE_HIT_RADIUS
+                && (in_distance < out_distance
+                    || (in_distance == out_distance && pos.x <= clip_x + clip_width / 2.0))
+            {
+                Some(AudioClipFadeEdge::In)
+            } else if out_distance <= FADE_HANDLE_HIT_RADIUS {
+                Some(AudioClipFadeEdge::Out)
+            } else {
+                None
+            };
+            if let Some(edge) = edge {
+                return Some((clip.clip_id, edge, start_beat, clip.duration));
+            }
+        }
+        None
+    }
 }
 
 impl canvas::Program<Message> for TrackClipCanvas {
@@ -475,6 +530,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
             return match drag {
                 ClipDragAction::MoveClip { .. } => mouse::Interaction::Grabbing,
                 ClipDragAction::ResizeClip { .. } => mouse::Interaction::ResizingHorizontally,
+                ClipDragAction::FadeClip { .. } => mouse::Interaction::ResizingHorizontally,
                 ClipDragAction::RegionSelect { .. } => mouse::Interaction::Crosshair,
                 ClipDragAction::PendingSeek { .. } => mouse::Interaction::Pointer,
                 ClipDragAction::PanViewport { .. } => mouse::Interaction::Grabbing,
@@ -482,6 +538,9 @@ impl canvas::Program<Message> for TrackClipCanvas {
         }
 
         if let Some(pos) = cursor.position_in(bounds) {
+            if self.fade_handle_hit(pos).is_some() {
+                return mouse::Interaction::ResizingHorizontally;
+            }
             if let Some((_, _, near_right, _, _)) = self.hit_test(pos.x) {
                 let in_title_bar = pos.y < CLIP_Y + CLIP_TITLE_HEIGHT;
                 if near_right && in_title_bar {
@@ -528,6 +587,18 @@ impl canvas::Program<Message> for TrackClipCanvas {
             //   Body (below title):    seek / region-select
             canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
                 if let Some(pos) = cursor.position_in(bounds) {
+                    if let Some((clip_id, edge, clip_start_beat, duration_frames)) =
+                        self.fade_handle_hit(pos)
+                    {
+                        state.drag = Some(ClipDragAction::FadeClip {
+                            undo_gesture: UndoGestureId::new(),
+                            clip_id,
+                            edge,
+                            clip_start_beat,
+                            duration_frames,
+                        });
+                        return (canvas::event::Status::Captured, None);
+                    }
                     if let Some((clip_id, is_note_clip, near_right, pos_beats, _dur_beats)) =
                         self.hit_test(pos.x)
                     {
@@ -832,6 +903,33 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                         .in_undo_gesture(*undo_gesture);
                                     return (canvas::event::Status::Captured, Some(edit));
                                 }
+                            }
+                            ClipDragAction::FadeClip {
+                                undo_gesture,
+                                clip_id,
+                                edge,
+                                clip_start_beat,
+                                duration_frames,
+                            } => {
+                                let current_beat = self.x_to_beat(local_x);
+                                let duration_beats = *duration_frames as f64 / self.spb();
+                                let frames = match edge {
+                                    AudioClipFadeEdge::In => {
+                                        (current_beat - clip_start_beat).clamp(0.0, duration_beats)
+                                    }
+                                    AudioClipFadeEdge::Out => (clip_start_beat + duration_beats
+                                        - current_beat)
+                                        .clamp(0.0, duration_beats),
+                                };
+                                let frames = (frames * self.spb()).round() as u64;
+                                let edit = Message::Arrangement(ArrangementMsg::SetAudioClipFade {
+                                    track_id,
+                                    clip_id: *clip_id,
+                                    edge: *edge,
+                                    frames,
+                                })
+                                .in_undo_gesture(*undo_gesture);
+                                return (canvas::event::Status::Captured, Some(edit));
                             }
                             ClipDragAction::PanViewport {
                                 start_local_x,

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -13,58 +13,16 @@ use crate::domains::transport::TransportMsg;
 use crate::domains::view::ViewMsg;
 use crate::message::Message;
 use crate::state::{
-    ArrangementMarqueeRect, ArrangementSelection, AudioClipFadeEdge, ContextMenuTarget, GridConfig,
-    ProjectTrack, TrackTimelineContent, UndoGestureId,
+    ArrangementMarqueeRect, ArrangementSelection, ContextMenuTarget, GridConfig, ProjectTrack,
+    TrackTimelineContent, UndoGestureId,
 };
 use crate::timeline_geometry::TimelineGeometry;
 use crate::widgets::local_drag::LocalDrag;
 use crate::widgets::timeline::marquee;
 use vibez_core::id::{ClipId, TrackId};
 
+use super::clip_drag::ClipDragAction;
 use super::*;
-
-/// Drag action in progress on the clip canvas.
-#[derive(Debug, Clone)]
-pub enum ClipDragAction {
-    MoveClip {
-        undo_gesture: UndoGestureId,
-        clip_id: ClipId,
-        is_note_clip: bool,
-        /// Initial local x pixel where the drag started.
-        start_local_x: f32,
-        start_scroll_beats: f64,
-        original_position_beats: f64,
-        start_y: f32,
-    },
-    ResizeClip {
-        undo_gesture: UndoGestureId,
-        clip_id: ClipId,
-        is_note_clip: bool,
-        clip_start_beat: f64,
-    },
-    FadeClip {
-        undo_gesture: UndoGestureId,
-        clip_id: ClipId,
-        edge: AudioClipFadeEdge,
-        clip_start_beat: f64,
-        duration_frames: u64,
-    },
-    PendingSeek {
-        beat: f64,
-        start_x: f32,
-        /// Press point in column coordinates, so a drag that leaves this
-        /// lane is still resolvable against the whole arrangement.
-        anchor_column_y: f32,
-    },
-    RegionSelect {
-        anchor_beat: f64,
-        anchor_column_y: f32,
-    },
-    PanViewport {
-        start_local_x: f32,
-        start_scroll_beats: f64,
-    },
-}
 
 /// Pointer travel before a press becomes a rubber-band rather than a seek.
 const MARQUEE_MIN_PX: f32 = 4.0;
@@ -72,17 +30,6 @@ const MARQUEE_MIN_PX: f32 = 4.0;
 /// Vertical travel before a clip drag may change lane. Without it a
 /// horizontal drag near a row boundary would flicker between tracks.
 const CROSS_TRACK_MIN_PX: f32 = 20.0;
-
-pub(super) fn fade_handle_xs(clip_x: f32, clip_width: f32, clip: &TimelineClip) -> (f32, f32) {
-    if clip.duration == 0 {
-        return (clip_x, clip_x + clip_width);
-    }
-    let pixels_per_frame = clip_width / clip.duration as f32;
-    (
-        clip_x + clip.fade_in_frames as f32 * pixels_per_frame,
-        clip_x + clip_width - clip.fade_out_frames as f32 * pixels_per_frame,
-    )
-}
 
 /// Where an unmodified vertical wheel gesture should be handled.
 ///
@@ -470,41 +417,6 @@ impl TrackClipCanvas {
 
         None
     }
-
-    fn fade_handle_hit(&self, pos: iced::Point) -> Option<(ClipId, AudioClipFadeEdge, f64, u64)> {
-        if (pos.y - FADE_HANDLE_Y).abs() > FADE_HANDLE_HIT_RADIUS {
-            return None;
-        }
-        let spb = self.spb();
-        for clip in &self.clips {
-            if !self.selected_clips.contains(&clip.clip_id) {
-                continue;
-            }
-            let start_beat = clip.position as f64 / spb;
-            let clip_x = self.beat_to_x(start_beat);
-            let clip_width = self.geometry().width_for_beats(clip.duration as f64 / spb);
-            if pos.x < clip_x || pos.x > clip_x + clip_width {
-                continue;
-            }
-            let (fade_in_x, fade_out_x) = fade_handle_xs(clip_x, clip_width, clip);
-            let in_distance = (pos.x - fade_in_x).abs();
-            let out_distance = (pos.x - fade_out_x).abs();
-            let edge = if in_distance <= FADE_HANDLE_HIT_RADIUS
-                && (in_distance < out_distance
-                    || (in_distance == out_distance && pos.x <= clip_x + clip_width / 2.0))
-            {
-                Some(AudioClipFadeEdge::In)
-            } else if out_distance <= FADE_HANDLE_HIT_RADIUS {
-                Some(AudioClipFadeEdge::Out)
-            } else {
-                None
-            };
-            if let Some(edge) = edge {
-                return Some((clip.clip_id, edge, start_beat, clip.duration));
-            }
-        }
-        None
-    }
 }
 
 impl canvas::Program<Message> for TrackClipCanvas {
@@ -530,7 +442,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
             return match drag {
                 ClipDragAction::MoveClip { .. } => mouse::Interaction::Grabbing,
                 ClipDragAction::ResizeClip { .. } => mouse::Interaction::ResizingHorizontally,
-                ClipDragAction::FadeClip { .. } => mouse::Interaction::ResizingHorizontally,
+                ClipDragAction::FadeClip(_) => mouse::Interaction::ResizingHorizontally,
                 ClipDragAction::RegionSelect { .. } => mouse::Interaction::Crosshair,
                 ClipDragAction::PendingSeek { .. } => mouse::Interaction::Pointer,
                 ClipDragAction::PanViewport { .. } => mouse::Interaction::Grabbing,
@@ -587,16 +499,8 @@ impl canvas::Program<Message> for TrackClipCanvas {
             //   Body (below title):    seek / region-select
             canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
                 if let Some(pos) = cursor.position_in(bounds) {
-                    if let Some((clip_id, edge, clip_start_beat, duration_frames)) =
-                        self.fade_handle_hit(pos)
-                    {
-                        state.drag = Some(ClipDragAction::FadeClip {
-                            undo_gesture: UndoGestureId::new(),
-                            clip_id,
-                            edge,
-                            clip_start_beat,
-                            duration_frames,
-                        });
+                    if let Some(drag) = self.fade_handle_hit(pos) {
+                        state.drag = Some(ClipDragAction::FadeClip(drag));
                         return (canvas::event::Status::Captured, None);
                     }
                     if let Some((clip_id, is_note_clip, near_right, pos_beats, _dur_beats)) =
@@ -904,31 +808,14 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                     return (canvas::event::Status::Captured, Some(edit));
                                 }
                             }
-                            ClipDragAction::FadeClip {
-                                undo_gesture,
-                                clip_id,
-                                edge,
-                                clip_start_beat,
-                                duration_frames,
-                            } => {
-                                let current_beat = self.x_to_beat(local_x);
-                                let duration_beats = *duration_frames as f64 / self.spb();
-                                let frames = match edge {
-                                    AudioClipFadeEdge::In => {
-                                        (current_beat - clip_start_beat).clamp(0.0, duration_beats)
-                                    }
-                                    AudioClipFadeEdge::Out => (clip_start_beat + duration_beats
-                                        - current_beat)
-                                        .clamp(0.0, duration_beats),
-                                };
-                                let frames = (frames * self.spb()).round() as u64;
+                            ClipDragAction::FadeClip(drag) => {
                                 let edit = Message::Arrangement(ArrangementMsg::SetAudioClipFade {
                                     track_id,
-                                    clip_id: *clip_id,
-                                    edge: *edge,
-                                    frames,
+                                    clip_id: drag.clip_id,
+                                    edge: drag.edge,
+                                    frames: drag.frames_at_x(local_x),
                                 })
-                                .in_undo_gesture(*undo_gesture);
+                                .in_undo_gesture(drag.undo_gesture);
                                 return (canvas::event::Status::Captured, Some(edit));
                             }
                             ClipDragAction::PanViewport {

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -261,6 +261,34 @@ impl TrackClipCanvas {
                 // Selection highlight
                 let is_selected =
                     !is_recording_preview && self.selected_clips.contains(&clip.clip_id);
+                if !is_recording_preview
+                    && (is_selected || clip.fade_in_frames > 0 || clip.fade_out_frames > 0)
+                {
+                    let (fade_in_x, fade_out_x) = fade_handle_xs(clip_x, clip_w, clip);
+                    let top = clip_y + CLIP_TITLE_HEIGHT + 2.0;
+                    let bottom = clip_y + clip_h - 2.0;
+                    let envelope = canvas::Path::new(|builder| {
+                        builder.move_to(iced::Point::new(clip_x, bottom));
+                        builder.line_to(iced::Point::new(fade_in_x, top));
+                        builder.line_to(iced::Point::new(fade_out_x, top));
+                        builder.line_to(iced::Point::new(clip_x + clip_w, bottom));
+                    });
+                    frame.stroke(
+                        &envelope,
+                        canvas::Stroke::default()
+                            .with_color(theme::with_alpha(theme::text(), 0.72))
+                            .with_width(1.25),
+                    );
+                    if is_selected {
+                        for x in [fade_in_x, fade_out_x] {
+                            frame.fill_rectangle(
+                                iced::Point::new(x - 2.5, FADE_HANDLE_Y - 2.5),
+                                iced::Size::new(5.0, 5.0),
+                                theme::accent(),
+                            );
+                        }
+                    }
+                }
                 let border_color = if is_selected {
                     theme::accent()
                 } else {

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -7,6 +7,7 @@ use iced::{Color, Rectangle, Renderer};
 use crate::theme;
 use crate::timeline_geometry::TimelineGeometry;
 
+use super::fade_drag::fade_handle_xs;
 use super::*;
 
 fn fit_clip_title(name: &str, clip_width: f32, loop_icon_visible: bool) -> Option<String> {

--- a/crates/vibez-ui/src/widgets/timeline/clips_tests.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_tests.rs
@@ -10,6 +10,7 @@ use iced::keyboard::{Event, Key, Location, Modifiers};
 use iced::widget::canvas;
 use iced::{mouse, Color, Point, Rectangle, Size};
 
+use crate::domains::arrangement::ArrangementMsg;
 use crate::domains::view::ViewMsg;
 use crate::message::Message;
 use crate::state::{ContextMenuTarget, GridConfig, ProjectTrack, TrackTimelineContent};
@@ -352,6 +353,8 @@ fn physical_right_click_opens_clip_and_empty_arrange_context_menus() {
         loop_enabled: false,
         loop_start: 0,
         loop_end: 0,
+        fade_in_frames: 0,
+        fade_out_frames: 0,
         warp_stale: false,
     });
     let (status, message) = right_click(&canvas, Point::new(10.0, 10.0));
@@ -433,6 +436,8 @@ fn audio_recording_waveform_is_visible_but_not_hit_testable() {
         loop_enabled: false,
         loop_start: 0,
         loop_end: 0,
+        fade_in_frames: 0,
+        fade_out_frames: 0,
         warp_stale: false,
     });
 
@@ -441,4 +446,71 @@ fn audio_recording_waveform_is_visible_but_not_hit_testable() {
         preview_id
     );
     assert!(canvas.hit_test(10.0).is_none());
+}
+
+#[test]
+fn selected_audio_fade_handle_drag_emits_realtime_edits_in_one_undo_gesture() {
+    let mut canvas = empty_track_canvas();
+    let clip_id = ClipId::new();
+    canvas.clips.push(TimelineClip {
+        clip_id,
+        position: 0,
+        duration: 44_100,
+        name: "Clip".into(),
+        peaks: Arc::new(Vec::new()),
+        peak_span_frames: None,
+        loop_enabled: false,
+        loop_start: 0,
+        loop_end: 44_100,
+        fade_in_frames: 11_025,
+        fade_out_frames: 0,
+        warp_stale: false,
+    });
+    canvas.selected_clips.insert(clip_id);
+    let bounds = Rectangle::new(Point::ORIGIN, Size::new(800.0, 80.0));
+    let mut state = ClipInteractionState::default();
+    let handle = Point::new(10.0, FADE_HANDLE_Y);
+
+    let (status, message) = <TrackClipCanvas as canvas::Program<Message>>::update(
+        &canvas,
+        &mut state,
+        canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)),
+        bounds,
+        mouse::Cursor::Available(handle),
+    );
+    assert_eq!(status, canvas::event::Status::Captured);
+    assert!(message.is_none());
+
+    let drag = |state: &mut ClipInteractionState, x: f32| {
+        <TrackClipCanvas as canvas::Program<Message>>::update(
+            &canvas,
+            state,
+            canvas::Event::Mouse(iced::mouse::Event::CursorMoved {
+                position: Point::new(x, FADE_HANDLE_Y),
+            }),
+            bounds,
+            mouse::Cursor::Available(Point::new(x, FADE_HANDLE_Y)),
+        )
+        .1
+    };
+    let first = drag(&mut state, 20.0);
+    let second = drag(&mut state, 30.0);
+
+    let extract = |message: Option<Message>| match message {
+        Some(Message::UndoGesture { id, edit }) => match *edit {
+            Message::Arrangement(ArrangementMsg::SetAudioClipFade {
+                clip_id: edited,
+                edge: crate::state::AudioClipFadeEdge::In,
+                frames,
+                ..
+            }) => Some((id, edited, frames)),
+            _ => None,
+        },
+        _ => None,
+    };
+    let (first_gesture, first_clip, first_frames) = extract(first).expect("first fade edit");
+    let (second_gesture, second_clip, second_frames) = extract(second).expect("second fade edit");
+    assert_eq!(first_gesture, second_gesture);
+    assert_eq!((first_clip, second_clip), (clip_id, clip_id));
+    assert_eq!((first_frames, second_frames), (22_050, 33_075));
 }

--- a/crates/vibez-ui/src/widgets/timeline/fade_drag.rs
+++ b/crates/vibez-ui/src/widgets/timeline/fade_drag.rs
@@ -1,0 +1,148 @@
+//! Audio Clip fade-handle hit testing and reciprocal drag geometry.
+
+use iced::Point;
+
+use crate::state::{AudioClipFadeEdge, UndoGestureId};
+use vibez_core::id::ClipId;
+
+use super::clips::TrackClipCanvas;
+use super::{TimelineClip, FADE_HANDLE_HIT_RADIUS, FADE_HANDLE_Y};
+
+#[derive(Debug, Clone)]
+pub struct FadeClipDrag {
+    pub undo_gesture: UndoGestureId,
+    pub clip_id: ClipId,
+    pub edge: AudioClipFadeEdge,
+    clip_x: f32,
+    clip_width: f32,
+    duration_frames: u64,
+}
+
+impl FadeClipDrag {
+    fn new(
+        clip_id: ClipId,
+        edge: AudioClipFadeEdge,
+        clip_x: f32,
+        clip_width: f32,
+        duration_frames: u64,
+    ) -> Self {
+        Self {
+            undo_gesture: UndoGestureId::new(),
+            clip_id,
+            edge,
+            clip_x,
+            clip_width,
+            duration_frames,
+        }
+    }
+
+    /// Use the exact inverse of [`fade_handle_xs`] so a handle drawn at one
+    /// frame cannot jitter to an adjacent frame when the pointer has not moved.
+    pub(super) fn frames_at_x(&self, x: f32) -> u64 {
+        if self.clip_width <= 0.0 || self.duration_frames == 0 {
+            return 0;
+        }
+        let progress = ((x - self.clip_x) / self.clip_width).clamp(0.0, 1.0);
+        let progress = match self.edge {
+            AudioClipFadeEdge::In => progress,
+            AudioClipFadeEdge::Out => 1.0 - progress,
+        };
+        (progress as f64 * self.duration_frames as f64).round() as u64
+    }
+}
+
+pub(super) fn fade_handle_xs(clip_x: f32, clip_width: f32, clip: &TimelineClip) -> (f32, f32) {
+    if clip.duration == 0 {
+        return (clip_x, clip_x + clip_width);
+    }
+    let pixels_per_frame = clip_width / clip.duration as f32;
+    (
+        clip_x + clip.fade_in_frames as f32 * pixels_per_frame,
+        clip_x + clip_width - clip.fade_out_frames as f32 * pixels_per_frame,
+    )
+}
+
+impl TrackClipCanvas {
+    pub(super) fn fade_handle_hit(&self, pos: Point) -> Option<FadeClipDrag> {
+        if (pos.y - FADE_HANDLE_Y).abs() > FADE_HANDLE_HIT_RADIUS {
+            return None;
+        }
+        let spb = self.spb();
+        for clip in &self.clips {
+            if !self.selected_clips.contains(&clip.clip_id) {
+                continue;
+            }
+            let start_beat = clip.position as f64 / spb;
+            let clip_x = self.beat_to_x(start_beat);
+            let clip_width = self.geometry().width_for_beats(clip.duration as f64 / spb);
+            if pos.x < clip_x || pos.x > clip_x + clip_width {
+                continue;
+            }
+            let (fade_in_x, fade_out_x) = fade_handle_xs(clip_x, clip_width, clip);
+            let in_distance = (pos.x - fade_in_x).abs();
+            let out_distance = (pos.x - fade_out_x).abs();
+            let edge = if in_distance <= FADE_HANDLE_HIT_RADIUS
+                && (in_distance < out_distance
+                    || (in_distance == out_distance && pos.x <= clip_x + clip_width / 2.0))
+            {
+                Some(AudioClipFadeEdge::In)
+            } else if out_distance <= FADE_HANDLE_HIT_RADIUS {
+                Some(AudioClipFadeEdge::Out)
+            } else {
+                None
+            };
+            if let Some(edge) = edge {
+                return Some(FadeClipDrag::new(
+                    clip.clip_id,
+                    edge,
+                    clip_x,
+                    clip_width,
+                    clip.duration,
+                ));
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drag_math_is_reciprocal_with_drawn_handle_positions() {
+        let clip = TimelineClip {
+            clip_id: ClipId::new(),
+            position: 0,
+            duration: 48_000,
+            name: String::new(),
+            peaks: Default::default(),
+            peak_span_frames: None,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 48_000,
+            fade_in_frames: 12_345,
+            fade_out_frames: 6_789,
+            warp_stale: false,
+        };
+        let (fade_in_x, fade_out_x) = fade_handle_xs(37.0, 481.0, &clip);
+
+        let fade_in = FadeClipDrag::new(
+            clip.clip_id,
+            AudioClipFadeEdge::In,
+            37.0,
+            481.0,
+            clip.duration,
+        );
+        let fade_out = FadeClipDrag::new(
+            clip.clip_id,
+            AudioClipFadeEdge::Out,
+            37.0,
+            481.0,
+            clip.duration,
+        );
+
+        assert_eq!(fade_in.frames_at_x(fade_in_x), clip.fade_in_frames);
+        assert_eq!(fade_out.frames_at_x(fade_out_x), clip.fade_out_frames);
+    }
+}

--- a/crates/vibez-ui/src/widgets/timeline/mod.rs
+++ b/crates/vibez-ui/src/widgets/timeline/mod.rs
@@ -194,14 +194,17 @@ pub(super) const CLIP_Y: f32 = 4.0;
 pub(super) const FADE_HANDLE_Y: f32 = CLIP_Y + CLIP_TITLE_HEIGHT + 6.0;
 pub(super) const FADE_HANDLE_HIT_RADIUS: f32 = 7.0;
 
+mod clip_drag;
 mod clips;
 mod clips_draw;
 #[cfg(test)]
 mod clips_tests;
+mod fade_drag;
 pub mod marquee;
 mod minimap;
 mod ruler;
 
+pub use clip_drag::ClipDragAction;
 pub use clips::*;
 pub use marquee::{build_row_spans, TrackRowSpan, TRACK_ROW_HEIGHT};
 pub use minimap::*;

--- a/crates/vibez-ui/src/widgets/timeline/mod.rs
+++ b/crates/vibez-ui/src/widgets/timeline/mod.rs
@@ -21,6 +21,8 @@ pub struct TimelineClip {
     pub loop_enabled: bool,
     pub loop_start: u64,
     pub loop_end: u64,
+    pub fade_in_frames: u64,
+    pub fade_out_frames: u64,
     /// True when this clip is warped but its `warped_to_bpm` no longer
     /// matches the current project BPM. The canvas draws a diagonal
     /// stripe overlay so the user can see at a glance that a re-warp
@@ -189,6 +191,8 @@ pub(super) const RESIZE_EDGE_PX: f32 = 8.0;
 pub(super) const CLIP_TITLE_HEIGHT: f32 = 18.0;
 /// Top padding of clips within the track canvas.
 pub(super) const CLIP_Y: f32 = 4.0;
+pub(super) const FADE_HANDLE_Y: f32 = CLIP_Y + CLIP_TITLE_HEIGHT + 6.0;
+pub(super) const FADE_HANDLE_HIT_RADIUS: f32 = 7.0;
 
 mod clips;
 mod clips_draw;


### PR DESCRIPTION
## Summary

- draw Audio Clip fade envelopes and compact handles in Arrange and Section timelines
- keep fade hit targets below the title bar so clip move and trim gestures remain separate
- preview audible fades in real time while dragging
- group every pointer drag into one Undo gesture

## Stack

- depends on #196

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`