### PR TITLE
Cover combined audio clip operation regressions

### DIFF
--- a/crates/vibez-engine/src/render.rs
+++ b/crates/vibez-engine/src/render.rs
@@ -1055,6 +1055,93 @@ mod tests {
     }
 
     #[test]
+    fn clip_bounce_keeps_reverse_warp_and_shaped_fades_in_one_render() {
+        let mut track = bare_track("audio");
+        track.pan = DEFAULT_TRACK_PAN;
+        let track_id = track.id;
+        let clip_id = ClipId::new();
+        let audio = Arc::new(DecodedAudio {
+            channels: vec![vec![0.0, 0.1, 0.25, 0.4, 0.55, 0.7, 0.85, 1.0, 0.5]],
+            sample_rate: 44_100,
+        });
+        let mut warp_markers = vibez_core::warp_marker::WarpMarkers::default();
+        assert!(warp_markers.add(2, 3, 0, 8, 8));
+        let fades = vibez_core::track::ClipFades::new(3, 3, 8)
+            .with_fade_in_curve(vibez_core::track::FadeCurve::new(70))
+            .with_fade_out_curve(vibez_core::track::FadeCurve::new(-60));
+        let clip = ClipInfo {
+            id: clip_id,
+            track_id,
+            name: "edited".into(),
+            position: 0,
+            source_offset: 0,
+            start_marker: None,
+            duration: 8,
+            source: None,
+            file_path: None,
+            loop_enabled: false,
+            loop_start: 0,
+            loop_end: 8,
+            gain_db: Default::default(),
+            fades,
+            playback_direction: vibez_core::track::ClipPlaybackDirection::Reverse,
+            transient_markers: Default::default(),
+            warp_markers: warp_markers.clone(),
+            transpose: Default::default(),
+            original_bpm: None,
+            warped: true,
+            warped_to_bpm: Some(120.0),
+        };
+        let request = BounceRequest {
+            master: None,
+            buses: Vec::new(),
+            tracks: vec![track],
+            audio_clips: vec![clip],
+            note_clips: Vec::new(),
+            clip_audio: HashMap::from([(clip_id, Arc::clone(&audio))]),
+            sampler_audio: HashMap::new(),
+            drum_pad_audio: HashMap::new(),
+            mode: BounceMode::Clip {
+                track_id,
+                clip_id,
+                is_note_clip: false,
+            },
+            range_samples: (0, 8),
+            bpm: 120.0,
+            sample_rate: 44_100,
+            swing: vibez_core::perform::SwingAmount::STRAIGHT,
+        };
+        let mut live = vec![0.0; 8];
+        PreparedPlaybackSource::new(
+            vec![EngineClip {
+                id: clip_id,
+                audio,
+                position: 0,
+                source_offset: 0,
+                start_marker: 0,
+                duration: 8,
+                loop_enabled: false,
+                loop_start: 0,
+                loop_end: 8,
+                linear_gain: 1.0,
+                fades,
+                playback_direction: vibez_core::track::ClipPlaybackDirection::Reverse,
+                warp_markers,
+            }],
+            Vec::new(),
+            Vec::new(),
+        )
+        .render_audio(&mut live, 0, 8, 1, None);
+
+        let bounced = render_offline(&request);
+        let pan = std::f32::consts::FRAC_1_SQRT_2;
+        for (frame, expected) in live.into_iter().enumerate() {
+            assert!((bounced.audio.channels[0][frame] - expected * pan).abs() < 1e-6);
+            assert!((bounced.audio.channels[1][frame] - expected * pan).abs() < 1e-6);
+        }
+    }
+
+    #[test]
     fn mute_silences_master_bounce() {
         let mut track = bare_track("audio");
         track.mute = true;

--- a/crates/vibez-ui/src/app/project_format_v1_tests.rs
+++ b/crates/vibez-ui/src/app/project_format_v1_tests.rs
@@ -4,7 +4,9 @@ use super::*;
 use vibez_core::audio_buffer::DecodedAudio;
 use vibez_core::id::ClipId;
 use vibez_core::midi::{InstrumentKind, TrackKind};
-use vibez_core::track::{ClipPlaybackDirection, InstrumentStateInfo, TrackInfo};
+use vibez_core::track::{
+    ClipFades, ClipPlaybackDirection, FadeCurve, InstrumentStateInfo, TrackInfo,
+};
 use vibez_core::transient::{TransientMarker, TransientMarkerKind, TransientMarkers};
 use vibez_core::warp_marker::{WarpMarker, WarpMarkers};
 use vibez_engine::commands::{AuditionStart, EngineCommand};
@@ -110,6 +112,10 @@ async fn supported_format_matrix_catalogs_auditions_imports_and_reopens() {
             imported.num_frames() as u64,
             imported.num_frames() as u64,
         );
+        let duration = imported.num_frames() as u64;
+        let fades = ClipFades::new(duration / 10, duration / 8, duration)
+            .with_fade_in_curve(FadeCurve::new(65))
+            .with_fade_out_curve(FadeCurve::new(-45));
         let project_path = directory.path().join("format-roundtrip.vzp");
         let project = Project {
             tracks: vec![track.clone()],
@@ -121,14 +127,14 @@ async fn supported_format_matrix_catalogs_auditions_imports_and_reopens() {
                     position: 0,
                     source_offset: 0,
                     start_marker: None,
-                    duration: imported.num_frames() as u64,
+                    duration,
                     source: Some(staged),
                     file_path: None,
                     loop_enabled: false,
                     loop_start: 0,
                     loop_end: 0,
                     gain_db: Default::default(),
-                    fades: Default::default(),
+                    fades,
                     playback_direction: ClipPlaybackDirection::Reverse,
                     transient_markers,
                     warp_markers,
@@ -172,6 +178,10 @@ async fn supported_format_matrix_catalogs_auditions_imports_and_reopens() {
         assert_eq!(
             reopened.project.arrange.clips[0].playback_direction,
             ClipPlaybackDirection::Reverse,
+            "{file_name}"
+        );
+        assert_eq!(
+            reopened.project.arrange.clips[0].fades, fades,
             "{file_name}"
         );
         assert_eq!(

--- a/crates/vibez-ui/src/state/undo_tests.rs
+++ b/crates/vibez-ui/src/state/undo_tests.rs
@@ -514,6 +514,133 @@ fn undo_snapshot_restores_complete_audio_clip_inspector_state() {
 }
 
 #[test]
+fn reverse_fades_and_crossfade_curve_restore_as_individual_undo_steps() {
+    let mut state = AppState::default();
+    let track_id = TrackId::new();
+    let outgoing_id = ClipId::new();
+    let incoming_id = ClipId::new();
+    Arc::make_mut(&mut state.project_tracks)
+        .tracks
+        .push(ProjectTrack::new(track_id, "Audio".into(), 0));
+    let audio = Arc::new(DecodedAudio {
+        channels: vec![vec![0.25; 2_000]],
+        sample_rate: 48_000,
+    });
+    let make_clip = |id, position| UiClip {
+        id,
+        name: "Loop".into(),
+        audio: Arc::clone(&audio),
+        source: None,
+        position,
+        source_offset: 0,
+        start_marker: 0,
+        duration: 1_000,
+        loop_enabled: false,
+        loop_start: 0,
+        loop_end: 1_000,
+        gain_db: Default::default(),
+        fades: Default::default(),
+        playback_direction: Default::default(),
+        transient_markers: Default::default(),
+        warp_markers: Default::default(),
+        transpose: Default::default(),
+        original_bpm: None,
+        warped: false,
+        warped_to_bpm: None,
+        original_audio: None,
+    };
+    Arc::make_mut(&mut state.arrangement.timeline)
+        .ensure(track_id)
+        .clips
+        .extend([make_clip(outgoing_id, 0), make_clip(incoming_id, 750)]);
+    let mut engine = RecordingEngine::default();
+    let mut edit = |state: &mut AppState, message| {
+        let before = snapshot(state);
+        state.arrangement.update(
+            Arc::make_mut(&mut state.project_tracks),
+            message,
+            &mut engine,
+            ArrangementCtx::default(),
+        );
+        state.project.history.push_edit(before, None);
+    };
+
+    edit(
+        &mut state,
+        ArrangementMsg::ToggleClipReverse(track_id, outgoing_id),
+    );
+    edit(
+        &mut state,
+        ArrangementMsg::SetAudioClipFade {
+            track_id,
+            clip_id: outgoing_id,
+            edge: super::AudioClipFadeEdge::In,
+            frames: 100,
+        },
+    );
+    edit(
+        &mut state,
+        ArrangementMsg::SetAudioClipFadeCurve {
+            track_id,
+            clip_id: outgoing_id,
+            edge: super::AudioClipFadeEdge::In,
+            curve: vibez_core::track::FadeCurve::new(70),
+        },
+    );
+    edit(
+        &mut state,
+        ArrangementMsg::SetAudioClipFade {
+            track_id,
+            clip_id: outgoing_id,
+            edge: super::AudioClipFadeEdge::Out,
+            frames: 250,
+        },
+    );
+    edit(
+        &mut state,
+        ArrangementMsg::SetAudioClipCrossfadeCurve {
+            track_id,
+            outgoing_id,
+            incoming_id,
+            curve: vibez_core::track::FadeCurve::new(-55),
+        },
+    );
+    assert_eq!(state.project.history.undo.len(), 5);
+
+    undo_once(&mut state);
+    let clips = &state.arrangement.timeline.get(track_id).unwrap().clips;
+    assert_eq!(clips[0].fades.fade_out_curve(), Default::default());
+    assert_eq!(clips[1].fades.fade_in_curve(), Default::default());
+    assert_eq!(clips[0].fades.crossfade_out_to(), Some(incoming_id));
+
+    undo_once(&mut state);
+    let clips = &state.arrangement.timeline.get(track_id).unwrap().clips;
+    assert_eq!(clips[0].fades.fade_out_frames(), 0);
+    assert_eq!(clips[1].fades.fade_in_frames(), 0);
+    assert!(clips[0].fades.crossfade_out_to().is_none());
+
+    undo_once(&mut state);
+    assert_eq!(
+        state.arrangement.timeline.get(track_id).unwrap().clips[0]
+            .fades
+            .fade_in_curve(),
+        Default::default()
+    );
+    undo_once(&mut state);
+    assert_eq!(
+        state.arrangement.timeline.get(track_id).unwrap().clips[0]
+            .fades
+            .fade_in_frames(),
+        0
+    );
+    undo_once(&mut state);
+    assert_eq!(
+        state.arrangement.timeline.get(track_id).unwrap().clips[0].playback_direction,
+        vibez_core::track::ClipPlaybackDirection::Forward
+    );
+}
+
+#[test]
 fn add_move_and_delete_transient_markers_each_restore_through_undo() {
     let mut state = AppState::default();
     let track_id = TrackId::new();


### PR DESCRIPTION
Adds the missing interaction-level regressions for the Audio Clip stack.

Coverage
- Undo restores reverse, fade length, fade curve, crossfade creation and crossfade curve as separate edits
- Save and reopen preserves shaped fades alongside reverse, transient markers and warp markers for every supported audio format
- Clip Bounce matches live playback when reverse, piecewise warping and shaped fades are active together
- Existing slicing and slice-to-Drum-Rack Undo tests continue to cover both slicing routes

Validation
- cargo test -p vibez-core --lib
- cargo test -p vibez-engine --lib
- cargo test -p vibez-ui --lib
- cargo clippy -p vibez-core -p vibez-engine -p vibez-ui --all-targets -- -D warnings
- cargo fmt --all --check