### PR TITLE
feat: slice audio clips to drum rack

### DIFF
--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -482,8 +482,29 @@ impl MediaSourceRef {
 }
 
 /// Persisted state for a future native drum rack.
+pub const DRUM_RACK_PAD_COUNT: usize = 16;
+pub const DRUM_RACK_BASE_NOTE: u8 = 36;
+
+pub const fn drum_rack_pad_pitch(pad_index: usize) -> Option<u8> {
+    if pad_index < DRUM_RACK_PAD_COUNT {
+        Some(DRUM_RACK_BASE_NOTE + pad_index as u8)
+    } else {
+        None
+    }
+}
+
+pub const fn drum_rack_pad_index(pitch: u8) -> Option<usize> {
+    if pitch >= DRUM_RACK_BASE_NOTE && pitch < DRUM_RACK_BASE_NOTE + DRUM_RACK_PAD_COUNT as u8 {
+        Some((pitch - DRUM_RACK_BASE_NOTE) as usize)
+    } else {
+        None
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DrumPadState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub source: Option<MediaSourceRef>,
     pub gain: f32,
     pub pan: f32,

--- a/crates/vibez-instruments/src/drum_rack.rs
+++ b/crates/vibez-instruments/src/drum_rack.rs
@@ -3,12 +3,10 @@ use std::sync::Arc;
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::effect::ParamDescriptor;
 use vibez_core::midi::InstrumentKind;
-use vibez_core::track::DrumPadState;
+use vibez_core::track::{drum_rack_pad_index, DrumPadState, DRUM_RACK_PAD_COUNT};
 
 use crate::Instrument;
 
-const PAD_COUNT: usize = 16;
-const BASE_PAD_NOTE: u8 = 36;
 const MAX_VOICES: usize = 32;
 
 #[derive(Debug, Clone)]
@@ -91,14 +89,13 @@ impl DrumRack {
     pub fn new(sample_rate: f32) -> Self {
         Self {
             sample_rate,
-            pads: (0..PAD_COUNT).map(|_| Pad::default()).collect(),
+            pads: (0..DRUM_RACK_PAD_COUNT).map(|_| Pad::default()).collect(),
             voices: (0..MAX_VOICES).map(|_| Voice::inactive()).collect(),
         }
     }
 
     fn pitch_to_pad(pitch: u8) -> Option<usize> {
-        let offset = pitch.checked_sub(BASE_PAD_NOTE)? as usize;
-        (offset < PAD_COUNT).then_some(offset)
+        drum_rack_pad_index(pitch)
     }
 
     fn frame_range(pad: &Pad, sample: &DecodedAudio) -> Option<(usize, usize)> {
@@ -301,9 +298,9 @@ impl Instrument for DrumRack {
             pad.fine_tune = state.fine_tune;
             pad.one_shot = state.one_shot;
             pad.choke_group = state.choke_group;
-            if pad.sample_name.is_none() {
-                pad.sample_name = state.source.as_ref().map(|source| source.display_name());
-            }
+            pad.sample_name = state
+                .name
+                .or_else(|| state.source.as_ref().map(|source| source.display_name()));
         }
     }
 }

--- a/crates/vibez-project/tests/project_format_v1.rs
+++ b/crates/vibez-project/tests/project_format_v1.rs
@@ -286,7 +286,8 @@ fn sliced_drum_rack_pads_and_reconstruction_notes_survive_reopen_with_one_media_
     let source = || MediaSourceRef::LocalFile {
         path: source_path.clone(),
     };
-    let pad = |start, end| DrumPadState {
+    let pad = |name: &str, start, end| DrumPadState {
+        name: Some(name.into()),
         source: Some(source()),
         gain: 1.0,
         pan: 0.0,
@@ -295,13 +296,13 @@ fn sliced_drum_rack_pads_and_reconstruction_notes_survive_reopen_with_one_media_
         coarse_tune: 0,
         fine_tune: 0.0,
         one_shot: true,
-        choke_group: Some(1),
+        choke_group: None,
     };
     let mut track = TrackInfo::new("Slices 1");
     track.kind = TrackKind::Midi;
     track.instrument = Some(InstrumentKind::DrumRack);
     track.native_instrument = Some(InstrumentStateInfo::DrumRack {
-        pads: vec![pad(0.0, 0.4), pad(0.4, 1.0)],
+        pads: vec![pad("Loop Slice 1", 0.0, 0.4), pad("Loop Slice 2", 0.4, 1.0)],
     });
     let note_clip = NoteClipInfo {
         id: ClipId::new(),
@@ -312,13 +313,13 @@ fn sliced_drum_rack_pads_and_reconstruction_notes_survive_reopen_with_one_media_
         notes: vec![
             MidiNote {
                 pitch: 36,
-                velocity: 100,
+                velocity: 127,
                 start_beat: 0.0,
                 duration_beats: 3.2,
             },
             MidiNote {
                 pitch: 37,
-                velocity: 100,
+                velocity: 127,
                 start_beat: 3.2,
                 duration_beats: 4.8,
             },
@@ -353,6 +354,8 @@ fn sliced_drum_rack_pads_and_reconstruction_notes_survive_reopen_with_one_media_
     };
     assert_eq!((pads[0].start, pads[0].end), (0.0, 0.4));
     assert_eq!((pads[1].start, pads[1].end), (0.4, 1.0));
+    assert_eq!(pads[0].name.as_deref(), Some("Loop Slice 1"));
+    assert_eq!(pads[1].name.as_deref(), Some("Loop Slice 2"));
     let ids: Vec<_> = pads
         .iter()
         .filter_map(|pad| match pad.source.as_ref()? {

--- a/crates/vibez-project/tests/project_format_v1.rs
+++ b/crates/vibez-project/tests/project_format_v1.rs
@@ -4,8 +4,10 @@ use std::process::Command;
 use std::time::Duration;
 
 use vibez_core::id::{ClipId, SectionId};
+use vibez_core::midi::{InstrumentKind, MidiNote, NoteClipInfo, TrackKind};
 use vibez_core::track::{
-    ClipFades, ClipGainDb, ClipInfo, ClipTranspose, MediaSourceRef, TrackInfo,
+    ClipFades, ClipGainDb, ClipInfo, ClipTranspose, DrumPadState, InstrumentStateInfo,
+    MediaSourceRef, TrackInfo,
 };
 use vibez_project::project_format_v1::{
     detect_project_format, hex_sha256, representative_document, save_project_v1, stage_local_file,
@@ -273,6 +275,93 @@ fn arrange_and_section_share_one_embedded_media_row() {
             .unwrap(),
         bytes
     );
+}
+
+#[test]
+fn sliced_drum_rack_pads_and_reconstruction_notes_survive_reopen_with_one_media_row() {
+    let directory = tempfile::tempdir().unwrap();
+    let source_path = directory.path().join("sliced-loop.wav");
+    let destination = directory.path().join("sliced-rack.vzp");
+    fs::write(&source_path, vec![23_u8; 4_096]).unwrap();
+    let source = || MediaSourceRef::LocalFile {
+        path: source_path.clone(),
+    };
+    let pad = |start, end| DrumPadState {
+        source: Some(source()),
+        gain: 1.0,
+        pan: 0.0,
+        start,
+        end,
+        coarse_tune: 0,
+        fine_tune: 0.0,
+        one_shot: true,
+        choke_group: Some(1),
+    };
+    let mut track = TrackInfo::new("Slices 1");
+    track.kind = TrackKind::Midi;
+    track.instrument = Some(InstrumentKind::DrumRack);
+    track.native_instrument = Some(InstrumentStateInfo::DrumRack {
+        pads: vec![pad(0.0, 0.4), pad(0.4, 1.0)],
+    });
+    let note_clip = NoteClipInfo {
+        id: ClipId::new(),
+        track_id: track.id,
+        name: "Loop Slices".into(),
+        position_beats: 4.0,
+        duration_beats: 8.0,
+        notes: vec![
+            MidiNote {
+                pitch: 36,
+                velocity: 100,
+                start_beat: 0.0,
+                duration_beats: 3.2,
+            },
+            MidiNote {
+                pitch: 37,
+                velocity: 100,
+                start_beat: 3.2,
+                duration_beats: 4.8,
+            },
+        ],
+        start_marker_beats: Some(0.0),
+        loop_enabled: false,
+        loop_start_beats: 0.0,
+        loop_end_beats: 8.0,
+        groove_grid: Default::default(),
+    };
+    let project = Project {
+        tracks: vec![track],
+        arrange: TimelineInfo {
+            note_clips: vec![note_clip],
+            ..TimelineInfo::default()
+        },
+        ..Project::default()
+    };
+
+    save_project_v1(&destination, None, project).unwrap();
+    let loaded = ProjectContainer::open(&destination)
+        .unwrap()
+        .load_document()
+        .unwrap();
+
+    assert_eq!(loaded.project_media.len(), 1);
+    assert_eq!(loaded.project.arrange.note_clips[0].notes.len(), 2);
+    let InstrumentStateInfo::DrumRack { pads } =
+        loaded.project.tracks[0].native_instrument.as_ref().unwrap()
+    else {
+        panic!("Drum Rack state");
+    };
+    assert_eq!((pads[0].start, pads[0].end), (0.0, 0.4));
+    assert_eq!((pads[1].start, pads[1].end), (0.4, 1.0));
+    let ids: Vec<_> = pads
+        .iter()
+        .filter_map(|pad| match pad.source.as_ref()? {
+            MediaSourceRef::ProjectMedia { id, .. } => Some(id),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(ids.len(), 2);
+    assert_eq!(ids[0], ids[1]);
 }
 
 #[test]

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -54,6 +54,16 @@ fn prepare_playing_section_refresh(
         .map(|section| section.prepare_playback_source(project_tracks))
 }
 
+fn section_to_refresh_after_project_track_replay(
+    replayed_track: Option<vibez_core::id::TrackId>,
+    location: vibez_project::TimelineLocation,
+) -> Option<SectionId> {
+    match (replayed_track, location) {
+        (Some(_), vibez_project::TimelineLocation::Section(section_id)) => Some(section_id),
+        _ => None,
+    }
+}
+
 impl App {
     fn begin_section_residency(&mut self, section_id: SectionId) -> Task<Message> {
         let Some(section) = self.state.perform.sections.by_id(section_id).cloned() else {
@@ -281,8 +291,8 @@ impl App {
                 self.replay_track_to_engine(&track);
             }
         }
-        if let (Some(_), vibez_project::TimelineLocation::Section(section_id)) =
-            (replayed_project_track, location)
+        if let Some(section_id) =
+            section_to_refresh_after_project_track_replay(replayed_project_track, location)
         {
             self.refresh_playing_section_after_edit(section_id);
         }
@@ -641,7 +651,7 @@ impl App {
                 track.sample_source = None;
                 track.sample_audio = None;
                 track.instrument_params.clear();
-                track.drum_rack_pads = (0..16)
+                track.drum_rack_pads = (0..vibez_core::track::DRUM_RACK_PAD_COUNT)
                     .map(|_| crate::state::UiDrumPad::default())
                     .collect();
                 track.selected_drum_pad = 0;
@@ -981,5 +991,33 @@ mod perform_action_tests {
             other_id,
         )
         .is_none());
+    }
+
+    #[test]
+    fn section_slice_refresh_is_requested_only_after_a_new_project_track_is_replayed() {
+        let section_id = crate::domains::perform::Section::new(0).id;
+        let track_id = TrackId::new();
+
+        assert_eq!(
+            section_to_refresh_after_project_track_replay(
+                Some(track_id),
+                vibez_project::TimelineLocation::Section(section_id),
+            ),
+            Some(section_id)
+        );
+        assert_eq!(
+            section_to_refresh_after_project_track_replay(
+                None,
+                vibez_project::TimelineLocation::Section(section_id),
+            ),
+            None
+        );
+        assert_eq!(
+            section_to_refresh_after_project_track_replay(
+                Some(track_id),
+                vibez_project::TimelineLocation::Arrange,
+            ),
+            None
+        );
     }
 }

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -275,6 +275,17 @@ impl App {
                 );
             }
         }
+        let replayed_project_track = action.replay_project_track.take();
+        if let Some(track_id) = replayed_project_track {
+            if let Some(track) = self.state.find_track(track_id).cloned() {
+                self.replay_track_to_engine(&track);
+            }
+        }
+        if let (Some(_), vibez_project::TimelineLocation::Section(section_id)) =
+            (replayed_project_track, location)
+        {
+            self.refresh_playing_section_after_edit(section_id);
+        }
         if let Some(track_id) = action.close_track_guis {
             if let Some(ref mut mgr) = self.plugin_window_manager {
                 mgr.close_track_effects(track_id);

--- a/crates/vibez-ui/src/app/async_helpers.rs
+++ b/crates/vibez-ui/src/app/async_helpers.rs
@@ -863,7 +863,7 @@ pub(super) async fn load_project_async(
                                 pad_index,
                                 source: source.clone(),
                                 audio: Arc::new(audio),
-                                name: source.display_name(),
+                                name: pad.name.clone().unwrap_or_else(|| source.display_name()),
                                 state: pad.clone(),
                             }),
                             Err(err) => warnings.push(format!("Skipped {label} ({err})")),

--- a/crates/vibez-ui/src/app/bounce.rs
+++ b/crates/vibez-ui/src/app/bounce.rs
@@ -12,7 +12,8 @@ use vibez_core::id::{ClipId, TrackId};
 use vibez_engine::commands::EngineCommand;
 
 use crate::message::Message;
-use crate::state::{ArrangementSelection, ProjectTrack, UiClip};
+use crate::state::{ArrangementSelection, UiClip};
+use vibez_core::midi::TrackKind;
 
 use super::*;
 
@@ -120,16 +121,14 @@ impl App {
     }
 
     pub(super) fn finalize_bounce(&mut self, outcome: crate::message::BounceOutcome) {
-        let track_num = self.next_unique_track_number("Bounce");
-        Arc::make_mut(&mut self.state.project_tracks).next_track_number = track_num + 1;
-        let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-        let track_id = TrackId::new();
-        let track_name = format!("Bounce {track_num}");
-
-        self.send_command(EngineCommand::AddTrack(track_id, track_name.clone()));
-        Arc::make_mut(&mut self.state.project_tracks)
-            .tracks
-            .push(ProjectTrack::new(track_id, track_name, color_index));
+        let track_id = {
+            let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+            Arc::make_mut(&mut self.state.project_tracks).add_numbered_track(
+                "Bounce",
+                TrackKind::Audio,
+                &mut engine,
+            )
+        };
 
         let clip_id = ClipId::new();
         let duration = outcome.audio.num_frames() as u64;

--- a/crates/vibez-ui/src/app/drum_rack_preparation.rs
+++ b/crates/vibez-ui/src/app/drum_rack_preparation.rs
@@ -1,0 +1,219 @@
+//! Offline preparation for faithful Audio Clip to Drum Rack conversion.
+
+use std::sync::Arc;
+
+use vibez_core::track::{MediaProvenance, MediaSourceRef};
+
+pub(super) async fn prepare_drum_rack_audio_async(
+    clip: crate::state::UiClip,
+) -> Result<crate::message::PreparedDrumRackAudio, String> {
+    tokio::task::spawn_blocking(move || {
+        let source = clip
+            .source
+            .clone()
+            .ok_or_else(|| "Slice to Drum Rack needs available Source Media".to_string())?;
+        let frame_count = usize::try_from(clip.duration)
+            .map_err(|_| "Audio Clip is too long to prepare as Drum Rack media".to_string())?;
+        if frame_count == 0 || clip.audio.num_channels() == 0 {
+            return Err("Slice to Drum Rack needs available audio".to_string());
+        }
+
+        let channels = (0..clip.audio.num_channels())
+            .map(|channel| {
+                (0..clip.duration)
+                    .map(|clip_frame| {
+                        let source_frame = clip.source_frame_position_at(clip_frame);
+                        let fade_gain = clip.fades.gain_at(clip_frame, clip.duration);
+                        clip.audio.sample_linear(channel, source_frame) * fade_gain
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        let rendered = Arc::new(vibez_core::audio_buffer::DecodedAudio {
+            channels,
+            sample_rate: clip.audio.sample_rate,
+        });
+        debug_assert_eq!(rendered.num_frames(), frame_count);
+
+        let source_name = source.display_name();
+        let stem = std::path::Path::new(&source_name)
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned())
+            .filter(|stem| !stem.is_empty())
+            .unwrap_or_else(|| "audio-clip".into());
+        let file_name = format!("{stem}-slices.wav");
+        let bytes = vibez_audio_io::file_io::encode_wav(&rendered);
+        let staged = stage_rendered_audio(source, &file_name, &bytes)?;
+        let persisted =
+            vibez_audio_io::file_io::decode_audio_cursor(std::io::Cursor::new(bytes), Some("wav"))
+                .map_err(|error| format!("Drum Rack media verification failed: {error}"))?;
+        debug_assert_eq!(persisted.num_frames(), frame_count);
+
+        Ok(crate::message::PreparedDrumRackAudio {
+            source: staged,
+            audio: Arc::new(persisted),
+        })
+    })
+    .await
+    .map_err(|error| format!("Drum Rack preparation task failed: {error}"))?
+}
+
+fn stage_rendered_audio(
+    source: MediaSourceRef,
+    file_name: &str,
+    bytes: &[u8],
+) -> Result<MediaSourceRef, String> {
+    let staged = match source {
+        MediaSourceRef::StagedRemoteProjectMedia { provenance, .. } => {
+            vibez_project::project_format_v1::stage_remote_content(file_name, bytes, *provenance)
+        }
+        MediaSourceRef::ProjectMedia {
+            provenance: Some(provenance),
+            ..
+        } if matches!(provenance.as_ref(), MediaProvenance::Remote { .. }) => {
+            vibez_project::project_format_v1::stage_remote_content(file_name, bytes, *provenance)
+        }
+        MediaSourceRef::LocalFile { path }
+        | MediaSourceRef::StagedProjectMedia {
+            source_path: path, ..
+        } => vibez_project::project_format_v1::stage_local_content(&path, file_name, bytes),
+        MediaSourceRef::ProjectMedia { provenance, .. } => {
+            let source_path = provenance
+                .and_then(|provenance| match *provenance {
+                    MediaProvenance::Local { source_path } => Some(source_path),
+                    MediaProvenance::Remote { .. } => None,
+                })
+                .unwrap_or_else(|| std::path::PathBuf::from("Project Media"));
+            vibez_project::project_format_v1::stage_local_content(&source_path, file_name, bytes)
+        }
+        MediaSourceRef::DropboxFile { .. } => {
+            return Err("Slice to Drum Rack needs materialized Project Media".into());
+        }
+    };
+    staged.map_err(|error| format!("Drum Rack media staging failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibez_core::track::{ClipFades, ClipGainDb, ClipPlaybackDirection};
+
+    #[tokio::test]
+    async fn preparation_flattens_reverse_loop_gain_and_fades_into_project_media() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("loop.wav");
+        let audio = Arc::new(vibez_core::audio_buffer::DecodedAudio {
+            channels: vec![(0..8).map(|frame| frame as f32).collect()],
+            sample_rate: 48_000,
+        });
+        let clip = crate::state::UiClip {
+            id: vibez_core::id::ClipId::new(),
+            name: "Loop".into(),
+            audio,
+            source: Some(MediaSourceRef::LocalFile {
+                path: source_path.clone(),
+            }),
+            position: 0,
+            source_offset: 0,
+            start_marker: 2,
+            duration: 6,
+            loop_enabled: true,
+            loop_start: 2,
+            loop_end: 4,
+            gain_db: ClipGainDb::new(12.0).unwrap(),
+            fades: ClipFades::new(1, 1, 6),
+            playback_direction: ClipPlaybackDirection::Reverse,
+            transient_markers: Default::default(),
+            warp_markers: Default::default(),
+            transpose: Default::default(),
+            original_bpm: None,
+            warped: false,
+            warped_to_bpm: None,
+            original_audio: None,
+        };
+
+        let prepared = prepare_drum_rack_audio_async(clip).await.unwrap();
+
+        assert_eq!(prepared.audio.num_frames(), 6);
+        let expected = [0.0, 1.0, 1.0, 1.0, 1.0, 0.0];
+        for (actual, expected) in prepared.audio.channels[0].iter().zip(expected) {
+            assert!((actual - expected).abs() < 1e-4);
+        }
+        assert!(matches!(
+            prepared.source,
+            MediaSourceRef::StagedProjectMedia { source_path: path, .. } if path == source_path
+        ));
+    }
+
+    #[tokio::test]
+    async fn prepared_warped_audio_and_pad_name_survive_save_and_reopen() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("warped.wav");
+        let project_path = directory.path().join("warped-slices.vzp");
+        let mut clip = crate::state::UiClip {
+            id: vibez_core::id::ClipId::new(),
+            name: "Warped Loop".into(),
+            audio: Arc::new(vibez_core::audio_buffer::DecodedAudio {
+                channels: vec![(0..8).map(|frame| frame as f32 / 10.0).collect()],
+                sample_rate: 48_000,
+            }),
+            source: Some(MediaSourceRef::LocalFile { path: source_path }),
+            position: 0,
+            source_offset: 0,
+            start_marker: 0,
+            duration: 6,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 6,
+            gain_db: Default::default(),
+            fades: Default::default(),
+            playback_direction: ClipPlaybackDirection::Reverse,
+            transient_markers: Default::default(),
+            warp_markers: Default::default(),
+            transpose: vibez_core::track::ClipTranspose::new(7),
+            original_bpm: Some(120.0),
+            warped: true,
+            warped_to_bpm: Some(140.0),
+            original_audio: None,
+        };
+        assert!(clip.warp_markers.add(4, 3, 0, 8, 6));
+        let prepared = prepare_drum_rack_audio_async(clip).await.unwrap();
+        let expected = Arc::clone(&prepared.audio);
+
+        let mut track = vibez_core::track::TrackInfo::new("Slices 1");
+        track.kind = vibez_core::midi::TrackKind::Midi;
+        track.instrument = Some(vibez_core::midi::InstrumentKind::DrumRack);
+        track.native_instrument = Some(vibez_core::track::InstrumentStateInfo::DrumRack {
+            pads: vec![vibez_core::track::DrumPadState {
+                name: Some("Warped Loop Slice 1".into()),
+                source: Some(prepared.source),
+                gain: 1.0,
+                pan: 0.0,
+                start: 0.0,
+                end: 1.0,
+                coarse_tune: 0,
+                fine_tune: 0.0,
+                one_shot: true,
+                choke_group: None,
+            }],
+        });
+        let project = vibez_project::Project {
+            tracks: vec![track],
+            ..vibez_project::Project::default()
+        };
+        vibez_project::project_format_v1::save_project_v1(&project_path, None, project).unwrap();
+
+        let reopened = crate::app::async_helpers::load_project_async(project_path, None)
+            .await
+            .unwrap();
+        assert!(reopened.warnings.is_empty());
+        assert_eq!(reopened.drum_rack_pad_samples.len(), 1);
+        let pad = &reopened.drum_rack_pad_samples[0];
+        assert_eq!(pad.state.name.as_deref(), Some("Warped Loop Slice 1"));
+        assert_eq!(pad.name, "Warped Loop Slice 1");
+        assert_eq!(pad.audio.num_frames(), expected.num_frames());
+        for (actual, expected) in pad.audio.channels[0].iter().zip(&expected.channels[0]) {
+            assert!((actual - expected).abs() < 1e-4);
+        }
+    }
+}

--- a/crates/vibez-ui/src/app/media.rs
+++ b/crates/vibez-ui/src/app/media.rs
@@ -12,7 +12,7 @@ use vibez_core::track::MediaSourceRef;
 use vibez_engine::commands::{AuditionStart, EngineCommand};
 
 use crate::message::{BrowserImportTarget, Message, PreparedBrowserImport};
-use crate::state::{AuditionMode, ProjectTrack, SampleBrowserEntry, UiClip, UiDrumPad};
+use crate::state::{AuditionMode, SampleBrowserEntry, UiClip, UiDrumPad};
 
 use super::*;
 
@@ -416,16 +416,14 @@ impl App {
             }
         }
 
-        let track_num = self.next_unique_track_number("Audio");
-        Arc::make_mut(&mut self.state.project_tracks).next_track_number = track_num + 1;
-        let id = TrackId::new();
-        let color_index = ((track_num - 1) % 8) as u8;
-        let name = format!("Audio {track_num}");
-
-        self.send_command(EngineCommand::AddTrack(id, name.clone()));
-        Arc::make_mut(&mut self.state.project_tracks)
-            .tracks
-            .push(ProjectTrack::new(id, name, color_index));
+        let id = {
+            let mut engine = crate::domains::EngineTx(&mut self.cmd_tx);
+            Arc::make_mut(&mut self.state.project_tracks).add_numbered_track(
+                "Audio",
+                TrackKind::Audio,
+                &mut engine,
+            )
+        };
         self.state.arrange_content_mut(id);
         self.state.arrangement.selected_track = Some(id);
         id

--- a/crates/vibez-ui/src/app/media_import.rs
+++ b/crates/vibez-ui/src/app/media_import.rs
@@ -10,7 +10,7 @@ use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::TrackKind;
 use vibez_core::track::MediaSourceRef;
 use vibez_dropbox::DropboxEntry;
-use vibez_engine::commands::{AuditionStart, EngineCommand};
+use vibez_engine::commands::EngineCommand;
 
 use crate::message::{BrowserImportTarget, Message};
 use crate::state::UiClip;
@@ -731,32 +731,9 @@ impl App {
                 )
             }
             None => {
-                // No active drag: treat release as a click.
-                // Select the pad AND audition its loaded sample
-                // via the engine's Audition Bus (bypasses
-                // transport + mute + solo; one-shot). This is
-                // the fastest way to hear what's on a pad
-                // without drawing notes into the piano roll.
-                let audition = self
-                    .state
-                    .find_track(track_id)
-                    .and_then(|track| track.drum_rack_pads.get(pad_index))
-                    .and_then(|pad| {
-                        pad.audio.as_ref().map(|audio| {
-                            (
-                                Arc::clone(audio),
-                                pad.name.clone().unwrap_or_else(|| "sample".into()),
-                            )
-                        })
-                    });
-                if let Some((audio, name)) = audition {
-                    self.send_command(EngineCommand::StartAudition {
-                        audio,
-                        start: AuditionStart::Immediate,
-                        looped: false,
-                    });
-                    self.state.status_text = format!("Pad {}: {}", pad_index + 1, name);
-                }
+                // A click is a note sent through the Drum Rack's own track.
+                // Browser audition is reserved for Browser previews, otherwise
+                // one pad press reaches two independent playback paths.
                 self.update(Message::select_drum_rack_pad(track_id, pad_index))
             }
         }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -160,6 +160,7 @@ mod audio_take_finalization;
 mod audio_tasks;
 mod bounce;
 mod capture;
+mod drum_rack_preparation;
 mod engine_events;
 mod keyboard;
 mod local_watcher;
@@ -168,6 +169,7 @@ mod tracked_request;
 
 use async_helpers::*;
 pub(crate) use audio_tasks::*;
+use drum_rack_preparation::*;
 pub(crate) use keyboard::*;
 mod dropbox_io;
 mod media;
@@ -587,27 +589,6 @@ impl App {
             self.state.view.scroll_offset_beats,
         )
         .pixels_per_beat()
-    }
-
-    /// Walk `next_track_number` forward past any names already in use so
-    /// that `format!("{prefix} {n}")` is unique. Prevents e.g. two lanes
-    /// both named "Track 2" when numbering gets out of sync after loads,
-    /// deletes, or undo chains.
-    fn next_unique_track_number(&mut self, prefix: &str) -> u32 {
-        loop {
-            let candidate = self.state.project_tracks.next_track_number;
-            let name = format!("{prefix} {candidate}");
-            let clash = self
-                .state
-                .project_tracks
-                .tracks
-                .iter()
-                .any(|t| t.name == name);
-            if !clash {
-                return candidate;
-            }
-            Arc::make_mut(&mut self.state.project_tracks).next_track_number += 1;
-        }
     }
 
     /// Auto-scroll the arrangement when a clip's right edge nears the visible boundary.

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -207,6 +207,53 @@ impl App {
                 };
                 self.apply_devices_action(action);
             }
+            Message::SetDrumRackSliceMarkers(markers) => {
+                if let Some(dialog) = self.state.view.drum_rack_slice_dialog.as_mut() {
+                    dialog.markers = markers;
+                }
+            }
+            Message::CancelDrumRackSlice => {
+                self.state.view.drum_rack_slice_dialog = None;
+            }
+            Message::ConfirmDrumRackSlice => {
+                let Some(dialog) = self.state.view.drum_rack_slice_dialog.take() else {
+                    return Task::none();
+                };
+                let Some(clip) = self
+                    .timeline_content_at(dialog.location, dialog.track_id)
+                    .and_then(|content| content.clips.iter().find(|clip| clip.id == dialog.clip_id))
+                    .cloned()
+                else {
+                    self.state.status_text = "The Audio Clip is no longer available".into();
+                    return Task::none();
+                };
+                let slice_count =
+                    crate::domains::arrangement::slice_region_count(&clip, dialog.markers);
+                if slice_count == 0 || slice_count > vibez_core::track::DRUM_RACK_PAD_COUNT {
+                    self.state.view.drum_rack_slice_dialog = Some(dialog);
+                    self.state.status_text = if slice_count == 0 {
+                        "The selected marker type has no interior slices".into()
+                    } else {
+                        format!(
+                            "{slice_count} slices will not fit the {}-pad Drum Rack",
+                            vibez_core::track::DRUM_RACK_PAD_COUNT
+                        )
+                    };
+                    return Task::none();
+                }
+                self.state.status_text = "Preparing Drum Rack slices…".into();
+                let expected_clip = Box::new(clip.clone());
+                return Task::perform(prepare_drum_rack_audio_async(clip), move |result| {
+                    Message::AudioClipDrumRackPrepared {
+                        location: dialog.location,
+                        track_id: dialog.track_id,
+                        clip_id: dialog.clip_id,
+                        markers: dialog.markers,
+                        expected_clip: expected_clip.clone(),
+                        result,
+                    }
+                });
+            }
             Message::Arrangement(msg) => {
                 if let ArrangementMsg::RequestSliceAudioClipToDrumRack { track_id, clip_id } = &msg
                 {
@@ -219,17 +266,36 @@ impl App {
                     else {
                         return Task::none();
                     };
-                    self.state.status_text = "Preparing Drum Rack slices…".into();
-                    let expected_clip = Box::new(clip.clone());
-                    return Task::perform(prepare_drum_rack_audio_async(clip), move |result| {
-                        Message::AudioClipDrumRackPrepared {
+                    if clip.source.is_none() {
+                        self.state.status_text =
+                            "Slice to Drum Rack needs available Source Media".into();
+                        return Task::none();
+                    }
+                    let transient_count = crate::domains::arrangement::slice_region_count(
+                        &clip,
+                        crate::domains::arrangement::AudioSliceMarkers::Transients,
+                    );
+                    let warp_count = crate::domains::arrangement::slice_region_count(
+                        &clip,
+                        crate::domains::arrangement::AudioSliceMarkers::Warp,
+                    );
+                    if transient_count == 0 && warp_count == 0 {
+                        self.state.status_text =
+                            "Add an interior Transient or Warp marker before slicing".into();
+                        return Task::none();
+                    }
+                    self.state.view.drum_rack_slice_dialog =
+                        Some(crate::state::DrumRackSliceDialog {
                             location,
                             track_id,
                             clip_id,
-                            expected_clip: expected_clip.clone(),
-                            result,
-                        }
-                    });
+                            markers: if transient_count > 0 {
+                                crate::domains::arrangement::AudioSliceMarkers::Transients
+                            } else {
+                                crate::domains::arrangement::AudioSliceMarkers::Warp
+                            },
+                        });
+                    return Task::none();
                 }
                 let deferred_snapshot = msg.defers_project_edit().then(|| self.take_snapshot());
                 let playhead_beats = self.focused_editor_playhead_beats();
@@ -266,6 +332,7 @@ impl App {
                 location,
                 track_id,
                 clip_id,
+                markers,
                 expected_clip,
                 result,
             } => match result {
@@ -285,6 +352,7 @@ impl App {
                         ArrangementMsg::SliceAudioClipToDrumRack {
                             track_id,
                             clip_id,
+                            markers,
                             source: prepared.source,
                             audio: prepared.audio,
                         },

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -208,6 +208,29 @@ impl App {
                 self.apply_devices_action(action);
             }
             Message::Arrangement(msg) => {
+                if let ArrangementMsg::RequestSliceAudioClipToDrumRack { track_id, clip_id } = &msg
+                {
+                    let (track_id, clip_id) = (*track_id, *clip_id);
+                    let location = self.active_timeline_location();
+                    let Some(clip) = self
+                        .timeline_content_at(location, track_id)
+                        .and_then(|content| content.clips.iter().find(|clip| clip.id == clip_id))
+                        .cloned()
+                    else {
+                        return Task::none();
+                    };
+                    self.state.status_text = "Preparing Drum Rack slices…".into();
+                    let expected_clip = Box::new(clip.clone());
+                    return Task::perform(prepare_drum_rack_audio_async(clip), move |result| {
+                        Message::AudioClipDrumRackPrepared {
+                            location,
+                            track_id,
+                            clip_id,
+                            expected_clip: expected_clip.clone(),
+                            result,
+                        }
+                    });
+                }
                 let deferred_snapshot = msg.defers_project_edit().then(|| self.take_snapshot());
                 let playhead_beats = self.focused_editor_playhead_beats();
                 let samples_per_beat = if self.state.transport.bpm > 0.0 {
@@ -239,6 +262,38 @@ impl App {
                 return self
                     .apply_arrangement_action_in_transaction(action, owns_project_transaction);
             }
+            Message::AudioClipDrumRackPrepared {
+                location,
+                track_id,
+                clip_id,
+                expected_clip,
+                result,
+            } => match result {
+                Ok(prepared) => {
+                    let current = self
+                        .timeline_content_at(location, track_id)
+                        .and_then(|content| content.clips.iter().find(|clip| clip.id == clip_id));
+                    if self.active_timeline_location() != location
+                        || !current
+                            .is_some_and(|clip| clip.has_same_audible_geometry(&expected_clip))
+                    {
+                        self.state.status_text =
+                            "Drum Rack slices cancelled because the Audio Clip changed".into();
+                        return Task::none();
+                    }
+                    return self.update(Message::Arrangement(
+                        ArrangementMsg::SliceAudioClipToDrumRack {
+                            track_id,
+                            clip_id,
+                            source: prepared.source,
+                            audio: prepared.audio,
+                        },
+                    ));
+                }
+                Err(error) => {
+                    self.state.status_text = format!("Slice to Drum Rack failed: {error}");
+                }
+            },
             Message::PianoRoll(msg) => {
                 let ctx = crate::domains::piano_roll::PianoRollCtx {
                     snap_grid: self

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -414,6 +414,9 @@ impl App {
     }
 
     pub(super) fn on_escape_pressed(&mut self) -> Task<Message> {
+        if self.state.view.drum_rack_slice_dialog.take().is_some() {
+            return Task::none();
+        }
         if !self
             .state
             .active_timeline_editor()

--- a/crates/vibez-ui/src/app/update_timeline.rs
+++ b/crates/vibez-ui/src/app/update_timeline.rs
@@ -256,11 +256,12 @@ impl App {
                 ctx,
             );
             self.state.perform.commit_selected_section_timeline();
-            if if deferred_project_edit {
+            let changed = if deferred_project_edit {
                 action.mark_dirty
             } else {
                 section_content_changed
-            } {
+            };
+            if changed && action.replay_project_track.is_none() {
                 if let Some(section_id) = self.state.perform.selected_section {
                     self.refresh_playing_section_after_edit(section_id);
                 }

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -751,7 +751,10 @@ impl App {
                 // Use container + mouse_area so press events reach us and
                 // drag-drop works. iced Button would capture ButtonPressed
                 // and hide it from mouse_area.
-                let pad_note = crate::widgets::piano_roll::pitch_name(36 + pad_index as u8);
+                let pad_note = crate::widgets::piano_roll::pitch_name(
+                    vibez_core::track::drum_rack_pad_pitch(pad_index)
+                        .expect("Drum Rack UI renders only valid pad slots"),
+                );
                 let pad_body = container(
                     column![
                         text(format!("{:02}  {pad_note}", pad_index + 1))

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -48,7 +48,171 @@ fn context_menu_x(requested_x: f32, menu_width: f32, window_width: f32) -> f32 {
     requested_x.clamp(0.0, maximum_x)
 }
 
+fn drum_rack_slice_choice(
+    label: &'static str,
+    count: usize,
+    selected: bool,
+    markers: AudioSliceMarkers,
+) -> Element<'static, Message> {
+    button(
+        column![
+            text(label)
+                .size(13)
+                .color(if selected { th::accent() } else { th::text() }),
+            text(if count == 0 {
+                "No interior slices".into()
+            } else {
+                format!("{count} slices")
+            })
+            .size(10)
+            .color(th::text_dim())
+        ]
+        .spacing(3),
+    )
+    .on_press(Message::SetDrumRackSliceMarkers(markers))
+    .padding([9, 11])
+    .width(Length::Fill)
+    .style(move |_theme: &Theme, status| button::Style {
+        background: Some(
+            if selected {
+                th::accent_dim()
+            } else if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                th::bg_hover()
+            } else {
+                th::bg_elevated()
+            }
+            .into(),
+        ),
+        text_color: th::text(),
+        border: iced::Border {
+            color: if selected { th::accent() } else { th::border() },
+            width: 1.0,
+            radius: 4.0.into(),
+        },
+        ..Default::default()
+    })
+    .into()
+}
+
+fn drum_rack_slice_can_create(slice_count: usize) -> bool {
+    slice_count > 0 && slice_count <= vibez_core::track::DRUM_RACK_PAD_COUNT
+}
+
 impl App {
+    pub(super) fn view_drum_rack_slice_overlay(&self) -> Element<'_, Message> {
+        let dialog = self
+            .state
+            .view
+            .drum_rack_slice_dialog
+            .expect("Drum Rack slice overlay requires a pending request");
+        let clip = self
+            .timeline_content_at(dialog.location, dialog.track_id)
+            .and_then(|content| content.clips.iter().find(|clip| clip.id == dialog.clip_id));
+        let transient_count = clip.map_or(0, |clip| {
+            crate::domains::arrangement::slice_region_count(clip, AudioSliceMarkers::Transients)
+        });
+        let warp_count = clip.map_or(0, |clip| {
+            crate::domains::arrangement::slice_region_count(clip, AudioSliceMarkers::Warp)
+        });
+        let selected_count = match dialog.markers {
+            AudioSliceMarkers::Transients => transient_count,
+            AudioSliceMarkers::Warp => warp_count,
+        };
+        let pad_count = vibez_core::track::DRUM_RACK_PAD_COUNT;
+        let can_create = drum_rack_slice_can_create(selected_count);
+        let guidance = if selected_count == 0 {
+            "This marker type has no interior slices.".to_string()
+        } else if selected_count > pad_count {
+            format!(
+                "{selected_count} slices cannot fit {pad_count} pads. Use fewer markers or choose Warp markers."
+            )
+        } else {
+            format!("{selected_count} slices will fill {selected_count} of {pad_count} pads.")
+        };
+        let cancel = button(text("Cancel").size(12).color(th::text()))
+            .on_press(Message::CancelDrumRackSlice)
+            .padding([7, 14]);
+        let create = button(text("Create Drum Rack").size(12).color(th::bg_dark()))
+            .on_press_maybe(can_create.then_some(Message::ConfirmDrumRackSlice))
+            .padding([7, 14])
+            .style(move |_theme: &Theme, status| {
+                let background = if !can_create {
+                    th::text_muted()
+                } else if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                    th::accent_dim()
+                } else {
+                    th::accent()
+                };
+                button::Style {
+                    background: Some(background.into()),
+                    text_color: th::bg_dark(),
+                    border: iced::Border {
+                        radius: 3.0.into(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }
+            });
+        let card = container(
+            column![
+                text("Slice to Drum Rack").size(18).color(th::text()),
+                text("Choose which timing markers become pads.")
+                    .size(11)
+                    .color(th::text_dim()),
+                row![
+                    drum_rack_slice_choice(
+                        "Transient markers",
+                        transient_count,
+                        dialog.markers == AudioSliceMarkers::Transients,
+                        AudioSliceMarkers::Transients,
+                    ),
+                    drum_rack_slice_choice(
+                        "Warp markers",
+                        warp_count,
+                        dialog.markers == AudioSliceMarkers::Warp,
+                        AudioSliceMarkers::Warp,
+                    ),
+                ]
+                .spacing(8),
+                text(guidance).size(11).color(if can_create {
+                    th::text_dim()
+                } else {
+                    th::danger()
+                }),
+                text("A MIDI clip will be created to reconstruct the original rhythm.")
+                    .size(10)
+                    .color(th::text_muted()),
+                row![horizontal_space(), cancel, create]
+                    .spacing(8)
+                    .align_y(iced::Alignment::Center),
+            ]
+            .spacing(12),
+        )
+        .width(Length::Fixed(440.0))
+        .padding(18)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_surface().into()),
+            border: iced::Border {
+                color: th::border_light(),
+                width: 1.0,
+                radius: 6.0.into(),
+            },
+            ..Default::default()
+        });
+
+        mouse_area(
+            center(card)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.55).into()),
+                    ..Default::default()
+                }),
+        )
+        .on_press(Message::CancelDrumRackSlice)
+        .into()
+    }
+
     pub(super) fn view_track_deletion_overlay(&self) -> Element<'_, Message> {
         let track_id = self
             .state
@@ -897,6 +1061,14 @@ impl App {
                         markers: AudioSliceMarkers::Warp,
                     }),
                 ));
+                col = col.push(menu_btn(
+                    icons::MUSIC,
+                    "Slice to Drum Rack…".into(),
+                    Message::Arrangement(ArrangementMsg::RequestSliceAudioClipToDrumRack {
+                        track_id,
+                        clip_id,
+                    }),
+                ));
                 col.into()
             }
             ContextMenuTarget::ArrangementEmpty => column![
@@ -947,7 +1119,10 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::{context_menu_x, project_track_deletion_list_height, CONTEXT_MENU_CLIP_WIDTH};
+    use super::{
+        context_menu_x, drum_rack_slice_can_create, project_track_deletion_list_height,
+        CONTEXT_MENU_CLIP_WIDTH,
+    };
 
     #[test]
     fn deletion_location_list_grows_with_content_then_caps() {
@@ -962,5 +1137,13 @@ mod tests {
         let x = context_menu_x(1_862.0, CONTEXT_MENU_CLIP_WIDTH, 1_920.0);
 
         assert_eq!(x, 1_676.0);
+    }
+
+    #[test]
+    fn drum_rack_slice_dialog_never_accepts_empty_or_overflowing_racks() {
+        assert!(!drum_rack_slice_can_create(0));
+        assert!(drum_rack_slice_can_create(1));
+        assert!(drum_rack_slice_can_create(16));
+        assert!(!drum_rack_slice_can_create(17));
     }
 }

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -169,6 +169,8 @@ impl App {
             .is_some()
         {
             stack![base_layout, self.view_track_deletion_overlay()].into()
+        } else if self.state.view.drum_rack_slice_dialog.is_some() {
+            stack![base_layout, self.view_drum_rack_slice_overlay()].into()
         } else if self.state.settings_open {
             stack![base_layout, self.view_settings_modal()].into()
         } else if self.state.about_open {

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::id::{ClipId, TrackId};
-use vibez_core::track::ClipTranspose;
+use vibez_core::track::{ClipTranspose, MediaSourceRef};
 
 use crate::state::{ArrangementSelection, AudioClipInspectorField, AudioClipRotaryField};
 
@@ -228,9 +228,15 @@ pub enum ArrangementMsg {
         clip_id: ClipId,
         markers: AudioSliceMarkers,
     },
+    RequestSliceAudioClipToDrumRack {
+        track_id: TrackId,
+        clip_id: ClipId,
+    },
     SliceAudioClipToDrumRack {
         track_id: TrackId,
         clip_id: ClipId,
+        source: MediaSourceRef,
+        audio: Arc<DecodedAudio>,
     },
     SplitNoteClip {
         track_id: TrackId,
@@ -335,6 +341,7 @@ impl ArrangementMsg {
                 | Self::DuplicateNoteClip(..)
                 | Self::SplitAudioClip { .. }
                 | Self::SliceAudioClipAtMarkers { .. }
+                | Self::RequestSliceAudioClipToDrumRack { .. }
                 | Self::SliceAudioClipToDrumRack { .. }
                 | Self::SplitNoteClip { .. }
                 | Self::SplitSelectedAtPlayhead
@@ -376,6 +383,7 @@ impl ArrangementMsg {
                 | ArrangementMsg::PreviewAudioClipRotaryValue { .. }
                 | ArrangementMsg::SelectTransientMarker { .. }
                 | ArrangementMsg::SelectWarpMarker { .. }
+                | ArrangementMsg::RequestSliceAudioClipToDrumRack { .. }
         )
     }
 

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -235,6 +235,7 @@ pub enum ArrangementMsg {
     SliceAudioClipToDrumRack {
         track_id: TrackId,
         clip_id: ClipId,
+        markers: AudioSliceMarkers,
         source: MediaSourceRef,
         audio: Arc<DecodedAudio>,
     },

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -228,6 +228,10 @@ pub enum ArrangementMsg {
         clip_id: ClipId,
         markers: AudioSliceMarkers,
     },
+    SliceAudioClipToDrumRack {
+        track_id: TrackId,
+        clip_id: ClipId,
+    },
     SplitNoteClip {
         track_id: TrackId,
         clip_id: ClipId,
@@ -331,6 +335,7 @@ impl ArrangementMsg {
                 | Self::DuplicateNoteClip(..)
                 | Self::SplitAudioClip { .. }
                 | Self::SliceAudioClipAtMarkers { .. }
+                | Self::SliceAudioClipToDrumRack { .. }
                 | Self::SplitNoteClip { .. }
                 | Self::SplitSelectedAtPlayhead
                 | Self::JoinSelectedClips
@@ -401,6 +406,7 @@ impl ArrangementMsg {
                     | Self::MoveWarpMarker { .. }
                     | Self::RemoveWarpMarker { .. }
                     | Self::SliceAudioClipAtMarkers { .. }
+                    | Self::SliceAudioClipToDrumRack { .. }
             )
     }
 }
@@ -413,6 +419,9 @@ pub struct ArrangementAction {
     pub close_track_guis: Option<TrackId>,
     /// Remove this shared identity from every Section timeline too.
     pub remove_track_from_sections: Option<TrackId>,
+    /// Seed one newly-created Project Track and its Arrange content through
+    /// the canonical replay path after all project stores have been updated.
+    pub replay_project_track: Option<TrackId>,
     /// Status bar text.
     pub status: Option<String>,
     /// Selecting a clip focuses the detail panel's Clip tab.

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -28,6 +28,7 @@ pub use messages::{
 };
 mod clipboard;
 mod crossfades;
+mod slice_to_drum_rack;
 mod slicing;
 
 /// Every channel carries a flat SSL-style EQ. Also used for the master
@@ -785,6 +786,9 @@ impl TimelineEditorState {
                 markers,
             } => {
                 return self.slice_audio_clip_at_markers(engine, track_id, clip_id, markers);
+            }
+            ArrangementMsg::SliceAudioClipToDrumRack { track_id, clip_id } => {
+                return self.slice_audio_clip_to_drum_rack(project_tracks, track_id, clip_id, ctx);
             }
             ArrangementMsg::SplitNoteClip {
                 track_id,

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -30,6 +30,7 @@ mod clipboard;
 mod crossfades;
 mod slice_to_drum_rack;
 mod slicing;
+pub(crate) use slicing::slice_region_count;
 
 /// Every channel carries a flat SSL-style EQ. Also used for the master
 /// bus, which is why it is crate-visible.
@@ -818,6 +819,7 @@ impl TimelineEditorState {
             ArrangementMsg::SliceAudioClipToDrumRack {
                 track_id,
                 clip_id,
+                markers,
                 source,
                 audio,
             } => {
@@ -825,8 +827,11 @@ impl TimelineEditorState {
                     project_tracks,
                     track_id,
                     clip_id,
-                    source,
-                    audio,
+                    slice_to_drum_rack::DrumRackSliceMaterial {
+                        markers,
+                        source,
+                        audio,
+                    },
                     ctx,
                 );
             }

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -69,6 +69,31 @@ impl ProjectTracksState {
         }
     }
 
+    /// Create one numbered Project Track with the standard channel strip.
+    /// Callers remain responsible for adding its timeline lane and selecting it.
+    pub(crate) fn add_numbered_track(
+        &mut self,
+        prefix: &str,
+        kind: TrackKind,
+        engine: &mut impl EngineHandle,
+    ) -> TrackId {
+        let track_number = self.next_unique_track_number(prefix);
+        self.next_track_number = track_number + 1;
+        let id = TrackId::new();
+        let name = format!("{prefix} {track_number}");
+        let color_index = (track_number.wrapping_sub(1) % 8) as u8;
+        let mut track = if kind.is_midi() {
+            engine.send(EngineCommand::AddMidiTrack(id, name.clone()));
+            ProjectTrack::new_instrument(id, name, kind, color_index)
+        } else {
+            engine.send(EngineCommand::AddTrack(id, name.clone()));
+            ProjectTrack::new(id, name, color_index)
+        };
+        attach_channel_eq(engine, &mut track);
+        self.tracks.push(track);
+        id
+    }
+
     fn move_track(&mut self, track_id: TrackId, up: bool, engine: &mut impl EngineHandle) {
         if let Some(idx) = self.tracks.iter().position(|t| t.id == track_id) {
             let target = if up {
@@ -787,8 +812,23 @@ impl TimelineEditorState {
             } => {
                 return self.slice_audio_clip_at_markers(engine, track_id, clip_id, markers);
             }
-            ArrangementMsg::SliceAudioClipToDrumRack { track_id, clip_id } => {
-                return self.slice_audio_clip_to_drum_rack(project_tracks, track_id, clip_id, ctx);
+            ArrangementMsg::RequestSliceAudioClipToDrumRack { .. } => {
+                return ArrangementAction::default();
+            }
+            ArrangementMsg::SliceAudioClipToDrumRack {
+                track_id,
+                clip_id,
+                source,
+                audio,
+            } => {
+                return self.slice_audio_clip_to_drum_rack(
+                    project_tracks,
+                    track_id,
+                    clip_id,
+                    source,
+                    audio,
+                    ctx,
+                );
             }
             ArrangementMsg::SplitNoteClip {
                 track_id,

--- a/crates/vibez-ui/src/domains/arrangement/project_tracks.rs
+++ b/crates/vibez-ui/src/domains/arrangement/project_tracks.rs
@@ -76,31 +76,17 @@ impl ArrangementState {
         let mut action = ArrangementAction::default();
         match msg {
             ArrangementMsg::AddTrack => {
-                let track_num = project_tracks.next_unique_track_number("Track");
-                let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-                project_tracks.next_track_number = track_num + 1;
-                let id = TrackId::new();
-                let name = format!("Track {track_num}");
-                engine.send(EngineCommand::AddTrack(id, name.clone()));
-                let mut track = ProjectTrack::new(id, name, color_index);
-                attach_channel_eq(engine, &mut track);
-                project_tracks.tracks.push(track);
+                let id = project_tracks.add_numbered_track("Track", TrackKind::Audio, engine);
                 Arc::make_mut(&mut self.timeline).ensure(id);
                 self.selected_track = Some(id);
                 action.status = Some(format!("{} tracks", project_tracks.tracks.len()));
             }
             ArrangementMsg::AddMidiTrack | ArrangementMsg::AddInstrumentTrack => {
-                let track_num = project_tracks.next_unique_track_number("MIDI");
-                let color_index = (track_num.wrapping_sub(1) % 8) as u8;
-                project_tracks.next_track_number = track_num + 1;
-                let id = TrackId::new();
-                let name = format!("MIDI {track_num}");
-                engine.send(EngineCommand::AddMidiTrack(id, name.clone()));
-                let mut track =
-                    ProjectTrack::new_instrument(id, name, TrackKind::Midi, color_index);
-                track.has_instrument = false;
-                attach_channel_eq(engine, &mut track);
-                project_tracks.tracks.push(track);
+                let id = project_tracks.add_numbered_track("MIDI", TrackKind::Midi, engine);
+                project_tracks
+                    .find_mut(id)
+                    .expect("new Project Track")
+                    .has_instrument = false;
                 Arc::make_mut(&mut self.timeline).ensure(id);
                 self.selected_track = Some(id);
                 action.status = Some(format!("{} tracks", project_tracks.tracks.len()));

--- a/crates/vibez-ui/src/domains/arrangement/slice_to_drum_rack.rs
+++ b/crates/vibez-ui/src/domains/arrangement/slice_to_drum_rack.rs
@@ -2,22 +2,20 @@
 
 use std::sync::Arc;
 
+use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::id::{ClipId, TrackId};
 use vibez_core::midi::{InstrumentKind, MidiNote, TrackKind};
 use vibez_core::perform::GrooveGrid;
+use vibez_core::track::{drum_rack_pad_pitch, MediaSourceRef, DRUM_RACK_PAD_COUNT};
 
 use crate::state::{
-    ArrangementSelection, ProjectTrack, ProjectTracksState, TimelineEditorState, UiDrumPad,
-    UiNoteClip,
+    ArrangementSelection, ProjectTracksState, TimelineEditorState, UiDrumPad, UiNoteClip,
 };
 
-use super::fragment_geometry::audio_fragment_geometry;
-use super::slicing::marker_cut_positions;
-use super::{attach_channel_eq, ArrangementAction, ArrangementCtx, AudioSliceMarkers};
+use super::slicing::{marker_cut_positions, slice_boundaries};
+use super::{ArrangementAction, ArrangementCtx, AudioSliceMarkers};
 
-const MAX_SLICES: usize = 16;
-const FIRST_PAD_NOTE: u8 = 36;
-const SLICE_VELOCITY: u8 = 100;
+const SLICE_VELOCITY: u8 = 127;
 
 impl TimelineEditorState {
     pub(super) fn slice_audio_clip_to_drum_rack(
@@ -25,6 +23,8 @@ impl TimelineEditorState {
         project_tracks: &mut ProjectTracksState,
         source_track_id: TrackId,
         source_clip_id: ClipId,
+        source: MediaSourceRef,
+        audio: Arc<DecodedAudio>,
         ctx: ArrangementCtx,
     ) -> ArrangementAction {
         let Some(original) = self
@@ -34,15 +34,14 @@ impl TimelineEditorState {
         else {
             return ArrangementAction::default();
         };
-        let Some(source) = original.source.clone() else {
-            return failure("Slice to Drum Rack needs available Source Media");
-        };
-        if original.audio.num_frames() == 0 || ctx.samples_per_beat <= 0.0 {
+        if usize::try_from(original.duration) != Ok(audio.num_frames())
+            || ctx.samples_per_beat <= 0.0
+        {
             return failure("Slice to Drum Rack needs available audio and a valid tempo");
         }
 
         let transient_cuts = marker_cut_positions(&original, AudioSliceMarkers::Transients);
-        let (mut cuts, marker_kind) = if transient_cuts.is_empty() {
+        let (cuts, marker_kind) = if transient_cuts.is_empty() {
             (
                 marker_cut_positions(&original, AudioSliceMarkers::Warp),
                 AudioSliceMarkers::Warp,
@@ -53,65 +52,58 @@ impl TimelineEditorState {
         if cuts.is_empty() {
             return failure("Add at least one interior Transient or Warp Marker first");
         }
-        cuts.truncate(MAX_SLICES - 1);
-
-        let mut boundaries = Vec::with_capacity(cuts.len() + 2);
-        boundaries.push(0);
-        boundaries.extend(cuts);
-        boundaries.push(original.duration);
-        let source_frames = original.audio.num_frames() as f32;
+        let all_boundaries = slice_boundaries(&original, cuts);
+        let total_regions = all_boundaries.len() - 1;
+        let boundaries = if total_regions > DRUM_RACK_PAD_COUNT {
+            let mut limited = all_boundaries[..DRUM_RACK_PAD_COUNT].to_vec();
+            limited.push(original.duration);
+            limited
+        } else {
+            all_boundaries
+        };
+        let source_frames = audio.num_frames() as f32;
         let mut pads = Vec::with_capacity(boundaries.len() - 1);
         let mut notes = Vec::with_capacity(boundaries.len() - 1);
         for (index, boundary) in boundaries.windows(2).enumerate() {
             let local_start = boundary[0];
             let duration = boundary[1] - boundary[0];
-            let (source_start, _, warp_markers) =
-                audio_fragment_geometry(&original, local_start, duration);
-            let source_end = warp_markers
-                .source_end(source_start.saturating_add(duration))
-                .min(original.audio.num_frames() as u64);
+            let source_start = local_start;
+            let source_end = local_start.saturating_add(duration);
             if source_end <= source_start {
                 return failure("A marker produced an empty Drum Rack slice");
             }
             pads.push(UiDrumPad {
                 name: Some(format!("{} Slice {}", original.name, index + 1)),
                 source: Some(source.clone()),
-                audio: Some(Arc::clone(&original.audio)),
-                gain: original.gain_db.linear().clamp(0.0, 2.0),
+                audio: Some(Arc::clone(&audio)),
+                gain: original.gain_db.linear(),
                 pan: 0.0,
                 start: source_start as f32 / source_frames,
                 end: source_end as f32 / source_frames,
                 coarse_tune: 0,
                 fine_tune: 0.0,
                 one_shot: true,
-                choke_group: Some(1),
+                choke_group: None,
             });
             notes.push(MidiNote {
-                pitch: FIRST_PAD_NOTE + index as u8,
+                pitch: drum_rack_pad_pitch(index).expect("slice count is capped to the rack"),
                 velocity: SLICE_VELOCITY,
                 start_beat: local_start as f64 / ctx.samples_per_beat,
                 duration_beats: duration as f64 / ctx.samples_per_beat,
             });
         }
 
-        let track_number = project_tracks.next_unique_track_number("Slices");
-        project_tracks.next_track_number = track_number + 1;
-        let track_id = TrackId::new();
-        let track_name = format!("Slices {track_number}");
-        let color_index = (track_number.wrapping_sub(1) % 8) as u8;
-        let mut track = ProjectTrack::new_instrument(
-            track_id,
-            track_name.clone(),
-            TrackKind::Midi,
-            color_index,
-        );
+        let mut no_engine = crate::domains::DiscardingEngine;
+        let track_id = project_tracks.add_numbered_track("Slices", TrackKind::Midi, &mut no_engine);
+        let track = project_tracks
+            .find_mut(track_id)
+            .expect("new Project Track");
+        let track_name = track.name.clone();
         track.has_instrument = true;
         track.instrument_kind = Some(InstrumentKind::DrumRack);
         for (slot, pad) in track.drum_rack_pads.iter_mut().zip(pads) {
             *slot = pad;
         }
-        let mut no_engine = crate::domains::DiscardingEngine;
-        attach_channel_eq(&mut no_engine, &mut track);
 
         let note_clip_id = ClipId::new();
         let duration_beats = original.duration as f64 / ctx.samples_per_beat;
@@ -129,7 +121,6 @@ impl TimelineEditorState {
             groove_grid: GrooveGrid::Off,
         };
 
-        project_tracks.tracks.push(track);
         Arc::make_mut(&mut self.timeline)
             .ensure(track_id)
             .note_clips
@@ -142,12 +133,19 @@ impl TimelineEditorState {
         });
         self.selected_note_clip = Some((track_id, note_clip_id));
 
+        let truncation = (total_regions > DRUM_RACK_PAD_COUNT).then(|| {
+            format!(
+                "; {} later marker regions were folded into the last pad",
+                total_regions - DRUM_RACK_PAD_COUNT
+            )
+        });
         ArrangementAction {
             replay_project_track: Some(track_id),
             status: Some(format!(
-                "Created {track_name} with {} {} slices",
+                "Created {track_name} with {} {} slices{}",
                 boundaries.len() - 1,
-                marker_name(marker_kind)
+                marker_name(marker_kind),
+                truncation.as_deref().unwrap_or_default()
             )),
             mark_dirty: true,
             ..ArrangementAction::default()

--- a/crates/vibez-ui/src/domains/arrangement/slice_to_drum_rack.rs
+++ b/crates/vibez-ui/src/domains/arrangement/slice_to_drum_rack.rs
@@ -1,0 +1,170 @@
+//! Convert a marked Audio Clip into a native Drum Rack and reconstruction MIDI Clip.
+
+use std::sync::Arc;
+
+use vibez_core::id::{ClipId, TrackId};
+use vibez_core::midi::{InstrumentKind, MidiNote, TrackKind};
+use vibez_core::perform::GrooveGrid;
+
+use crate::state::{
+    ArrangementSelection, ProjectTrack, ProjectTracksState, TimelineEditorState, UiDrumPad,
+    UiNoteClip,
+};
+
+use super::fragment_geometry::audio_fragment_geometry;
+use super::slicing::marker_cut_positions;
+use super::{attach_channel_eq, ArrangementAction, ArrangementCtx, AudioSliceMarkers};
+
+const MAX_SLICES: usize = 16;
+const FIRST_PAD_NOTE: u8 = 36;
+const SLICE_VELOCITY: u8 = 100;
+
+impl TimelineEditorState {
+    pub(super) fn slice_audio_clip_to_drum_rack(
+        &mut self,
+        project_tracks: &mut ProjectTracksState,
+        source_track_id: TrackId,
+        source_clip_id: ClipId,
+        ctx: ArrangementCtx,
+    ) -> ArrangementAction {
+        let Some(original) = self
+            .find_content(source_track_id)
+            .and_then(|content| content.clips.iter().find(|clip| clip.id == source_clip_id))
+            .cloned()
+        else {
+            return ArrangementAction::default();
+        };
+        let Some(source) = original.source.clone() else {
+            return failure("Slice to Drum Rack needs available Source Media");
+        };
+        if original.audio.num_frames() == 0 || ctx.samples_per_beat <= 0.0 {
+            return failure("Slice to Drum Rack needs available audio and a valid tempo");
+        }
+
+        let transient_cuts = marker_cut_positions(&original, AudioSliceMarkers::Transients);
+        let (mut cuts, marker_kind) = if transient_cuts.is_empty() {
+            (
+                marker_cut_positions(&original, AudioSliceMarkers::Warp),
+                AudioSliceMarkers::Warp,
+            )
+        } else {
+            (transient_cuts, AudioSliceMarkers::Transients)
+        };
+        if cuts.is_empty() {
+            return failure("Add at least one interior Transient or Warp Marker first");
+        }
+        cuts.truncate(MAX_SLICES - 1);
+
+        let mut boundaries = Vec::with_capacity(cuts.len() + 2);
+        boundaries.push(0);
+        boundaries.extend(cuts);
+        boundaries.push(original.duration);
+        let source_frames = original.audio.num_frames() as f32;
+        let mut pads = Vec::with_capacity(boundaries.len() - 1);
+        let mut notes = Vec::with_capacity(boundaries.len() - 1);
+        for (index, boundary) in boundaries.windows(2).enumerate() {
+            let local_start = boundary[0];
+            let duration = boundary[1] - boundary[0];
+            let (source_start, _, warp_markers) =
+                audio_fragment_geometry(&original, local_start, duration);
+            let source_end = warp_markers
+                .source_end(source_start.saturating_add(duration))
+                .min(original.audio.num_frames() as u64);
+            if source_end <= source_start {
+                return failure("A marker produced an empty Drum Rack slice");
+            }
+            pads.push(UiDrumPad {
+                name: Some(format!("{} Slice {}", original.name, index + 1)),
+                source: Some(source.clone()),
+                audio: Some(Arc::clone(&original.audio)),
+                gain: original.gain_db.linear().clamp(0.0, 2.0),
+                pan: 0.0,
+                start: source_start as f32 / source_frames,
+                end: source_end as f32 / source_frames,
+                coarse_tune: 0,
+                fine_tune: 0.0,
+                one_shot: true,
+                choke_group: Some(1),
+            });
+            notes.push(MidiNote {
+                pitch: FIRST_PAD_NOTE + index as u8,
+                velocity: SLICE_VELOCITY,
+                start_beat: local_start as f64 / ctx.samples_per_beat,
+                duration_beats: duration as f64 / ctx.samples_per_beat,
+            });
+        }
+
+        let track_number = project_tracks.next_unique_track_number("Slices");
+        project_tracks.next_track_number = track_number + 1;
+        let track_id = TrackId::new();
+        let track_name = format!("Slices {track_number}");
+        let color_index = (track_number.wrapping_sub(1) % 8) as u8;
+        let mut track = ProjectTrack::new_instrument(
+            track_id,
+            track_name.clone(),
+            TrackKind::Midi,
+            color_index,
+        );
+        track.has_instrument = true;
+        track.instrument_kind = Some(InstrumentKind::DrumRack);
+        for (slot, pad) in track.drum_rack_pads.iter_mut().zip(pads) {
+            *slot = pad;
+        }
+        let mut no_engine = crate::domains::DiscardingEngine;
+        attach_channel_eq(&mut no_engine, &mut track);
+
+        let note_clip_id = ClipId::new();
+        let duration_beats = original.duration as f64 / ctx.samples_per_beat;
+        let note_clip = UiNoteClip {
+            id: note_clip_id,
+            name: format!("{} Slices", original.name),
+            position_beats: original.position as f64 / ctx.samples_per_beat,
+            duration_beats,
+            notes,
+            selected_notes: Default::default(),
+            start_marker_beats: 0.0,
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: duration_beats,
+            groove_grid: GrooveGrid::Off,
+        };
+
+        project_tracks.tracks.push(track);
+        Arc::make_mut(&mut self.timeline)
+            .ensure(track_id)
+            .note_clips
+            .push(note_clip);
+        self.selected_track = Some(track_id);
+        self.selected_clips.clear();
+        self.selected_clips.insert(ArrangementSelection::NoteClip {
+            track_id,
+            clip_id: note_clip_id,
+        });
+        self.selected_note_clip = Some((track_id, note_clip_id));
+
+        ArrangementAction {
+            replay_project_track: Some(track_id),
+            status: Some(format!(
+                "Created {track_name} with {} {} slices",
+                boundaries.len() - 1,
+                marker_name(marker_kind)
+            )),
+            mark_dirty: true,
+            ..ArrangementAction::default()
+        }
+    }
+}
+
+fn failure(message: &str) -> ArrangementAction {
+    ArrangementAction {
+        status: Some(message.into()),
+        ..ArrangementAction::default()
+    }
+}
+
+const fn marker_name(markers: AudioSliceMarkers) -> &'static str {
+    match markers {
+        AudioSliceMarkers::Transients => "Transient",
+        AudioSliceMarkers::Warp => "Warp",
+    }
+}

--- a/crates/vibez-ui/src/domains/arrangement/slice_to_drum_rack.rs
+++ b/crates/vibez-ui/src/domains/arrangement/slice_to_drum_rack.rs
@@ -17,16 +17,26 @@ use super::{ArrangementAction, ArrangementCtx, AudioSliceMarkers};
 
 const SLICE_VELOCITY: u8 = 127;
 
+pub(super) struct DrumRackSliceMaterial {
+    pub markers: AudioSliceMarkers,
+    pub source: MediaSourceRef,
+    pub audio: Arc<DecodedAudio>,
+}
+
 impl TimelineEditorState {
     pub(super) fn slice_audio_clip_to_drum_rack(
         &mut self,
         project_tracks: &mut ProjectTracksState,
         source_track_id: TrackId,
         source_clip_id: ClipId,
-        source: MediaSourceRef,
-        audio: Arc<DecodedAudio>,
+        material: DrumRackSliceMaterial,
         ctx: ArrangementCtx,
     ) -> ArrangementAction {
+        let DrumRackSliceMaterial {
+            markers,
+            source,
+            audio,
+        } = material;
         let Some(original) = self
             .find_content(source_track_id)
             .and_then(|content| content.clips.iter().find(|clip| clip.id == source_clip_id))
@@ -40,27 +50,20 @@ impl TimelineEditorState {
             return failure("Slice to Drum Rack needs available audio and a valid tempo");
         }
 
-        let transient_cuts = marker_cut_positions(&original, AudioSliceMarkers::Transients);
-        let (cuts, marker_kind) = if transient_cuts.is_empty() {
-            (
-                marker_cut_positions(&original, AudioSliceMarkers::Warp),
-                AudioSliceMarkers::Warp,
-            )
-        } else {
-            (transient_cuts, AudioSliceMarkers::Transients)
-        };
+        let cuts = marker_cut_positions(&original, markers);
         if cuts.is_empty() {
-            return failure("Add at least one interior Transient or Warp Marker first");
+            return failure(&format!(
+                "Add at least one interior {} first",
+                marker_name(markers)
+            ));
         }
-        let all_boundaries = slice_boundaries(&original, cuts);
-        let total_regions = all_boundaries.len() - 1;
-        let boundaries = if total_regions > DRUM_RACK_PAD_COUNT {
-            let mut limited = all_boundaries[..DRUM_RACK_PAD_COUNT].to_vec();
-            limited.push(original.duration);
-            limited
-        } else {
-            all_boundaries
-        };
+        let boundaries = slice_boundaries(&original, cuts);
+        let total_regions = boundaries.len() - 1;
+        if total_regions > DRUM_RACK_PAD_COUNT {
+            return failure(&format!(
+                "{total_regions} slices will not fit the {DRUM_RACK_PAD_COUNT}-pad Drum Rack; reduce the markers first"
+            ));
+        }
         let source_frames = audio.num_frames() as f32;
         let mut pads = Vec::with_capacity(boundaries.len() - 1);
         let mut notes = Vec::with_capacity(boundaries.len() - 1);
@@ -133,19 +136,12 @@ impl TimelineEditorState {
         });
         self.selected_note_clip = Some((track_id, note_clip_id));
 
-        let truncation = (total_regions > DRUM_RACK_PAD_COUNT).then(|| {
-            format!(
-                "; {} later marker regions were folded into the last pad",
-                total_regions - DRUM_RACK_PAD_COUNT
-            )
-        });
         ArrangementAction {
             replay_project_track: Some(track_id),
             status: Some(format!(
-                "Created {track_name} with {} {} slices{}",
+                "Created {track_name} with {} {} slices",
                 boundaries.len() - 1,
-                marker_name(marker_kind),
-                truncation.as_deref().unwrap_or_default()
+                marker_name(markers),
             )),
             mark_dirty: true,
             ..ArrangementAction::default()

--- a/crates/vibez-ui/src/domains/arrangement/slicing.rs
+++ b/crates/vibez-ui/src/domains/arrangement/slicing.rs
@@ -86,7 +86,7 @@ impl TimelineEditorState {
     }
 }
 
-pub(super) fn marker_cut_positions(clip: &UiClip, markers: AudioSliceMarkers) -> Vec<u64> {
+pub(crate) fn marker_cut_positions(clip: &UiClip, markers: AudioSliceMarkers) -> Vec<u64> {
     let source_frames: Vec<_> = match markers {
         AudioSliceMarkers::Transients => clip
             .transient_markers
@@ -135,7 +135,7 @@ pub(super) fn marker_cut_positions(clip: &UiClip, markers: AudioSliceMarkers) ->
 /// Complete Clip-local boundaries for independently playable slices. Loop
 /// wraps are boundaries even when no marker lands there, because a single
 /// one-shot slice cannot represent a discontinuous source range.
-pub(super) fn slice_boundaries(clip: &UiClip, mut cuts: Vec<u64>) -> Vec<u64> {
+pub(crate) fn slice_boundaries(clip: &UiClip, mut cuts: Vec<u64>) -> Vec<u64> {
     cuts.extend(clip.timeline().wraps().filter_map(|position| {
         let cut = match clip.playback_direction {
             ClipPlaybackDirection::Forward => position,
@@ -151,6 +151,15 @@ pub(super) fn slice_boundaries(clip: &UiClip, mut cuts: Vec<u64>) -> Vec<u64> {
     boundaries.extend(cuts);
     boundaries.push(clip.duration);
     boundaries
+}
+
+pub(crate) fn slice_region_count(clip: &UiClip, markers: AudioSliceMarkers) -> usize {
+    let cuts = marker_cut_positions(clip, markers);
+    if cuts.is_empty() {
+        0
+    } else {
+        slice_boundaries(clip, cuts).len() - 1
+    }
 }
 
 const fn marker_label(markers: AudioSliceMarkers) -> &'static str {

--- a/crates/vibez-ui/src/domains/arrangement/tests/audio_markers.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests/audio_markers.rs
@@ -8,8 +8,12 @@ fn slice_to_drum_rack_builds_one_native_track_and_reconstruction_clip() {
     original.source = Some(MediaSourceRef::LocalFile {
         path: "shared-loop.wav".into(),
     });
+    original.gain_db = vibez_core::track::ClipGainDb::new(12.0).unwrap();
     original.transient_markers.replace_suggestions([250, 600]);
-    let shared_audio = Arc::clone(&original.audio);
+    let shared_audio = Arc::new(vibez_core::audio_buffer::DecodedAudio {
+        channels: vec![vec![0.0; original.duration as usize]],
+        sample_rate: original.audio.sample_rate,
+    });
     let shared_source = original.source.clone();
     let mut engine = RecordingEngine::default();
 
@@ -17,6 +21,8 @@ fn slice_to_drum_rack_builds_one_native_track_and_reconstruction_clip() {
         ArrangementMsg::SliceAudioClipToDrumRack {
             track_id: source_track_id,
             clip_id: source_clip_id,
+            source: shared_source.clone().unwrap(),
+            audio: Arc::clone(&shared_audio),
         },
         &mut engine,
         ArrangementCtx {
@@ -43,6 +49,7 @@ fn slice_to_drum_rack_builds_one_native_track_and_reconstruction_clip() {
             .is_some_and(|audio| Arc::ptr_eq(audio, &shared_audio))
             && pad.source == shared_source
     }));
+    assert!(loaded_pads.iter().all(|pad| pad.gain > 2.0));
     let source_frames = shared_audio.num_frames() as f32;
     assert_eq!(loaded_pads[0].start, 0.0);
     assert!((loaded_pads[0].end - 250.0 / source_frames).abs() < f32::EPSILON);
@@ -60,9 +67,72 @@ fn slice_to_drum_rack_builds_one_native_track_and_reconstruction_clip() {
             .iter()
             .map(|note| (note.pitch, note.velocity, note.start_beat))
             .collect::<Vec<_>>(),
-        vec![(36, 100, 0.0), (37, 100, 2.5), (38, 100, 6.0)]
+        vec![(36, 127, 0.0), (37, 127, 2.5), (38, 127, 6.0)]
     );
-    assert!(engine.0.is_empty(), "the app replays the complete new Track");
+    assert!(
+        engine.0.is_empty(),
+        "the app replays the complete new Track"
+    );
+}
+
+#[test]
+fn slice_to_drum_rack_turns_loop_wraps_into_distinct_flattened_pad_ranges() {
+    let mut arrangement = arrangement_with_tracks(1);
+    let (source_track_id, source_clip_id) = add_audio_clip(&mut arrangement, 0, 0, 300);
+    let original = &mut arrangement.tracks[0].clips[0];
+    original.loop_enabled = true;
+    original.loop_start = 0;
+    original.loop_end = 100;
+    original.transient_markers.replace_suggestions([25]);
+    let audio = Arc::clone(&original.audio);
+    let mut engine = RecordingEngine::default();
+
+    let action = arrangement.update(
+        ArrangementMsg::SliceAudioClipToDrumRack {
+            track_id: source_track_id,
+            clip_id: source_clip_id,
+            source: MediaSourceRef::LocalFile {
+                path: "loop-slices.wav".into(),
+            },
+            audio,
+        },
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..ArrangementCtx::default()
+        },
+    );
+
+    let drum_track = arrangement
+        .find_track(action.replay_project_track.unwrap())
+        .unwrap();
+    let pads: Vec<_> = drum_track
+        .drum_rack_pads
+        .iter()
+        .filter(|pad| pad.source.is_some())
+        .map(|pad| (pad.start, pad.end))
+        .collect();
+    assert_eq!(pads.len(), 6);
+    let expected_frames = [
+        (0, 25),
+        (25, 100),
+        (100, 125),
+        (125, 200),
+        (200, 225),
+        (225, 300),
+    ];
+    for ((start, end), (expected_start, expected_end)) in pads.into_iter().zip(expected_frames) {
+        assert!((start - expected_start as f32 / 300.0).abs() < f32::EPSILON);
+        assert!((end - expected_end as f32 / 300.0).abs() < f32::EPSILON);
+    }
+    assert_eq!(
+        drum_track.note_clips[0]
+            .notes
+            .iter()
+            .map(|note| note.start_beat)
+            .collect::<Vec<_>>(),
+        vec![0.0, 0.25, 1.0, 1.25, 2.0, 2.25]
+    );
 }
 
 #[test]
@@ -76,12 +146,16 @@ fn slice_to_drum_rack_falls_back_to_warp_markers_and_caps_the_rack_at_sixteen() 
     for frame in (50..1_000).step_by(50) {
         assert!(original.warp_markers.add(frame, frame, 0, 1_000, 1_000));
     }
+    let source = original.source.clone().unwrap();
+    let audio = Arc::clone(&original.audio);
     let mut engine = RecordingEngine::default();
 
     let action = arrangement.update(
         ArrangementMsg::SliceAudioClipToDrumRack {
             track_id: source_track_id,
             clip_id: source_clip_id,
+            source,
+            audio,
         },
         &mut engine,
         ArrangementCtx {
@@ -102,40 +176,27 @@ fn slice_to_drum_rack_falls_back_to_warp_markers_and_caps_the_rack_at_sixteen() 
         16
     );
     assert_eq!(drum_track.note_clips[0].notes.len(), 16);
-    assert!(action.status.unwrap().contains("Warp slices"));
+    let status = action.status.unwrap();
+    assert!(status.contains("Warp slices"));
+    assert!(status.contains("folded into the last pad"));
 }
 
 #[test]
-fn slice_to_drum_rack_missing_media_or_markers_leaves_no_partial_track() {
+fn slice_to_drum_rack_without_markers_leaves_no_partial_track() {
     let mut arrangement = arrangement_with_tracks(1);
     let (source_track_id, source_clip_id) = add_audio_clip(&mut arrangement, 0, 0, 1_000);
-    arrangement.tracks[0].clips[0]
-        .transient_markers
-        .replace_suggestions([250]);
+    let source = MediaSourceRef::LocalFile {
+        path: "shared-loop.wav".into(),
+    };
+    let audio = Arc::clone(&arrangement.tracks[0].clips[0].audio);
     let mut engine = RecordingEngine::default();
 
-    let missing_media = arrangement.update(
-        ArrangementMsg::SliceAudioClipToDrumRack {
-            track_id: source_track_id,
-            clip_id: source_clip_id,
-        },
-        &mut engine,
-        ArrangementCtx {
-            samples_per_beat: 100.0,
-            ..ArrangementCtx::default()
-        },
-    );
-    assert!(!missing_media.mark_dirty);
-    assert_eq!(arrangement.tracks.len(), 1);
-
-    arrangement.tracks[0].clips[0].source = Some(MediaSourceRef::LocalFile {
-        path: "shared-loop.wav".into(),
-    });
-    arrangement.tracks[0].clips[0].transient_markers = Default::default();
     let missing_markers = arrangement.update(
         ArrangementMsg::SliceAudioClipToDrumRack {
             track_id: source_track_id,
             clip_id: source_clip_id,
+            source,
+            audio,
         },
         &mut engine,
         ArrangementCtx {

--- a/crates/vibez-ui/src/domains/arrangement/tests/audio_markers.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests/audio_markers.rs
@@ -21,6 +21,7 @@ fn slice_to_drum_rack_builds_one_native_track_and_reconstruction_clip() {
         ArrangementMsg::SliceAudioClipToDrumRack {
             track_id: source_track_id,
             clip_id: source_clip_id,
+            markers: AudioSliceMarkers::Transients,
             source: shared_source.clone().unwrap(),
             audio: Arc::clone(&shared_audio),
         },
@@ -91,6 +92,7 @@ fn slice_to_drum_rack_turns_loop_wraps_into_distinct_flattened_pad_ranges() {
         ArrangementMsg::SliceAudioClipToDrumRack {
             track_id: source_track_id,
             clip_id: source_clip_id,
+            markers: AudioSliceMarkers::Transients,
             source: MediaSourceRef::LocalFile {
                 path: "loop-slices.wav".into(),
             },
@@ -136,7 +138,7 @@ fn slice_to_drum_rack_turns_loop_wraps_into_distinct_flattened_pad_ranges() {
 }
 
 #[test]
-fn slice_to_drum_rack_falls_back_to_warp_markers_and_caps_the_rack_at_sixteen() {
+fn slice_to_drum_rack_rejects_more_regions_than_available_pads() {
     let mut arrangement = arrangement_with_tracks(1);
     let (source_track_id, source_clip_id) = add_audio_clip(&mut arrangement, 0, 0, 1_000);
     let original = &mut arrangement.tracks[0].clips[0];
@@ -154,6 +156,7 @@ fn slice_to_drum_rack_falls_back_to_warp_markers_and_caps_the_rack_at_sixteen() 
         ArrangementMsg::SliceAudioClipToDrumRack {
             track_id: source_track_id,
             clip_id: source_clip_id,
+            markers: AudioSliceMarkers::Warp,
             source,
             audio,
         },
@@ -164,21 +167,12 @@ fn slice_to_drum_rack_falls_back_to_warp_markers_and_caps_the_rack_at_sixteen() 
         },
     );
 
-    let drum_track = arrangement
-        .find_track(action.replay_project_track.unwrap())
-        .unwrap();
-    assert_eq!(
-        drum_track
-            .drum_rack_pads
-            .iter()
-            .filter(|pad| pad.source.is_some())
-            .count(),
-        16
-    );
-    assert_eq!(drum_track.note_clips[0].notes.len(), 16);
+    assert!(!action.mark_dirty);
+    assert!(action.replay_project_track.is_none());
+    assert_eq!(arrangement.tracks.len(), 1);
     let status = action.status.unwrap();
-    assert!(status.contains("Warp slices"));
-    assert!(status.contains("folded into the last pad"));
+    assert!(status.contains("20 slices"));
+    assert!(status.contains("will not fit"));
 }
 
 #[test]
@@ -195,6 +189,7 @@ fn slice_to_drum_rack_without_markers_leaves_no_partial_track() {
         ArrangementMsg::SliceAudioClipToDrumRack {
             track_id: source_track_id,
             clip_id: source_clip_id,
+            markers: AudioSliceMarkers::Transients,
             source,
             audio,
         },

--- a/crates/vibez-ui/src/domains/arrangement/tests/audio_markers.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests/audio_markers.rs
@@ -1,6 +1,154 @@
 use super::*;
 
 #[test]
+fn slice_to_drum_rack_builds_one_native_track_and_reconstruction_clip() {
+    let mut arrangement = arrangement_with_tracks(1);
+    let (source_track_id, source_clip_id) = add_audio_clip(&mut arrangement, 0, 100, 1_000);
+    let original = &mut arrangement.tracks[0].clips[0];
+    original.source = Some(MediaSourceRef::LocalFile {
+        path: "shared-loop.wav".into(),
+    });
+    original.transient_markers.replace_suggestions([250, 600]);
+    let shared_audio = Arc::clone(&original.audio);
+    let shared_source = original.source.clone();
+    let mut engine = RecordingEngine::default();
+
+    let action = arrangement.update(
+        ArrangementMsg::SliceAudioClipToDrumRack {
+            track_id: source_track_id,
+            clip_id: source_clip_id,
+        },
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..ArrangementCtx::default()
+        },
+    );
+
+    assert!(action.mark_dirty);
+    let drum_track_id = action.replay_project_track.expect("new Project Track");
+    assert_eq!(arrangement.tracks.len(), 2);
+    let drum_track = arrangement.find_track(drum_track_id).unwrap();
+    assert_eq!(drum_track.instrument_kind, Some(InstrumentKind::DrumRack));
+    assert!(drum_track.kind.is_midi());
+    let loaded_pads: Vec<_> = drum_track
+        .drum_rack_pads
+        .iter()
+        .filter(|pad| pad.source.is_some())
+        .collect();
+    assert_eq!(loaded_pads.len(), 3);
+    assert!(loaded_pads.iter().all(|pad| {
+        pad.audio
+            .as_ref()
+            .is_some_and(|audio| Arc::ptr_eq(audio, &shared_audio))
+            && pad.source == shared_source
+    }));
+    let source_frames = shared_audio.num_frames() as f32;
+    assert_eq!(loaded_pads[0].start, 0.0);
+    assert!((loaded_pads[0].end - 250.0 / source_frames).abs() < f32::EPSILON);
+    assert!((loaded_pads[1].start - 250.0 / source_frames).abs() < f32::EPSILON);
+    assert!((loaded_pads[1].end - 600.0 / source_frames).abs() < f32::EPSILON);
+    assert!((loaded_pads[2].start - 600.0 / source_frames).abs() < f32::EPSILON);
+    assert!((loaded_pads[2].end - 1_000.0 / source_frames).abs() < f32::EPSILON);
+    assert_eq!(drum_track.note_clips.len(), 1);
+    let note_clip = &drum_track.note_clips[0];
+    assert_eq!(note_clip.position_beats, 1.0);
+    assert_eq!(note_clip.duration_beats, 10.0);
+    assert_eq!(
+        note_clip
+            .notes
+            .iter()
+            .map(|note| (note.pitch, note.velocity, note.start_beat))
+            .collect::<Vec<_>>(),
+        vec![(36, 100, 0.0), (37, 100, 2.5), (38, 100, 6.0)]
+    );
+    assert!(engine.0.is_empty(), "the app replays the complete new Track");
+}
+
+#[test]
+fn slice_to_drum_rack_falls_back_to_warp_markers_and_caps_the_rack_at_sixteen() {
+    let mut arrangement = arrangement_with_tracks(1);
+    let (source_track_id, source_clip_id) = add_audio_clip(&mut arrangement, 0, 0, 1_000);
+    let original = &mut arrangement.tracks[0].clips[0];
+    original.source = Some(MediaSourceRef::LocalFile {
+        path: "shared-loop.wav".into(),
+    });
+    for frame in (50..1_000).step_by(50) {
+        assert!(original.warp_markers.add(frame, frame, 0, 1_000, 1_000));
+    }
+    let mut engine = RecordingEngine::default();
+
+    let action = arrangement.update(
+        ArrangementMsg::SliceAudioClipToDrumRack {
+            track_id: source_track_id,
+            clip_id: source_clip_id,
+        },
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..ArrangementCtx::default()
+        },
+    );
+
+    let drum_track = arrangement
+        .find_track(action.replay_project_track.unwrap())
+        .unwrap();
+    assert_eq!(
+        drum_track
+            .drum_rack_pads
+            .iter()
+            .filter(|pad| pad.source.is_some())
+            .count(),
+        16
+    );
+    assert_eq!(drum_track.note_clips[0].notes.len(), 16);
+    assert!(action.status.unwrap().contains("Warp slices"));
+}
+
+#[test]
+fn slice_to_drum_rack_missing_media_or_markers_leaves_no_partial_track() {
+    let mut arrangement = arrangement_with_tracks(1);
+    let (source_track_id, source_clip_id) = add_audio_clip(&mut arrangement, 0, 0, 1_000);
+    arrangement.tracks[0].clips[0]
+        .transient_markers
+        .replace_suggestions([250]);
+    let mut engine = RecordingEngine::default();
+
+    let missing_media = arrangement.update(
+        ArrangementMsg::SliceAudioClipToDrumRack {
+            track_id: source_track_id,
+            clip_id: source_clip_id,
+        },
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..ArrangementCtx::default()
+        },
+    );
+    assert!(!missing_media.mark_dirty);
+    assert_eq!(arrangement.tracks.len(), 1);
+
+    arrangement.tracks[0].clips[0].source = Some(MediaSourceRef::LocalFile {
+        path: "shared-loop.wav".into(),
+    });
+    arrangement.tracks[0].clips[0].transient_markers = Default::default();
+    let missing_markers = arrangement.update(
+        ArrangementMsg::SliceAudioClipToDrumRack {
+            track_id: source_track_id,
+            clip_id: source_clip_id,
+        },
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..ArrangementCtx::default()
+        },
+    );
+    assert!(!missing_markers.mark_dirty);
+    assert_eq!(arrangement.tracks.len(), 1);
+    assert!(engine.0.is_empty());
+}
+
+#[test]
 fn audio_loop_region_must_be_ordered_and_inside_the_visible_clip() {
     let mut arrangement = arrangement_with_tracks(1);
     let (track_id, clip_id) = add_audio_clip(&mut arrangement, 0, 0, 1_000);

--- a/crates/vibez-ui/src/domains/arrangement/tests/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests/mod.rs
@@ -8,8 +8,8 @@ use super::*;
 use crate::domains::test_support::RecordingEngine;
 use crate::state::{AudioClipInspectorField, UiClip};
 use vibez_core::automation::{AutomationLane, AutomationPoint, AutomationTarget};
-use vibez_core::midi::MidiNote;
-use vibez_core::track::{AudioInputRoute, ClipPlaybackDirection};
+use vibez_core::midi::{InstrumentKind, MidiNote};
+use vibez_core::track::{AudioInputRoute, ClipPlaybackDirection, MediaSourceRef};
 use vibez_core::transient::{TransientMarker, TransientMarkerKind};
 use vibez_core::warp_marker::WarpMarker;
 fn add_audio_clip(

--- a/crates/vibez-ui/src/domains/devices.rs
+++ b/crates/vibez-ui/src/domains/devices.rs
@@ -300,7 +300,7 @@ impl DevicesState {
                     track.sample_source = None;
                     track.sample_audio = None;
                     track.instrument_params = instrument_params.clone();
-                    track.drum_rack_pads = (0..16).map(|_| UiDrumPad::default()).collect();
+                    track.drum_rack_pads = crate::state::default_drum_rack_pads();
                     track.selected_drum_pad = 0;
                     track.plugin_instrument_name = None;
                     track.plugin_instrument_ref = None;
@@ -329,7 +329,7 @@ impl DevicesState {
                     track.sample_source = None;
                     track.sample_audio = None;
                     track.instrument_params.clear();
-                    track.drum_rack_pads = (0..16).map(|_| UiDrumPad::default()).collect();
+                    track.drum_rack_pads = crate::state::default_drum_rack_pads();
                     track.selected_drum_pad = 0;
                     track.plugin_instrument_name = None;
                     track.plugin_instrument_ref = None;
@@ -355,7 +355,9 @@ impl DevicesState {
             }
             DevicesMsg::SelectDrumRackPad(track_id, pad_index) => {
                 // Audition the pad like Ableton: hear it on click.
-                let pitch = 36 + pad_index.min(127) as u8;
+                let Some(pitch) = vibez_core::track::drum_rack_pad_pitch(pad_index) else {
+                    return action;
+                };
                 engine.send(EngineCommand::AuditionNote {
                     track_id,
                     pitch,

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -152,6 +152,12 @@ pub struct LoadedDrumRackPadData {
 }
 
 #[derive(Debug, Clone)]
+pub struct PreparedDrumRackAudio {
+    pub source: MediaSourceRef,
+    pub audio: Arc<DecodedAudio>,
+}
+
+#[derive(Debug, Clone)]
 pub struct SampleLibraryScanResult {
     pub entries: Vec<SampleBrowserEntry>,
     pub folders: Vec<SampleBrowserFolder>,
@@ -453,6 +459,13 @@ pub enum Message {
     Devices(crate::domains::devices::DevicesMsg),
     /// Arrangement domain (tracks, selection; clips arriving next).
     Arrangement(crate::domains::arrangement::ArrangementMsg),
+    AudioClipDrumRackPrepared {
+        location: TimelineLocation,
+        track_id: TrackId,
+        clip_id: ClipId,
+        expected_clip: Box<crate::state::UiClip>,
+        result: Result<PreparedDrumRackAudio, String>,
+    },
     PianoRoll(crate::domains::piano_roll::PianoRollMsg),
     Browser(crate::domains::browser::BrowserMsg),
     Project(crate::domains::project::ProjectMsg),

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -459,10 +459,14 @@ pub enum Message {
     Devices(crate::domains::devices::DevicesMsg),
     /// Arrangement domain (tracks, selection; clips arriving next).
     Arrangement(crate::domains::arrangement::ArrangementMsg),
+    SetDrumRackSliceMarkers(crate::domains::arrangement::AudioSliceMarkers),
+    ConfirmDrumRackSlice,
+    CancelDrumRackSlice,
     AudioClipDrumRackPrepared {
         location: TimelineLocation,
         track_id: TrackId,
         clip_id: ClipId,
+        markers: crate::domains::arrangement::AudioSliceMarkers,
         expected_clip: Box<crate::state::UiClip>,
         result: Result<PreparedDrumRackAudio, String>,
     },

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -654,7 +654,9 @@ impl Default for AppState {
 }
 
 pub fn default_drum_rack_pads() -> Vec<UiDrumPad> {
-    (0..16).map(|_| UiDrumPad::default()).collect()
+    (0..vibez_core::track::DRUM_RACK_PAD_COUNT)
+        .map(|_| UiDrumPad::default())
+        .collect()
 }
 
 impl AppState {

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -111,6 +111,7 @@ pub struct ViewState {
     pub adaptive_grid: bool,
     pub adaptive_grid_bias: i8,
     pub context_menu: Option<ContextMenu>,
+    pub drum_rack_slice_dialog: Option<DrumRackSliceDialog>,
     pub edit_menu_open: bool,
     pub cursor_x: f32, // globally tracked for popup positioning and pane drags
     pub cursor_y: f32,
@@ -136,6 +137,7 @@ impl Default for ViewState {
             adaptive_grid: false,
             adaptive_grid_bias: 0,
             context_menu: None,
+            drum_rack_slice_dialog: None,
             edit_menu_open: false,
             cursor_x: 0.0,
             cursor_y: 0.0,
@@ -157,6 +159,14 @@ impl ViewState {
             self.adaptive_grid_bias,
         )
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DrumRackSliceDialog {
+    pub location: vibez_project::TimelineLocation,
+    pub track_id: TrackId,
+    pub clip_id: ClipId,
+    pub markers: crate::domains::arrangement::AudioSliceMarkers,
 }
 
 /// Right-click context menu state.

--- a/crates/vibez-ui/src/state/ui_types.rs
+++ b/crates/vibez-ui/src/state/ui_types.rs
@@ -150,20 +150,39 @@ impl UiClip {
     }
 
     pub(crate) fn source_frame_at(&self, clip_frame: u64) -> u64 {
+        self.source_frame_position_at(clip_frame).round() as u64
+    }
+
+    pub(crate) fn source_frame_position_at(&self, clip_frame: u64) -> f64 {
         let timeline_frame = self.timeline().source_at(
             self.playback_direction
                 .map_clip_frame(clip_frame, self.duration),
         );
         if self.warp_markers.is_empty() {
-            return timeline_frame;
+            return timeline_frame as f64;
         }
-        self.warp_markers
-            .source_at_timeline(
-                timeline_frame.saturating_sub(self.source_offset) as f64,
-                self.source_offset,
-                self.warp_timeline_end(),
-            )
-            .round() as u64
+        self.warp_markers.source_at_timeline(
+            timeline_frame.saturating_sub(self.source_offset) as f64,
+            self.source_offset,
+            self.warp_timeline_end(),
+        )
+    }
+
+    pub(crate) fn has_same_audible_geometry(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.audio, &other.audio)
+            && self.duration == other.duration
+            && self.source_offset == other.source_offset
+            && self.start_marker == other.start_marker
+            && self.loop_enabled == other.loop_enabled
+            && self.loop_start == other.loop_start
+            && self.loop_end == other.loop_end
+            && self.gain_db == other.gain_db
+            && self.fades == other.fades
+            && self.playback_direction == other.playback_direction
+            && self.warp_markers == other.warp_markers
+            && self.transpose == other.transpose
+            && self.warped == other.warped
+            && self.warped_to_bpm == other.warped_to_bpm
     }
 
     pub(crate) fn timeline_frame_at_source(&self, source_frame: u64) -> u64 {
@@ -283,6 +302,7 @@ impl Default for UiDrumPad {
 impl UiDrumPad {
     pub fn to_state(&self) -> DrumPadState {
         DrumPadState {
+            name: self.name.clone(),
             source: self.source.clone(),
             gain: self.gain,
             pan: self.pan,
@@ -297,7 +317,10 @@ impl UiDrumPad {
 
     pub fn from_state(state: &DrumPadState) -> Self {
         Self {
-            name: state.source.as_ref().map(MediaSourceRef::display_name),
+            name: state
+                .name
+                .clone()
+                .or_else(|| state.source.as_ref().map(MediaSourceRef::display_name)),
             source: state.source.clone(),
             audio: None,
             gain: state.gain,

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -734,6 +734,88 @@ fn one_marker_slice_action_undoes_back_to_the_original_audio_clip() {
 }
 
 #[test]
+fn slice_to_drum_rack_undo_removes_the_track_instrument_and_midi_clip_together() {
+    let mut state = AppState::default();
+    let source_track_id = TrackId::new();
+    let source_clip_id = ClipId::new();
+    Arc::make_mut(&mut state.project_tracks)
+        .tracks
+        .push(ProjectTrack::new(source_track_id, "Audio".into(), 0));
+    let mut clip = UiClip {
+        id: source_clip_id,
+        name: "Loop".into(),
+        audio: Arc::new(DecodedAudio {
+            channels: vec![vec![0.0; 1_000]],
+            sample_rate: 48_000,
+        }),
+        source: Some(vibez_core::track::MediaSourceRef::LocalFile {
+            path: "loop.wav".into(),
+        }),
+        position: 0,
+        source_offset: 0,
+        start_marker: 0,
+        duration: 1_000,
+        loop_enabled: false,
+        loop_start: 0,
+        loop_end: 1_000,
+        gain_db: Default::default(),
+        fades: Default::default(),
+        playback_direction: Default::default(),
+        transient_markers: Default::default(),
+        warp_markers: Default::default(),
+        transpose: Default::default(),
+        original_bpm: None,
+        warped: false,
+        warped_to_bpm: None,
+        original_audio: None,
+    };
+    clip.transient_markers.replace_suggestions([500]);
+    Arc::make_mut(&mut state.arrangement.timeline)
+        .ensure(source_track_id)
+        .clips
+        .push(clip);
+    let before = snapshot(&state);
+    let mut engine = RecordingEngine::default();
+
+    let action = state.arrangement.update(
+        Arc::make_mut(&mut state.project_tracks),
+        ArrangementMsg::SliceAudioClipToDrumRack {
+            track_id: source_track_id,
+            clip_id: source_clip_id,
+        },
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..ArrangementCtx::default()
+        },
+    );
+    let generated_track_id = action.replay_project_track.unwrap();
+    assert!(action.mark_dirty);
+    state.project.history.push_edit(before, None);
+    assert!(state
+        .project_tracks
+        .find(generated_track_id)
+        .is_some_and(
+            |track| track.instrument_kind == Some(vibez_core::midi::InstrumentKind::DrumRack)
+        ));
+    assert_eq!(
+        state
+            .arrangement
+            .timeline
+            .get(generated_track_id)
+            .unwrap()
+            .note_clips
+            .len(),
+        1
+    );
+
+    undo_once(&mut state);
+    assert!(state.project_tracks.find(generated_track_id).is_none());
+    assert!(state.arrangement.timeline.get(generated_track_id).is_none());
+    assert!(state.project_tracks.find(source_track_id).is_some());
+}
+
+#[test]
 fn cut_and_each_paste_are_separate_undo_steps_while_clipboard_survives_undo() {
     let mut state = AppState::default();
     let track_id = TrackId::new();

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -770,6 +770,8 @@ fn slice_to_drum_rack_undo_removes_the_track_instrument_and_midi_clip_together()
         original_audio: None,
     };
     clip.transient_markers.replace_suggestions([500]);
+    let prepared_audio = Arc::clone(&clip.audio);
+    let prepared_source = clip.source.clone().unwrap();
     Arc::make_mut(&mut state.arrangement.timeline)
         .ensure(source_track_id)
         .clips
@@ -782,6 +784,8 @@ fn slice_to_drum_rack_undo_removes_the_track_instrument_and_midi_clip_together()
         ArrangementMsg::SliceAudioClipToDrumRack {
             track_id: source_track_id,
             clip_id: source_clip_id,
+            source: prepared_source,
+            audio: prepared_audio,
         },
         &mut engine,
         ArrangementCtx {

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -784,6 +784,7 @@ fn slice_to_drum_rack_undo_removes_the_track_instrument_and_midi_clip_together()
         ArrangementMsg::SliceAudioClipToDrumRack {
             track_id: source_track_id,
             clip_id: source_clip_id,
+            markers: AudioSliceMarkers::Transients,
             source: prepared_source,
             audio: prepared_audio,
         },


### PR DESCRIPTION
## Summary

- add Slice to Drum Rack from the Audio Clip editor
- prefer Transient Markers and fall back to Warp Markers
- flatten the Clip audio heard through loop, Reverse, Warp, Transpose, gain and edge fades off the UI thread
- stage that flattened audio as project-owned media before creating the rack, so in-session and reopened playback use the same bytes
- create a native Drum Rack Project Track with up to sixteen pad zones and an explicit truncation status
- generate a full-velocity MIDI Clip that reconstructs the slice timing without hidden attenuation
- preserve pad bounds, names, gain, Project Media and MIDI notes through save/reopen
- share the canonical slice-boundary walk, Drum Rack layout constants and numbered Project Track factory
- seed the complete new Track through canonical project replay in Arrange and Section construction
- make Track, instrument, pads and MIDI Clip one Undoable project edit

## Validation

- `cargo test --workspace --all-features` (651 UI tests; full workspace green)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

Stacked on #202.