### PR TITLE
fix: use a labelled reverse icon control

### DIFF
--- a/crates/vibez-ui/src/app/views_audio_clip.rs
+++ b/crates/vibez-ui/src/app/views_audio_clip.rs
@@ -1,6 +1,8 @@
 //! Audio Clip Inspector panel and waveform controls.
 
-use iced::widget::{button, canvas, column, container, horizontal_space, row, text, text_input};
+use iced::widget::{
+    button, canvas, column, container, horizontal_space, row, text, text_input, tooltip,
+};
 use iced::{Color, Element, Length, Theme};
 
 use crate::domains::arrangement::ArrangementMsg;
@@ -315,23 +317,19 @@ impl App {
                 {
                     let reversed = clip.playback_direction
                         == vibez_core::track::ClipPlaybackDirection::Reverse;
-                    button(
-                        text(if reversed {
-                            "REVERSE ON"
-                        } else {
-                            "REVERSE OFF"
-                        })
-                        .size(8)
-                        .color(if reversed {
-                            th::accent()
-                        } else {
-                            th::text_dim()
-                        }),
+                    let reverse_button = button(
+                        icons::icon(icons::FLIP_HORIZONTAL_2)
+                            .size(13)
+                            .color(if reversed {
+                                th::accent()
+                            } else {
+                                th::text_dim()
+                            }),
                     )
                     .on_press(Message::Arrangement(ArrangementMsg::ToggleClipReverse(
                         track_id, clip.id,
                     )))
-                    .padding([3, 6])
+                    .padding([4, 7])
                     .style(move |_theme: &Theme, status| button::Style {
                         background: Some(
                             if reversed {
@@ -361,7 +359,29 @@ impl App {
                             radius: 2.0.into(),
                         },
                         ..Default::default()
-                    })
+                    });
+                    let hint = container(
+                        text(if reversed {
+                            "Reverse playback is on. Click for forward playback."
+                        } else {
+                            "Reverse audio playback"
+                        })
+                        .size(10)
+                        .color(th::text()),
+                    )
+                    .padding([5, 7])
+                    .style(|_theme: &Theme| container::Style {
+                        background: Some(th::bg_elevated().into()),
+                        border: iced::Border {
+                            color: th::border_light(),
+                            width: 1.0,
+                            radius: 3.0.into(),
+                        },
+                        ..Default::default()
+                    });
+                    tooltip(reverse_button, hint, tooltip::Position::Top)
+                        .gap(6)
+                        .padding(0)
                 },
             ]
             .align_y(iced::Alignment::Center),

--- a/crates/vibez-ui/src/icons.rs
+++ b/crates/vibez-ui/src/icons.rs
@@ -37,6 +37,7 @@ pub const SCISSORS: char = '\u{E152}';
 pub const REPEAT: char = '\u{E146}';
 pub const PENCIL: char = '\u{E131}';
 pub const MOUSE_POINTER: char = '\u{E0F3}';
+pub const FLIP_HORIZONTAL_2: char = '\u{E35D}';
 
 /// Create an icon text element with the Lucide font.
 pub fn icon(codepoint: char) -> iced::widget::Text<'static> {


### PR DESCRIPTION
## What changed
- replace the wide Reverse On/Off text control with the Lucide flip-horizontal icon
- retain the active accent treatment when reverse playback is enabled
- explain both states with a tooltip above the control

## Validation
- cargo check -p vibez-ui --all-targets
- cargo clippy -p vibez-ui --all-targets -- -D warnings