### PR TITLE
feat: add linked audio clip crossfades

### DIFF
--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -334,7 +334,7 @@ impl ClipFades {
         }
     }
 
-    /// Per-frame linear amplitude. This is safe to call on the audio thread.
+    /// Per-frame amplitude. This is safe to call on the audio thread.
     #[inline]
     pub fn gain_at(self, clip_frame: u64, duration: u64) -> f32 {
         if clip_frame >= duration {

--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -146,6 +146,10 @@ pub struct ClipFades {
     fade_in_frames: u64,
     #[serde(default)]
     fade_out_frames: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    crossfade_in_from: Option<ClipId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    crossfade_out_to: Option<ClipId>,
 }
 
 impl<'de> Deserialize<'de> for ClipFades {
@@ -159,12 +163,18 @@ impl<'de> Deserialize<'de> for ClipFades {
             fade_in_frames: u64,
             #[serde(default)]
             fade_out_frames: u64,
+            #[serde(default)]
+            crossfade_in_from: Option<ClipId>,
+            #[serde(default)]
+            crossfade_out_to: Option<ClipId>,
         }
 
         let persisted = PersistedFades::deserialize(deserializer)?;
         Ok(Self {
             fade_in_frames: persisted.fade_in_frames,
             fade_out_frames: persisted.fade_out_frames,
+            crossfade_in_from: persisted.crossfade_in_from,
+            crossfade_out_to: persisted.crossfade_out_to,
         })
     }
 }
@@ -185,6 +195,8 @@ impl ClipFades {
         Self {
             fade_in_frames,
             fade_out_frames,
+            crossfade_in_from: None,
+            crossfade_out_to: None,
         }
     }
 
@@ -197,7 +209,9 @@ impl ClipFades {
     }
 
     pub const fn with_fade_in(self, frames: u64, duration: u64) -> Self {
-        Self::new(frames, self.fade_out_frames, duration)
+        let mut fades = Self::new(frames, self.fade_out_frames, duration);
+        fades.crossfade_out_to = self.crossfade_out_to;
+        fades
     }
 
     pub const fn with_fade_out(self, frames: u64, duration: u64) -> Self {
@@ -211,11 +225,24 @@ impl ClipFades {
         Self {
             fade_in_frames,
             fade_out_frames,
+            crossfade_in_from: self.crossfade_in_from,
+            crossfade_out_to: None,
         }
     }
 
     pub const fn clamped_to(self, duration: u64) -> Self {
-        Self::new(self.fade_in_frames, self.fade_out_frames, duration)
+        let mut fades = Self::new(self.fade_in_frames, self.fade_out_frames, duration);
+        fades.crossfade_in_from = if fades.fade_in_frames > 0 {
+            self.crossfade_in_from
+        } else {
+            None
+        };
+        fades.crossfade_out_to = if fades.fade_out_frames > 0 {
+            self.crossfade_out_to
+        } else {
+            None
+        };
+        fades
     }
 
     pub fn scaled(self, old_duration: u64, new_duration: u64) -> Self {
@@ -223,11 +250,14 @@ impl ClipFades {
             return Self::default();
         }
         let ratio = new_duration as f64 / old_duration as f64;
-        Self::new(
+        let mut fades = Self::new(
             (self.fade_in_frames as f64 * ratio).round() as u64,
             (self.fade_out_frames as f64 * ratio).round() as u64,
             new_duration,
-        )
+        );
+        fades.crossfade_in_from = self.crossfade_in_from;
+        fades.crossfade_out_to = self.crossfade_out_to;
+        fades
     }
 
     /// Preserve only fades belonging to an original edge when a Clip is
@@ -248,7 +278,60 @@ impl ClipFades {
     }
 
     pub const fn is_neutral(value: &Self) -> bool {
-        value.fade_in_frames == 0 && value.fade_out_frames == 0
+        value.fade_in_frames == 0
+            && value.fade_out_frames == 0
+            && value.crossfade_in_from.is_none()
+            && value.crossfade_out_to.is_none()
+    }
+
+    pub const fn crossfade_in_from(self) -> Option<ClipId> {
+        self.crossfade_in_from
+    }
+
+    pub const fn crossfade_out_to(self) -> Option<ClipId> {
+        self.crossfade_out_to
+    }
+
+    pub const fn linked_fade_in(self, frames: u64, from: ClipId, duration: u64) -> Self {
+        let mut fades = self.with_fade_in(frames, duration);
+        fades.crossfade_in_from = if fades.fade_in_frames > 0 {
+            Some(from)
+        } else {
+            None
+        };
+        fades
+    }
+
+    pub const fn linked_fade_out(self, frames: u64, to: ClipId, duration: u64) -> Self {
+        let mut fades = self.with_fade_out(frames, duration);
+        fades.crossfade_out_to = if fades.fade_out_frames > 0 {
+            Some(to)
+        } else {
+            None
+        };
+        fades
+    }
+
+    pub const fn unlinked(self) -> Self {
+        Self {
+            crossfade_in_from: None,
+            crossfade_out_to: None,
+            ..self
+        }
+    }
+
+    pub const fn unlink_fade_in(self) -> Self {
+        Self {
+            crossfade_in_from: None,
+            ..self
+        }
+    }
+
+    pub const fn unlink_fade_out(self) -> Self {
+        Self {
+            crossfade_out_to: None,
+            ..self
+        }
     }
 
     /// Per-frame linear amplitude. This is safe to call on the audio thread.
@@ -258,13 +341,23 @@ impl ClipFades {
             return 0.0;
         }
         let fade_in = if self.fade_in_frames > 0 && clip_frame < self.fade_in_frames {
-            clip_frame as f32 / self.fade_in_frames as f32
+            let progress = clip_frame as f32 / self.fade_in_frames as f32;
+            if self.crossfade_in_from.is_some() {
+                (progress * std::f32::consts::FRAC_PI_2).sin()
+            } else {
+                progress
+            }
         } else {
             1.0
         };
         let frames_after = duration - 1 - clip_frame;
         let fade_out = if self.fade_out_frames > 0 && frames_after < self.fade_out_frames {
-            frames_after as f32 / self.fade_out_frames as f32
+            if self.crossfade_out_to.is_some() {
+                let progress = (frames_after + 1) as f32 / self.fade_out_frames as f32;
+                (progress * std::f32::consts::FRAC_PI_2).sin()
+            } else {
+                frames_after as f32 / self.fade_out_frames as f32
+            }
         } else {
             1.0
         };
@@ -701,7 +794,11 @@ mod tests {
         clip.file_path = Some(PathBuf::from("/audio/vocal.wav"));
         clip.original_bpm = Some(174.0);
         clip.gain_db = ClipGainDb::new(-3.5).unwrap();
-        clip.fades = ClipFades::new(4_410, 8_820, clip.duration);
+        clip.fades = ClipFades::new(4_410, 8_820, clip.duration).linked_fade_out(
+            8_820,
+            ClipId::new(),
+            clip.duration,
+        );
         clip.transpose = ClipTranspose::new(7);
         clip.warped = true;
         clip.warped_to_bpm = Some(140.0);
@@ -782,5 +879,20 @@ mod tests {
         assert_eq!(fades.for_fragment(100, 0, 40), ClipFades::new(10, 0, 40));
         assert_eq!(fades.for_fragment(100, 40, 60), ClipFades::new(0, 20, 60));
         assert_eq!(fades.for_fragment(100, 20, 40), ClipFades::default());
+    }
+
+    #[test]
+    fn linked_crossfade_edges_form_an_equal_power_pair() {
+        let outgoing_id = ClipId::new();
+        let incoming_id = ClipId::new();
+        let frames = 16;
+        let outgoing = ClipFades::default().linked_fade_out(frames, incoming_id, frames);
+        let incoming = ClipFades::default().linked_fade_in(frames, outgoing_id, frames);
+
+        for frame in 0..frames {
+            let power =
+                outgoing.gain_at(frame, frames).powi(2) + incoming.gain_at(frame, frames).powi(2);
+            assert!((power - 1.0).abs() < 1e-5, "frame {frame}: {power}");
+        }
     }
 }

--- a/crates/vibez-engine/src/playback_source.rs
+++ b/crates/vibez-engine/src/playback_source.rs
@@ -579,6 +579,57 @@ mod tests {
     }
 
     #[test]
+    fn linked_overlap_renders_as_a_complementary_equal_power_pair() {
+        let outgoing_id = ClipId::new();
+        let incoming_id = ClipId::new();
+        let source = PreparedPlaybackSource::new(
+            vec![
+                EngineClip {
+                    id: outgoing_id,
+                    audio: Arc::new(DecodedAudio {
+                        channels: vec![vec![1.0; 8], vec![0.0; 8]],
+                        sample_rate: 48_000,
+                    }),
+                    position: 0,
+                    source_offset: 0,
+                    start_marker: 0,
+                    duration: 8,
+                    loop_enabled: false,
+                    loop_start: 0,
+                    loop_end: 8,
+                    linear_gain: 1.0,
+                    fades: ClipFades::default().linked_fade_out(4, incoming_id, 8),
+                },
+                EngineClip {
+                    id: incoming_id,
+                    audio: Arc::new(DecodedAudio {
+                        channels: vec![vec![0.0; 8], vec![1.0; 8]],
+                        sample_rate: 48_000,
+                    }),
+                    position: 4,
+                    source_offset: 0,
+                    start_marker: 0,
+                    duration: 8,
+                    loop_enabled: false,
+                    loop_start: 0,
+                    loop_end: 8,
+                    linear_gain: 1.0,
+                    fades: ClipFades::default().linked_fade_in(4, outgoing_id, 8),
+                },
+            ],
+            Vec::new(),
+            Vec::new(),
+        );
+        let mut output = vec![0.0; 8];
+
+        assert!(source.render_audio(&mut output, 4, 4, 2, None));
+        for frame in output.chunks_exact(2) {
+            let power = frame[0].powi(2) + frame[1].powi(2);
+            assert!((power - 1.0).abs() < 1e-5, "{frame:?}: {power}");
+        }
+    }
+
+    #[test]
     fn total_length_combines_resident_audio_and_note_sources() {
         let audio = Arc::new(DecodedAudio {
             channels: vec![vec![0.5; 100]],

--- a/crates/vibez-project/src/lib.rs
+++ b/crates/vibez-project/src/lib.rs
@@ -364,6 +364,7 @@ mod tests {
     fn project_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.vibez");
+        let crossfade_peer = ClipId::new();
 
         let project = Project {
             master: None,
@@ -391,7 +392,11 @@ mod tests {
                     loop_start: 0,
                     loop_end: 0,
                     gain_db: Default::default(),
-                    fades: Default::default(),
+                    fades: vibez_core::track::ClipFades::default().linked_fade_out(
+                        4_410,
+                        crossfade_peer,
+                        44_100,
+                    ),
                     transpose: Default::default(),
                     original_bpm: None,
                     warped: false,
@@ -412,6 +417,10 @@ mod tests {
         assert_eq!(loaded.tracks[0].name, "Synth");
         assert_eq!(loaded.arrange.clips.len(), 1);
         assert_eq!(loaded.arrange.clips[0].name, "loop.wav");
+        assert_eq!(
+            loaded.arrange.clips[0].fades.crossfade_out_to(),
+            Some(crossfade_peer)
+        );
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -486,7 +486,8 @@ impl App {
         }
     }
 
-    pub(super) fn rebuild_from_loaded_project(&mut self, loaded: ProjectLoadResult) {
+    pub(super) fn rebuild_from_loaded_project(&mut self, mut loaded: ProjectLoadResult) {
+        super::project_sections::sanitize_loaded_crossfades(&mut loaded.clips);
         let remote_provenance = first_remote_provenance_label(&loaded.project);
         self.clear_project_runtime();
         self.state.project.unresolved_clips = loaded.unresolved_clips;

--- a/crates/vibez-ui/src/app/project_sections.rs
+++ b/crates/vibez-ui/src/app/project_sections.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use vibez_core::id::ClipId;
+use vibez_core::id::{ClipId, TrackId};
 use vibez_core::track::{ClipFades, ClipInfo, MediaSourceRef};
 use vibez_project::{SectionInfo, TimelineAutomationInfo, TimelineInfo, TimelineLocation};
 
@@ -161,27 +161,45 @@ pub(super) fn install_loaded_clip(
     });
 }
 
-#[allow(clippy::too_many_arguments)]
+#[derive(Clone, Copy)]
+struct LoadedCrossfadeCandidate {
+    location: TimelineLocation,
+    track_id: TrackId,
+    id: ClipId,
+    start: u64,
+    duration: u64,
+    fades: ClipFades,
+}
+
+impl LoadedCrossfadeCandidate {
+    fn from_loaded(loaded: &crate::message::LoadedTimelineClip) -> Self {
+        Self {
+            location: loaded.location,
+            track_id: loaded.info.track_id,
+            id: loaded.info.id,
+            start: loaded.info.position,
+            duration: loaded.info.duration,
+            fades: loaded.info.fades,
+        }
+    }
+}
+
 fn valid_crossfade_pair(
-    outgoing_id: ClipId,
-    incoming_id: ClipId,
-    outgoing_start: u64,
-    outgoing_duration: u64,
-    outgoing_fades: ClipFades,
-    incoming_start: u64,
-    incoming_duration: u64,
-    incoming_fades: ClipFades,
+    outgoing: LoadedCrossfadeCandidate,
+    incoming: LoadedCrossfadeCandidate,
 ) -> bool {
-    let outgoing_end = outgoing_start.saturating_add(outgoing_duration);
-    let incoming_end = incoming_start.saturating_add(incoming_duration);
-    let overlap = outgoing_end.saturating_sub(incoming_start);
-    outgoing_start < incoming_start
-        && incoming_start < outgoing_end
+    let outgoing_end = outgoing.start.saturating_add(outgoing.duration);
+    let incoming_end = incoming.start.saturating_add(incoming.duration);
+    let overlap = outgoing_end.saturating_sub(incoming.start);
+    outgoing.location == incoming.location
+        && outgoing.track_id == incoming.track_id
+        && outgoing.start < incoming.start
+        && incoming.start < outgoing_end
         && outgoing_end <= incoming_end
-        && outgoing_fades.crossfade_out_to() == Some(incoming_id)
-        && incoming_fades.crossfade_in_from() == Some(outgoing_id)
-        && outgoing_fades.fade_out_frames() == overlap
-        && incoming_fades.fade_in_frames() == overlap
+        && outgoing.fades.crossfade_out_to() == Some(incoming.id)
+        && incoming.fades.crossfade_in_from() == Some(outgoing.id)
+        && outgoing.fades.fade_out_frames() == overlap
+        && incoming.fades.fade_in_frames() == overlap
 }
 
 pub(super) fn sanitize_loaded_crossfades(clips: &mut [crate::message::LoadedTimelineClip]) {
@@ -190,56 +208,22 @@ pub(super) fn sanitize_loaded_crossfades(clips: &mut [crate::message::LoadedTime
     }
     let snapshot: Vec<_> = clips
         .iter()
-        .map(|loaded| {
-            (
-                loaded.location,
-                loaded.info.track_id,
-                loaded.info.id,
-                loaded.info.position,
-                loaded.info.duration,
-                loaded.info.fades,
-            )
-        })
+        .map(LoadedCrossfadeCandidate::from_loaded)
         .collect();
     for loaded in clips {
         let info = &loaded.info;
+        let candidate = LoadedCrossfadeCandidate::from_loaded(loaded);
         let incoming_valid = info.fades.crossfade_in_from().is_none_or(|outgoing_id| {
             snapshot
                 .iter()
-                .find(|entry| {
-                    entry.0 == loaded.location && entry.1 == info.track_id && entry.2 == outgoing_id
-                })
-                .is_some_and(|outgoing| {
-                    valid_crossfade_pair(
-                        outgoing.2,
-                        info.id,
-                        outgoing.3,
-                        outgoing.4,
-                        outgoing.5,
-                        info.position,
-                        info.duration,
-                        info.fades,
-                    )
-                })
+                .find(|entry| entry.id == outgoing_id)
+                .is_some_and(|outgoing| valid_crossfade_pair(*outgoing, candidate))
         });
         let outgoing_valid = info.fades.crossfade_out_to().is_none_or(|incoming_id| {
             snapshot
                 .iter()
-                .find(|entry| {
-                    entry.0 == loaded.location && entry.1 == info.track_id && entry.2 == incoming_id
-                })
-                .is_some_and(|incoming| {
-                    valid_crossfade_pair(
-                        info.id,
-                        incoming.2,
-                        info.position,
-                        info.duration,
-                        info.fades,
-                        incoming.3,
-                        incoming.4,
-                        incoming.5,
-                    )
-                })
+                .find(|entry| entry.id == incoming_id)
+                .is_some_and(|incoming| valid_crossfade_pair(candidate, *incoming))
         });
         if !incoming_valid {
             loaded.clip.info.fades = loaded.clip.info.fades.unlink_fade_in();

--- a/crates/vibez-ui/src/app/project_sections.rs
+++ b/crates/vibez-ui/src/app/project_sections.rs
@@ -3,7 +3,8 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use vibez_core::track::{ClipInfo, MediaSourceRef};
+use vibez_core::id::ClipId;
+use vibez_core::track::{ClipFades, ClipInfo, MediaSourceRef};
 use vibez_project::{SectionInfo, TimelineAutomationInfo, TimelineInfo, TimelineLocation};
 
 use crate::domains::perform::{Section, SectionStore};
@@ -160,6 +161,95 @@ pub(super) fn install_loaded_clip(
     });
 }
 
+#[allow(clippy::too_many_arguments)]
+fn valid_crossfade_pair(
+    outgoing_id: ClipId,
+    incoming_id: ClipId,
+    outgoing_start: u64,
+    outgoing_duration: u64,
+    outgoing_fades: ClipFades,
+    incoming_start: u64,
+    incoming_duration: u64,
+    incoming_fades: ClipFades,
+) -> bool {
+    let outgoing_end = outgoing_start.saturating_add(outgoing_duration);
+    let incoming_end = incoming_start.saturating_add(incoming_duration);
+    let overlap = outgoing_end.saturating_sub(incoming_start);
+    outgoing_start < incoming_start
+        && incoming_start < outgoing_end
+        && outgoing_end <= incoming_end
+        && outgoing_fades.crossfade_out_to() == Some(incoming_id)
+        && incoming_fades.crossfade_in_from() == Some(outgoing_id)
+        && outgoing_fades.fade_out_frames() == overlap
+        && incoming_fades.fade_in_frames() == overlap
+}
+
+pub(super) fn sanitize_loaded_crossfades(clips: &mut [crate::message::LoadedTimelineClip]) {
+    for loaded in clips.iter_mut() {
+        loaded.clip.info.fades = loaded.clip.info.fades.clamped_to(loaded.clip.info.duration);
+    }
+    let snapshot: Vec<_> = clips
+        .iter()
+        .map(|loaded| {
+            (
+                loaded.location,
+                loaded.info.track_id,
+                loaded.info.id,
+                loaded.info.position,
+                loaded.info.duration,
+                loaded.info.fades,
+            )
+        })
+        .collect();
+    for loaded in clips {
+        let info = &loaded.info;
+        let incoming_valid = info.fades.crossfade_in_from().is_none_or(|outgoing_id| {
+            snapshot
+                .iter()
+                .find(|entry| {
+                    entry.0 == loaded.location && entry.1 == info.track_id && entry.2 == outgoing_id
+                })
+                .is_some_and(|outgoing| {
+                    valid_crossfade_pair(
+                        outgoing.2,
+                        info.id,
+                        outgoing.3,
+                        outgoing.4,
+                        outgoing.5,
+                        info.position,
+                        info.duration,
+                        info.fades,
+                    )
+                })
+        });
+        let outgoing_valid = info.fades.crossfade_out_to().is_none_or(|incoming_id| {
+            snapshot
+                .iter()
+                .find(|entry| {
+                    entry.0 == loaded.location && entry.1 == info.track_id && entry.2 == incoming_id
+                })
+                .is_some_and(|incoming| {
+                    valid_crossfade_pair(
+                        info.id,
+                        incoming.2,
+                        info.position,
+                        info.duration,
+                        info.fades,
+                        incoming.3,
+                        incoming.4,
+                        incoming.5,
+                    )
+                })
+        });
+        if !incoming_valid {
+            loaded.clip.info.fades = loaded.clip.info.fades.unlink_fade_in();
+        }
+        if !outgoing_valid {
+            loaded.clip.info.fades = loaded.clip.info.fades.unlink_fade_out();
+        }
+    }
+}
+
 pub(super) fn apply_timeline_sources(timeline: &mut ArrangementTimeline, saved: &TimelineInfo) {
     for saved_clip in &saved.clips {
         if let Some(clip) = timeline.get_mut(saved_clip.track_id).and_then(|content| {
@@ -200,6 +290,81 @@ mod tests {
     use super::*;
     use vibez_core::id::{ClipId, TrackId};
     use vibez_core::midi::MidiNote;
+
+    fn loaded_audio_clip(
+        location: TimelineLocation,
+        track_id: TrackId,
+        clip_id: ClipId,
+        position: u64,
+        duration: u64,
+        fades: ClipFades,
+    ) -> crate::message::LoadedTimelineClip {
+        crate::message::LoadedTimelineClip {
+            location,
+            clip: crate::message::LoadedClipData {
+                info: ClipInfo {
+                    id: clip_id,
+                    track_id,
+                    name: "Clip".into(),
+                    position,
+                    source_offset: 0,
+                    start_marker: None,
+                    duration,
+                    source: None,
+                    file_path: None,
+                    loop_enabled: false,
+                    loop_start: 0,
+                    loop_end: duration,
+                    gain_db: Default::default(),
+                    fades,
+                    transpose: Default::default(),
+                    original_bpm: None,
+                    warped: false,
+                    warped_to_bpm: None,
+                },
+                audio: Arc::new(vibez_core::audio_buffer::DecodedAudio {
+                    channels: vec![vec![0.0; duration as usize]],
+                    sample_rate: 48_000,
+                }),
+                original_audio: None,
+            },
+        }
+    }
+
+    #[test]
+    fn project_load_keeps_reciprocal_crossfades_and_repairs_stale_links() {
+        let track_id = TrackId::new();
+        let outgoing_id = ClipId::new();
+        let incoming_id = ClipId::new();
+        let outgoing = ClipFades::default().linked_fade_out(250, incoming_id, 1_000);
+        let incoming = ClipFades::default().linked_fade_in(250, outgoing_id, 1_000);
+        let mut valid = vec![
+            loaded_audio_clip(
+                TimelineLocation::Arrange,
+                track_id,
+                outgoing_id,
+                0,
+                1_000,
+                outgoing,
+            ),
+            loaded_audio_clip(
+                TimelineLocation::Arrange,
+                track_id,
+                incoming_id,
+                750,
+                1_000,
+                incoming,
+            ),
+        ];
+        sanitize_loaded_crossfades(&mut valid);
+        assert_eq!(valid[0].info.fades.crossfade_out_to(), Some(incoming_id));
+        assert_eq!(valid[1].info.fades.crossfade_in_from(), Some(outgoing_id));
+
+        valid[1].clip.info.position = 1_100;
+        sanitize_loaded_crossfades(&mut valid);
+        assert!(valid[0].info.fades.crossfade_out_to().is_none());
+        assert!(valid[1].info.fades.crossfade_in_from().is_none());
+    }
 
     #[test]
     fn authored_section_midi_projects_to_document_and_back() {

--- a/crates/vibez-ui/src/app/views_arrangement.rs
+++ b/crates/vibez-ui/src/app/views_arrangement.rs
@@ -344,6 +344,8 @@ impl App {
                         loop_end: 0,
                         fade_in_frames: 0,
                         fade_out_frames: 0,
+                        crossfade_in: false,
+                        crossfade_out: false,
                         warp_stale: false,
                     });
             }

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -684,6 +684,13 @@ impl App {
                     "Join Clips (Ctrl+J)".into(),
                     Message::join_selected_clips(),
                 ));
+                if !is_note_clip {
+                    col = col.push(menu_btn(
+                        icons::AUDIO_WAVEFORM,
+                        "Crossfade Selected Clips".into(),
+                        Message::Arrangement(ArrangementMsg::CrossfadeSelectedAudioClips),
+                    ));
+                }
                 col = col.push(menu_btn(
                     icons::SCISSORS,
                     "Trim Track Mutes".into(),

--- a/crates/vibez-ui/src/domains/arrangement/audio_clip_inspector.rs
+++ b/crates/vibez-ui/src/domains/arrangement/audio_clip_inspector.rs
@@ -81,8 +81,8 @@ impl TimelineEditorState {
     ) -> ArrangementAction {
         let mut action = ArrangementAction::default();
         let Some(clip) = self
-            .find_content_mut(track_id)
-            .and_then(|content| content.clips.iter_mut().find(|clip| clip.id == clip_id))
+            .find_content(track_id)
+            .and_then(|content| content.clips.iter().find(|clip| clip.id == clip_id))
         else {
             return action;
         };
@@ -102,6 +102,15 @@ impl TimelineEditorState {
             action.status = Some("Refreshing Clip render after a newer edit...".into());
             return action;
         }
+        if success.geometry.is_some() {
+            self.unlink_crossfades_for_clip(engine, track_id, clip_id);
+        }
+        let Some(clip) = self
+            .find_content_mut(track_id)
+            .and_then(|content| content.clips.iter_mut().find(|clip| clip.id == clip_id))
+        else {
+            return action;
+        };
         clip.audio = Arc::clone(&success.audio);
         let replaces_geometry = success.geometry.is_some();
         if let Some(geometry) = success.geometry {
@@ -165,6 +174,15 @@ impl TimelineEditorState {
         else {
             return action;
         };
+        if matches!(
+            field,
+            AudioClipInspectorField::FadeIn
+                | AudioClipInspectorField::FadeOut
+                | AudioClipInspectorField::SourceStart
+                | AudioClipInspectorField::SourceEnd
+        ) {
+            self.unlink_crossfades_for_clip(engine, track_id, clip_id);
+        }
         let Some(clip) = self
             .find_content_mut(track_id)
             .and_then(|content| content.clips.iter_mut().find(|clip| clip.id == clip_id))

--- a/crates/vibez-ui/src/domains/arrangement/audio_clip_inspector.rs
+++ b/crates/vibez-ui/src/domains/arrangement/audio_clip_inspector.rs
@@ -174,14 +174,23 @@ impl TimelineEditorState {
         else {
             return action;
         };
-        if matches!(
-            field,
-            AudioClipInspectorField::FadeIn
-                | AudioClipInspectorField::FadeOut
-                | AudioClipInspectorField::SourceStart
-                | AudioClipInspectorField::SourceEnd
-        ) {
-            self.unlink_crossfades_for_clip(engine, track_id, clip_id);
+        match field {
+            AudioClipInspectorField::FadeIn => self.unlink_crossfade_edge_for_clip(
+                engine,
+                track_id,
+                clip_id,
+                crate::state::AudioClipFadeEdge::In,
+            ),
+            AudioClipInspectorField::FadeOut => self.unlink_crossfade_edge_for_clip(
+                engine,
+                track_id,
+                clip_id,
+                crate::state::AudioClipFadeEdge::Out,
+            ),
+            AudioClipInspectorField::SourceStart | AudioClipInspectorField::SourceEnd => {
+                self.unlink_crossfades_for_clip(engine, track_id, clip_id);
+            }
+            _ => {}
         }
         let Some(clip) = self
             .find_content_mut(track_id)

--- a/crates/vibez-ui/src/domains/arrangement/clipboard.rs
+++ b/crates/vibez-ui/src/domains/arrangement/clipboard.rs
@@ -86,6 +86,7 @@ impl TimelineEditorState {
         for selection in &selections {
             match selection {
                 ArrangementSelection::AudioClip { track_id, clip_id } => {
+                    self.unlink_crossfades_for_clip(engine, *track_id, *clip_id);
                     engine.send(EngineCommand::RemoveClip(*track_id, *clip_id));
                     if let Some(track) = self.find_content_mut(*track_id) {
                         track.clips.retain(|clip| clip.id != *clip_id);
@@ -138,6 +139,7 @@ impl TimelineEditorState {
                     let delta = ((overlap_start - clip_start) * spb).round() as u64;
                     let duration = ((overlap_end - overlap_start) * spb).round() as u64;
                     let mut fragment = clip.clone();
+                    fragment.fades = fragment.fades.unlinked();
                     fragment.position = 0;
                     fragment.duration = duration.max(1);
                     fragment.fades =
@@ -200,11 +202,13 @@ impl TimelineEditorState {
                         if let Some(clip) = self.find_content(*track_id).and_then(|content| {
                             content.clips.iter().find(|clip| clip.id == *clip_id)
                         }) {
+                            let mut copied_clip = clip.clone();
+                            copied_clip.fades = copied_clip.fades.unlinked();
                             copied.push(ClipboardClip::Audio {
                                 track_id: *track_id,
                                 track_offset: 0,
                                 position_beats: clip.position as f64 / spb,
-                                clip: clip.clone(),
+                                clip: copied_clip,
                             });
                         }
                     }
@@ -327,6 +331,7 @@ impl TimelineEditorState {
                 paste_anchor_beats + (entry.position_beats() - earliest_position_beats);
             match entry {
                 ClipboardClip::Audio { mut clip, .. } => {
+                    clip.fades = clip.fades.unlinked();
                     clip.id = ClipId::new();
                     clip.position = (position_beats * ctx.samples_per_beat).round().max(0.0) as u64;
                     engine.send(EngineCommand::AddClip {

--- a/crates/vibez-ui/src/domains/arrangement/clipboard_tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/clipboard_tests.rs
@@ -122,8 +122,10 @@ fn audio_cross_timeline_paste_remints_identity_and_anchors_at_playhead() {
     let project = project_tracks(&[TrackKind::Audio, TrackKind::Audio]);
     let source_track = project.tracks[0].id;
     let destination_track = project.tracks[1].id;
-    let source = audio_clip(600);
+    let mut source = audio_clip(600);
     let source_id = source.id;
+    source.fades =
+        vibez_core::track::ClipFades::default().linked_fade_out(50, ClipId::new(), source.duration);
     let media = Arc::clone(&source.audio);
     let mut source_editor = TimelineEditorState::default();
     Arc::make_mut(&mut source_editor.timeline)
@@ -159,6 +161,8 @@ fn audio_cross_timeline_paste_remints_identity_and_anchors_at_playhead() {
     assert_ne!(pasted.id, source_id);
     assert_eq!(pasted.position, 9_000);
     assert!(Arc::ptr_eq(&pasted.audio, &media));
+    assert_eq!(pasted.fades.fade_out_frames(), 50);
+    assert!(pasted.fades.crossfade_out_to().is_none());
     assert_eq!(
         source_editor.timeline.get(source_track).unwrap().clips[0].id,
         source_id

--- a/crates/vibez-ui/src/domains/arrangement/crossfades.rs
+++ b/crates/vibez-ui/src/domains/arrangement/crossfades.rs
@@ -1,0 +1,162 @@
+//! Explicit linked crossfades between two overlapping Audio Clips.
+
+use vibez_core::id::{ClipId, TrackId};
+use vibez_engine::commands::EngineCommand;
+
+use crate::state::{ArrangementSelection, TimelineEditorState};
+
+use super::{ArrangementAction, EngineHandle};
+
+impl TimelineEditorState {
+    /// Remove every link touching one Clip while retaining its audible fade
+    /// lengths as ordinary linear fades. Geometry edits call this before they
+    /// can make a persisted relationship stale.
+    pub(super) fn unlink_crossfades_for_clip(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        track_id: TrackId,
+        clip_id: ClipId,
+    ) {
+        let Some(content) = self.find_content_mut(track_id) else {
+            return;
+        };
+        let Some(fades) = content
+            .clips
+            .iter()
+            .find(|clip| clip.id == clip_id)
+            .map(|clip| clip.fades)
+        else {
+            return;
+        };
+        let incoming = fades.crossfade_in_from();
+        let outgoing = fades.crossfade_out_to();
+        let mut changed = Vec::new();
+        for clip in &mut content.clips {
+            let next = if clip.id == clip_id {
+                clip.fades.unlinked()
+            } else if incoming == Some(clip.id) && clip.fades.crossfade_out_to() == Some(clip_id) {
+                clip.fades.unlink_fade_out()
+            } else if outgoing == Some(clip.id) && clip.fades.crossfade_in_from() == Some(clip_id) {
+                clip.fades.unlink_fade_in()
+            } else {
+                continue;
+            };
+            if next != clip.fades {
+                clip.fades = next;
+                changed.push((clip.id, next));
+            }
+        }
+        for (changed_id, fades) in changed {
+            engine.send(EngineCommand::SetClipFades {
+                track_id,
+                clip_id: changed_id,
+                fades,
+            });
+        }
+    }
+
+    pub(super) fn crossfade_selected_audio_clips(
+        &mut self,
+        engine: &mut impl EngineHandle,
+    ) -> ArrangementAction {
+        let selected: Vec<_> = self
+            .selected_clips
+            .iter()
+            .filter_map(|selection| match selection {
+                ArrangementSelection::AudioClip { track_id, clip_id } => {
+                    Some((*track_id, *clip_id))
+                }
+                ArrangementSelection::NoteClip { .. } => None,
+            })
+            .collect();
+        if self.selected_clips.len() != 2 || selected.len() != 2 || selected[0].0 != selected[1].0 {
+            return ArrangementAction {
+                status: Some("Select two overlapping Audio Clips on one Track".into()),
+                ..ArrangementAction::default()
+            };
+        }
+        let track_id = selected[0].0;
+        let Some(content) = self.find_content(track_id) else {
+            return ArrangementAction::default();
+        };
+        let mut clips: Vec<_> = selected
+            .iter()
+            .filter_map(|(_, id)| {
+                content
+                    .clips
+                    .iter()
+                    .find(|clip| clip.id == *id)
+                    .map(|clip| {
+                        (
+                            clip.id,
+                            clip.position,
+                            clip.position.saturating_add(clip.duration),
+                        )
+                    })
+            })
+            .collect();
+        clips.sort_by_key(|(_, start, _)| *start);
+        let [(outgoing_id, outgoing_start, outgoing_end), (incoming_id, incoming_start, incoming_end)] =
+            clips.as_slice()
+        else {
+            return ArrangementAction::default();
+        };
+        if outgoing_start == incoming_start
+            || incoming_start >= outgoing_end
+            || outgoing_end > incoming_end
+        {
+            return ArrangementAction {
+                status: Some("The selected Clips need one shared edge overlap".into()),
+                ..ArrangementAction::default()
+            };
+        }
+        let outgoing_id = *outgoing_id;
+        let incoming_id = *incoming_id;
+        let overlap = outgoing_end - incoming_start;
+
+        self.unlink_crossfades_for_clip(engine, track_id, outgoing_id);
+        self.unlink_crossfades_for_clip(engine, track_id, incoming_id);
+        let Some(content) = self.find_content_mut(track_id) else {
+            return ArrangementAction::default();
+        };
+        let Some(outgoing_index) = content.clips.iter().position(|clip| clip.id == outgoing_id)
+        else {
+            return ArrangementAction::default();
+        };
+        let Some(incoming_index) = content.clips.iter().position(|clip| clip.id == incoming_id)
+        else {
+            return ArrangementAction::default();
+        };
+        let (outgoing, incoming) = if outgoing_index < incoming_index {
+            let (left, right) = content.clips.split_at_mut(incoming_index);
+            (&mut left[outgoing_index], &mut right[0])
+        } else {
+            let (left, right) = content.clips.split_at_mut(outgoing_index);
+            (&mut right[0], &mut left[incoming_index])
+        };
+        outgoing.fades = outgoing
+            .fades
+            .linked_fade_out(overlap, incoming_id, outgoing.duration);
+        incoming.fades = incoming
+            .fades
+            .linked_fade_in(overlap, outgoing_id, incoming.duration);
+        let outgoing_fades = outgoing.fades;
+        let incoming_fades = incoming.fades;
+        engine.send(EngineCommand::SetClipFades {
+            track_id,
+            clip_id: outgoing_id,
+            fades: outgoing_fades,
+        });
+        engine.send(EngineCommand::SetClipFades {
+            track_id,
+            clip_id: incoming_id,
+            fades: incoming_fades,
+        });
+
+        ArrangementAction {
+            status: Some("Created equal-power crossfade".into()),
+            mark_dirty: true,
+            ..ArrangementAction::default()
+        }
+    }
+}

--- a/crates/vibez-ui/src/domains/arrangement/crossfades.rs
+++ b/crates/vibez-ui/src/domains/arrangement/crossfades.rs
@@ -3,11 +3,67 @@
 use vibez_core::id::{ClipId, TrackId};
 use vibez_engine::commands::EngineCommand;
 
-use crate::state::{ArrangementSelection, TimelineEditorState};
+use crate::state::{ArrangementSelection, AudioClipFadeEdge, TimelineEditorState};
 
 use super::{ArrangementAction, EngineHandle};
 
 impl TimelineEditorState {
+    pub(super) fn unlink_crossfade_edge_for_clip(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        track_id: TrackId,
+        clip_id: ClipId,
+        edge: AudioClipFadeEdge,
+    ) {
+        let Some(content) = self.find_content_mut(track_id) else {
+            return;
+        };
+        let Some(fades) = content
+            .clips
+            .iter()
+            .find(|clip| clip.id == clip_id)
+            .map(|clip| clip.fades)
+        else {
+            return;
+        };
+        let peer = match edge {
+            AudioClipFadeEdge::In => fades.crossfade_in_from(),
+            AudioClipFadeEdge::Out => fades.crossfade_out_to(),
+        };
+        let mut changed = Vec::new();
+        for clip in &mut content.clips {
+            let next = if clip.id == clip_id {
+                match edge {
+                    AudioClipFadeEdge::In => clip.fades.unlink_fade_in(),
+                    AudioClipFadeEdge::Out => clip.fades.unlink_fade_out(),
+                }
+            } else if peer == Some(clip.id) {
+                match edge {
+                    AudioClipFadeEdge::In if clip.fades.crossfade_out_to() == Some(clip_id) => {
+                        clip.fades.unlink_fade_out()
+                    }
+                    AudioClipFadeEdge::Out if clip.fades.crossfade_in_from() == Some(clip_id) => {
+                        clip.fades.unlink_fade_in()
+                    }
+                    _ => continue,
+                }
+            } else {
+                continue;
+            };
+            if next != clip.fades {
+                clip.fades = next;
+                changed.push((clip.id, next));
+            }
+        }
+        for (changed_id, fades) in changed {
+            engine.send(EngineCommand::SetClipFades {
+                track_id,
+                clip_id: changed_id,
+                fades,
+            });
+        }
+    }
+
     /// Remove every link touching one Clip while retaining its audible fade
     /// lengths as ordinary linear fades. Geometry edits call this before they
     /// can make a persisted relationship stale.
@@ -114,8 +170,8 @@ impl TimelineEditorState {
         let incoming_id = *incoming_id;
         let overlap = outgoing_end - incoming_start;
 
-        self.unlink_crossfades_for_clip(engine, track_id, outgoing_id);
-        self.unlink_crossfades_for_clip(engine, track_id, incoming_id);
+        self.unlink_crossfade_edge_for_clip(engine, track_id, outgoing_id, AudioClipFadeEdge::Out);
+        self.unlink_crossfade_edge_for_clip(engine, track_id, incoming_id, AudioClipFadeEdge::In);
         let Some(content) = self.find_content_mut(track_id) else {
             return ArrangementAction::default();
         };

--- a/crates/vibez-ui/src/domains/arrangement/media_ops.rs
+++ b/crates/vibez-ui/src/domains/arrangement/media_ops.rs
@@ -283,6 +283,7 @@ impl TimelineEditorState {
         new_duration: u64,
     ) -> ArrangementAction {
         let mut action = ArrangementAction::default();
+        self.unlink_crossfades_for_clip(engine, track_id, clip_id);
         let mut sync_data = None;
         let mut clip_end_beat = None;
         if let Some(track) = self.find_content_mut(track_id) {
@@ -352,6 +353,7 @@ impl TimelineEditorState {
         success: ClipWarpSuccess,
     ) -> ArrangementAction {
         let mut action = ArrangementAction::default();
+        self.unlink_crossfades_for_clip(engine, track_id, clip_id);
         engine.send(EngineCommand::ReplaceClipAudio {
             track_id,
             clip_id,
@@ -471,6 +473,7 @@ impl TimelineEditorState {
             .and_then(|track| track.clips.iter().find(|clip| clip.id == old_clip_id))
             .map(|clip| clip.gain_db)
             .unwrap_or_default();
+        self.unlink_crossfades_for_clip(engine, track_id, old_clip_id);
         engine.send(EngineCommand::RemoveClip(track_id, old_clip_id));
         if let Some(track) = self.find_content_mut(track_id) {
             track.clips.retain(|c| c.id != old_clip_id);
@@ -635,7 +638,9 @@ impl TimelineEditorState {
                     }
                     let source_frame = audio_source_frame(clip, local as u64);
                     if let Some(sample) = clip.audio.channels[ch].get(source_frame) {
-                        dst[dst_frame] = *sample * clip.gain_db.linear();
+                        dst[dst_frame] += *sample
+                            * clip.gain_db.linear()
+                            * clip.fades.gain_at(local as u64, clip.duration);
                     }
                 }
             }
@@ -649,6 +654,7 @@ impl TimelineEditorState {
 
         // Remove all originals
         for cid in &clip_ids {
+            self.unlink_crossfades_for_clip(engine, track_id, *cid);
             engine.send(EngineCommand::RemoveClip(track_id, *cid));
             if let Some(track) = self.find_content_mut(track_id) {
                 track.clips.retain(|c| c.id != *cid);
@@ -820,6 +826,7 @@ impl TimelineEditorState {
         original_id: ClipId,
         fragments: Vec<UiClip>,
     ) {
+        self.unlink_crossfades_for_clip(engine, track_id, original_id);
         engine.send(EngineCommand::RemoveClip(track_id, original_id));
         if let Some(content) = self.find_content_mut(track_id) {
             content.clips.retain(|clip| clip.id != original_id);

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -175,6 +175,7 @@ pub enum ArrangementMsg {
     },
     SplitSelectedAtPlayhead,
     JoinSelectedClips,
+    CrossfadeSelectedAudioClips,
     /// Replace selected clips with the portions where their track's captured
     /// Track Mute automation is off.
     TrimSelectedByTrackMutes,
@@ -262,6 +263,7 @@ impl ArrangementMsg {
                 | Self::SplitNoteClip { .. }
                 | Self::SplitSelectedAtPlayhead
                 | Self::JoinSelectedClips
+                | Self::CrossfadeSelectedAudioClips
                 | Self::TrimSelectedByTrackMutes
                 | Self::DeleteClipsInRegion { .. }
                 | Self::SplitClipsAtRegion { .. }

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -27,6 +27,7 @@ pub use messages::{
     ClipTransposeRenderRequest,
 };
 mod clipboard;
+mod crossfades;
 
 /// Every channel carries a flat SSL-style EQ. Also used for the master
 /// bus, which is why it is crate-visible.
@@ -363,6 +364,7 @@ impl TimelineEditorState {
                 }
             }
             ArrangementMsg::RemoveClip(track_id, clip_id) => {
+                self.unlink_crossfades_for_clip(engine, track_id, clip_id);
                 engine.send(EngineCommand::RemoveClip(track_id, clip_id));
                 if let Some(track) = self.find_content_mut(track_id) {
                     track.clips.retain(|c| c.id != clip_id);
@@ -474,6 +476,7 @@ impl TimelineEditorState {
                 clip_id,
                 new_position,
             } => {
+                self.unlink_crossfades_for_clip(engine, track_id, clip_id);
                 if let Some(track) = self.find_content_mut(track_id) {
                     if let Some(clip) = track.clips.iter_mut().find(|c| c.id == clip_id) {
                         clip.position = new_position;
@@ -517,6 +520,7 @@ impl TimelineEditorState {
                 edge,
                 frames,
             } => {
+                self.unlink_crossfades_for_clip(engine, track_id, clip_id);
                 if let Some(clip) = self
                     .find_content_mut(track_id)
                     .and_then(|content| content.clips.iter_mut().find(|clip| clip.id == clip_id))
@@ -548,6 +552,9 @@ impl TimelineEditorState {
                 clip_id,
                 is_note_clip,
             } => {
+                if !is_note_clip {
+                    self.unlink_crossfades_for_clip(engine, source_track, clip_id);
+                }
                 if is_note_clip {
                     // Move note clip between instrument tracks
                     let mut clip_data = None;
@@ -644,6 +651,7 @@ impl TimelineEditorState {
                     for selection in &selections {
                         match selection {
                             ArrangementSelection::AudioClip { track_id, clip_id } => {
+                                self.unlink_crossfades_for_clip(engine, *track_id, *clip_id);
                                 engine.send(EngineCommand::RemoveClip(*track_id, *clip_id));
                                 if let Some(track) = self.find_content_mut(*track_id) {
                                     track.clips.retain(|c| c.id != *clip_id);
@@ -685,6 +693,7 @@ impl TimelineEditorState {
                                         duplicate.name = clip.name.clone();
                                         duplicate.position =
                                             clip.position.saturating_add(clip.duration);
+                                        duplicate.fades = duplicate.fades.unlinked();
                                         duplicate
                                     })
                                 });
@@ -1000,6 +1009,9 @@ impl TimelineEditorState {
             }
             ArrangementMsg::JoinSelectedClips => {
                 return self.op_join_selected_clips(engine, ctx);
+            }
+            ArrangementMsg::CrossfadeSelectedAudioClips => {
+                return self.crossfade_selected_audio_clips(engine);
             }
             ArrangementMsg::TrimSelectedByTrackMutes => {
                 return self.op_trim_selected_by_track_mutes(engine, ctx);

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -520,7 +520,7 @@ impl TimelineEditorState {
                 edge,
                 frames,
             } => {
-                self.unlink_crossfades_for_clip(engine, track_id, clip_id);
+                self.unlink_crossfade_edge_for_clip(engine, track_id, clip_id, edge);
                 if let Some(clip) = self
                     .find_content_mut(track_id)
                     .and_then(|content| content.clips.iter_mut().find(|clip| clip.id == clip_id))

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -520,6 +520,24 @@ impl TimelineEditorState {
                 edge,
                 frames,
             } => {
+                let changes_audible_fades = self
+                    .find_content(track_id)
+                    .and_then(|content| content.clips.iter().find(|clip| clip.id == clip_id))
+                    .is_some_and(|clip| {
+                        let next = match edge {
+                            crate::state::AudioClipFadeEdge::In => {
+                                clip.fades.with_fade_in(frames, clip.duration)
+                            }
+                            crate::state::AudioClipFadeEdge::Out => {
+                                clip.fades.with_fade_out(frames, clip.duration)
+                            }
+                        };
+                        next.fade_in_frames() != clip.fades.fade_in_frames()
+                            || next.fade_out_frames() != clip.fades.fade_out_frames()
+                    });
+                if !changes_audible_fades {
+                    return ArrangementAction::default();
+                }
                 self.unlink_crossfade_edge_for_clip(engine, track_id, clip_id, edge);
                 if let Some(clip) = self
                     .find_content_mut(track_id)
@@ -533,9 +551,6 @@ impl TimelineEditorState {
                             clip.fades.with_fade_out(frames, clip.duration)
                         }
                     };
-                    if fades == clip.fades {
-                        return ArrangementAction::default();
-                    }
                     clip.fades = fades;
                     engine.send(EngineCommand::SetClipFades {
                         track_id,

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -607,6 +607,52 @@ fn one_clip_can_keep_independent_crossfades_on_both_edges() {
 }
 
 #[test]
+fn unchanged_fade_drag_keeps_its_crossfade_link() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, outgoing_id) = add_audio_clip(&mut a, 0, 0, 1_000);
+    let (_, incoming_id) = add_audio_clip(&mut a, 0, 750, 1_000);
+    let mut engine = RecordingEngine::default();
+    a.selected_clips = HashSet::from([
+        ArrangementSelection::AudioClip {
+            track_id,
+            clip_id: outgoing_id,
+        },
+        ArrangementSelection::AudioClip {
+            track_id,
+            clip_id: incoming_id,
+        },
+    ]);
+    a.update(
+        ArrangementMsg::CrossfadeSelectedAudioClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    engine.0.clear();
+
+    let action = a.update(
+        ArrangementMsg::SetAudioClipFade {
+            track_id,
+            clip_id: outgoing_id,
+            edge: crate::state::AudioClipFadeEdge::Out,
+            frames: 250,
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    assert!(!action.mark_dirty);
+    assert!(engine.0.is_empty());
+    assert_eq!(
+        a.tracks[0].clips[0].fades.crossfade_out_to(),
+        Some(incoming_id)
+    );
+    assert_eq!(
+        a.tracks[0].clips[1].fades.crossfade_in_from(),
+        Some(outgoing_id)
+    );
+}
+
+#[test]
 fn create_note_clip_needs_midi_track_and_active_selection() {
     let mut a = arrangement_with_tracks(1);
     let audio_tid = a.tracks[0].id;

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -565,6 +565,48 @@ fn moving_one_crossfaded_clip_unlinks_both_edges_without_losing_fade_lengths() {
 }
 
 #[test]
+fn one_clip_can_keep_independent_crossfades_on_both_edges() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, first_id) = add_audio_clip(&mut a, 0, 0, 1_000);
+    let (_, middle_id) = add_audio_clip(&mut a, 0, 750, 1_000);
+    let (_, last_id) = add_audio_clip(&mut a, 0, 1_500, 1_000);
+    let mut engine = RecordingEngine::default();
+    let selection = |left, right| {
+        HashSet::from([
+            ArrangementSelection::AudioClip {
+                track_id,
+                clip_id: left,
+            },
+            ArrangementSelection::AudioClip {
+                track_id,
+                clip_id: right,
+            },
+        ])
+    };
+
+    a.selected_clips = selection(first_id, middle_id);
+    a.update(
+        ArrangementMsg::CrossfadeSelectedAudioClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    a.selected_clips = selection(middle_id, last_id);
+    a.update(
+        ArrangementMsg::CrossfadeSelectedAudioClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    let middle = a.tracks[0]
+        .clips
+        .iter()
+        .find(|clip| clip.id == middle_id)
+        .unwrap();
+    assert_eq!(middle.fades.crossfade_in_from(), Some(first_id));
+    assert_eq!(middle.fades.crossfade_out_to(), Some(last_id));
+}
+
+#[test]
 fn create_note_clip_needs_midi_track_and_active_selection() {
     let mut a = arrangement_with_tracks(1);
     let audio_tid = a.tracks[0].id;

--- a/crates/vibez-ui/src/domains/arrangement/tests.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests.rs
@@ -364,7 +364,8 @@ fn split_audio_clip_replaces_clip_with_two_halves() {
     let mut a = arrangement_with_tracks(1);
     let (tid, cid) = add_audio_clip(&mut a, 0, 0, 1000);
     let mut engine = RecordingEngine::default();
-    a.tracks[0].clips[0].fades = vibez_core::track::ClipFades::new(100, 200, 1000);
+    a.tracks[0].clips[0].fades =
+        vibez_core::track::ClipFades::new(100, 200, 1000).linked_fade_out(200, ClipId::new(), 1000);
     a.update(
         ArrangementMsg::SplitAudioClip {
             track_id: tid,
@@ -383,7 +384,12 @@ fn split_audio_clip_replaces_clip_with_two_halves() {
     assert_eq!(a.tracks[0].clips[0].fades.fade_out_frames(), 0);
     assert_eq!(a.tracks[0].clips[1].fades.fade_in_frames(), 0);
     assert_eq!(a.tracks[0].clips[1].fades.fade_out_frames(), 200);
-    assert!(matches!(engine.0[0], EngineCommand::RemoveClip(..)));
+    assert!(a.tracks[0].clips[0].fades.crossfade_out_to().is_none());
+    assert!(a.tracks[0].clips[1].fades.crossfade_out_to().is_none());
+    assert!(engine
+        .0
+        .iter()
+        .any(|command| matches!(command, EngineCommand::RemoveClip(..))));
 }
 
 #[test]
@@ -452,6 +458,110 @@ fn join_rejects_mixed_selection_types() {
         action.status.as_deref(),
         Some("Join requires same type and track")
     );
+}
+
+#[test]
+fn two_selected_edge_overlaps_create_one_equal_power_crossfade() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, outgoing_id) = add_audio_clip(&mut a, 0, 0, 1_000);
+    let (_, incoming_id) = add_audio_clip(&mut a, 0, 750, 1_000);
+    a.selected_clips = HashSet::from([
+        ArrangementSelection::AudioClip {
+            track_id,
+            clip_id: outgoing_id,
+        },
+        ArrangementSelection::AudioClip {
+            track_id,
+            clip_id: incoming_id,
+        },
+    ]);
+    let mut engine = RecordingEngine::default();
+
+    let action = a.update(
+        ArrangementMsg::CrossfadeSelectedAudioClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    let outgoing = a.tracks[0]
+        .clips
+        .iter()
+        .find(|clip| clip.id == outgoing_id)
+        .unwrap();
+    let incoming = a.tracks[0]
+        .clips
+        .iter()
+        .find(|clip| clip.id == incoming_id)
+        .unwrap();
+    assert_eq!(
+        action.status.as_deref(),
+        Some("Created equal-power crossfade")
+    );
+    assert_eq!(outgoing.fades.fade_out_frames(), 250);
+    assert_eq!(outgoing.fades.crossfade_out_to(), Some(incoming_id));
+    assert_eq!(incoming.fades.fade_in_frames(), 250);
+    assert_eq!(incoming.fades.crossfade_in_from(), Some(outgoing_id));
+    assert_eq!(
+        engine
+            .0
+            .iter()
+            .filter(|command| matches!(command, EngineCommand::SetClipFades { .. }))
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn moving_one_crossfaded_clip_unlinks_both_edges_without_losing_fade_lengths() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, outgoing_id) = add_audio_clip(&mut a, 0, 0, 1_000);
+    let (_, incoming_id) = add_audio_clip(&mut a, 0, 750, 1_000);
+    a.selected_clips = HashSet::from([
+        ArrangementSelection::AudioClip {
+            track_id,
+            clip_id: outgoing_id,
+        },
+        ArrangementSelection::AudioClip {
+            track_id,
+            clip_id: incoming_id,
+        },
+    ]);
+    let mut engine = RecordingEngine::default();
+    a.update(
+        ArrangementMsg::CrossfadeSelectedAudioClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    engine.0.clear();
+
+    a.update(
+        ArrangementMsg::MoveAudioClip {
+            track_id,
+            clip_id: incoming_id,
+            new_position: 1_100,
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    let outgoing = a.tracks[0]
+        .clips
+        .iter()
+        .find(|clip| clip.id == outgoing_id)
+        .unwrap();
+    let incoming = a.tracks[0]
+        .clips
+        .iter()
+        .find(|clip| clip.id == incoming_id)
+        .unwrap();
+    assert_eq!(outgoing.fades.fade_out_frames(), 250);
+    assert_eq!(incoming.fades.fade_in_frames(), 250);
+    assert!(outgoing.fades.crossfade_out_to().is_none());
+    assert!(incoming.fades.crossfade_in_from().is_none());
+    assert!(matches!(
+        engine.0.last(),
+        Some(EngineCommand::MoveClip { .. })
+    ));
 }
 
 #[test]

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -170,6 +170,8 @@ impl TrackClipCanvas {
                 loop_end: c.loop_end,
                 fade_in_frames: c.fades.fade_in_frames(),
                 fade_out_frames: c.fades.fade_out_frames(),
+                crossfade_in: c.fades.crossfade_in_from().is_some(),
+                crossfade_out: c.fades.crossfade_out_to().is_some(),
                 warp_stale: c.warped
                     && c.warped_to_bpm
                         .map(|b| (b - bpm).abs() > 0.01)

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -268,11 +268,30 @@ impl TrackClipCanvas {
                     let (fade_in_x, fade_out_x) = fade_handle_xs(clip_x, clip_w, clip);
                     let top = clip_y + CLIP_TITLE_HEIGHT + 2.0;
                     let bottom = clip_y + clip_h - 2.0;
+                    let curve_gain = |progress: f32, equal_power: bool| {
+                        if equal_power {
+                            (progress * std::f32::consts::FRAC_PI_2).sin()
+                        } else {
+                            progress
+                        }
+                    };
                     let envelope = canvas::Path::new(|builder| {
                         builder.move_to(iced::Point::new(clip_x, bottom));
-                        builder.line_to(iced::Point::new(fade_in_x, top));
+                        for step in 1..=12 {
+                            let progress = step as f32 / 12.0;
+                            let x = clip_x + (fade_in_x - clip_x) * progress;
+                            let y =
+                                bottom - (bottom - top) * curve_gain(progress, clip.crossfade_in);
+                            builder.line_to(iced::Point::new(x, y));
+                        }
                         builder.line_to(iced::Point::new(fade_out_x, top));
-                        builder.line_to(iced::Point::new(clip_x + clip_w, bottom));
+                        for step in 1..=12 {
+                            let progress = step as f32 / 12.0;
+                            let x = fade_out_x + (clip_x + clip_w - fade_out_x) * progress;
+                            let gain = curve_gain(1.0 - progress, clip.crossfade_out);
+                            let y = bottom - (bottom - top) * gain;
+                            builder.line_to(iced::Point::new(x, y));
+                        }
                     });
                     frame.stroke(
                         &envelope,
@@ -288,6 +307,22 @@ impl TrackClipCanvas {
                                 theme::accent(),
                             );
                         }
+                    }
+                    for x in [
+                        clip.crossfade_in.then_some((clip_x + fade_in_x) / 2.0),
+                        clip.crossfade_out
+                            .then_some((fade_out_x + clip_x + clip_w) / 2.0),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    {
+                        frame.fill_text(canvas::Text {
+                            content: "X".into(),
+                            position: iced::Point::new(x - 3.0, top + 3.0),
+                            color: theme::accent(),
+                            size: iced::Pixels(9.0),
+                            ..Default::default()
+                        });
                     }
                 }
                 let border_color = if is_selected {

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -316,13 +316,18 @@ impl TrackClipCanvas {
                     .into_iter()
                     .flatten()
                     {
-                        frame.fill_text(canvas::Text {
-                            content: "X".into(),
-                            position: iced::Point::new(x - 3.0, top + 3.0),
-                            color: theme::accent(),
-                            size: iced::Pixels(9.0),
-                            ..Default::default()
+                        let cross = canvas::Path::new(|builder| {
+                            builder.move_to(iced::Point::new(x - 3.0, top + 2.0));
+                            builder.line_to(iced::Point::new(x + 3.0, top + 8.0));
+                            builder.move_to(iced::Point::new(x + 3.0, top + 2.0));
+                            builder.line_to(iced::Point::new(x - 3.0, top + 8.0));
                         });
+                        frame.stroke(
+                            &cross,
+                            canvas::Stroke::default()
+                                .with_color(theme::accent())
+                                .with_width(1.4),
+                        );
                     }
                 }
                 let border_color = if is_selected {

--- a/crates/vibez-ui/src/widgets/timeline/clips_tests.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_tests.rs
@@ -355,6 +355,8 @@ fn physical_right_click_opens_clip_and_empty_arrange_context_menus() {
         loop_end: 0,
         fade_in_frames: 0,
         fade_out_frames: 0,
+        crossfade_in: false,
+        crossfade_out: false,
         warp_stale: false,
     });
     let (status, message) = right_click(&canvas, Point::new(10.0, 10.0));
@@ -438,6 +440,8 @@ fn audio_recording_waveform_is_visible_but_not_hit_testable() {
         loop_end: 0,
         fade_in_frames: 0,
         fade_out_frames: 0,
+        crossfade_in: false,
+        crossfade_out: false,
         warp_stale: false,
     });
 
@@ -464,6 +468,8 @@ fn selected_audio_fade_handle_drag_emits_realtime_edits_in_one_undo_gesture() {
         loop_end: 44_100,
         fade_in_frames: 11_025,
         fade_out_frames: 0,
+        crossfade_in: false,
+        crossfade_out: false,
         warp_stale: false,
     });
     canvas.selected_clips.insert(clip_id);

--- a/crates/vibez-ui/src/widgets/timeline/fade_drag.rs
+++ b/crates/vibez-ui/src/widgets/timeline/fade_drag.rs
@@ -123,6 +123,8 @@ mod tests {
             loop_end: 48_000,
             fade_in_frames: 12_345,
             fade_out_frames: 6_789,
+            crossfade_in: false,
+            crossfade_out: false,
             warp_stale: false,
         };
         let (fade_in_x, fade_out_x) = fade_handle_xs(37.0, 481.0, &clip);

--- a/crates/vibez-ui/src/widgets/timeline/mod.rs
+++ b/crates/vibez-ui/src/widgets/timeline/mod.rs
@@ -23,6 +23,8 @@ pub struct TimelineClip {
     pub loop_end: u64,
     pub fade_in_frames: u64,
     pub fade_out_frames: u64,
+    pub crossfade_in: bool,
+    pub crossfade_out: bool,
     /// True when this clip is warped but its `warped_to_bpm` no longer
     /// matches the current project BPM. The canvas draws a diagonal
     /// stripe overlay so the user can see at a glance that a re-warp


### PR DESCRIPTION
## Summary

- create an explicit equal-power crossfade from two selected Audio Clips with one shared-edge overlap
- persist reciprocal Clip links and repair stale or incomplete relationships during project load
- render complementary curves through the shared live, Section, Bounce, and export path
- show curved envelopes and crossfade marks in Arrange and Section timelines
- let a middle Clip keep independent incoming and outgoing crossfades
- unlink only an edited fade edge, or both edges for geometry changes, while retaining ordinary fade lengths

## Stack

- depends on #196 and #197

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`