### PR TITLE
Make audio crossfades direct and editable

### DIFF
--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -795,4 +795,50 @@ mod tests {
             assert!((power - 1.0).abs() < 1e-5, "frame {frame}: {power}");
         }
     }
+
+    #[test]
+    fn shaped_crossfade_edges_remain_a_complementary_power_pair() {
+        for curve in [FadeCurve::new(-100), FadeCurve::new(0), FadeCurve::new(100)] {
+            for step in 0..=20 {
+                let progress = step as f32 / 20.0;
+                let (outgoing, incoming) = curve.crossfade_gains(progress);
+                assert!((outgoing * outgoing + incoming * incoming - 1.0).abs() < 1e-5);
+            }
+        }
+
+        let outgoing_id = ClipId::new();
+        let incoming_id = ClipId::new();
+        let curve = FadeCurve::new(65);
+        let outgoing = ClipFades::default()
+            .linked_fade_out(100, incoming_id, 100)
+            .with_linked_fade_out_curve(curve);
+        let incoming = ClipFades::default()
+            .linked_fade_in(100, outgoing_id, 100)
+            .with_linked_fade_in_curve(curve);
+        assert_eq!(outgoing.fade_out_curve(), curve);
+        assert_eq!(incoming.fade_in_curve(), curve);
+        for frame in 0..100 {
+            let power = outgoing.gain_at(frame, 100).powi(2) + incoming.gain_at(frame, 100).powi(2);
+            assert!((power - 1.0).abs() < 1e-5, "frame {frame}: {power}");
+        }
+    }
+
+    #[test]
+    fn unlinking_a_shaped_crossfade_keeps_its_length_but_returns_to_linear() {
+        let peer = ClipId::new();
+        let linked = ClipFades::default()
+            .linked_fade_out(50, peer, 100)
+            .with_linked_fade_out_curve(FadeCurve::new(80));
+        let unlinked = linked.unlink_fade_out();
+
+        assert_eq!(unlinked.fade_out_frames(), 50);
+        assert_eq!(unlinked.fade_out_curve(), FadeCurve::default());
+        assert!(unlinked.crossfade_out_to().is_none());
+
+        let reopened: ClipFades =
+            serde_json::from_str(&serde_json::to_string(&unlinked).unwrap()).unwrap();
+        let relinked = reopened.linked_fade_out(50, peer, 100);
+        assert_eq!(relinked.fade_out_curve(), FadeCurve::new(80));
+        assert_eq!(relinked.crossfade_out_to(), Some(peer));
+    }
 }

--- a/crates/vibez-core/src/track/fades.rs
+++ b/crates/vibez-core/src/track/fades.rs
@@ -57,10 +57,28 @@ impl FadeCurve {
     #[inline]
     pub fn gain_for(self, progress: f32, equal_power: bool) -> f32 {
         if equal_power {
-            (progress.clamp(0.0, 1.0) * std::f32::consts::FRAC_PI_2).sin()
+            self.crossfade_gains(progress).1
         } else {
             self.gain(progress)
         }
+    }
+
+    /// Gain while moving left-to-right through a fade-out region.
+    #[inline]
+    pub fn fade_out_gain(self, progress: f32, equal_power: bool) -> f32 {
+        if equal_power {
+            self.crossfade_gains(progress).0
+        } else {
+            self.gain(1.0 - progress)
+        }
+    }
+
+    /// Complementary gains for a linked crossfade. The curve moves the
+    /// crossover while the sine/cosine pair keeps total power steady.
+    #[inline]
+    pub fn crossfade_gains(self, progress: f32) -> (f32, f32) {
+        let phase = self.gain(progress) * std::f32::consts::FRAC_PI_2;
+        (phase.cos(), phase.sin())
     }
 }
 
@@ -69,20 +87,73 @@ impl FadeCurve {
 /// Values are expressed in timeline frames. They are deliberately independent
 /// of source and loop positions, so a looped Clip fades only where the Clip
 /// begins and ends instead of on every loop pass.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ClipFades {
-    #[serde(default)]
     fade_in_frames: u64,
-    #[serde(default)]
     fade_out_frames: u64,
-    #[serde(default, skip_serializing_if = "FadeCurve::is_linear")]
     fade_in_curve: FadeCurve,
-    #[serde(default, skip_serializing_if = "FadeCurve::is_linear")]
     fade_out_curve: FadeCurve,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    crossfade_in_from: Option<ClipId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    crossfade_out_to: Option<ClipId>,
+    crossfade_in_peer: Option<ClipId>,
+    crossfade_out_peer: Option<ClipId>,
+    crossfade_in_active: bool,
+    crossfade_out_active: bool,
+    previous_crossfade_in_curve: FadeCurve,
+    previous_crossfade_out_curve: FadeCurve,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+struct CrossfadeMemory {
+    peer: ClipId,
+    curve: FadeCurve,
+}
+
+impl Serialize for ClipFades {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct PersistedFades {
+            fade_in_frames: u64,
+            fade_out_frames: u64,
+            #[serde(skip_serializing_if = "FadeCurve::is_linear")]
+            fade_in_curve: FadeCurve,
+            #[serde(skip_serializing_if = "FadeCurve::is_linear")]
+            fade_out_curve: FadeCurve,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            crossfade_in_from: Option<ClipId>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            crossfade_out_to: Option<ClipId>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            previous_crossfade_in: Option<CrossfadeMemory>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            previous_crossfade_out: Option<CrossfadeMemory>,
+        }
+
+        PersistedFades {
+            fade_in_frames: self.fade_in_frames,
+            fade_out_frames: self.fade_out_frames,
+            fade_in_curve: self.fade_in_curve,
+            fade_out_curve: self.fade_out_curve,
+            crossfade_in_from: self.crossfade_in_from(),
+            crossfade_out_to: self.crossfade_out_to(),
+            previous_crossfade_in: (!self.crossfade_in_active)
+                .then_some(self.crossfade_in_peer)
+                .flatten()
+                .map(|peer| CrossfadeMemory {
+                    peer,
+                    curve: self.previous_crossfade_in_curve,
+                }),
+            previous_crossfade_out: (!self.crossfade_out_active)
+                .then_some(self.crossfade_out_peer)
+                .flatten()
+                .map(|peer| CrossfadeMemory {
+                    peer,
+                    curve: self.previous_crossfade_out_curve,
+                }),
+        }
+        .serialize(serializer)
+    }
 }
 
 impl<'de> Deserialize<'de> for ClipFades {
@@ -104,28 +175,52 @@ impl<'de> Deserialize<'de> for ClipFades {
             crossfade_in_from: Option<ClipId>,
             #[serde(default)]
             crossfade_out_to: Option<ClipId>,
+            #[serde(default)]
+            previous_crossfade_in: Option<CrossfadeMemory>,
+            #[serde(default)]
+            previous_crossfade_out: Option<CrossfadeMemory>,
         }
 
         let persisted = PersistedFades::deserialize(deserializer)?;
+        let has_fade_in = persisted.fade_in_frames > 0;
+        let has_fade_out = persisted.fade_out_frames > 0;
+        let crossfade_in_active = has_fade_in && persisted.crossfade_in_from.is_some();
+        let crossfade_out_active = has_fade_out && persisted.crossfade_out_to.is_some();
         Ok(Self {
             fade_in_frames: persisted.fade_in_frames,
             fade_out_frames: persisted.fade_out_frames,
-            fade_in_curve: if persisted.fade_in_frames > 0 {
+            fade_in_curve: if has_fade_in {
                 persisted.fade_in_curve
             } else {
                 FadeCurve::default()
             },
-            fade_out_curve: if persisted.fade_out_frames > 0 {
+            fade_out_curve: if has_fade_out {
                 persisted.fade_out_curve
             } else {
                 FadeCurve::default()
             },
-            crossfade_in_from: (persisted.fade_in_frames > 0)
-                .then_some(persisted.crossfade_in_from)
-                .flatten(),
-            crossfade_out_to: (persisted.fade_out_frames > 0)
-                .then_some(persisted.crossfade_out_to)
-                .flatten(),
+            crossfade_in_peer: if crossfade_in_active {
+                persisted.crossfade_in_from
+            } else if has_fade_in {
+                persisted.previous_crossfade_in.map(|memory| memory.peer)
+            } else {
+                None
+            },
+            crossfade_out_peer: if crossfade_out_active {
+                persisted.crossfade_out_to
+            } else if has_fade_out {
+                persisted.previous_crossfade_out.map(|memory| memory.peer)
+            } else {
+                None
+            },
+            crossfade_in_active,
+            crossfade_out_active,
+            previous_crossfade_in_curve: persisted
+                .previous_crossfade_in
+                .map_or(FadeCurve::default(), |memory| memory.curve),
+            previous_crossfade_out_curve: persisted
+                .previous_crossfade_out
+                .map_or(FadeCurve::default(), |memory| memory.curve),
         })
     }
 }
@@ -148,8 +243,12 @@ impl ClipFades {
             fade_out_frames,
             fade_in_curve: FadeCurve::new(0),
             fade_out_curve: FadeCurve::new(0),
-            crossfade_in_from: None,
-            crossfade_out_to: None,
+            crossfade_in_peer: None,
+            crossfade_out_peer: None,
+            crossfade_in_active: false,
+            crossfade_out_active: false,
+            previous_crossfade_in_curve: FadeCurve::new(0),
+            previous_crossfade_out_curve: FadeCurve::new(0),
         }
     }
 
@@ -172,7 +271,11 @@ impl ClipFades {
     pub const fn with_fade_in(self, frames: u64, duration: u64) -> Self {
         let mut fades = Self::new(frames, self.fade_out_frames, duration);
         fades.fade_in_curve = if fades.fade_in_frames > 0 {
-            self.fade_in_curve
+            if self.crossfade_in_active {
+                FadeCurve::new(0)
+            } else {
+                self.fade_in_curve
+            }
         } else {
             FadeCurve::new(0)
         };
@@ -181,7 +284,23 @@ impl ClipFades {
         } else {
             FadeCurve::new(0)
         };
-        fades.crossfade_out_to = self.crossfade_out_to;
+        fades.crossfade_in_peer = if fades.fade_in_frames > 0 {
+            self.crossfade_in_peer
+        } else {
+            None
+        };
+        fades.crossfade_out_peer = if fades.fade_out_frames > 0 {
+            self.crossfade_out_peer
+        } else {
+            None
+        };
+        fades.crossfade_out_active = fades.fade_out_frames > 0 && self.crossfade_out_active;
+        fades.previous_crossfade_in_curve = if self.crossfade_in_active {
+            self.fade_in_curve
+        } else {
+            self.previous_crossfade_in_curve
+        };
+        fades.previous_crossfade_out_curve = self.previous_crossfade_out_curve;
         fades
     }
 
@@ -202,12 +321,32 @@ impl ClipFades {
                 FadeCurve::new(0)
             },
             fade_out_curve: if fade_out_frames > 0 {
-                self.fade_out_curve
+                if self.crossfade_out_active {
+                    FadeCurve::new(0)
+                } else {
+                    self.fade_out_curve
+                }
             } else {
                 FadeCurve::new(0)
             },
-            crossfade_in_from: self.crossfade_in_from,
-            crossfade_out_to: None,
+            crossfade_in_peer: if fade_in_frames > 0 {
+                self.crossfade_in_peer
+            } else {
+                None
+            },
+            crossfade_out_peer: if fade_out_frames > 0 {
+                self.crossfade_out_peer
+            } else {
+                None
+            },
+            crossfade_in_active: fade_in_frames > 0 && self.crossfade_in_active,
+            crossfade_out_active: false,
+            previous_crossfade_in_curve: self.previous_crossfade_in_curve,
+            previous_crossfade_out_curve: if self.crossfade_out_active {
+                self.fade_out_curve
+            } else {
+                self.previous_crossfade_out_curve
+            },
         }
     }
 
@@ -223,16 +362,20 @@ impl ClipFades {
         } else {
             FadeCurve::new(0)
         };
-        fades.crossfade_in_from = if fades.fade_in_frames > 0 {
-            self.crossfade_in_from
+        fades.crossfade_in_peer = if fades.fade_in_frames > 0 {
+            self.crossfade_in_peer
         } else {
             None
         };
-        fades.crossfade_out_to = if fades.fade_out_frames > 0 {
-            self.crossfade_out_to
+        fades.crossfade_out_peer = if fades.fade_out_frames > 0 {
+            self.crossfade_out_peer
         } else {
             None
         };
+        fades.crossfade_in_active = fades.fade_in_frames > 0 && self.crossfade_in_active;
+        fades.crossfade_out_active = fades.fade_out_frames > 0 && self.crossfade_out_active;
+        fades.previous_crossfade_in_curve = self.previous_crossfade_in_curve;
+        fades.previous_crossfade_out_curve = self.previous_crossfade_out_curve;
         fades
     }
 
@@ -246,10 +389,30 @@ impl ClipFades {
             (self.fade_out_frames as f64 * ratio).round() as u64,
             new_duration,
         );
-        fades.crossfade_in_from = self.crossfade_in_from;
-        fades.crossfade_out_to = self.crossfade_out_to;
-        fades.fade_in_curve = self.fade_in_curve;
-        fades.fade_out_curve = self.fade_out_curve;
+        fades.crossfade_in_peer = if fades.fade_in_frames > 0 {
+            self.crossfade_in_peer
+        } else {
+            None
+        };
+        fades.crossfade_out_peer = if fades.fade_out_frames > 0 {
+            self.crossfade_out_peer
+        } else {
+            None
+        };
+        fades.crossfade_in_active = fades.fade_in_frames > 0 && self.crossfade_in_active;
+        fades.crossfade_out_active = fades.fade_out_frames > 0 && self.crossfade_out_active;
+        fades.fade_in_curve = if fades.fade_in_frames > 0 {
+            self.fade_in_curve
+        } else {
+            FadeCurve::new(0)
+        };
+        fades.fade_out_curve = if fades.fade_out_frames > 0 {
+            self.fade_out_curve
+        } else {
+            FadeCurve::new(0)
+        };
+        fades.previous_crossfade_in_curve = self.previous_crossfade_in_curve;
+        fades.previous_crossfade_out_curve = self.previous_crossfade_out_curve;
         fades
     }
 
@@ -268,15 +431,35 @@ impl ClipFades {
             if keeps_end { self.fade_out_frames } else { 0 },
             fragment_duration,
         );
-        fades.fade_in_curve = if keeps_start {
+        fades.fade_in_curve = if keeps_start && !self.crossfade_in_active {
             self.fade_in_curve
         } else {
             FadeCurve::new(0)
         };
-        fades.fade_out_curve = if keeps_end {
+        fades.fade_out_curve = if keeps_end && !self.crossfade_out_active {
             self.fade_out_curve
         } else {
             FadeCurve::new(0)
+        };
+        fades.crossfade_in_peer = if keeps_start {
+            self.crossfade_in_peer
+        } else {
+            None
+        };
+        fades.crossfade_out_peer = if keeps_end {
+            self.crossfade_out_peer
+        } else {
+            None
+        };
+        fades.previous_crossfade_in_curve = if self.crossfade_in_active {
+            self.fade_in_curve
+        } else {
+            self.previous_crossfade_in_curve
+        };
+        fades.previous_crossfade_out_curve = if self.crossfade_out_active {
+            self.fade_out_curve
+        } else {
+            self.previous_crossfade_out_curve
         };
         fades
     }
@@ -284,59 +467,79 @@ impl ClipFades {
     pub const fn is_neutral(value: &Self) -> bool {
         value.fade_in_frames == 0
             && value.fade_out_frames == 0
-            && value.crossfade_in_from.is_none()
-            && value.crossfade_out_to.is_none()
+            && !value.crossfade_in_active
+            && !value.crossfade_out_active
     }
 
     pub const fn crossfade_in_from(self) -> Option<ClipId> {
-        self.crossfade_in_from
+        if self.crossfade_in_active {
+            self.crossfade_in_peer
+        } else {
+            None
+        }
     }
 
     pub const fn crossfade_out_to(self) -> Option<ClipId> {
-        self.crossfade_out_to
-    }
-
-    pub const fn linked_fade_in(self, frames: u64, from: ClipId, duration: u64) -> Self {
-        let mut fades = self.with_fade_in(frames, duration);
-        fades.fade_in_curve = FadeCurve::new(0);
-        fades.crossfade_in_from = if fades.fade_in_frames > 0 {
-            Some(from)
+        if self.crossfade_out_active {
+            self.crossfade_out_peer
         } else {
             None
+        }
+    }
+
+    pub fn linked_fade_in(self, frames: u64, from: ClipId, duration: u64) -> Self {
+        let mut fades = self.with_fade_in(frames, duration);
+        fades.fade_in_curve = if self.crossfade_in_peer == Some(from) {
+            self.previous_crossfade_in_curve
+        } else {
+            FadeCurve::new(0)
         };
+        fades.crossfade_in_peer = (fades.fade_in_frames > 0).then_some(from);
+        fades.crossfade_in_active = fades.fade_in_frames > 0;
+        fades.previous_crossfade_in_curve = FadeCurve::new(0);
         fades
     }
 
-    pub const fn linked_fade_out(self, frames: u64, to: ClipId, duration: u64) -> Self {
+    pub fn linked_fade_out(self, frames: u64, to: ClipId, duration: u64) -> Self {
         let mut fades = self.with_fade_out(frames, duration);
-        fades.fade_out_curve = FadeCurve::new(0);
-        fades.crossfade_out_to = if fades.fade_out_frames > 0 {
-            Some(to)
+        fades.fade_out_curve = if self.crossfade_out_peer == Some(to) {
+            self.previous_crossfade_out_curve
         } else {
-            None
+            FadeCurve::new(0)
         };
+        fades.crossfade_out_peer = (fades.fade_out_frames > 0).then_some(to);
+        fades.crossfade_out_active = fades.fade_out_frames > 0;
+        fades.previous_crossfade_out_curve = FadeCurve::new(0);
         fades
     }
 
     pub const fn unlinked(self) -> Self {
-        Self {
-            crossfade_in_from: None,
-            crossfade_out_to: None,
-            ..self
-        }
+        self.unlink_fade_in().unlink_fade_out()
     }
 
     pub const fn unlink_fade_in(self) -> Self {
-        Self {
-            crossfade_in_from: None,
-            ..self
+        if self.crossfade_in_active {
+            Self {
+                fade_in_curve: FadeCurve::new(0),
+                crossfade_in_active: false,
+                previous_crossfade_in_curve: self.fade_in_curve,
+                ..self
+            }
+        } else {
+            self
         }
     }
 
     pub const fn unlink_fade_out(self) -> Self {
-        Self {
-            crossfade_out_to: None,
-            ..self
+        if self.crossfade_out_active {
+            Self {
+                fade_out_curve: FadeCurve::new(0),
+                crossfade_out_active: false,
+                previous_crossfade_out_curve: self.fade_out_curve,
+                ..self
+            }
+        } else {
+            self
         }
     }
 
@@ -362,6 +565,28 @@ impl ClipFades {
         }
     }
 
+    pub const fn with_linked_fade_in_curve(self, curve: FadeCurve) -> Self {
+        Self {
+            fade_in_curve: if self.crossfade_in_active {
+                curve
+            } else {
+                self.fade_in_curve
+            },
+            ..self
+        }
+    }
+
+    pub const fn with_linked_fade_out_curve(self, curve: FadeCurve) -> Self {
+        Self {
+            fade_out_curve: if self.crossfade_out_active {
+                curve
+            } else {
+                self.fade_out_curve
+            },
+            ..self
+        }
+    }
+
     /// Per-frame amplitude. This is safe to call on the audio thread.
     #[inline]
     pub fn gain_at(self, clip_frame: u64, duration: u64) -> f32 {
@@ -371,19 +596,19 @@ impl ClipFades {
         let fade_in = if self.fade_in_frames > 0 && clip_frame < self.fade_in_frames {
             let progress = clip_frame as f32 / self.fade_in_frames as f32;
             self.fade_in_curve
-                .gain_for(progress, self.crossfade_in_from.is_some())
+                .gain_for(progress, self.crossfade_in_active)
         } else {
             1.0
         };
         let frames_after = duration - 1 - clip_frame;
         let fade_out = if self.fade_out_frames > 0 && frames_after < self.fade_out_frames {
-            let progress = if self.crossfade_out_to.is_some() {
+            let progress = if self.crossfade_out_active {
                 (frames_after + 1) as f32 / self.fade_out_frames as f32
             } else {
                 frames_after as f32 / self.fade_out_frames as f32
             };
             self.fade_out_curve
-                .gain_for(progress, self.crossfade_out_to.is_some())
+                .fade_out_gain(1.0 - progress, self.crossfade_out_active)
         } else {
             1.0
         };

--- a/crates/vibez-ui/src/app/views_arrangement.rs
+++ b/crates/vibez-ui/src/app/views_arrangement.rs
@@ -346,8 +346,8 @@ impl App {
                         fade_out_frames: 0,
                         fade_in_curve: Default::default(),
                         fade_out_curve: Default::default(),
-                        crossfade_in: false,
-                        crossfade_out: false,
+                        crossfade_in_from: None,
+                        crossfade_out_to: None,
                         warp_stale: false,
                     });
             }

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -856,7 +856,7 @@ impl App {
                     ));
                     col = col.push(menu_btn(
                         icons::AUDIO_WAVEFORM,
-                        "Crossfade Selected Clips".into(),
+                        "Create Crossfade".into(),
                         Message::Arrangement(ArrangementMsg::CrossfadeSelectedAudioClips),
                     ));
                 }

--- a/crates/vibez-ui/src/domains/arrangement/crossfades.rs
+++ b/crates/vibez-ui/src/domains/arrangement/crossfades.rs
@@ -227,6 +227,13 @@ impl TimelineEditorState {
         incoming_id: ClipId,
         overlap: u64,
     ) -> bool {
+        let preserved_curve = self.find_content(track_id).and_then(|content| {
+            let outgoing = content.clips.iter().find(|clip| clip.id == outgoing_id)?;
+            let incoming = content.clips.iter().find(|clip| clip.id == incoming_id)?;
+            (outgoing.fades.crossfade_out_to() == Some(incoming_id)
+                && incoming.fades.crossfade_in_from() == Some(outgoing_id))
+            .then_some(outgoing.fades.fade_out_curve())
+        });
         self.unlink_crossfade_edge_for_clip(engine, track_id, outgoing_id, AudioClipFadeEdge::Out);
         self.unlink_crossfade_edge_for_clip(engine, track_id, incoming_id, AudioClipFadeEdge::In);
         let Some(content) = self.find_content_mut(track_id) else {
@@ -253,6 +260,10 @@ impl TimelineEditorState {
         incoming.fades = incoming
             .fades
             .linked_fade_in(overlap, outgoing_id, incoming.duration);
+        if let Some(curve) = preserved_curve {
+            outgoing.fades = outgoing.fades.with_linked_fade_out_curve(curve);
+            incoming.fades = incoming.fades.with_linked_fade_in_curve(curve);
+        }
         let outgoing_fades = outgoing.fades;
         let incoming_fades = incoming.fades;
         engine.send(EngineCommand::SetClipFades {

--- a/crates/vibez-ui/src/domains/arrangement/crossfades.rs
+++ b/crates/vibez-ui/src/domains/arrangement/crossfades.rs
@@ -1,6 +1,7 @@
 //! Explicit linked crossfades between two overlapping Audio Clips.
 
 use vibez_core::id::{ClipId, TrackId};
+use vibez_core::track::FadeCurve;
 use vibez_engine::commands::EngineCommand;
 
 use crate::state::{ArrangementSelection, AudioClipFadeEdge, TimelineEditorState};
@@ -8,6 +9,43 @@ use crate::state::{ArrangementSelection, AudioClipFadeEdge, TimelineEditorState}
 use super::{ArrangementAction, EngineHandle};
 
 impl TimelineEditorState {
+    pub(super) fn crossfade_candidate_for_fade(
+        &self,
+        track_id: TrackId,
+        clip_id: ClipId,
+        edge: AudioClipFadeEdge,
+        frames: u64,
+    ) -> Option<(ClipId, ClipId)> {
+        let clips = &self.find_content(track_id)?.clips;
+        let clip = clips.iter().find(|clip| clip.id == clip_id)?;
+        let clip_end = clip.position.saturating_add(clip.duration);
+        match edge {
+            AudioClipFadeEdge::Out => clips
+                .iter()
+                .filter(|incoming| {
+                    incoming.id != clip_id
+                        && incoming.position > clip.position
+                        && incoming.position < clip_end
+                        && clip_end <= incoming.position.saturating_add(incoming.duration)
+                        && clip_end.saturating_sub(incoming.position) == frames
+                })
+                .max_by_key(|incoming| incoming.position)
+                .map(|incoming| (clip_id, incoming.id)),
+            AudioClipFadeEdge::In => clips
+                .iter()
+                .filter(|outgoing| {
+                    let outgoing_end = outgoing.position.saturating_add(outgoing.duration);
+                    outgoing.id != clip_id
+                        && outgoing.position < clip.position
+                        && clip.position < outgoing_end
+                        && outgoing_end <= clip_end
+                        && outgoing_end.saturating_sub(clip.position) == frames
+                })
+                .min_by_key(|outgoing| outgoing.position.saturating_add(outgoing.duration))
+                .map(|outgoing| (outgoing.id, clip_id)),
+        }
+    }
+
     pub(super) fn unlink_crossfade_edge_for_clip(
         &mut self,
         engine: &mut impl EngineHandle,
@@ -170,18 +208,37 @@ impl TimelineEditorState {
         let incoming_id = *incoming_id;
         let overlap = outgoing_end - incoming_start;
 
+        if !self.link_crossfade_pair(engine, track_id, outgoing_id, incoming_id, overlap) {
+            return ArrangementAction::default();
+        }
+
+        ArrangementAction {
+            status: Some("Created crossfade".into()),
+            mark_dirty: true,
+            ..ArrangementAction::default()
+        }
+    }
+
+    pub(super) fn link_crossfade_pair(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        track_id: TrackId,
+        outgoing_id: ClipId,
+        incoming_id: ClipId,
+        overlap: u64,
+    ) -> bool {
         self.unlink_crossfade_edge_for_clip(engine, track_id, outgoing_id, AudioClipFadeEdge::Out);
         self.unlink_crossfade_edge_for_clip(engine, track_id, incoming_id, AudioClipFadeEdge::In);
         let Some(content) = self.find_content_mut(track_id) else {
-            return ArrangementAction::default();
+            return false;
         };
         let Some(outgoing_index) = content.clips.iter().position(|clip| clip.id == outgoing_id)
         else {
-            return ArrangementAction::default();
+            return false;
         };
         let Some(incoming_index) = content.clips.iter().position(|clip| clip.id == incoming_id)
         else {
-            return ArrangementAction::default();
+            return false;
         };
         let (outgoing, incoming) = if outgoing_index < incoming_index {
             let (left, right) = content.clips.split_at_mut(incoming_index);
@@ -208,11 +265,52 @@ impl TimelineEditorState {
             clip_id: incoming_id,
             fades: incoming_fades,
         });
+        true
+    }
 
-        ArrangementAction {
-            status: Some("Created equal-power crossfade".into()),
-            mark_dirty: true,
-            ..ArrangementAction::default()
+    pub(super) fn set_crossfade_curve(
+        &mut self,
+        engine: &mut impl EngineHandle,
+        track_id: TrackId,
+        outgoing_id: ClipId,
+        incoming_id: ClipId,
+        curve: FadeCurve,
+    ) -> bool {
+        let Some(content) = self.find_content_mut(track_id) else {
+            return false;
+        };
+        let Some(outgoing_index) = content.clips.iter().position(|clip| clip.id == outgoing_id)
+        else {
+            return false;
+        };
+        let Some(incoming_index) = content.clips.iter().position(|clip| clip.id == incoming_id)
+        else {
+            return false;
+        };
+        let reciprocal = content.clips[outgoing_index].fades.crossfade_out_to()
+            == Some(incoming_id)
+            && content.clips[incoming_index].fades.crossfade_in_from() == Some(outgoing_id);
+        if !reciprocal
+            || (content.clips[outgoing_index].fades.fade_out_curve() == curve
+                && content.clips[incoming_index].fades.fade_in_curve() == curve)
+        {
+            return false;
         }
+
+        content.clips[outgoing_index].fades = content.clips[outgoing_index]
+            .fades
+            .with_linked_fade_out_curve(curve);
+        content.clips[incoming_index].fades = content.clips[incoming_index]
+            .fades
+            .with_linked_fade_in_curve(curve);
+        for index in [outgoing_index, incoming_index] {
+            let clip = &content.clips[index];
+            engine.send(EngineCommand::SetClipFades {
+                track_id,
+                clip_id: clip.id,
+                fades: clip.fades,
+            });
+        }
+        true
     }
 }

--- a/crates/vibez-ui/src/domains/arrangement/fade_edits.rs
+++ b/crates/vibez-ui/src/domains/arrangement/fade_edits.rs
@@ -17,6 +17,34 @@ impl TimelineEditorState {
         edge: AudioClipFadeEdge,
         frames: u64,
     ) -> ArrangementAction {
+        if let Some((outgoing_id, incoming_id)) =
+            self.crossfade_candidate_for_fade(track_id, clip_id, edge, frames)
+        {
+            let already_linked = self.find_content(track_id).is_some_and(|content| {
+                let outgoing = content.clips.iter().find(|clip| clip.id == outgoing_id);
+                let incoming = content.clips.iter().find(|clip| clip.id == incoming_id);
+                outgoing.is_some_and(|clip| {
+                    clip.fades.crossfade_out_to() == Some(incoming_id)
+                        && clip.fades.fade_out_frames() == frames
+                }) && incoming.is_some_and(|clip| {
+                    clip.fades.crossfade_in_from() == Some(outgoing_id)
+                        && clip.fades.fade_in_frames() == frames
+                })
+            });
+            if already_linked {
+                return ArrangementAction::default();
+            }
+            if self.link_crossfade_pair(engine, track_id, outgoing_id, incoming_id, frames) {
+                self.discard_audio_clip_inspector_edits_for(outgoing_id);
+                self.discard_audio_clip_inspector_edits_for(incoming_id);
+                return ArrangementAction {
+                    mark_dirty: true,
+                    ..ArrangementAction::default()
+                };
+            }
+            return ArrangementAction::default();
+        }
+
         let changes_audible_fades = self
             .find_content(track_id)
             .and_then(|content| content.clips.iter().find(|clip| clip.id == clip_id))

--- a/crates/vibez-ui/src/domains/arrangement/messages.rs
+++ b/crates/vibez-ui/src/domains/arrangement/messages.rs
@@ -123,6 +123,12 @@ pub enum ArrangementMsg {
         edge: crate::state::AudioClipFadeEdge,
         curve: vibez_core::track::FadeCurve,
     },
+    SetAudioClipCrossfadeCurve {
+        track_id: TrackId,
+        outgoing_id: ClipId,
+        incoming_id: ClipId,
+        curve: vibez_core::track::FadeCurve,
+    },
     MoveClipToTrack {
         source_track: TrackId,
         target_track: TrackId,
@@ -319,6 +325,7 @@ impl ArrangementMsg {
                 | Self::ResizeAudioClip { .. }
                 | Self::SetAudioClipFade { .. }
                 | Self::SetAudioClipFadeCurve { .. }
+                | Self::SetAudioClipCrossfadeCurve { .. }
                 | Self::MoveClipToTrack { .. }
                 | Self::ToggleClipLoop(..)
                 | Self::ToggleClipReverse(..)
@@ -415,6 +422,7 @@ impl ArrangementMsg {
                 Self::SubmitAudioClipInspectorField { .. }
                     | Self::SetAudioClipFade { .. }
                     | Self::SetAudioClipFadeCurve { .. }
+                    | Self::SetAudioClipCrossfadeCurve { .. }
                     | Self::AddTransientMarker { .. }
                     | Self::MoveTransientMarker { .. }
                     | Self::RemoveTransientMarker { .. }

--- a/crates/vibez-ui/src/domains/arrangement/mod.rs
+++ b/crates/vibez-ui/src/domains/arrangement/mod.rs
@@ -360,6 +360,16 @@ impl TimelineEditorState {
                 edge,
                 curve,
             } => return self.set_audio_clip_fade_curve(engine, track_id, clip_id, edge, curve),
+            ArrangementMsg::SetAudioClipCrossfadeCurve {
+                track_id,
+                outgoing_id,
+                incoming_id,
+                curve,
+            } => {
+                if self.set_crossfade_curve(engine, track_id, outgoing_id, incoming_id, curve) {
+                    action.mark_dirty = true;
+                }
+            }
             ArrangementMsg::MoveClipToTrack {
                 source_track,
                 target_track,

--- a/crates/vibez-ui/src/domains/arrangement/tests/crossfades.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests/crossfades.rs
@@ -202,6 +202,16 @@ fn moving_one_crossfaded_clip_unlinks_both_edges_without_losing_fade_lengths() {
         &mut engine,
         ArrangementCtx::default(),
     );
+    a.update(
+        ArrangementMsg::SetAudioClipCrossfadeCurve {
+            track_id,
+            outgoing_id,
+            incoming_id,
+            curve: vibez_core::track::FadeCurve::new(70),
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
     engine.0.clear();
 
     a.update(
@@ -228,10 +238,41 @@ fn moving_one_crossfaded_clip_unlinks_both_edges_without_losing_fade_lengths() {
     assert_eq!(incoming.fades.fade_in_frames(), 250);
     assert!(outgoing.fades.crossfade_out_to().is_none());
     assert!(incoming.fades.crossfade_in_from().is_none());
+    assert_eq!(
+        outgoing.fades.fade_out_curve(),
+        vibez_core::track::FadeCurve::default()
+    );
+    assert_eq!(
+        incoming.fades.fade_in_curve(),
+        vibez_core::track::FadeCurve::default()
+    );
     assert!(matches!(
         engine.0.last(),
         Some(EngineCommand::MoveClip { .. })
     ));
+
+    a.update(
+        ArrangementMsg::MoveAudioClip {
+            track_id,
+            clip_id: incoming_id,
+            new_position: 750,
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    a.update(
+        ArrangementMsg::CrossfadeSelectedAudioClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    assert_eq!(
+        a.tracks[0].clips[0].fades.fade_out_curve(),
+        vibez_core::track::FadeCurve::new(70)
+    );
+    assert_eq!(
+        a.tracks[0].clips[1].fades.fade_in_curve(),
+        vibez_core::track::FadeCurve::new(70)
+    );
 }
 
 #[test]
@@ -297,6 +338,17 @@ fn unchanged_fade_drag_keeps_its_crossfade_link() {
         &mut engine,
         ArrangementCtx::default(),
     );
+    let curve = vibez_core::track::FadeCurve::new(55);
+    a.update(
+        ArrangementMsg::SetAudioClipCrossfadeCurve {
+            track_id,
+            outgoing_id,
+            incoming_id,
+            curve,
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
     engine.0.clear();
 
     let action = a.update(
@@ -320,4 +372,6 @@ fn unchanged_fade_drag_keeps_its_crossfade_link() {
         a.tracks[0].clips[1].fades.crossfade_in_from(),
         Some(outgoing_id)
     );
+    assert_eq!(a.tracks[0].clips[0].fades.fade_out_curve(), curve);
+    assert_eq!(a.tracks[0].clips[1].fades.fade_in_curve(), curve);
 }

--- a/crates/vibez-ui/src/domains/arrangement/tests/crossfades.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests/crossfades.rs
@@ -83,14 +83,94 @@ fn two_selected_edge_overlaps_create_one_equal_power_crossfade() {
         .iter()
         .find(|clip| clip.id == incoming_id)
         .unwrap();
-    assert_eq!(
-        action.status.as_deref(),
-        Some("Created equal-power crossfade")
-    );
+    assert_eq!(action.status.as_deref(), Some("Created crossfade"));
     assert_eq!(outgoing.fades.fade_out_frames(), 250);
     assert_eq!(outgoing.fades.crossfade_out_to(), Some(incoming_id));
     assert_eq!(incoming.fades.fade_in_frames(), 250);
     assert_eq!(incoming.fades.crossfade_in_from(), Some(outgoing_id));
+    assert_eq!(
+        engine
+            .0
+            .iter()
+            .filter(|command| matches!(command, EngineCommand::SetClipFades { .. }))
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn dragging_a_fade_handle_to_the_neighbour_edge_creates_the_crossfade() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, outgoing_id) = add_audio_clip(&mut a, 0, 0, 1_000);
+    let (_, incoming_id) = add_audio_clip(&mut a, 0, 750, 1_000);
+    a.selected_clips = HashSet::from([ArrangementSelection::AudioClip {
+        track_id,
+        clip_id: outgoing_id,
+    }]);
+    let mut engine = RecordingEngine::default();
+
+    let action = a.update(
+        ArrangementMsg::SetAudioClipFade {
+            track_id,
+            clip_id: outgoing_id,
+            edge: crate::state::AudioClipFadeEdge::Out,
+            frames: 250,
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    assert!(action.mark_dirty);
+    assert_eq!(
+        a.tracks[0].clips[0].fades.crossfade_out_to(),
+        Some(incoming_id)
+    );
+    assert_eq!(
+        a.tracks[0].clips[1].fades.crossfade_in_from(),
+        Some(outgoing_id)
+    );
+    assert_eq!(a.tracks[0].clips[0].fades.fade_out_frames(), 250);
+    assert_eq!(a.tracks[0].clips[1].fades.fade_in_frames(), 250);
+}
+
+#[test]
+fn one_crossfade_curve_edit_updates_both_reciprocal_edges() {
+    let mut a = arrangement_with_tracks(1);
+    let (track_id, outgoing_id) = add_audio_clip(&mut a, 0, 0, 1_000);
+    let (_, incoming_id) = add_audio_clip(&mut a, 0, 750, 1_000);
+    let mut engine = RecordingEngine::default();
+    a.selected_clips = HashSet::from([
+        ArrangementSelection::AudioClip {
+            track_id,
+            clip_id: outgoing_id,
+        },
+        ArrangementSelection::AudioClip {
+            track_id,
+            clip_id: incoming_id,
+        },
+    ]);
+    a.update(
+        ArrangementMsg::CrossfadeSelectedAudioClips,
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+    engine.0.clear();
+    let curve = vibez_core::track::FadeCurve::new(60);
+
+    let action = a.update(
+        ArrangementMsg::SetAudioClipCrossfadeCurve {
+            track_id,
+            outgoing_id,
+            incoming_id,
+            curve,
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    assert!(action.mark_dirty);
+    assert_eq!(a.tracks[0].clips[0].fades.fade_out_curve(), curve);
+    assert_eq!(a.tracks[0].clips[1].fades.fade_in_curve(), curve);
     assert_eq!(
         engine
             .0

--- a/crates/vibez-ui/src/widgets/timeline/clip_drag.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clip_drag.rs
@@ -3,7 +3,7 @@
 use crate::state::UndoGestureId;
 use vibez_core::id::ClipId;
 
-use super::fade_drag::{FadeClipDrag, FadeCurveDrag};
+use super::fade_drag::{CrossfadeCurveDrag, FadeClipDrag, FadeCurveDrag};
 
 #[derive(Debug, Clone)]
 pub enum ClipDragAction {
@@ -24,6 +24,7 @@ pub enum ClipDragAction {
     },
     FadeClip(FadeClipDrag),
     FadeCurve(FadeCurveDrag),
+    CrossfadeCurve(CrossfadeCurveDrag),
     PendingSeek {
         beat: f64,
         start_x: f32,

--- a/crates/vibez-ui/src/widgets/timeline/clips.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips.rs
@@ -1,7 +1,7 @@
 //! Per-track clip lane canvas: clip drawing, drag/resize/split
 //! interaction, sample drop targets.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use iced::mouse;
 use iced::widget::canvas;
@@ -68,6 +68,7 @@ pub struct TrackClipCanvas {
     pub marquee: Option<ArrangementMarqueeRect>,
     pub selected_clips: HashSet<ClipId>,
     pub clips: Vec<TimelineClip>,
+    pub crossfades: Vec<TimelineCrossfade>,
     pub note_clips: Vec<TimelineNoteClip>,
     /// Transient Section Record visualization. It is deliberately excluded
     /// from hit testing and edit messages.
@@ -152,7 +153,7 @@ impl TrackClipCanvas {
         } else {
             1.0
         };
-        let clips = content
+        let clips: Vec<_> = content
             .clips
             .iter()
             .filter(|clip| {
@@ -174,12 +175,40 @@ impl TrackClipCanvas {
                 fade_out_frames: c.fades.fade_out_frames(),
                 fade_in_curve: c.fades.fade_in_curve(),
                 fade_out_curve: c.fades.fade_out_curve(),
-                crossfade_in: c.fades.crossfade_in_from().is_some(),
-                crossfade_out: c.fades.crossfade_out_to().is_some(),
+                crossfade_in_from: c.fades.crossfade_in_from(),
+                crossfade_out_to: c.fades.crossfade_out_to(),
                 warp_stale: c.warped
                     && c.warped_to_bpm
                         .map(|b| (b - bpm).abs() > 0.01)
                         .unwrap_or(false),
+            })
+            .collect();
+        let clips_by_id: HashMap<_, _> = clips.iter().map(|clip| (clip.clip_id, clip)).collect();
+        let crossfades = clips
+            .iter()
+            .filter_map(|outgoing| {
+                let incoming_id = outgoing.crossfade_out_to?;
+                let incoming = clips_by_id.get(&incoming_id)?;
+                if incoming.crossfade_in_from != Some(outgoing.clip_id) {
+                    return None;
+                }
+                let overlap_start = incoming.position.max(outgoing.position);
+                let overlap_end = incoming
+                    .position
+                    .saturating_add(incoming.duration)
+                    .min(outgoing.position.saturating_add(outgoing.duration));
+                let overlap = overlap_end.saturating_sub(overlap_start);
+                (overlap > 0
+                    && outgoing.fade_out_frames == overlap
+                    && incoming.fade_in_frames == overlap
+                    && outgoing.fade_out_curve == incoming.fade_in_curve)
+                    .then_some(TimelineCrossfade {
+                        outgoing_id: outgoing.clip_id,
+                        incoming_id,
+                        overlap_start,
+                        overlap_end,
+                        curve: outgoing.fade_out_curve,
+                    })
             })
             .collect();
         let note_clips = content
@@ -231,6 +260,7 @@ impl TrackClipCanvas {
             marquee: None,
             selected_clips,
             clips,
+            crossfades,
             note_clips,
             recording_preview: None,
             audio_recording_preview: None,
@@ -340,15 +370,6 @@ impl TrackClipCanvas {
             .iter()
             .position(|row| column_y >= row.top && column_y < row.bottom())
     }
-
-    /// Samples per beat.
-    pub(super) fn spb(&self) -> f64 {
-        if self.bpm > 0.0 {
-            self.sample_rate as f64 * 60.0 / self.bpm
-        } else {
-            1.0
-        }
-    }
 }
 
 impl canvas::Program<Message> for TrackClipCanvas {
@@ -376,6 +397,7 @@ impl canvas::Program<Message> for TrackClipCanvas {
                 ClipDragAction::ResizeClip { .. } => mouse::Interaction::ResizingHorizontally,
                 ClipDragAction::FadeClip(_) => mouse::Interaction::ResizingHorizontally,
                 ClipDragAction::FadeCurve(_) => mouse::Interaction::ResizingVertically,
+                ClipDragAction::CrossfadeCurve(_) => mouse::Interaction::ResizingVertically,
                 ClipDragAction::RegionSelect { .. } => mouse::Interaction::Crosshair,
                 ClipDragAction::PendingSeek { .. } => mouse::Interaction::Pointer,
                 ClipDragAction::PanViewport { .. } => mouse::Interaction::Grabbing,
@@ -388,7 +410,10 @@ impl canvas::Program<Message> for TrackClipCanvas {
                     fade_drag::FadeControlDrag::Length(_) => {
                         mouse::Interaction::ResizingHorizontally
                     }
-                    fade_drag::FadeControlDrag::Curve(_) => mouse::Interaction::ResizingVertically,
+                    fade_drag::FadeControlDrag::Curve(_)
+                    | fade_drag::FadeControlDrag::CrossfadeCurve(_) => {
+                        mouse::Interaction::ResizingVertically
+                    }
                 };
             }
             if let Some((_, _, near_right, _, _)) = self.hit_test(pos.x) {
@@ -444,6 +469,9 @@ impl canvas::Program<Message> for TrackClipCanvas {
                             }
                             fade_drag::FadeControlDrag::Curve(drag) => {
                                 ClipDragAction::FadeCurve(drag)
+                            }
+                            fade_drag::FadeControlDrag::CrossfadeCurve(drag) => {
+                                ClipDragAction::CrossfadeCurve(drag)
                             }
                         });
                         return (canvas::event::Status::Captured, None);
@@ -772,6 +800,18 @@ impl canvas::Program<Message> for TrackClipCanvas {
                                         curve: drag.curve_at_y(local.y),
                                     })
                                     .in_undo_gesture(drag.undo_gesture);
+                                return (canvas::event::Status::Captured, Some(edit));
+                            }
+                            ClipDragAction::CrossfadeCurve(drag) => {
+                                let edit = Message::Arrangement(
+                                    ArrangementMsg::SetAudioClipCrossfadeCurve {
+                                        track_id,
+                                        outgoing_id: drag.outgoing_id,
+                                        incoming_id: drag.incoming_id,
+                                        curve: drag.curve_at_y(local.y),
+                                    },
+                                )
+                                .in_undo_gesture(drag.undo_gesture);
                                 return (canvas::event::Status::Captured, Some(edit));
                             }
                             ClipDragAction::PanViewport {

--- a/crates/vibez-ui/src/widgets/timeline/clips/hit_test.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips/hit_test.rs
@@ -3,6 +3,15 @@
 use super::*;
 
 impl TrackClipCanvas {
+    /// Samples per beat for Audio Clip geometry.
+    pub(crate) fn spb(&self) -> f64 {
+        if self.bpm > 0.0 {
+            self.sample_rate as f64 * 60.0 / self.bpm
+        } else {
+            1.0
+        }
+    }
+
     /// Build the marquee message for a drag from `anchor` to the pointer,
     /// both already in column coordinates.
     pub(super) fn marquee_message(

--- a/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_draw.rs
@@ -275,7 +275,9 @@ impl TrackClipCanvas {
                             let x = clip_x + (fade_in_x - clip_x) * progress;
                             let y = bottom
                                 - (bottom - top)
-                                    * clip.fade_in_curve.gain_for(progress, clip.crossfade_in);
+                                    * clip
+                                        .fade_in_curve
+                                        .gain_for(progress, clip.crossfade_in_from.is_some());
                             builder.line_to(iced::Point::new(x, y));
                         }
                         builder.line_to(iced::Point::new(fade_out_x, top));
@@ -284,7 +286,7 @@ impl TrackClipCanvas {
                             let x = fade_out_x + (clip_x + clip_w - fade_out_x) * progress;
                             let gain = clip
                                 .fade_out_curve
-                                .gain_for(1.0 - progress, clip.crossfade_out);
+                                .fade_out_gain(progress, clip.crossfade_out_to.is_some());
                             let y = bottom - (bottom - top) * gain;
                             builder.line_to(iced::Point::new(x, y));
                         }
@@ -311,27 +313,6 @@ impl TrackClipCanvas {
                                 frame.fill(&canvas::Path::circle(handle, 3.25), theme::accent());
                             }
                         }
-                    }
-                    for x in [
-                        clip.crossfade_in.then_some((clip_x + fade_in_x) / 2.0),
-                        clip.crossfade_out
-                            .then_some((fade_out_x + clip_x + clip_w) / 2.0),
-                    ]
-                    .into_iter()
-                    .flatten()
-                    {
-                        let cross = canvas::Path::new(|builder| {
-                            builder.move_to(iced::Point::new(x - 3.0, top + 2.0));
-                            builder.line_to(iced::Point::new(x + 3.0, top + 8.0));
-                            builder.move_to(iced::Point::new(x + 3.0, top + 2.0));
-                            builder.line_to(iced::Point::new(x - 3.0, top + 8.0));
-                        });
-                        frame.stroke(
-                            &cross,
-                            canvas::Stroke::default()
-                                .with_color(theme::accent())
-                                .with_width(1.4),
-                        );
                     }
                 }
                 let border_color = if is_selected {
@@ -435,6 +416,34 @@ impl TrackClipCanvas {
                         offset += stripe_spacing;
                     }
                 }
+            }
+        }
+
+        // Keep one visible marker for every linked relationship. Selecting
+        // either Clip reveals the shared curve handle at its actual height.
+        for (outgoing_id, incoming_id, handle) in self.crossfade_curve_handles(h) {
+            let marker = canvas::Path::new(|builder| {
+                builder.move_to(iced::Point::new(handle.x - 3.0, CLIP_Y + 4.0));
+                builder.line_to(iced::Point::new(handle.x + 3.0, CLIP_Y + 10.0));
+                builder.move_to(iced::Point::new(handle.x + 3.0, CLIP_Y + 4.0));
+                builder.line_to(iced::Point::new(handle.x - 3.0, CLIP_Y + 10.0));
+            });
+            frame.stroke(
+                &marker,
+                canvas::Stroke::default()
+                    .with_color(theme::accent())
+                    .with_width(1.4),
+            );
+            if self.selected_clips.contains(&outgoing_id)
+                || self.selected_clips.contains(&incoming_id)
+            {
+                frame.fill(&canvas::Path::circle(handle, 4.0), theme::accent());
+                frame.stroke(
+                    &canvas::Path::circle(handle, 4.0),
+                    canvas::Stroke::default()
+                        .with_color(theme::text())
+                        .with_width(1.0),
+                );
             }
         }
 

--- a/crates/vibez-ui/src/widgets/timeline/clips_tests.rs
+++ b/crates/vibez-ui/src/widgets/timeline/clips_tests.rs
@@ -358,8 +358,8 @@ fn physical_right_click_opens_clip_and_empty_arrange_context_menus() {
         fade_out_frames: 0,
         fade_in_curve: Default::default(),
         fade_out_curve: Default::default(),
-        crossfade_in: false,
-        crossfade_out: false,
+        crossfade_in_from: None,
+        crossfade_out_to: None,
         warp_stale: false,
     });
     let (status, message) = right_click(&canvas, Point::new(10.0, 10.0));
@@ -445,8 +445,8 @@ fn audio_recording_waveform_is_visible_but_not_hit_testable() {
         fade_out_frames: 0,
         fade_in_curve: Default::default(),
         fade_out_curve: Default::default(),
-        crossfade_in: false,
-        crossfade_out: false,
+        crossfade_in_from: None,
+        crossfade_out_to: None,
         warp_stale: false,
     });
 
@@ -475,8 +475,8 @@ fn selected_audio_fade_handle_drag_emits_realtime_edits_in_one_undo_gesture() {
         fade_out_frames: 0,
         fade_in_curve: Default::default(),
         fade_out_curve: Default::default(),
-        crossfade_in: false,
-        crossfade_out: false,
+        crossfade_in_from: None,
+        crossfade_out_to: None,
         warp_stale: false,
     });
     canvas.selected_clips.insert(clip_id);
@@ -529,6 +529,78 @@ fn selected_audio_fade_handle_drag_emits_realtime_edits_in_one_undo_gesture() {
 }
 
 #[test]
+fn fade_drag_snaps_to_an_overlapping_neighbour_across_pointer_moves() {
+    let mut canvas = empty_track_canvas();
+    let outgoing_id = ClipId::new();
+    let incoming_id = ClipId::new();
+    let timeline_clip = |clip_id, position, name: &str| TimelineClip {
+        clip_id,
+        position,
+        duration: 44_100,
+        name: name.into(),
+        peaks: Arc::new(Vec::new()),
+        peak_span_frames: None,
+        loop_enabled: false,
+        loop_start: 0,
+        loop_end: 44_100,
+        fade_in_frames: 0,
+        fade_out_frames: 0,
+        fade_in_curve: Default::default(),
+        fade_out_curve: Default::default(),
+        crossfade_in_from: None,
+        crossfade_out_to: None,
+        warp_stale: false,
+    };
+    canvas.clips.push(timeline_clip(outgoing_id, 0, "Outgoing"));
+    canvas
+        .clips
+        .push(timeline_clip(incoming_id, 33_075, "Incoming"));
+    canvas.selected_clips.insert(outgoing_id);
+    let bounds = Rectangle::new(Point::ORIGIN, Size::new(800.0, 80.0));
+    let outgoing_end_x = canvas.beat_to_x(2.0);
+    let neighbour_x = canvas.beat_to_x(1.5);
+    let mut state = ClipInteractionState::default();
+
+    let pressed = <TrackClipCanvas as canvas::Program<Message>>::update(
+        &canvas,
+        &mut state,
+        canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)),
+        bounds,
+        mouse::Cursor::Available(Point::new(outgoing_end_x, FADE_HANDLE_Y)),
+    )
+    .0;
+    assert_eq!(pressed, canvas::event::Status::Captured);
+
+    for x in [
+        neighbour_x - FADE_HANDLE_HIT_RADIUS,
+        neighbour_x + FADE_HANDLE_HIT_RADIUS,
+    ] {
+        let message = <TrackClipCanvas as canvas::Program<Message>>::update(
+            &canvas,
+            &mut state,
+            canvas::Event::Mouse(iced::mouse::Event::CursorMoved {
+                position: Point::new(x, FADE_HANDLE_Y),
+            }),
+            bounds,
+            mouse::Cursor::Available(Point::new(x, FADE_HANDLE_Y)),
+        )
+        .1;
+        assert!(matches!(
+            message,
+            Some(Message::UndoGesture { edit, .. }) if matches!(
+                *edit,
+                Message::Arrangement(ArrangementMsg::SetAudioClipFade {
+                    clip_id,
+                    edge: crate::state::AudioClipFadeEdge::Out,
+                    frames: 11_025,
+                    ..
+                }) if clip_id == outgoing_id
+            )
+        ));
+    }
+}
+
+#[test]
 fn selected_audio_fade_curve_handle_drag_emits_vertical_curve_edits() {
     let mut canvas = empty_track_canvas();
     let clip_id = ClipId::new();
@@ -546,8 +618,8 @@ fn selected_audio_fade_curve_handle_drag_emits_vertical_curve_edits() {
         fade_out_frames: 0,
         fade_in_curve: Default::default(),
         fade_out_curve: Default::default(),
-        crossfade_in: false,
-        crossfade_out: false,
+        crossfade_in_from: None,
+        crossfade_out_to: None,
         warp_stale: false,
     });
     canvas.selected_clips.insert(clip_id);
@@ -598,6 +670,58 @@ fn selected_audio_fade_curve_handle_drag_emits_vertical_curve_edits() {
 }
 
 #[test]
+fn linked_crossfade_has_one_shared_curve_handle_and_edit() {
+    let mut canvas = empty_track_canvas();
+    let outgoing_id = ClipId::new();
+    let incoming_id = ClipId::new();
+    canvas.crossfades.push(TimelineCrossfade {
+        outgoing_id,
+        incoming_id,
+        overlap_start: 33_075,
+        overlap_end: 44_100,
+        curve: Default::default(),
+    });
+    canvas.selected_clips.insert(outgoing_id);
+    let bounds = Rectangle::new(Point::ORIGIN, Size::new(800.0, 80.0));
+    let handles: Vec<_> = canvas.crossfade_curve_handles(bounds.height).collect();
+    assert_eq!(handles.len(), 1);
+    let handle = handles[0].2;
+    let mut state = ClipInteractionState::default();
+
+    let pressed = <TrackClipCanvas as canvas::Program<Message>>::update(
+        &canvas,
+        &mut state,
+        canvas::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)),
+        bounds,
+        mouse::Cursor::Available(handle),
+    )
+    .0;
+    assert_eq!(pressed, canvas::event::Status::Captured);
+
+    let target = Point::new(handle.x, CLIP_Y + CLIP_TITLE_HEIGHT + 2.0);
+    let message = <TrackClipCanvas as canvas::Program<Message>>::update(
+        &canvas,
+        &mut state,
+        canvas::Event::Mouse(iced::mouse::Event::CursorMoved { position: target }),
+        bounds,
+        mouse::Cursor::Available(target),
+    )
+    .1;
+    assert!(matches!(
+        message,
+        Some(Message::UndoGesture { edit, .. }) if matches!(
+            *edit,
+            Message::Arrangement(ArrangementMsg::SetAudioClipCrossfadeCurve {
+                outgoing_id: outgoing,
+                incoming_id: incoming,
+                curve,
+                ..
+            }) if outgoing == outgoing_id && incoming == incoming_id && curve.percent() == 100
+        )
+    ));
+}
+
+#[test]
 fn overlapping_fade_controls_choose_the_handle_nearest_the_pointer() {
     let mut canvas = empty_track_canvas();
     let clip_id = ClipId::new();
@@ -615,8 +739,8 @@ fn overlapping_fade_controls_choose_the_handle_nearest_the_pointer() {
         fade_out_frames: 0,
         fade_in_curve: vibez_core::track::FadeCurve::new(100),
         fade_out_curve: Default::default(),
-        crossfade_in: false,
-        crossfade_out: false,
+        crossfade_in_from: None,
+        crossfade_out_to: None,
         warp_stale: false,
     });
     canvas.selected_clips.insert(clip_id);

--- a/crates/vibez-ui/src/widgets/timeline/fade_drag.rs
+++ b/crates/vibez-ui/src/widgets/timeline/fade_drag.rs
@@ -35,6 +35,37 @@ pub(super) enum FadeControlDrag {
     Curve(FadeCurveDrag),
 }
 
+#[derive(Debug, Clone)]
+pub struct CrossfadeCurveDrag {
+    pub undo_gesture: UndoGestureId,
+    pub outgoing_id: ClipId,
+    pub incoming_id: ClipId,
+    top: f32,
+    bottom: f32,
+}
+
+impl CrossfadeCurveDrag {
+    fn new(outgoing_id: ClipId, incoming_id: ClipId, canvas_height: f32) -> Self {
+        Self {
+            undo_gesture: UndoGestureId::new(),
+            outgoing_id,
+            incoming_id,
+            top: CLIP_Y + CLIP_TITLE_HEIGHT + 2.0,
+            bottom: canvas_height - CLIP_Y - 2.0,
+        }
+    }
+
+    pub(super) fn curve_at_y(&self, y: f32) -> FadeCurve {
+        let height = (self.bottom - self.top).max(1.0);
+        let min_gain = FadeCurve::new(-100).crossfade_gains(0.5).1;
+        let max_gain = FadeCurve::new(100).crossfade_gains(0.5).1;
+        let gain = ((self.bottom - y) / height).clamp(min_gain, max_gain);
+        let warped = gain.asin() / std::f32::consts::FRAC_PI_2;
+        let exponent = warped.ln() / 0.5_f32.ln();
+        FadeCurve::new((-50.0 * exponent.log2()).round() as i16)
+    }
+}
+
 impl FadeCurveDrag {
     fn new(clip_id: ClipId, edge: AudioClipFadeEdge, canvas_height: f32, handle: Point) -> Self {
         Self {
@@ -121,12 +152,17 @@ pub(super) fn fade_curve_handle(
 ) -> Option<Point> {
     let (fade_in_x, fade_out_x) = fade_handle_xs(clip_x, clip_width, clip);
     let (start_x, end_x, curve, linked) = match edge {
-        AudioClipFadeEdge::In => (clip_x, fade_in_x, clip.fade_in_curve, clip.crossfade_in),
+        AudioClipFadeEdge::In => (
+            clip_x,
+            fade_in_x,
+            clip.fade_in_curve,
+            clip.crossfade_in_from.is_some(),
+        ),
         AudioClipFadeEdge::Out => (
             fade_out_x,
             clip_x + clip_width,
             clip.fade_out_curve,
-            clip.crossfade_out,
+            clip.crossfade_out_to.is_some(),
         ),
     };
     if linked || (end_x - start_x).abs() <= f32::EPSILON {
@@ -141,6 +177,56 @@ pub(super) fn fade_curve_handle(
 }
 
 impl TrackClipCanvas {
+    pub(super) fn crossfade_curve_handles(
+        &self,
+        canvas_height: f32,
+    ) -> Vec<(ClipId, ClipId, Point)> {
+        let top = CLIP_Y + CLIP_TITLE_HEIGHT + 2.0;
+        let bottom = canvas_height - CLIP_Y - 2.0;
+        let spb = self.spb();
+        self.clips
+            .iter()
+            .filter_map(|outgoing| {
+                let incoming_id = outgoing.crossfade_out_to?;
+                let incoming = self.clips.iter().find(|clip| {
+                    clip.clip_id == incoming_id && clip.crossfade_in_from == Some(outgoing.clip_id)
+                })?;
+                let overlap_start = incoming.position.max(outgoing.position);
+                let overlap_end = incoming
+                    .position
+                    .saturating_add(incoming.duration)
+                    .min(outgoing.position.saturating_add(outgoing.duration));
+                if overlap_end <= overlap_start {
+                    return None;
+                }
+                let x = (self.beat_to_x(overlap_start as f64 / spb)
+                    + self.beat_to_x(overlap_end as f64 / spb))
+                    / 2.0;
+                let incoming_gain = outgoing.fade_out_curve.crossfade_gains(0.5).1;
+                let y = bottom - (bottom - top) * incoming_gain;
+                Some((outgoing.clip_id, incoming_id, Point::new(x, y)))
+            })
+            .collect()
+    }
+
+    pub(super) fn crossfade_curve_hit(
+        &self,
+        pos: Point,
+        canvas_height: f32,
+    ) -> Option<CrossfadeCurveDrag> {
+        self.crossfade_curve_handles(canvas_height)
+            .into_iter()
+            .find(|(outgoing_id, incoming_id, handle)| {
+                (self.selected_clips.contains(outgoing_id)
+                    || self.selected_clips.contains(incoming_id))
+                    && (pos.x - handle.x).abs() <= FADE_HANDLE_HIT_RADIUS
+                    && (pos.y - handle.y).abs() <= FADE_HANDLE_HIT_RADIUS
+            })
+            .map(|(outgoing_id, incoming_id, _)| {
+                CrossfadeCurveDrag::new(outgoing_id, incoming_id, canvas_height)
+            })
+    }
+
     pub(super) fn fade_curve_hit(&self, pos: Point, canvas_height: f32) -> Option<FadeCurveDrag> {
         let spb = self.spb();
         for clip in &self.clips {
@@ -261,8 +347,8 @@ mod tests {
             fade_out_frames: 6_789,
             fade_in_curve: Default::default(),
             fade_out_curve: Default::default(),
-            crossfade_in: false,
-            crossfade_out: false,
+            crossfade_in_from: None,
+            crossfade_out_to: None,
             warp_stale: false,
         };
         let (fade_in_x, fade_out_x) = fade_handle_xs(37.0, 481.0, &clip);

--- a/crates/vibez-ui/src/widgets/timeline/fade_drag.rs
+++ b/crates/vibez-ui/src/widgets/timeline/fade_drag.rs
@@ -18,6 +18,13 @@ pub struct FadeClipDrag {
     clip_width: f32,
     duration_frames: u64,
     handle: Point,
+    snap: Option<FadeSnap>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FadeSnap {
+    x: f32,
+    frames: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -33,6 +40,17 @@ pub struct FadeCurveDrag {
 pub(super) enum FadeControlDrag {
     Length(FadeClipDrag),
     Curve(FadeCurveDrag),
+    CrossfadeCurve(CrossfadeCurveDrag),
+}
+
+impl FadeControlDrag {
+    fn distance_squared(&self, point: Point) -> f32 {
+        match self {
+            Self::Length(drag) => drag.distance_squared(point),
+            Self::Curve(drag) => drag.distance_squared(point),
+            Self::CrossfadeCurve(drag) => drag.distance_squared(point),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -42,17 +60,23 @@ pub struct CrossfadeCurveDrag {
     pub incoming_id: ClipId,
     top: f32,
     bottom: f32,
+    handle: Point,
 }
 
 impl CrossfadeCurveDrag {
-    fn new(outgoing_id: ClipId, incoming_id: ClipId, canvas_height: f32) -> Self {
+    fn new(outgoing_id: ClipId, incoming_id: ClipId, canvas_height: f32, handle: Point) -> Self {
         Self {
             undo_gesture: UndoGestureId::new(),
             outgoing_id,
             incoming_id,
             top: CLIP_Y + CLIP_TITLE_HEIGHT + 2.0,
             bottom: canvas_height - CLIP_Y - 2.0,
+            handle,
         }
+    }
+
+    fn distance_squared(&self, point: Point) -> f32 {
+        (point.x - self.handle.x).powi(2) + (point.y - self.handle.y).powi(2)
     }
 
     pub(super) fn curve_at_y(&self, y: f32) -> FadeCurve {
@@ -101,6 +125,7 @@ impl FadeClipDrag {
         clip_width: f32,
         duration_frames: u64,
         handle: Point,
+        snap: Option<FadeSnap>,
     ) -> Self {
         Self {
             undo_gesture: UndoGestureId::new(),
@@ -110,6 +135,7 @@ impl FadeClipDrag {
             clip_width,
             duration_frames,
             handle,
+            snap,
         }
     }
 
@@ -120,6 +146,11 @@ impl FadeClipDrag {
     /// Use the exact inverse of [`fade_handle_xs`] so a handle drawn at one
     /// frame cannot jitter to an adjacent frame when the pointer has not moved.
     pub(super) fn frames_at_x(&self, x: f32) -> u64 {
+        if let Some(snap) = self.snap {
+            if (x - snap.x).abs() <= FADE_HANDLE_HIT_RADIUS {
+                return snap.frames;
+            }
+        }
         if self.clip_width <= 0.0 || self.duration_frames == 0 {
             return 0;
         }
@@ -177,36 +208,63 @@ pub(super) fn fade_curve_handle(
 }
 
 impl TrackClipCanvas {
+    fn crossfade_snap_for(&self, clip: &TimelineClip, edge: AudioClipFadeEdge) -> Option<FadeSnap> {
+        let clip_end = clip.position.saturating_add(clip.duration);
+        match edge {
+            AudioClipFadeEdge::Out => self
+                .clips
+                .iter()
+                .filter(|incoming| {
+                    incoming.clip_id != clip.clip_id
+                        && incoming.position > clip.position
+                        && incoming.position < clip_end
+                        && clip_end <= incoming.position.saturating_add(incoming.duration)
+                })
+                .max_by_key(|incoming| incoming.position)
+                .map(|incoming| FadeSnap {
+                    x: self.beat_to_x(incoming.position as f64 / self.spb()),
+                    frames: clip_end - incoming.position,
+                }),
+            AudioClipFadeEdge::In => self
+                .clips
+                .iter()
+                .filter(|outgoing| {
+                    let outgoing_end = outgoing.position.saturating_add(outgoing.duration);
+                    outgoing.clip_id != clip.clip_id
+                        && outgoing.position < clip.position
+                        && clip.position < outgoing_end
+                        && outgoing_end <= clip_end
+                })
+                .min_by_key(|outgoing| outgoing.position.saturating_add(outgoing.duration))
+                .map(|outgoing| {
+                    let outgoing_end = outgoing.position.saturating_add(outgoing.duration);
+                    FadeSnap {
+                        x: self.beat_to_x(outgoing_end as f64 / self.spb()),
+                        frames: outgoing_end - clip.position,
+                    }
+                }),
+        }
+    }
+
     pub(super) fn crossfade_curve_handles(
         &self,
         canvas_height: f32,
-    ) -> Vec<(ClipId, ClipId, Point)> {
+    ) -> impl Iterator<Item = (ClipId, ClipId, Point)> + '_ {
         let top = CLIP_Y + CLIP_TITLE_HEIGHT + 2.0;
         let bottom = canvas_height - CLIP_Y - 2.0;
         let spb = self.spb();
-        self.clips
-            .iter()
-            .filter_map(|outgoing| {
-                let incoming_id = outgoing.crossfade_out_to?;
-                let incoming = self.clips.iter().find(|clip| {
-                    clip.clip_id == incoming_id && clip.crossfade_in_from == Some(outgoing.clip_id)
-                })?;
-                let overlap_start = incoming.position.max(outgoing.position);
-                let overlap_end = incoming
-                    .position
-                    .saturating_add(incoming.duration)
-                    .min(outgoing.position.saturating_add(outgoing.duration));
-                if overlap_end <= overlap_start {
-                    return None;
-                }
-                let x = (self.beat_to_x(overlap_start as f64 / spb)
-                    + self.beat_to_x(overlap_end as f64 / spb))
-                    / 2.0;
-                let incoming_gain = outgoing.fade_out_curve.crossfade_gains(0.5).1;
-                let y = bottom - (bottom - top) * incoming_gain;
-                Some((outgoing.clip_id, incoming_id, Point::new(x, y)))
-            })
-            .collect()
+        self.crossfades.iter().map(move |crossfade| {
+            let x = (self.beat_to_x(crossfade.overlap_start as f64 / spb)
+                + self.beat_to_x(crossfade.overlap_end as f64 / spb))
+                / 2.0;
+            let incoming_gain = crossfade.curve.crossfade_gains(0.5).1;
+            let y = bottom - (bottom - top) * incoming_gain;
+            (
+                crossfade.outgoing_id,
+                crossfade.incoming_id,
+                Point::new(x, y),
+            )
+        })
     }
 
     pub(super) fn crossfade_curve_hit(
@@ -222,8 +280,8 @@ impl TrackClipCanvas {
                     && (pos.x - handle.x).abs() <= FADE_HANDLE_HIT_RADIUS
                     && (pos.y - handle.y).abs() <= FADE_HANDLE_HIT_RADIUS
             })
-            .map(|(outgoing_id, incoming_id, _)| {
-                CrossfadeCurveDrag::new(outgoing_id, incoming_id, canvas_height)
+            .map(|(outgoing_id, incoming_id, handle)| {
+                CrossfadeCurveDrag::new(outgoing_id, incoming_id, canvas_height, handle)
             })
     }
 
@@ -295,6 +353,7 @@ impl TrackClipCanvas {
                     clip_width,
                     clip.duration,
                     Point::new(handle_x, FADE_HANDLE_Y),
+                    self.crossfade_snap_for(clip, edge),
                 ));
             }
         }
@@ -309,21 +368,25 @@ impl TrackClipCanvas {
         pos: Point,
         canvas_height: f32,
     ) -> Option<FadeControlDrag> {
-        match (
-            self.fade_handle_hit(pos),
-            self.fade_curve_hit(pos, canvas_height),
-        ) {
-            (Some(length), Some(curve)) => {
-                if length.distance_squared(pos) <= curve.distance_squared(pos) {
-                    Some(FadeControlDrag::Length(length))
+        let candidates = [
+            self.fade_handle_hit(pos).map(FadeControlDrag::Length),
+            self.fade_curve_hit(pos, canvas_height)
+                .map(FadeControlDrag::Curve),
+            self.crossfade_curve_hit(pos, canvas_height)
+                .map(FadeControlDrag::CrossfadeCurve),
+        ];
+        candidates
+            .into_iter()
+            .flatten()
+            .fold(None, |nearest, candidate| {
+                if nearest.as_ref().is_none_or(|current: &FadeControlDrag| {
+                    candidate.distance_squared(pos) < current.distance_squared(pos)
+                }) {
+                    Some(candidate)
                 } else {
-                    Some(FadeControlDrag::Curve(curve))
+                    nearest
                 }
-            }
-            (Some(length), None) => Some(FadeControlDrag::Length(length)),
-            (None, Some(curve)) => Some(FadeControlDrag::Curve(curve)),
-            (None, None) => None,
-        }
+            })
     }
 }
 
@@ -360,6 +423,7 @@ mod tests {
             481.0,
             clip.duration,
             Point::new(fade_in_x, FADE_HANDLE_Y),
+            None,
         );
         let fade_out = FadeClipDrag::new(
             clip.clip_id,
@@ -368,9 +432,30 @@ mod tests {
             481.0,
             clip.duration,
             Point::new(fade_out_x, FADE_HANDLE_Y),
+            None,
         );
 
         assert_eq!(fade_in.frames_at_x(fade_in_x), clip.fade_in_frames);
         assert_eq!(fade_out.frames_at_x(fade_out_x), clip.fade_out_frames);
+    }
+
+    #[test]
+    fn fade_drag_magnetically_reaches_a_crossfade_edge() {
+        let drag = FadeClipDrag::new(
+            ClipId::new(),
+            AudioClipFadeEdge::Out,
+            0.0,
+            400.0,
+            1_000,
+            Point::new(400.0, FADE_HANDLE_Y),
+            Some(FadeSnap {
+                x: 300.0,
+                frames: 250,
+            }),
+        );
+
+        assert_eq!(drag.frames_at_x(300.0), 250);
+        assert_eq!(drag.frames_at_x(300.0 + FADE_HANDLE_HIT_RADIUS), 250);
+        assert_ne!(drag.frames_at_x(301.0 + FADE_HANDLE_HIT_RADIUS), 250);
     }
 }

--- a/crates/vibez-ui/src/widgets/timeline/mod.rs
+++ b/crates/vibez-ui/src/widgets/timeline/mod.rs
@@ -27,8 +27,8 @@ pub struct TimelineClip {
     pub fade_out_frames: u64,
     pub fade_in_curve: FadeCurve,
     pub fade_out_curve: FadeCurve,
-    pub crossfade_in: bool,
-    pub crossfade_out: bool,
+    pub crossfade_in_from: Option<ClipId>,
+    pub crossfade_out_to: Option<ClipId>,
     /// True when this clip is warped but its `warped_to_bpm` no longer
     /// matches the current project BPM. The canvas draws a diagonal
     /// stripe overlay so the user can see at a glance that a re-warp

--- a/crates/vibez-ui/src/widgets/timeline/mod.rs
+++ b/crates/vibez-ui/src/widgets/timeline/mod.rs
@@ -36,6 +36,15 @@ pub struct TimelineClip {
     pub warp_stale: bool,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct TimelineCrossfade {
+    pub outgoing_id: ClipId,
+    pub incoming_id: ClipId,
+    pub overlap_start: u64,
+    pub overlap_end: u64,
+    pub curve: FadeCurve,
+}
+
 /// Lightweight copy of a note clip for timeline rendering.
 pub struct TimelineNoteClip {
     pub clip_id: ClipId,


### PR DESCRIPTION
Reworks crossfades around the overlap itself. Dragging a fade handle to the neighbouring clip edge creates one reciprocal crossfade, and the overlap exposes one shared slope handle that shapes both clips together. The paired curves preserve constant power, persist through project reopen and use one Undo gesture.

The context command remains as a secondary route and is now labelled Create Crossfade.

Validation
- cargo test -p vibez-core --lib
- cargo test -p vibez-ui --lib
- cargo clippy -p vibez-core -p vibez-ui --all-targets -- -D warnings
- cargo fmt --all --check