### PR TITLE
Add continuous transient analysis sensitivity

### DIFF
--- a/crates/vibez-core/src/onset.rs
+++ b/crates/vibez-core/src/onset.rs
@@ -44,13 +44,17 @@ impl TransientSensitivity {
         self.0 as f32 / Self::MAX_PERCENT as f32
     }
 
-    fn threshold_through(self, midpoint: f32) -> f32 {
+    fn log_interpolate(self, low: f32, midpoint: f32, high: f32) -> f32 {
         let normalized = self.normalized();
         if normalized <= 0.5 {
-            0.9 * (midpoint / 0.9).powf(normalized / 0.5)
+            low * (midpoint / low).powf(normalized / 0.5)
         } else {
-            midpoint * (0.001 / midpoint).powf((normalized - 0.5) / 0.5)
+            midpoint * (high / midpoint).powf((normalized - 0.5) / 0.5)
         }
+    }
+
+    fn peak_threshold(self, midpoint: f32) -> f32 {
+        self.log_interpolate(0.9, midpoint, 0.001)
     }
 }
 
@@ -80,15 +84,25 @@ pub fn detect_onsets(audio: &DecodedAudio, sensitivity: TransientSensitivity) ->
         return Vec::new();
     }
     let mono = mix_to_mono(audio, frames);
-    let mut onsets = aubio::detect_onsets(
+    let global_peak = audio
+        .channels
+        .iter()
+        .flat_map(|channel| channel.iter())
+        .map(|sample| sample.abs())
+        .fold(0.0f32, f32::max);
+    let accepts_attack =
+        |frame: usize| frame > 0 && genuine_attack(audio, frame as u64, sensitivity, global_peak);
+    let mut onsets = aubio::detect_onsets_where(
         &mono,
         audio.sample_rate,
         aubio::Config::for_sensitivity(sensitivity),
+        accepts_attack,
     );
-    let energy_onsets = aubio::detect_energy_onsets(
+    let energy_onsets = aubio::detect_energy_onsets_where(
         &mono,
         audio.sample_rate,
         aubio::Config::for_energy_sensitivity(sensitivity),
+        accepts_attack,
     );
 
     // HFC is precise on bright attacks but can miss bass-heavy hits. Aubio's
@@ -102,16 +116,6 @@ pub fn detect_onsets(audio: &DecodedAudio, sensitivity: TransientSensitivity) ->
     }
     onsets.sort_unstable();
 
-    // Aubio's spectral descriptors can report a pitched decay cycle as a new
-    // onset. Transient markers are editing boundaries, so require each
-    // spectral candidate to coincide with a meaningful time-domain attack.
-    let global_peak = audio
-        .channels
-        .iter()
-        .flat_map(|channel| channel.iter())
-        .map(|sample| sample.abs())
-        .fold(0.0f32, f32::max);
-    onsets.retain(|&frame| genuine_attack(audio, frame, sensitivity, global_peak));
     // Clip start is already an explicit boundary in Vibez. Aubio reports a
     // non-silent file start as an onset, but showing that as a suggested
     // transient marker adds no editable information.
@@ -119,7 +123,7 @@ pub fn detect_onsets(audio: &DecodedAudio, sensitivity: TransientSensitivity) ->
     onsets
 }
 
-fn frames_for_ms(sample_rate: u32, milliseconds: f32) -> usize {
+pub(super) fn frames_for_ms(sample_rate: u32, milliseconds: f32) -> usize {
     (sample_rate as f32 * milliseconds / 1_000.0).round() as usize
 }
 
@@ -165,12 +169,7 @@ fn peak_and_rms(audio: &DecodedAudio, start: usize, end: usize) -> (f32, f32) {
 }
 
 fn attack_prominence_floor(sensitivity: TransientSensitivity) -> f32 {
-    let normalized = sensitivity.normalized();
-    if normalized <= 0.5 {
-        0.6 * (0.1f32 / 0.6).powf(normalized / 0.5)
-    } else {
-        0.1 * (0.005f32 / 0.1).powf((normalized - 0.5) / 0.5)
-    }
+    sensitivity.log_interpolate(0.6, 0.1, 0.005)
 }
 
 fn mix_to_mono(audio: &DecodedAudio, frames: usize) -> Vec<f32> {
@@ -579,19 +578,49 @@ mod tests {
 
     #[test]
     fn sensitivity_affects_yield() {
-        // Low-amplitude impulses: high sensitivity should retain at least as
-        // many as low sensitivity.
         let sr = 44_100u32;
-        let mut buf = vec![0.0f32; 44_100];
-        for i in (2_000..40_000).step_by(5_000) {
-            buf[i] = 0.05;
+        let amplitudes = [1.0f32, 0.65, 0.35, 0.18, 0.08, 0.03];
+        let mut buf = vec![0.0f32; 40_000];
+        for (index, amplitude) in amplitudes.into_iter().enumerate() {
+            let start = 2_000 + index * 5_512;
+            for offset in 0..1_024 {
+                let phase = std::f32::consts::TAU * 180.0 * offset as f32 / sr as f32;
+                buf[start + offset] = phase.sin() * (-(offset as f32) / 260.0).exp() * amplitude;
+            }
         }
         let audio = make_audio(vec![buf.clone(), buf], sr);
         let low = detect_onsets(&audio, TransientSensitivity::new(0)).len();
         let high = detect_onsets(&audio, TransientSensitivity::new(100)).len();
         assert!(
-            high >= low,
-            "high sensitivity {high} should not detect fewer attacks than low sensitivity {low}",
+            high > low,
+            "graded attacks must produce more markers at high sensitivity ({high}) than low ({low})",
+        );
+    }
+
+    #[test]
+    fn sensitivity_sweep_never_loses_an_accepted_attack() {
+        let sr = 44_100u32;
+        let mut channel = vec![0.0f32; 50_000];
+        for (index, amplitude) in [1.0f32, 0.8, 0.55, 0.3, 0.14, 0.06].into_iter().enumerate() {
+            let start = 2_000 + index * 5_512;
+            for offset in 0..1_024 {
+                let phase = std::f32::consts::TAU * 160.0 * offset as f32 / sr as f32;
+                channel[start + offset] =
+                    phase.sin() * (-(offset as f32) / 280.0).exp() * amplitude;
+            }
+        }
+        let audio = make_audio(vec![channel.clone(), channel], sr);
+        let counts: Vec<_> = (0..=10)
+            .map(|step| detect_onsets(&audio, TransientSensitivity::new(step * 10)).len())
+            .collect();
+
+        assert!(
+            counts.windows(2).all(|pair| pair[0] <= pair[1]),
+            "sensitivity sweep must be monotonic, got {counts:?}"
+        );
+        assert!(
+            counts.last() > counts.first(),
+            "sweep needs useful travel: {counts:?}"
         );
     }
 

--- a/crates/vibez-core/src/onset.rs
+++ b/crates/vibez-core/src/onset.rs
@@ -43,6 +43,15 @@ impl TransientSensitivity {
     pub(crate) fn normalized(self) -> f32 {
         self.0 as f32 / Self::MAX_PERCENT as f32
     }
+
+    fn threshold_through(self, midpoint: f32) -> f32 {
+        let normalized = self.normalized();
+        if normalized <= 0.5 {
+            0.9 * (midpoint / 0.9).powf(normalized / 0.5)
+        } else {
+            midpoint * (0.001 / midpoint).powf((normalized - 0.5) / 0.5)
+        }
+    }
 }
 
 impl Default for TransientSensitivity {
@@ -76,11 +85,92 @@ pub fn detect_onsets(audio: &DecodedAudio, sensitivity: TransientSensitivity) ->
         audio.sample_rate,
         aubio::Config::for_sensitivity(sensitivity),
     );
+    let energy_onsets = aubio::detect_energy_onsets(
+        &mono,
+        audio.sample_rate,
+        aubio::Config::for_energy_sensitivity(sensitivity),
+    );
+
+    // HFC is precise on bright attacks but can miss bass-heavy hits. Aubio's
+    // energy descriptor covers those. Keep HFC's timing when both descriptors
+    // identify the same attack, and add only genuinely distinct energy hits.
+    let merge_radius = frames_for_ms(audio.sample_rate, 50.0) as u64;
+    for frame in energy_onsets {
+        if !onsets.iter().any(|hfc| hfc.abs_diff(frame) <= merge_radius) {
+            onsets.push(frame);
+        }
+    }
+    onsets.sort_unstable();
+
+    // Aubio's spectral descriptors can report a pitched decay cycle as a new
+    // onset. Transient markers are editing boundaries, so require each
+    // spectral candidate to coincide with a meaningful time-domain attack.
+    let global_peak = audio
+        .channels
+        .iter()
+        .flat_map(|channel| channel.iter())
+        .map(|sample| sample.abs())
+        .fold(0.0f32, f32::max);
+    onsets.retain(|&frame| genuine_attack(audio, frame, sensitivity, global_peak));
     // Clip start is already an explicit boundary in Vibez. Aubio reports a
     // non-silent file start as an onset, but showing that as a suggested
     // transient marker adds no editable information.
     onsets.retain(|&frame| frame > 0 && frame < frames as u64);
     onsets
+}
+
+fn frames_for_ms(sample_rate: u32, milliseconds: f32) -> usize {
+    (sample_rate as f32 * milliseconds / 1_000.0).round() as usize
+}
+
+fn genuine_attack(
+    audio: &DecodedAudio,
+    frame: u64,
+    sensitivity: TransientSensitivity,
+    global_peak: f32,
+) -> bool {
+    if global_peak <= f32::EPSILON {
+        return false;
+    }
+
+    let frame = usize::try_from(frame).unwrap_or(usize::MAX);
+    let pre_start = frame.saturating_sub(frames_for_ms(audio.sample_rate, 35.0));
+    let pre_end = frame.saturating_sub(frames_for_ms(audio.sample_rate, 5.0));
+    let post_end = frame
+        .saturating_add(frames_for_ms(audio.sample_rate, 35.0))
+        .min(audio.num_frames());
+    let (_, pre_rms) = peak_and_rms(audio, pre_start, pre_end);
+    let (post_peak, post_rms) = peak_and_rms(audio, frame, post_end);
+
+    post_peak >= global_peak * attack_prominence_floor(sensitivity) && post_rms > pre_rms * 1.05
+}
+
+fn peak_and_rms(audio: &DecodedAudio, start: usize, end: usize) -> (f32, f32) {
+    let mut peak = 0.0f32;
+    let mut square_sum = 0.0f64;
+    let mut sample_count = 0usize;
+    for channel in &audio.channels {
+        for &sample in channel.get(start..end).unwrap_or_default() {
+            peak = peak.max(sample.abs());
+            square_sum += f64::from(sample) * f64::from(sample);
+            sample_count += 1;
+        }
+    }
+    let rms = if sample_count == 0 {
+        0.0
+    } else {
+        (square_sum / sample_count as f64).sqrt() as f32
+    };
+    (peak, rms)
+}
+
+fn attack_prominence_floor(sensitivity: TransientSensitivity) -> f32 {
+    let normalized = sensitivity.normalized();
+    if normalized <= 0.5 {
+        0.6 * (0.1f32 / 0.6).powf(normalized / 0.5)
+    } else {
+        0.1 * (0.005f32 / 0.1).powf((normalized - 0.5) / 0.5)
+    }
 }
 
 fn mix_to_mono(audio: &DecodedAudio, frames: usize) -> Vec<f32> {
@@ -489,7 +579,8 @@ mod tests {
 
     #[test]
     fn sensitivity_affects_yield() {
-        // Low-amplitude impulses: high sensitivity should reject them.
+        // Low-amplitude impulses: high sensitivity should retain at least as
+        // many as low sensitivity.
         let sr = 44_100u32;
         let mut buf = vec![0.0f32; 44_100];
         for i in (2_000..40_000).step_by(5_000) {
@@ -502,6 +593,42 @@ mod tests {
             high >= low,
             "high sensitivity {high} should not detect fewer attacks than low sensitivity {low}",
         );
+    }
+
+    #[test]
+    fn default_sensitivity_rejects_quiet_decay_ripples() {
+        let sr = 44_100u32;
+        let mut channel = vec![0.0f32; 22_050];
+        let strong = 4_000usize;
+        let ripple = 12_000usize;
+        for (start, amplitude) in [(strong, 1.0f32), (ripple, 0.04f32)] {
+            for offset in 0..1_024 {
+                let phase = std::f32::consts::TAU * 180.0 * offset as f32 / sr as f32;
+                channel[start + offset] =
+                    phase.sin() * (-(offset as f32) / 300.0).exp() * amplitude;
+            }
+        }
+        let audio = make_audio(vec![channel.clone(), channel], sr);
+        let global_peak = 1.0;
+
+        assert!(genuine_attack(
+            &audio,
+            strong as u64,
+            TransientSensitivity::DEFAULT,
+            global_peak,
+        ));
+        assert!(!genuine_attack(
+            &audio,
+            ripple as u64,
+            TransientSensitivity::DEFAULT,
+            global_peak,
+        ));
+        assert!(genuine_attack(
+            &audio,
+            ripple as u64,
+            TransientSensitivity::new(100),
+            global_peak,
+        ));
     }
 
     fn synthetic_kick_track(sr: u32, bpm: f64, duration_sec: f64) -> DecodedAudio {

--- a/crates/vibez-core/src/onset.rs
+++ b/crates/vibez-core/src/onset.rs
@@ -18,22 +18,36 @@ use crate::audio_buffer::DecodedAudio;
 
 mod aubio;
 
-/// Producer-facing amount of transient detail to retain during analysis.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum TransientDetectionDetail {
-    Fewer,
-    #[default]
-    Balanced,
-    More,
+/// Producer-facing transient sensitivity. Higher percentages retain quieter
+/// attacks; lower percentages keep only the most prominent attacks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TransientSensitivity(u8);
+
+impl TransientSensitivity {
+    pub const MIN_PERCENT: u8 = 0;
+    pub const MAX_PERCENT: u8 = 100;
+    pub const DEFAULT: Self = Self(50);
+
+    pub const fn new(percent: u8) -> Self {
+        Self(if percent > Self::MAX_PERCENT {
+            Self::MAX_PERCENT
+        } else {
+            percent
+        })
+    }
+
+    pub const fn percent(self) -> u8 {
+        self.0
+    }
+
+    pub(crate) fn normalized(self) -> f32 {
+        self.0 as f32 / Self::MAX_PERCENT as f32
+    }
 }
 
-impl TransientDetectionDetail {
-    pub fn sensitivity(self) -> f32 {
-        match self {
-            Self::Fewer => 3.0,
-            Self::Balanced => 1.5,
-            Self::More => 0.75,
-        }
+impl Default for TransientSensitivity {
+    fn default() -> Self {
+        Self::DEFAULT
     }
 }
 
@@ -49,10 +63,9 @@ const PREEMPHASIS: f32 = 0.97;
 
 /// Detect onsets in `audio` and return sample indices.
 ///
-/// `sensitivity` scales the adaptive threshold: `threshold = mean +
-/// sensitivity * std`. Typical range is `1.0` (loose) to `2.5`
-/// (tight). `1.5` is a reasonable default for drum loops.
-pub fn detect_onsets(audio: &DecodedAudio, sensitivity: f32) -> Vec<u64> {
+/// Sensitivity changes aubio's peak-picking threshold without changing its
+/// minimum inter-onset interval. Higher percentages retain more attacks.
+pub fn detect_onsets(audio: &DecodedAudio, sensitivity: TransientSensitivity) -> Vec<u64> {
     let frames = audio.num_frames();
     if frames < 1_024 || audio.sample_rate == 0 {
         return Vec::new();
@@ -235,7 +248,7 @@ pub fn detect_bpm(audio: &DecodedAudio, sample_rate: u32) -> Option<BpmEstimate>
     // Gate: sparse clips with weak ACF are rejected rather than
     // guessed. This is the difference between "we detected nothing"
     // and "we detected garbage".
-    let onsets_count = detect_onsets(audio, 1.5).len();
+    let onsets_count = detect_onsets(audio, TransientSensitivity::DEFAULT).len();
     if onsets_count < 8 && confidence_ratio < 1.5 {
         return None;
     }
@@ -361,19 +374,19 @@ mod tests {
     #[test]
     fn empty_audio_returns_no_onsets() {
         let audio = make_audio(vec![], 44_100);
-        assert!(detect_onsets(&audio, 1.5).is_empty());
+        assert!(detect_onsets(&audio, TransientSensitivity::DEFAULT).is_empty());
     }
 
     #[test]
     fn very_short_audio_returns_no_onsets() {
         let audio = make_audio(vec![vec![0.5; 20], vec![0.5; 20]], 44_100);
-        assert!(detect_onsets(&audio, 1.5).is_empty());
+        assert!(detect_onsets(&audio, TransientSensitivity::DEFAULT).is_empty());
     }
 
     #[test]
     fn silence_produces_no_onsets() {
         let audio = make_audio(vec![vec![0.0; 22_050], vec![0.0; 22_050]], 44_100);
-        assert!(detect_onsets(&audio, 1.5).is_empty());
+        assert!(detect_onsets(&audio, TransientSensitivity::DEFAULT).is_empty());
     }
 
     #[test]
@@ -381,7 +394,7 @@ mod tests {
         // A DC step is a legitimate transient at the attack, so we expect at
         // most one onset, located near the start, and none mid-signal.
         let audio = make_audio(vec![vec![0.25; 44_100], vec![0.25; 44_100]], 44_100);
-        let onsets = detect_onsets(&audio, 1.5);
+        let onsets = detect_onsets(&audio, TransientSensitivity::DEFAULT);
         assert!(onsets.len() <= 1, "got {:?}", onsets);
         if let Some(&first) = onsets.first() {
             assert!(first < 4_410, "unexpected mid-signal onset at {first}");
@@ -392,7 +405,7 @@ mod tests {
     fn impulse_train_detects_hits() {
         // 8 hits at 8820-sample spacing = 200ms at 44.1kHz.
         let audio = burst_train(44_100, &[8_820; 8]);
-        let onsets = detect_onsets(&audio, 1.2);
+        let onsets = detect_onsets(&audio, TransientSensitivity::new(60));
         assert!(
             onsets.len() >= 6,
             "expected ~8 detections, got {}: {:?}",
@@ -408,6 +421,19 @@ mod tests {
     }
 
     #[test]
+    fn strong_sixteenth_note_attacks_are_not_suppressed_by_sensitivity() {
+        // Sixteenth notes at 120 BPM are 125 ms apart. Sensitivity may reject
+        // quieter attacks, but it must not impose a longer timing gap that
+        // blindly removes every other strong hit.
+        let audio = burst_train(44_100, &[5_512; 8]);
+        let onsets = detect_onsets(&audio, TransientSensitivity::new(0));
+        assert!(
+            onsets.len() >= 7,
+            "expected the eight strong attacks to survive, got {onsets:?}"
+        );
+    }
+
+    #[test]
     fn refractory_prevents_double_triggers() {
         // Two spikes 10ms apart: should collapse to one onset (refractory 30ms).
         let sr = 44_100u32;
@@ -419,7 +445,7 @@ mod tests {
             }
         }
         let audio = make_audio(vec![buf.clone(), buf], sr);
-        let onsets = detect_onsets(&audio, 1.0);
+        let onsets = detect_onsets(&audio, TransientSensitivity::new(70));
         assert!(
             onsets.len() == 1,
             "refractory violated: {} onsets {:?}",
@@ -440,7 +466,7 @@ mod tests {
             }
         }
         let audio = make_audio(vec![buf.clone(), buf], sr);
-        let onsets = detect_onsets(&audio, 1.2);
+        let onsets = detect_onsets(&audio, TransientSensitivity::new(60));
         assert!(!onsets.is_empty());
         for exp in expected.iter() {
             let found = onsets.iter().any(|&o| (o as i64 - *exp as i64).abs() < 512);
@@ -455,7 +481,10 @@ mod tests {
     #[test]
     fn onset_detection_is_deterministic_for_identical_audio() {
         let audio = burst_train(44_100, &[8_820; 8]);
-        assert_eq!(detect_onsets(&audio, 1.5), detect_onsets(&audio, 1.5));
+        assert_eq!(
+            detect_onsets(&audio, TransientSensitivity::DEFAULT),
+            detect_onsets(&audio, TransientSensitivity::DEFAULT)
+        );
     }
 
     #[test]
@@ -467,13 +496,11 @@ mod tests {
             buf[i] = 0.05;
         }
         let audio = make_audio(vec![buf.clone(), buf], sr);
-        let loose = detect_onsets(&audio, 1.0).len();
-        let tight = detect_onsets(&audio, 3.0).len();
+        let low = detect_onsets(&audio, TransientSensitivity::new(0)).len();
+        let high = detect_onsets(&audio, TransientSensitivity::new(100)).len();
         assert!(
-            tight <= loose,
-            "tight {} should not exceed loose {}",
-            tight,
-            loose
+            high >= low,
+            "high sensitivity {high} should not detect fewer attacks than low sensitivity {low}",
         );
     }
 

--- a/crates/vibez-core/src/onset/aubio.rs
+++ b/crates/vibez-core/src/onset/aubio.rs
@@ -8,6 +8,7 @@
 //! aubio is licensed under GPL-3.0-or-later. Vibez carries the same compatible
 //! licence. Upstream source: <https://github.com/aubio/aubio/tree/0.4.9>.
 
+use super::TransientSensitivity;
 use rustfft::{num_complex::Complex32, Fft, FftPlanner};
 use std::sync::Arc;
 
@@ -28,19 +29,19 @@ pub(super) struct Config {
 }
 
 impl Config {
-    pub(super) fn for_sensitivity(sensitivity: f32) -> Self {
-        let sensitivity = sensitivity.clamp(0.25, 5.0);
-        let min_ioi_ms = if sensitivity <= 1.5 {
-            50.0 + ((sensitivity - 0.75) / 0.75).clamp(0.0, 1.0) * 60.0
+    pub(super) fn for_sensitivity(sensitivity: TransientSensitivity) -> Self {
+        // aubio documents 0.001..=0.900 as the useful peak-threshold range.
+        // Interpolate logarithmically through its HFC default at 50%, giving
+        // useful travel at both ends instead of bunching every result near the
+        // middle of the knob.
+        let normalized = sensitivity.normalized();
+        let threshold = if normalized <= 0.5 {
+            0.9 * (DEFAULT_THRESHOLD / 0.9).powf(normalized / 0.5)
         } else {
-            110.0 + ((sensitivity - 1.5) / 3.5).clamp(0.0, 1.0) * 70.0
+            DEFAULT_THRESHOLD * (0.001 / DEFAULT_THRESHOLD).powf((normalized - 0.5) / 0.5)
         };
         Self {
-            // Aubio's default HFC threshold is 0.058. Keep the existing Vibez
-            // midpoint (1.5) pinned to that reference value and make larger
-            // values progressively more selective.
-            threshold: DEFAULT_THRESHOLD * (sensitivity / 1.5),
-            min_ioi_ms,
+            threshold,
             ..Self::default()
         }
     }
@@ -359,13 +360,13 @@ mod tests {
     }
 
     #[test]
-    fn producer_detail_presets_increase_the_minimum_hit_spacing() {
-        let more = Config::for_sensitivity(0.75);
-        let balanced = Config::for_sensitivity(1.5);
-        let fewer = Config::for_sensitivity(3.0);
-        assert_eq!(more.min_ioi_ms, 50.0);
-        assert_eq!(balanced.min_ioi_ms, 110.0);
-        assert_eq!(fewer.min_ioi_ms, 140.0);
+    fn sensitivity_never_changes_the_minimum_hit_spacing() {
+        let fewer = Config::for_sensitivity(TransientSensitivity::new(0));
+        let balanced = Config::for_sensitivity(TransientSensitivity::new(50));
+        let more = Config::for_sensitivity(TransientSensitivity::new(100));
+        assert_eq!(more.min_ioi_ms, DEFAULT_MIN_IOI_MS);
+        assert_eq!(balanced.min_ioi_ms, DEFAULT_MIN_IOI_MS);
+        assert_eq!(fewer.min_ioi_ms, DEFAULT_MIN_IOI_MS);
         assert!(more.threshold < balanced.threshold);
         assert!(balanced.threshold < fewer.threshold);
     }

--- a/crates/vibez-core/src/onset/aubio.rs
+++ b/crates/vibez-core/src/onset/aubio.rs
@@ -36,14 +36,14 @@ impl Config {
         // useful travel at both ends instead of bunching every result near the
         // middle of the knob.
         Self {
-            threshold: sensitivity.threshold_through(DEFAULT_THRESHOLD),
+            threshold: sensitivity.peak_threshold(DEFAULT_THRESHOLD),
             ..Self::default()
         }
     }
 
     pub(super) fn for_energy_sensitivity(sensitivity: TransientSensitivity) -> Self {
         Self {
-            threshold: sensitivity.threshold_through(DEFAULT_ENERGY_THRESHOLD),
+            threshold: sensitivity.peak_threshold(DEFAULT_ENERGY_THRESHOLD),
             ..Self::default()
         }
     }
@@ -85,12 +85,27 @@ enum ConfigError {
     ZeroSampleRate,
 }
 
+#[cfg(test)]
 pub(super) fn detect_onsets(mono: &[f32], sample_rate: u32, config: Config) -> Vec<u64> {
-    detect_onsets_with_descriptor(mono, sample_rate, config, Descriptor::Hfc)
+    detect_onsets_where(mono, sample_rate, config, |_| true)
 }
 
-pub(super) fn detect_energy_onsets(mono: &[f32], sample_rate: u32, config: Config) -> Vec<u64> {
-    detect_onsets_with_descriptor(mono, sample_rate, config, Descriptor::Energy)
+pub(super) fn detect_onsets_where(
+    mono: &[f32],
+    sample_rate: u32,
+    config: Config,
+    accepts: impl FnMut(usize) -> bool,
+) -> Vec<u64> {
+    detect_onsets_with_descriptor(mono, sample_rate, config, Descriptor::Hfc, accepts)
+}
+
+pub(super) fn detect_energy_onsets_where(
+    mono: &[f32],
+    sample_rate: u32,
+    config: Config,
+    accepts: impl FnMut(usize) -> bool,
+) -> Vec<u64> {
+    detect_onsets_with_descriptor(mono, sample_rate, config, Descriptor::Energy, accepts)
 }
 
 fn detect_onsets_with_descriptor(
@@ -98,6 +113,7 @@ fn detect_onsets_with_descriptor(
     sample_rate: u32,
     config: Config,
     descriptor: Descriptor,
+    accepts: impl FnMut(usize) -> bool,
 ) -> Vec<u64> {
     let Ok(config) = config.validate(sample_rate) else {
         return Vec::new();
@@ -106,7 +122,7 @@ fn detect_onsets_with_descriptor(
         return Vec::new();
     }
 
-    Detector::new(sample_rate, config, descriptor).process(mono)
+    Detector::new(sample_rate, config, descriptor).process(mono, accepts)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -131,7 +147,7 @@ impl Detector {
     fn new(sample_rate: u32, config: Config, descriptor: Descriptor) -> Self {
         Self {
             hop_size: config.hop_size,
-            min_ioi: ((config.min_ioi_ms / 1_000.0) * sample_rate as f32).round() as usize,
+            min_ioi: super::frames_for_ms(sample_rate, config.min_ioi_ms),
             delay: (DEFAULT_DELAY_HOPS * config.hop_size as f32) as usize,
             silence_db: config.silence_db,
             total_frames: 0,
@@ -142,21 +158,25 @@ impl Detector {
         }
     }
 
-    fn process(mut self, mono: &[f32]) -> Vec<u64> {
+    fn process(mut self, mono: &[f32], mut accepts: impl FnMut(usize) -> bool) -> Vec<u64> {
         let mut onsets = Vec::new();
         let mut hop = vec![0.0; self.hop_size];
 
         for chunk in mono.chunks(self.hop_size) {
             hop.fill(0.0);
             hop[..chunk.len()].copy_from_slice(chunk);
-            if let Some(frame) = self.process_hop(&hop) {
+            if let Some(frame) = self.process_hop(&hop, &mut accepts) {
                 onsets.push(frame as u64);
             }
         }
         onsets
     }
 
-    fn process_hop(&mut self, input: &[f32]) -> Option<usize> {
+    fn process_hop(
+        &mut self,
+        input: &[f32],
+        accepts: &mut impl FnMut(usize) -> bool,
+    ) -> Option<usize> {
         let magnitudes = self.phase_vocoder.spectrum(input);
         let descriptor = match self.descriptor {
             Descriptor::Hfc => high_frequency_content(&magnitudes),
@@ -168,7 +188,9 @@ impl Detector {
 
         if peak > 0.0 && !silent {
             let new_onset = self.total_frames + (peak * self.hop_size as f32).round() as usize;
-            if self.last_onset + self.min_ioi < new_onset
+            let reported_onset = self.delay.max(new_onset).saturating_sub(self.delay);
+            if accepts(reported_onset)
+                && self.last_onset + self.min_ioi < new_onset
                 && !(self.last_onset > 0 && self.delay > new_onset)
             {
                 self.last_onset = self.delay.max(new_onset);
@@ -176,7 +198,10 @@ impl Detector {
             }
         } else if peak <= 0.0 && self.total_frames <= self.delay && !silent {
             let new_onset = self.total_frames;
-            if self.total_frames == 0 || self.last_onset + self.min_ioi < new_onset {
+            let reported_onset = self.total_frames;
+            if accepts(reported_onset)
+                && (self.total_frames == 0 || self.last_onset + self.min_ioi < new_onset)
+            {
                 self.last_onset = self.total_frames + self.delay;
                 accepted = true;
             }

--- a/crates/vibez-core/src/onset/aubio.rs
+++ b/crates/vibez-core/src/onset/aubio.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 const DEFAULT_WINDOW_SIZE: usize = 1_024;
 const DEFAULT_HOP_SIZE: usize = 256;
 const DEFAULT_THRESHOLD: f32 = 0.058;
+const DEFAULT_ENERGY_THRESHOLD: f32 = 0.3;
 const DEFAULT_MIN_IOI_MS: f32 = 50.0;
 const DEFAULT_SILENCE_DB: f32 = -70.0;
 const DEFAULT_DELAY_HOPS: f32 = 4.3;
@@ -34,14 +35,15 @@ impl Config {
         // Interpolate logarithmically through its HFC default at 50%, giving
         // useful travel at both ends instead of bunching every result near the
         // middle of the knob.
-        let normalized = sensitivity.normalized();
-        let threshold = if normalized <= 0.5 {
-            0.9 * (DEFAULT_THRESHOLD / 0.9).powf(normalized / 0.5)
-        } else {
-            DEFAULT_THRESHOLD * (0.001 / DEFAULT_THRESHOLD).powf((normalized - 0.5) / 0.5)
-        };
         Self {
-            threshold,
+            threshold: sensitivity.threshold_through(DEFAULT_THRESHOLD),
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn for_energy_sensitivity(sensitivity: TransientSensitivity) -> Self {
+        Self {
+            threshold: sensitivity.threshold_through(DEFAULT_ENERGY_THRESHOLD),
             ..Self::default()
         }
     }
@@ -84,6 +86,19 @@ enum ConfigError {
 }
 
 pub(super) fn detect_onsets(mono: &[f32], sample_rate: u32, config: Config) -> Vec<u64> {
+    detect_onsets_with_descriptor(mono, sample_rate, config, Descriptor::Hfc)
+}
+
+pub(super) fn detect_energy_onsets(mono: &[f32], sample_rate: u32, config: Config) -> Vec<u64> {
+    detect_onsets_with_descriptor(mono, sample_rate, config, Descriptor::Energy)
+}
+
+fn detect_onsets_with_descriptor(
+    mono: &[f32],
+    sample_rate: u32,
+    config: Config,
+    descriptor: Descriptor,
+) -> Vec<u64> {
     let Ok(config) = config.validate(sample_rate) else {
         return Vec::new();
     };
@@ -91,7 +106,13 @@ pub(super) fn detect_onsets(mono: &[f32], sample_rate: u32, config: Config) -> V
         return Vec::new();
     }
 
-    Detector::new(sample_rate, config).process(mono)
+    Detector::new(sample_rate, config, descriptor).process(mono)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Descriptor {
+    Hfc,
+    Energy,
 }
 
 struct Detector {
@@ -103,10 +124,11 @@ struct Detector {
     last_onset: usize,
     phase_vocoder: PhaseVocoder,
     peak_picker: PeakPicker,
+    descriptor: Descriptor,
 }
 
 impl Detector {
-    fn new(sample_rate: u32, config: Config) -> Self {
+    fn new(sample_rate: u32, config: Config, descriptor: Descriptor) -> Self {
         Self {
             hop_size: config.hop_size,
             min_ioi: ((config.min_ioi_ms / 1_000.0) * sample_rate as f32).round() as usize,
@@ -116,6 +138,7 @@ impl Detector {
             last_onset: 0,
             phase_vocoder: PhaseVocoder::new(config.window_size, config.hop_size),
             peak_picker: PeakPicker::new(config.threshold),
+            descriptor,
         }
     }
 
@@ -135,7 +158,10 @@ impl Detector {
 
     fn process_hop(&mut self, input: &[f32]) -> Option<usize> {
         let magnitudes = self.phase_vocoder.spectrum(input);
-        let descriptor = high_frequency_content(&magnitudes);
+        let descriptor = match self.descriptor {
+            Descriptor::Hfc => high_frequency_content(&magnitudes),
+            Descriptor::Energy => spectral_energy(&magnitudes),
+        };
         let peak = self.peak_picker.process(descriptor);
         let silent = db_spl(input) < self.silence_db;
         let mut accepted = false;
@@ -214,16 +240,23 @@ impl PhaseVocoder {
 
         self.fft_buffer[..=self.window_size / 2]
             .iter()
-            .map(|bin| bin.norm().ln_1p())
+            .map(|bin| bin.norm())
             .collect()
     }
+}
+
+fn spectral_energy(magnitudes: &[f32]) -> f32 {
+    magnitudes
+        .iter()
+        .map(|magnitude| magnitude * magnitude)
+        .sum()
 }
 
 fn high_frequency_content(magnitudes: &[f32]) -> f32 {
     magnitudes
         .iter()
         .enumerate()
-        .map(|(index, magnitude)| (index + 1) as f32 * magnitude)
+        .map(|(index, magnitude)| (index + 1) as f32 * magnitude.ln_1p())
         .sum()
 }
 
@@ -357,6 +390,13 @@ mod tests {
     #[test]
     fn ported_upstream_hfc_zero_spectrum_is_zero() {
         assert_eq!(high_frequency_content(&vec![0.0; 513]), 0.0);
+    }
+
+    // Port of the energy zero-spectrum case in
+    // tests/src/spectral/test-specdesc.c.
+    #[test]
+    fn ported_upstream_energy_zero_spectrum_is_zero() {
+        assert_eq!(spectral_energy(&vec![0.0; 513]), 0.0);
     }
 
     #[test]

--- a/crates/vibez-ui/src/app/async_helpers.rs
+++ b/crates/vibez-ui/src/app/async_helpers.rs
@@ -174,13 +174,11 @@ pub(super) async fn detect_clip_bpm_async(
 
 pub(super) async fn detect_clip_transients_async(
     audio: Arc<vibez_core::audio_buffer::DecodedAudio>,
-    detail: vibez_core::onset::TransientDetectionDetail,
+    sensitivity: vibez_core::onset::TransientSensitivity,
 ) -> Vec<u64> {
-    tokio::task::spawn_blocking(move || {
-        vibez_core::onset::detect_onsets(&audio, detail.sensitivity())
-    })
-    .await
-    .unwrap_or_default()
+    tokio::task::spawn_blocking(move || vibez_core::onset::detect_onsets(&audio, sensitivity))
+        .await
+        .unwrap_or_default()
 }
 
 pub(super) async fn transpose_clip_async(

--- a/crates/vibez-ui/src/app/audio_tasks.rs
+++ b/crates/vibez-ui/src/app/audio_tasks.rs
@@ -44,7 +44,6 @@ pub(crate) fn auto_open_midi_input(
 pub(crate) fn compute_audio_quantize(
     input: QuantizeInput,
 ) -> Result<crate::message::AudioQuantizeSuccess, String> {
-    const DEFAULT_SENSITIVITY: f32 = 1.5;
     const MIN_SLICE_FRAMES: usize = 64;
 
     let QuantizeInput {
@@ -61,10 +60,11 @@ pub(crate) fn compute_audio_quantize(
 
     let sr = sample_rate as f64;
     let clip_end_src = clip_source_offset.saturating_add(clip_duration);
-    let onsets: Vec<u64> = vibez_core::onset::detect_onsets(&audio, DEFAULT_SENSITIVITY)
-        .into_iter()
-        .filter(|&o| o >= clip_source_offset && o < clip_end_src)
-        .collect();
+    let onsets: Vec<u64> =
+        vibez_core::onset::detect_onsets(&audio, vibez_core::onset::TransientSensitivity::DEFAULT)
+            .into_iter()
+            .filter(|&o| o >= clip_source_offset && o < clip_end_src)
+            .collect();
     if onsets.is_empty() {
         return Err("No transients detected in clip".into());
     }

--- a/crates/vibez-ui/src/app/mod.rs
+++ b/crates/vibez-ui/src/app/mod.rs
@@ -219,6 +219,7 @@ mod views_settings_perform;
 mod views_settings_project;
 mod views_settings_updates;
 mod views_shell;
+mod views_transient_analysis;
 mod views_transport;
 mod window_policy;
 

--- a/crates/vibez-ui/src/app/transient_markers.rs
+++ b/crates/vibez-ui/src/app/transient_markers.rs
@@ -15,7 +15,7 @@ impl App {
         location: vibez_project::TimelineLocation,
         track_id: TrackId,
         clip_id: ClipId,
-        detail: vibez_core::onset::TransientDetectionDetail,
+        sensitivity: vibez_core::onset::TransientSensitivity,
         record_undo: bool,
     ) -> Task<Message> {
         let Some(content) = self.timeline_content_at(location, track_id) else {
@@ -32,7 +32,7 @@ impl App {
             self.state.status_text = format!("Detecting transients in {}...", clip.name);
         }
         Task::perform(
-            detect_clip_transients_async(detection_audio, detail),
+            detect_clip_transients_async(detection_audio, sensitivity),
             move |source_frames| {
                 Message::ClipTransientsDetected(crate::message::ClipTransientDetection {
                     location,
@@ -56,7 +56,7 @@ impl App {
             location,
             track_id,
             clip_id,
-            vibez_core::onset::TransientDetectionDetail::Balanced,
+            vibez_core::onset::TransientSensitivity::DEFAULT,
             false,
         )
     }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -229,15 +229,28 @@ impl App {
                             location,
                             track_id,
                             clip_id,
-                            detail: vibez_core::onset::TransientDetectionDetail::Balanced,
+                            sensitivity: vibez_core::onset::TransientSensitivity::DEFAULT,
+                            sensitivity_input: vibez_core::onset::TransientSensitivity::DEFAULT
+                                .percent()
+                                .to_string(),
                         });
                 } else {
                     self.state.status_text = "The Audio Clip is no longer available".into();
                 }
             }
-            Message::SetTransientAnalysisDetail(detail) => {
+            Message::SetTransientAnalysisSensitivity(percent) => {
                 if let Some(dialog) = self.state.view.transient_analysis_dialog.as_mut() {
-                    dialog.detail = detail;
+                    dialog.set_sensitivity(percent);
+                }
+            }
+            Message::TransientAnalysisSensitivityInputChanged(input) => {
+                if let Some(dialog) = self.state.view.transient_analysis_dialog.as_mut() {
+                    dialog.edit_sensitivity_input(input);
+                }
+            }
+            Message::SubmitTransientAnalysisSensitivity => {
+                if let Some(dialog) = self.state.view.transient_analysis_dialog.as_mut() {
+                    dialog.normalize_sensitivity_input();
                 }
             }
             Message::CancelTransientAnalysis => {
@@ -251,7 +264,7 @@ impl App {
                     dialog.location,
                     dialog.track_id,
                     dialog.clip_id,
-                    dialog.detail,
+                    dialog.sensitivity,
                     true,
                 );
             }
@@ -794,10 +807,15 @@ impl App {
                 location,
                 track_id,
                 clip_id,
-                detail,
+                sensitivity,
             } => {
-                return self
-                    .dispatch_detect_clip_transients(location, track_id, clip_id, detail, true);
+                return self.dispatch_detect_clip_transients(
+                    location,
+                    track_id,
+                    clip_id,
+                    sensitivity,
+                    true,
+                );
             }
             Message::ClipTransientsDetected(completion) => {
                 return self.finish_detect_clip_transients(completion, undo_gesture);

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -215,6 +215,46 @@ impl App {
             Message::CancelDrumRackSlice => {
                 self.state.view.drum_rack_slice_dialog = None;
             }
+            Message::OpenTransientAnalysisDialog {
+                location,
+                track_id,
+                clip_id,
+            } => {
+                let clip_exists = self
+                    .timeline_content_at(location, track_id)
+                    .is_some_and(|content| content.clips.iter().any(|clip| clip.id == clip_id));
+                if clip_exists {
+                    self.state.view.transient_analysis_dialog =
+                        Some(crate::state::TransientAnalysisDialog {
+                            location,
+                            track_id,
+                            clip_id,
+                            detail: vibez_core::onset::TransientDetectionDetail::Balanced,
+                        });
+                } else {
+                    self.state.status_text = "The Audio Clip is no longer available".into();
+                }
+            }
+            Message::SetTransientAnalysisDetail(detail) => {
+                if let Some(dialog) = self.state.view.transient_analysis_dialog.as_mut() {
+                    dialog.detail = detail;
+                }
+            }
+            Message::CancelTransientAnalysis => {
+                self.state.view.transient_analysis_dialog = None;
+            }
+            Message::ConfirmTransientAnalysis => {
+                let Some(dialog) = self.state.view.transient_analysis_dialog.take() else {
+                    return Task::none();
+                };
+                return self.dispatch_detect_clip_transients(
+                    dialog.location,
+                    dialog.track_id,
+                    dialog.clip_id,
+                    dialog.detail,
+                    true,
+                );
+            }
             Message::ConfirmDrumRackSlice => {
                 let Some(dialog) = self.state.view.drum_rack_slice_dialog.take() else {
                     return Task::none();

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -257,9 +257,19 @@ impl App {
                 self.state.view.transient_analysis_dialog = None;
             }
             Message::ConfirmTransientAnalysis => {
-                let Some(dialog) = self.state.view.transient_analysis_dialog.take() else {
+                let Some(dialog) = self.state.view.transient_analysis_dialog.as_mut() else {
                     return Task::none();
                 };
+                if !dialog.commit_sensitivity_input() {
+                    self.state.status_text = "Enter a sensitivity from 0 to 100%".into();
+                    return Task::none();
+                }
+                let dialog = self
+                    .state
+                    .view
+                    .transient_analysis_dialog
+                    .take()
+                    .expect("validated dialog remains open");
                 return self.dispatch_detect_clip_transients(
                     dialog.location,
                     dialog.track_id,
@@ -308,6 +318,22 @@ impl App {
                 });
             }
             Message::Arrangement(msg) => {
+                if matches!(msg, ArrangementMsg::DeleteSelectedClip) {
+                    let location = self.active_timeline_location();
+                    let deleted: std::collections::HashSet<_> = self
+                        .state
+                        .active_timeline_editor()
+                        .selected_clips
+                        .iter()
+                        .filter_map(|selection| match selection {
+                            crate::state::ArrangementSelection::AudioClip { track_id, clip_id } => {
+                                Some((*track_id, *clip_id))
+                            }
+                            crate::state::ArrangementSelection::NoteClip { .. } => None,
+                        })
+                        .collect();
+                    self.state.view.dismiss_clip_dialogs_for(location, &deleted);
+                }
                 if let ArrangementMsg::RequestSliceAudioClipToDrumRack { track_id, clip_id } = &msg
                 {
                     let (track_id, clip_id) = (*track_id, *clip_id);

--- a/crates/vibez-ui/src/app/update_media.rs
+++ b/crates/vibez-ui/src/app/update_media.rs
@@ -414,6 +414,9 @@ impl App {
     }
 
     pub(super) fn on_escape_pressed(&mut self) -> Task<Message> {
+        if self.state.view.transient_analysis_dialog.take().is_some() {
+            return Task::none();
+        }
         if self.state.view.drum_rack_slice_dialog.take().is_some() {
             return Task::none();
         }

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -1006,32 +1006,11 @@ impl App {
                 }
                 col = col.push(menu_btn(
                     icons::SLIDERS_VERTICAL,
-                    "Analyse · fewer markers".into(),
-                    Message::DetectClipTransients {
+                    "Transient analysis…".into(),
+                    Message::OpenTransientAnalysisDialog {
                         location,
                         track_id,
                         clip_id,
-                        detail: vibez_core::onset::TransientDetectionDetail::Fewer,
-                    },
-                ));
-                col = col.push(menu_btn(
-                    icons::SLIDERS_VERTICAL,
-                    "Analyse · balanced".into(),
-                    Message::DetectClipTransients {
-                        location,
-                        track_id,
-                        clip_id,
-                        detail: vibez_core::onset::TransientDetectionDetail::Balanced,
-                    },
-                ));
-                col = col.push(menu_btn(
-                    icons::SLIDERS_VERTICAL,
-                    "Analyse · more markers".into(),
-                    Message::DetectClipTransients {
-                        location,
-                        track_id,
-                        clip_id,
-                        detail: vibez_core::onset::TransientDetectionDetail::More,
                     },
                 ));
                 col = col.push(menu_btn(

--- a/crates/vibez-ui/src/app/views_shell.rs
+++ b/crates/vibez-ui/src/app/views_shell.rs
@@ -169,6 +169,8 @@ impl App {
             .is_some()
         {
             stack![base_layout, self.view_track_deletion_overlay()].into()
+        } else if self.state.view.transient_analysis_dialog.is_some() {
+            stack![base_layout, self.view_transient_analysis_overlay()].into()
         } else if self.state.view.drum_rack_slice_dialog.is_some() {
             stack![base_layout, self.view_drum_rack_slice_overlay()].into()
         } else if self.state.settings_open {

--- a/crates/vibez-ui/src/app/views_transient_analysis.rs
+++ b/crates/vibez-ui/src/app/views_transient_analysis.rs
@@ -1,62 +1,24 @@
 //! Transient analysis modal for the Audio Clip waveform.
 
-use iced::widget::{button, center, column, container, horizontal_space, mouse_area, row, text};
+use iced::widget::{
+    button, canvas, center, column, container, horizontal_space, mouse_area, row, text, text_input,
+};
 use iced::{Element, Length, Theme};
 
 use crate::icons;
 use crate::message::Message;
 use crate::theme as th;
+use crate::widgets::transient_sensitivity_knob::TransientSensitivityKnob;
 
 use super::*;
 
-fn detail_choice(
-    label: &'static str,
-    purpose: &'static str,
-    detail: vibez_core::onset::TransientDetectionDetail,
-    selected: bool,
-) -> Element<'static, Message> {
-    button(
-        column![
-            text(label)
-                .size(13)
-                .color(if selected { th::accent() } else { th::text() }),
-            text(purpose).size(10).color(th::text_dim()),
-        ]
-        .spacing(4),
-    )
-    .on_press(Message::SetTransientAnalysisDetail(detail))
-    .padding([10, 11])
-    .width(Length::Fill)
-    .style(move |_theme: &Theme, status| button::Style {
-        background: Some(
-            if selected {
-                th::accent_dim()
-            } else if matches!(status, button::Status::Hovered | button::Status::Pressed) {
-                th::bg_hover()
-            } else {
-                th::bg_elevated()
-            }
-            .into(),
-        ),
-        text_color: th::text(),
-        border: iced::Border {
-            color: if selected { th::accent() } else { th::border() },
-            width: 1.0,
-            radius: 4.0.into(),
-        },
-        ..Default::default()
-    })
-    .into()
-}
-
 impl App {
     pub(super) fn view_transient_analysis_overlay(&self) -> Element<'_, Message> {
-        use vibez_core::onset::TransientDetectionDetail::{Balanced, Fewer, More};
-
         let dialog = self
             .state
             .view
             .transient_analysis_dialog
+            .as_ref()
             .expect("Transient analysis overlay requires a pending request");
         let clip = self
             .timeline_content_at(dialog.location, dialog.track_id)
@@ -73,18 +35,64 @@ impl App {
         };
         let detected_count = marker_count(vibez_core::transient::TransientMarkerKind::Suggested);
         let manual_count = marker_count(vibez_core::transient::TransientMarkerKind::Authored);
-        let guidance = match dialog.detail {
-            Fewer => {
-                "Keeps the strongest attacks. Useful when a busy loop creates too many slices."
-            }
-            Balanced => "A practical starting point for most drum and percussion loops.",
-            More => "Includes quieter attacks and hits that sit close together.",
-        };
         let marker_summary = if manual_count == 0 {
-            format!("{detected_count} detected markers")
+            format!("{detected_count} detected")
         } else {
             format!("{detected_count} detected · {manual_count} manual")
         };
+
+        let sensitivity_knob: Element<'_, Message> =
+            canvas(TransientSensitivityKnob::new(dialog.sensitivity.percent()))
+                .width(Length::Fixed(68.0))
+                .height(Length::Fixed(68.0))
+                .into();
+        let sensitivity_input = text_input("0–100", &dialog.sensitivity_input)
+            .on_input(Message::TransientAnalysisSensitivityInputChanged)
+            .on_submit(Message::SubmitTransientAnalysisSensitivity)
+            .width(Length::Fixed(62.0))
+            .padding([5, 7])
+            .size(13);
+        let sensitivity_control = container(
+            row![
+                column![
+                    sensitivity_knob,
+                    text("Drag or scroll").size(9).color(th::text_muted())
+                ]
+                .align_x(iced::Alignment::Center)
+                .spacing(4),
+                column![
+                    text("SENSITIVITY").size(9).color(th::text_muted()),
+                    row![sensitivity_input, text("%").size(13).color(th::text_dim()),]
+                        .spacing(5)
+                        .align_y(iced::Alignment::Center),
+                    text("Higher values keep quieter attacks and create more markers.")
+                        .size(11)
+                        .color(th::text_dim()),
+                    row![
+                        text("Strong attacks").size(9).color(th::text_muted()),
+                        horizontal_space(),
+                        text("Fine detail").size(9).color(th::text_muted()),
+                    ]
+                    .width(Length::Fill),
+                ]
+                .spacing(6)
+                .width(Length::Fill),
+            ]
+            .spacing(16)
+            .align_y(iced::Alignment::Center),
+        )
+        .width(Length::Fill)
+        .padding([14, 16])
+        .style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_elevated().into()),
+            border: iced::Border {
+                color: th::border(),
+                width: 1.0,
+                radius: 5.0.into(),
+            },
+            ..Default::default()
+        });
+
         let cancel = button(text("Cancel").size(12).color(th::text()))
             .on_press(Message::CancelTransientAnalysis)
             .padding([7, 14]);
@@ -120,33 +128,8 @@ impl App {
                 .spacing(8)
                 .align_y(iced::Alignment::Center),
                 text(clip_name).size(11).color(th::text_dim()),
-                text("Choose how closely markers should follow the waveform.")
-                    .size(11)
-                    .color(th::text_dim()),
-                row![
-                    detail_choice("Fewer", "Strong hits", Fewer, dialog.detail == Fewer),
-                    detail_choice(
-                        "Balanced",
-                        "Most loops",
-                        Balanced,
-                        dialog.detail == Balanced,
-                    ),
-                    detail_choice("More", "Fine detail", More, dialog.detail == More),
-                ]
-                .spacing(8),
-                container(text(guidance).size(11).color(th::text_dim()))
-                    .width(Length::Fill)
-                    .padding([9, 11])
-                    .style(|_theme: &Theme| container::Style {
-                        background: Some(th::bg_elevated().into()),
-                        border: iced::Border {
-                            color: th::border(),
-                            width: 1.0,
-                            radius: 4.0.into(),
-                        },
-                        ..Default::default()
-                    }),
-                text("Manual markers stay in place when analysis runs.")
+                sensitivity_control,
+                text("Analysis replaces detected markers. Manual markers stay in place.")
                     .size(10)
                     .color(th::text_muted()),
                 row![horizontal_space(), cancel, analyse]
@@ -155,7 +138,7 @@ impl App {
             ]
             .spacing(12),
         )
-        .width(Length::Fixed(500.0))
+        .width(Length::Fixed(460.0))
         .padding(18)
         .style(|_theme: &Theme| container::Style {
             background: Some(th::bg_surface().into()),

--- a/crates/vibez-ui/src/app/views_transient_analysis.rs
+++ b/crates/vibez-ui/src/app/views_transient_analysis.rs
@@ -1,0 +1,182 @@
+//! Transient analysis modal for the Audio Clip waveform.
+
+use iced::widget::{button, center, column, container, horizontal_space, mouse_area, row, text};
+use iced::{Element, Length, Theme};
+
+use crate::icons;
+use crate::message::Message;
+use crate::theme as th;
+
+use super::*;
+
+fn detail_choice(
+    label: &'static str,
+    purpose: &'static str,
+    detail: vibez_core::onset::TransientDetectionDetail,
+    selected: bool,
+) -> Element<'static, Message> {
+    button(
+        column![
+            text(label)
+                .size(13)
+                .color(if selected { th::accent() } else { th::text() }),
+            text(purpose).size(10).color(th::text_dim()),
+        ]
+        .spacing(4),
+    )
+    .on_press(Message::SetTransientAnalysisDetail(detail))
+    .padding([10, 11])
+    .width(Length::Fill)
+    .style(move |_theme: &Theme, status| button::Style {
+        background: Some(
+            if selected {
+                th::accent_dim()
+            } else if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                th::bg_hover()
+            } else {
+                th::bg_elevated()
+            }
+            .into(),
+        ),
+        text_color: th::text(),
+        border: iced::Border {
+            color: if selected { th::accent() } else { th::border() },
+            width: 1.0,
+            radius: 4.0.into(),
+        },
+        ..Default::default()
+    })
+    .into()
+}
+
+impl App {
+    pub(super) fn view_transient_analysis_overlay(&self) -> Element<'_, Message> {
+        use vibez_core::onset::TransientDetectionDetail::{Balanced, Fewer, More};
+
+        let dialog = self
+            .state
+            .view
+            .transient_analysis_dialog
+            .expect("Transient analysis overlay requires a pending request");
+        let clip = self
+            .timeline_content_at(dialog.location, dialog.track_id)
+            .and_then(|content| content.clips.iter().find(|clip| clip.id == dialog.clip_id));
+        let clip_name = clip.map_or("Audio Clip", |clip| clip.name.as_str());
+        let marker_count = |kind| {
+            clip.map_or(0, |clip| {
+                clip.transient_markers
+                    .as_slice()
+                    .iter()
+                    .filter(|marker| marker.kind() == kind)
+                    .count()
+            })
+        };
+        let detected_count = marker_count(vibez_core::transient::TransientMarkerKind::Suggested);
+        let manual_count = marker_count(vibez_core::transient::TransientMarkerKind::Authored);
+        let guidance = match dialog.detail {
+            Fewer => {
+                "Keeps the strongest attacks. Useful when a busy loop creates too many slices."
+            }
+            Balanced => "A practical starting point for most drum and percussion loops.",
+            More => "Includes quieter attacks and hits that sit close together.",
+        };
+        let marker_summary = if manual_count == 0 {
+            format!("{detected_count} detected markers")
+        } else {
+            format!("{detected_count} detected · {manual_count} manual")
+        };
+        let cancel = button(text("Cancel").size(12).color(th::text()))
+            .on_press(Message::CancelTransientAnalysis)
+            .padding([7, 14]);
+        let analyse = button(text("Analyse").size(12).color(th::bg_dark()))
+            .on_press(Message::ConfirmTransientAnalysis)
+            .padding([7, 18])
+            .style(|_theme: &Theme, status| button::Style {
+                background: Some(
+                    if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                        th::accent_dim()
+                    } else {
+                        th::accent()
+                    }
+                    .into(),
+                ),
+                text_color: th::bg_dark(),
+                border: iced::Border {
+                    radius: 3.0.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+        let card = container(
+            column![
+                row![
+                    icons::icon(icons::SLIDERS_VERTICAL)
+                        .size(17)
+                        .color(th::accent()),
+                    text("Transient analysis").size(18).color(th::text()),
+                    horizontal_space(),
+                    text(marker_summary).size(10).color(th::text_muted()),
+                ]
+                .spacing(8)
+                .align_y(iced::Alignment::Center),
+                text(clip_name).size(11).color(th::text_dim()),
+                text("Choose how closely markers should follow the waveform.")
+                    .size(11)
+                    .color(th::text_dim()),
+                row![
+                    detail_choice("Fewer", "Strong hits", Fewer, dialog.detail == Fewer),
+                    detail_choice(
+                        "Balanced",
+                        "Most loops",
+                        Balanced,
+                        dialog.detail == Balanced,
+                    ),
+                    detail_choice("More", "Fine detail", More, dialog.detail == More),
+                ]
+                .spacing(8),
+                container(text(guidance).size(11).color(th::text_dim()))
+                    .width(Length::Fill)
+                    .padding([9, 11])
+                    .style(|_theme: &Theme| container::Style {
+                        background: Some(th::bg_elevated().into()),
+                        border: iced::Border {
+                            color: th::border(),
+                            width: 1.0,
+                            radius: 4.0.into(),
+                        },
+                        ..Default::default()
+                    }),
+                text("Manual markers stay in place when analysis runs.")
+                    .size(10)
+                    .color(th::text_muted()),
+                row![horizontal_space(), cancel, analyse]
+                    .spacing(8)
+                    .align_y(iced::Alignment::Center),
+            ]
+            .spacing(12),
+        )
+        .width(Length::Fixed(500.0))
+        .padding(18)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(th::bg_surface().into()),
+            border: iced::Border {
+                color: th::border_light(),
+                width: 1.0,
+                radius: 6.0.into(),
+            },
+            ..Default::default()
+        });
+
+        mouse_area(
+            center(card)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .style(|_theme: &Theme| container::Style {
+                    background: Some(iced::Color::from_rgba(0.0, 0.0, 0.0, 0.55).into()),
+                    ..Default::default()
+                }),
+        )
+        .on_press(Message::CancelTransientAnalysis)
+        .into()
+    }
+}

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -462,6 +462,14 @@ pub enum Message {
     SetDrumRackSliceMarkers(crate::domains::arrangement::AudioSliceMarkers),
     ConfirmDrumRackSlice,
     CancelDrumRackSlice,
+    OpenTransientAnalysisDialog {
+        location: TimelineLocation,
+        track_id: TrackId,
+        clip_id: ClipId,
+    },
+    SetTransientAnalysisDetail(vibez_core::onset::TransientDetectionDetail),
+    ConfirmTransientAnalysis,
+    CancelTransientAnalysis,
     AudioClipDrumRackPrepared {
         location: TimelineLocation,
         track_id: TrackId,

--- a/crates/vibez-ui/src/message.rs
+++ b/crates/vibez-ui/src/message.rs
@@ -467,7 +467,9 @@ pub enum Message {
         track_id: TrackId,
         clip_id: ClipId,
     },
-    SetTransientAnalysisDetail(vibez_core::onset::TransientDetectionDetail),
+    SetTransientAnalysisSensitivity(u8),
+    TransientAnalysisSensitivityInputChanged(String),
+    SubmitTransientAnalysisSensitivity,
     ConfirmTransientAnalysis,
     CancelTransientAnalysis,
     AudioClipDrumRackPrepared {
@@ -762,7 +764,7 @@ pub enum Message {
         location: TimelineLocation,
         track_id: TrackId,
         clip_id: ClipId,
-        detail: vibez_core::onset::TransientDetectionDetail,
+        sensitivity: vibez_core::onset::TransientSensitivity,
     },
     ClipTransientsDetected(ClipTransientDetection),
     /// Background BPM detection result. `bpm` is `None` when the

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -112,6 +112,7 @@ pub struct ViewState {
     pub adaptive_grid_bias: i8,
     pub context_menu: Option<ContextMenu>,
     pub drum_rack_slice_dialog: Option<DrumRackSliceDialog>,
+    pub transient_analysis_dialog: Option<TransientAnalysisDialog>,
     pub edit_menu_open: bool,
     pub cursor_x: f32, // globally tracked for popup positioning and pane drags
     pub cursor_y: f32,
@@ -138,6 +139,7 @@ impl Default for ViewState {
             adaptive_grid_bias: 0,
             context_menu: None,
             drum_rack_slice_dialog: None,
+            transient_analysis_dialog: None,
             edit_menu_open: false,
             cursor_x: 0.0,
             cursor_y: 0.0,
@@ -167,6 +169,14 @@ pub struct DrumRackSliceDialog {
     pub track_id: TrackId,
     pub clip_id: ClipId,
     pub markers: crate::domains::arrangement::AudioSliceMarkers,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransientAnalysisDialog {
+    pub location: vibez_project::TimelineLocation,
+    pub track_id: TrackId,
+    pub clip_id: ClipId,
+    pub detail: vibez_core::onset::TransientDetectionDetail,
 }
 
 /// Right-click context menu state.
@@ -1155,6 +1165,24 @@ mod tests {
     fn app_state_opens_in_perform_workspace() {
         let state = AppState::default();
         assert_eq!(state.view.workspace, Workspace::Perform);
+    }
+
+    #[test]
+    fn transient_analysis_is_a_dedicated_modal_with_balanced_default_detail() {
+        let mut state = AppState::default();
+        let dialog = TransientAnalysisDialog {
+            location: vibez_project::TimelineLocation::Arrange,
+            track_id: TrackId::new(),
+            clip_id: ClipId::new(),
+            detail: vibez_core::onset::TransientDetectionDetail::Balanced,
+        };
+
+        state.view.transient_analysis_dialog = Some(dialog);
+
+        assert_eq!(
+            state.view.transient_analysis_dialog.unwrap().detail,
+            vibez_core::onset::TransientDetectionDetail::Balanced
+        );
     }
 
     #[test]

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -171,12 +171,42 @@ pub struct DrumRackSliceDialog {
     pub markers: crate::domains::arrangement::AudioSliceMarkers,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransientAnalysisDialog {
     pub location: vibez_project::TimelineLocation,
     pub track_id: TrackId,
     pub clip_id: ClipId,
-    pub detail: vibez_core::onset::TransientDetectionDetail,
+    pub sensitivity: vibez_core::onset::TransientSensitivity,
+    pub sensitivity_input: String,
+}
+
+impl TransientAnalysisDialog {
+    pub fn set_sensitivity(&mut self, percent: u8) {
+        self.sensitivity = vibez_core::onset::TransientSensitivity::new(percent);
+        self.sensitivity_input = self.sensitivity.percent().to_string();
+    }
+
+    pub fn edit_sensitivity_input(&mut self, input: String) {
+        if let Some(sensitivity) = parse_transient_sensitivity(&input) {
+            self.sensitivity = sensitivity;
+        }
+        self.sensitivity_input = input;
+    }
+
+    pub fn normalize_sensitivity_input(&mut self) {
+        self.sensitivity_input = self.sensitivity.percent().to_string();
+    }
+}
+
+fn parse_transient_sensitivity(input: &str) -> Option<vibez_core::onset::TransientSensitivity> {
+    let percent = input
+        .trim()
+        .trim_end_matches('%')
+        .trim()
+        .parse::<u8>()
+        .ok()?;
+    (percent <= vibez_core::onset::TransientSensitivity::MAX_PERCENT)
+        .then(|| vibez_core::onset::TransientSensitivity::new(percent))
 }
 
 /// Right-click context menu state.
@@ -1168,20 +1198,36 @@ mod tests {
     }
 
     #[test]
-    fn transient_analysis_is_a_dedicated_modal_with_balanced_default_detail() {
+    fn transient_analysis_accepts_knob_and_exact_percent_edits() {
         let mut state = AppState::default();
-        let dialog = TransientAnalysisDialog {
+        let mut dialog = TransientAnalysisDialog {
             location: vibez_project::TimelineLocation::Arrange,
             track_id: TrackId::new(),
             clip_id: ClipId::new(),
-            detail: vibez_core::onset::TransientDetectionDetail::Balanced,
+            sensitivity: vibez_core::onset::TransientSensitivity::DEFAULT,
+            sensitivity_input: "50".into(),
         };
 
-        state.view.transient_analysis_dialog = Some(dialog);
+        dialog.set_sensitivity(73);
+        assert_eq!(dialog.sensitivity.percent(), 73);
+        assert_eq!(dialog.sensitivity_input, "73");
 
+        dialog.edit_sensitivity_input("84%".into());
+        assert_eq!(dialog.sensitivity.percent(), 84);
+        dialog.edit_sensitivity_input("nope".into());
+        assert_eq!(dialog.sensitivity.percent(), 84);
+        dialog.normalize_sensitivity_input();
+        assert_eq!(dialog.sensitivity_input, "84");
+
+        state.view.transient_analysis_dialog = Some(dialog);
         assert_eq!(
-            state.view.transient_analysis_dialog.unwrap().detail,
-            vibez_core::onset::TransientDetectionDetail::Balanced
+            state
+                .view
+                .transient_analysis_dialog
+                .unwrap()
+                .sensitivity
+                .percent(),
+            84
         );
     }
 

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -161,6 +161,27 @@ impl ViewState {
             self.adaptive_grid_bias,
         )
     }
+
+    pub fn dismiss_clip_dialogs_for(
+        &mut self,
+        location: vibez_project::TimelineLocation,
+        deleted: &HashSet<(TrackId, ClipId)>,
+    ) {
+        if self.drum_rack_slice_dialog.is_some_and(|dialog| {
+            dialog.location == location && deleted.contains(&(dialog.track_id, dialog.clip_id))
+        }) {
+            self.drum_rack_slice_dialog = None;
+        }
+        if self
+            .transient_analysis_dialog
+            .as_ref()
+            .is_some_and(|dialog| {
+                dialog.location == location && deleted.contains(&(dialog.track_id, dialog.clip_id))
+            })
+        {
+            self.transient_analysis_dialog = None;
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -196,6 +217,14 @@ impl TransientAnalysisDialog {
     pub fn normalize_sensitivity_input(&mut self) {
         self.sensitivity_input = self.sensitivity.percent().to_string();
     }
+
+    pub fn commit_sensitivity_input(&mut self) -> bool {
+        let Some(sensitivity) = parse_transient_sensitivity(&self.sensitivity_input) else {
+            return false;
+        };
+        self.set_sensitivity(sensitivity.percent());
+        true
+    }
 }
 
 fn parse_transient_sensitivity(input: &str) -> Option<vibez_core::onset::TransientSensitivity> {
@@ -203,10 +232,11 @@ fn parse_transient_sensitivity(input: &str) -> Option<vibez_core::onset::Transie
         .trim()
         .trim_end_matches('%')
         .trim()
-        .parse::<u8>()
+        .parse::<u16>()
         .ok()?;
-    (percent <= vibez_core::onset::TransientSensitivity::MAX_PERCENT)
-        .then(|| vibez_core::onset::TransientSensitivity::new(percent))
+    Some(vibez_core::onset::TransientSensitivity::new(
+        percent.min(u8::MAX.into()) as u8,
+    ))
 }
 
 /// Right-click context menu state.
@@ -1216,6 +1246,8 @@ mod tests {
         assert_eq!(dialog.sensitivity.percent(), 84);
         dialog.edit_sensitivity_input("nope".into());
         assert_eq!(dialog.sensitivity.percent(), 84);
+        assert!(!dialog.commit_sensitivity_input());
+        assert_eq!(dialog.sensitivity_input, "nope");
         dialog.normalize_sensitivity_input();
         assert_eq!(dialog.sensitivity_input, "84");
 
@@ -1229,6 +1261,32 @@ mod tests {
                 .percent(),
             84
         );
+    }
+
+    #[test]
+    fn deleting_an_audio_clip_dismisses_every_modal_targeting_it() {
+        let mut view = ViewState::default();
+        let location = vibez_project::TimelineLocation::Arrange;
+        let track_id = TrackId::new();
+        let clip_id = ClipId::new();
+        view.drum_rack_slice_dialog = Some(DrumRackSliceDialog {
+            location,
+            track_id,
+            clip_id,
+            markers: crate::domains::arrangement::AudioSliceMarkers::Transients,
+        });
+        view.transient_analysis_dialog = Some(TransientAnalysisDialog {
+            location,
+            track_id,
+            clip_id,
+            sensitivity: vibez_core::onset::TransientSensitivity::DEFAULT,
+            sensitivity_input: "50".into(),
+        });
+
+        view.dismiss_clip_dialogs_for(location, &HashSet::from([(track_id, clip_id)]));
+
+        assert!(view.drum_rack_slice_dialog.is_none());
+        assert!(view.transient_analysis_dialog.is_none());
     }
 
     #[test]

--- a/crates/vibez-ui/src/widgets/mod.rs
+++ b/crates/vibez-ui/src/widgets/mod.rs
@@ -19,5 +19,6 @@ mod playhead;
 pub mod swing_knob;
 pub mod timeline;
 pub mod track_header;
+pub mod transient_sensitivity_knob;
 pub mod vu_meter;
 pub mod waveform;

--- a/crates/vibez-ui/src/widgets/transient_sensitivity_knob.rs
+++ b/crates/vibez-ui/src/widgets/transient_sensitivity_knob.rs
@@ -157,9 +157,10 @@ impl canvas::Program<Message> for TransientSensitivityKnob {
                     mouse::ScrollDelta::Lines { y, .. } => y.signum(),
                     mouse::ScrollDelta::Pixels { y, .. } => y.signum(),
                 };
+                let step = if state.shift_held { 1.0 } else { 5.0 };
                 (
                     canvas::event::Status::Captured,
-                    Some(Self::message(self.percent as f32 + direction)),
+                    Some(Self::message(self.percent as f32 + direction * step)),
                 )
             }
             _ => (canvas::event::Status::Ignored, None),

--- a/crates/vibez-ui/src/widgets/transient_sensitivity_knob.rs
+++ b/crates/vibez-ui/src/widgets/transient_sensitivity_knob.rs
@@ -1,0 +1,196 @@
+//! Continuous transient-analysis sensitivity control.
+
+use iced::keyboard;
+use iced::mouse;
+use iced::widget::canvas;
+use iced::{Rectangle, Renderer, Theme};
+
+use crate::message::Message;
+use crate::theme;
+use crate::widgets::drag::ValueDrag;
+
+const ARC_START: f32 = std::f32::consts::FRAC_PI_4 * 3.0;
+const ARC_END: f32 = ARC_START + std::f32::consts::FRAC_PI_2 * 3.0;
+const NORMAL_SENSITIVITY: f32 = 1.0;
+const FINE_SENSITIVITY: f32 = 0.2;
+
+pub struct TransientSensitivityKnob {
+    percent: u8,
+}
+
+impl TransientSensitivityKnob {
+    pub fn new(percent: u8) -> Self {
+        Self {
+            percent: percent.min(100),
+        }
+    }
+
+    fn message(percent: f32) -> Message {
+        Message::SetTransientAnalysisSensitivity(percent.round().clamp(0.0, 100.0) as u8)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct TransientSensitivityKnobState {
+    drag: ValueDrag,
+    shift_held: bool,
+}
+
+impl canvas::Program<Message> for TransientSensitivityKnob {
+    type State = TransientSensitivityKnobState;
+
+    fn draw(
+        &self,
+        state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        let center = iced::Point::new(bounds.width / 2.0, bounds.height / 2.0);
+        let radius = (bounds.width.min(bounds.height) / 2.0 - 2.0).max(7.0);
+        let arc_radius = radius - 1.0;
+        let body_radius = radius - 5.5;
+        let normalized = self.percent as f32 / 100.0;
+        let value_angle = ARC_START + normalized * (ARC_END - ARC_START);
+        let engaged = state.drag.is_active() || cursor.is_over(bounds);
+        let round = canvas::Stroke {
+            line_cap: canvas::LineCap::Round,
+            ..canvas::Stroke::default()
+        };
+
+        frame.stroke(
+            &build_arc(center, arc_radius, ARC_START, ARC_END),
+            round.with_color(theme::knob_track()).with_width(3.0),
+        );
+        frame.stroke(
+            &build_arc(center, arc_radius, ARC_START, value_angle),
+            round.with_color(theme::accent()).with_width(3.0),
+        );
+
+        frame.fill(
+            &canvas::Path::circle(center, body_radius),
+            if engaged {
+                theme::knob_body_engaged()
+            } else {
+                theme::knob_body()
+            },
+        );
+        let pointer = canvas::Path::line(
+            iced::Point::new(
+                center.x + body_radius * 0.3 * value_angle.cos(),
+                center.y + body_radius * 0.3 * value_angle.sin(),
+            ),
+            iced::Point::new(
+                center.x + (body_radius - 1.0) * value_angle.cos(),
+                center.y + (body_radius - 1.0) * value_angle.sin(),
+            ),
+        );
+        frame.stroke(&pointer, round.with_color(theme::text()).with_width(2.0));
+
+        vec![frame.into_geometry()]
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Self::State,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if state.drag.is_active() {
+            mouse::Interaction::Grabbing
+        } else if cursor.is_over(bounds) {
+            mouse::Interaction::Grab
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        event: canvas::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (canvas::event::Status, Option<Message>) {
+        match event {
+            canvas::Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
+                state.shift_held = modifiers.shift();
+                (canvas::event::Status::Ignored, None)
+            }
+            canvas::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                if state.drag.grab(cursor, bounds, self.percent as f32) {
+                    (canvas::event::Status::Captured, None)
+                } else {
+                    (canvas::event::Status::Ignored, None)
+                }
+            }
+            canvas::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                if state.drag.release() {
+                    (canvas::event::Status::Captured, None)
+                } else {
+                    (canvas::event::Status::Ignored, None)
+                }
+            }
+            canvas::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                let sensitivity = if state.shift_held {
+                    FINE_SENSITIVITY
+                } else {
+                    NORMAL_SENSITIVITY
+                };
+                let message = state
+                    .drag
+                    .drag_to(cursor, 0.0, -sensitivity, 0.0..=100.0)
+                    .map(Self::message);
+                let status = if message.is_some() {
+                    canvas::event::Status::Captured
+                } else {
+                    canvas::event::Status::Ignored
+                };
+                (status, message)
+            }
+            canvas::Event::Mouse(mouse::Event::WheelScrolled { delta })
+                if cursor.is_over(bounds) =>
+            {
+                let direction = match delta {
+                    mouse::ScrollDelta::Lines { y, .. } => y.signum(),
+                    mouse::ScrollDelta::Pixels { y, .. } => y.signum(),
+                };
+                (
+                    canvas::event::Status::Captured,
+                    Some(Self::message(self.percent as f32 + direction)),
+                )
+            }
+            _ => (canvas::event::Status::Ignored, None),
+        }
+    }
+}
+
+fn build_arc(center: iced::Point, radius: f32, start: f32, end: f32) -> canvas::Path {
+    canvas::Path::new(|builder| {
+        builder.arc(canvas::path::Arc {
+            center,
+            radius,
+            start_angle: iced::Radians(start),
+            end_angle: iced::Radians(end),
+        });
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn knob_clamps_messages_to_an_exact_percentage() {
+        assert!(matches!(
+            TransientSensitivityKnob::message(71.6),
+            Message::SetTransientAnalysisSensitivity(72)
+        ));
+        assert!(matches!(
+            TransientSensitivityKnob::message(200.0),
+            Message::SetTransientAnalysisSensitivity(100)
+        ));
+    }
+}


### PR DESCRIPTION
Replaces the three immediate waveform-menu analysis commands with one Transient analysis entry and a dedicated Vibez-styled modal.

The modal has one continuous 0 to 100% sensitivity knob, an exact percentage field, mouse-wheel adjustment and clear guidance that higher values retain more attacks. Cancel, Escape and backdrop dismissal still work. Manual markers remain untouched.

Detector corrections
- sensitivity changes aubio peak thresholds without changing the established 50 ms minimum hit spacing
- aubio HFC remains the precise primary detector
- aubio energy analysis recovers bass-heavy attacks that HFC misses
- a time-domain prominence check rejects pitched decay cycles that are not useful editing boundaries
- high sensitivity can still expose those quieter events intentionally

On the exact DD 124 29E.wav loop reported in testing, the default setting now finds the 7 clear waveform attacks instead of 12 decay-cycle markers. It returns 3 strong attacks at 0%, 7 through 60%, and progressively exposes quieter events above that.

Validation
- compared the Rust HFC output with aubio 0.4.9 on the reported loop
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check