### PR TITLE
Use Drum Rack banks for audio slicing

### DIFF
--- a/crates/vibez-core/src/track.rs
+++ b/crates/vibez-core/src/track.rs
@@ -254,8 +254,10 @@ impl MediaSourceRef {
     }
 }
 
-/// Persisted state for a future native drum rack.
-pub const DRUM_RACK_PAD_COUNT: usize = 16;
+/// The rack stores four banks while the UI exposes one 4x4 bank at a time.
+pub const DRUM_RACK_BANK_SIZE: usize = 16;
+pub const DRUM_RACK_BANK_COUNT: usize = 4;
+pub const DRUM_RACK_PAD_COUNT: usize = DRUM_RACK_BANK_SIZE * DRUM_RACK_BANK_COUNT;
 pub const DRUM_RACK_BASE_NOTE: u8 = 36;
 
 pub const fn drum_rack_pad_pitch(pad_index: usize) -> Option<u8> {
@@ -840,5 +842,16 @@ mod tests {
         let relinked = reopened.linked_fade_out(50, peer, 100);
         assert_eq!(relinked.fade_out_curve(), FadeCurve::new(80));
         assert_eq!(relinked.crossfade_out_to(), Some(peer));
+    }
+
+    #[test]
+    fn drum_rack_maps_four_complete_pad_banks_above_c1() {
+        assert_eq!(DRUM_RACK_PAD_COUNT, 64);
+        assert_eq!(DRUM_RACK_BANK_COUNT, 4);
+        assert_eq!(drum_rack_pad_pitch(0), Some(36));
+        assert_eq!(drum_rack_pad_pitch(16), Some(52));
+        assert_eq!(drum_rack_pad_pitch(63), Some(99));
+        assert_eq!(drum_rack_pad_pitch(64), None);
+        assert_eq!(drum_rack_pad_index(99), Some(63));
     }
 }

--- a/crates/vibez-instruments/src/drum_rack.rs
+++ b/crates/vibez-instruments/src/drum_rack.rs
@@ -339,4 +339,16 @@ mod tests {
 
         assert!(buffer.iter().all(|sample| sample.abs() < 1e-6));
     }
+
+    #[test]
+    fn rack_renders_a_pad_from_a_later_bank() {
+        let mut rack = DrumRack::new(44_100.0);
+        rack.load_drum_pad_sample(20, make_test_audio(64, 0.5), "bank-two.wav".into());
+        rack.note_on(56, 127);
+
+        let mut buffer = vec![0.0; 128];
+        rack.render(&mut buffer, 2);
+
+        assert!(buffer.iter().any(|sample| sample.abs() > 0.0));
+    }
 }

--- a/crates/vibez-ui/src/app/project_io.rs
+++ b/crates/vibez-ui/src/app/project_io.rs
@@ -367,11 +367,7 @@ impl App {
                 source: track.sample_source.clone(),
             }),
             Some(InstrumentKind::DrumRack) => Some(InstrumentStateInfo::DrumRack {
-                pads: track
-                    .drum_rack_pads
-                    .iter()
-                    .map(UiDrumPad::to_state)
-                    .collect(),
+                pads: drum_rack_pads_for_save(&track.drum_rack_pads),
             }),
             None => None,
         };
@@ -597,7 +593,7 @@ impl App {
                         }
                     }
                     InstrumentStateInfo::DrumRack { pads } => {
-                        track.drum_rack_pads = pads.iter().map(UiDrumPad::from_state).collect();
+                        track.drum_rack_pads = expand_drum_rack_pads(pads);
                         track.selected_drum_pad = 0;
                         for (pad_index, pad) in pads.iter().cloned().enumerate() {
                             self.send_command(EngineCommand::SetDrumRackPadState {
@@ -1261,6 +1257,26 @@ fn first_remote_provenance_label(project: &Project) -> Option<String> {
         })
 }
 
+fn expand_drum_rack_pads(pads: &[vibez_core::track::DrumPadState]) -> Vec<UiDrumPad> {
+    let mut expanded = crate::state::default_drum_rack_pads();
+    for (slot, saved) in expanded.iter_mut().zip(pads) {
+        *slot = UiDrumPad::from_state(saved);
+    }
+    expanded
+}
+
+fn drum_rack_pads_for_save(pads: &[UiDrumPad]) -> Vec<vibez_core::track::DrumPadState> {
+    let empty = UiDrumPad::default().to_state();
+    let used = pads
+        .iter()
+        .rposition(|pad| pad.to_state() != empty)
+        .map_or(0, |index| index + 1);
+    let stored = used
+        .max(vibez_core::track::DRUM_RACK_BANK_SIZE)
+        .min(pads.len());
+    pads[..stored].iter().map(UiDrumPad::to_state).collect()
+}
+
 #[cfg(test)]
 mod instrument_invariant_tests {
     use super::*;
@@ -1299,5 +1315,32 @@ mod instrument_invariant_tests {
                 .map(|plugin| plugin.name.as_str()),
             Some("Surge XT")
         );
+    }
+
+    #[test]
+    fn legacy_one_bank_drum_racks_expand_without_moving_saved_pads() {
+        let first = crate::state::UiDrumPad {
+            name: Some("Kick".into()),
+            ..Default::default()
+        };
+        let mut saved = vec![first.to_state()];
+        saved.extend((1..16).map(|_| crate::state::UiDrumPad::default().to_state()));
+
+        let expanded = expand_drum_rack_pads(&saved);
+
+        assert_eq!(expanded.len(), vibez_core::track::DRUM_RACK_PAD_COUNT);
+        assert_eq!(expanded[0].name.as_deref(), Some("Kick"));
+        assert!(expanded[16..].iter().all(|pad| pad.source.is_none()));
+    }
+
+    #[test]
+    fn saving_a_multi_bank_rack_keeps_used_banks_without_serializing_empty_tail_banks() {
+        let mut pads = crate::state::default_drum_rack_pads();
+        pads[19].name = Some("Slice 20".into());
+
+        let saved = drum_rack_pads_for_save(&pads);
+
+        assert_eq!(saved.len(), 20);
+        assert_eq!(saved[19].name.as_deref(), Some("Slice 20"));
     }
 }

--- a/crates/vibez-ui/src/app/update.rs
+++ b/crates/vibez-ui/src/app/update.rs
@@ -298,8 +298,8 @@ impl App {
                         "The selected marker type has no interior slices".into()
                     } else {
                         format!(
-                            "{slice_count} slices will not fit the {}-pad Drum Rack",
-                            vibez_core::track::DRUM_RACK_PAD_COUNT
+                            "{slice_count} slices exceed the {}-pad Drum Rack",
+                            vibez_core::track::DRUM_RACK_PAD_COUNT,
                         )
                     };
                     return Task::none();

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -713,6 +713,10 @@ impl App {
         let selected_pad = track
             .selected_drum_pad
             .min(track.drum_rack_pads.len().saturating_sub(1));
+        let bank_size = vibez_core::track::DRUM_RACK_BANK_SIZE;
+        let bank_count = vibez_core::track::DRUM_RACK_BANK_COUNT;
+        let selected_bank = (selected_pad / bank_size).min(bank_count.saturating_sub(1));
+        let bank_start = selected_bank * bank_size;
         let title = Self::device_title_bar(Self::device_title_row(
             "Drum Rack",
             track_color,
@@ -723,7 +727,7 @@ impl App {
         for row_index in 0..4 {
             let mut pad_row = row![].spacing(4);
             for col_index in 0..4 {
-                let pad_index = row_index * 4 + col_index;
+                let pad_index = bank_start + row_index * 4 + col_index;
                 let pad = &track.drum_rack_pads[pad_index];
                 let active = selected_pad == pad_index;
                 let drop_target = matches!(
@@ -810,6 +814,46 @@ impl App {
             }
             grid = grid.push(pad_row);
         }
+
+        let bank_button = |label: &'static str, bank: Option<usize>| {
+            button(text(label).size(9).color(th::text_dim()))
+                .on_press_maybe(bank.map(|bank| {
+                    Message::Devices(crate::domains::devices::DevicesMsg::SelectDrumRackBank(
+                        track_id, bank,
+                    ))
+                }))
+                .padding([1, 7])
+                .style(move |_theme: &Theme, status| button::Style {
+                    background: Some(
+                        if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                            th::bg_hover()
+                        } else {
+                            th::bg_dark()
+                        }
+                        .into(),
+                    ),
+                    text_color: th::text_dim(),
+                    border: iced::Border {
+                        color: th::border(),
+                        width: 1.0,
+                        radius: 2.0.into(),
+                    },
+                    ..Default::default()
+                })
+        };
+        let bank_navigation = row![
+            text(format!("BANK {} / {bank_count}", selected_bank + 1))
+                .size(9)
+                .color(th::text_muted()),
+            horizontal_space(),
+            bank_button("‹  [", selected_bank.checked_sub(1)),
+            bank_button(
+                "]  ›",
+                (selected_bank + 1 < bank_count).then_some(selected_bank + 1)
+            ),
+        ]
+        .spacing(4)
+        .align_y(iced::Alignment::Center);
 
         let selected_name = track.drum_rack_pads[selected_pad]
             .name
@@ -1060,20 +1104,11 @@ impl App {
         ]
         .spacing(6);
 
-        // Pads and the selected pad's editor sit side by side in
-        // labeled sections; the panel scrolls horizontally so the
-        // card grows sideways, never past the rack height.
-        // Ableton-style pad bank: the grid lives in its own fixed
-        // vertical viewport with a slim scrollbar; the card height
-        // never depends on the pad count.
-        let pads_view: Element<'a, Message> = scrollable(grid)
-            .direction(scrollable::Direction::Vertical(
-                scrollable::Scrollbar::new()
-                    .width(4)
-                    .scroller_width(4)
-                    .spacing(2),
-            ))
-            .height(Length::Fixed(132.0))
+        // Pads and the selected pad's editor sit side by side. The rack owns
+        // four banks but renders one fixed 4x4 surface at a time, so adding
+        // pads never changes the device card's footprint.
+        let pads_view: Element<'a, Message> = column![bank_navigation, grid]
+            .spacing(5)
             .width(Length::Fixed(232.0))
             .into();
 

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -846,9 +846,9 @@ impl App {
                 .size(9)
                 .color(th::text_muted()),
             horizontal_space(),
-            bank_button("‹  [", selected_bank.checked_sub(1)),
+            bank_button("‹", selected_bank.checked_sub(1)),
             bank_button(
-                "]  ›",
+                "›",
                 (selected_bank + 1 < bank_count).then_some(selected_bank + 1)
             ),
         ]

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -815,8 +815,8 @@ impl App {
             grid = grid.push(pad_row);
         }
 
-        let bank_button = |label: &'static str, bank: Option<usize>| {
-            button(text(label).size(9).color(th::text_dim()))
+        let bank_button = |icon: char, bank: Option<usize>| {
+            button(icons::icon(icon).size(9).color(th::text_dim()))
                 .on_press_maybe(bank.map(|bank| {
                     Message::Devices(crate::domains::devices::DevicesMsg::SelectDrumRackBank(
                         track_id, bank,
@@ -846,9 +846,9 @@ impl App {
                 .size(9)
                 .color(th::text_muted()),
             horizontal_space(),
-            bank_button("‹", selected_bank.checked_sub(1)),
+            bank_button(icons::CHEVRON_LEFT, selected_bank.checked_sub(1)),
             bank_button(
-                "›",
+                icons::CHEVRON_RIGHT,
                 (selected_bank + 1 < bank_count).then_some(selected_bank + 1)
             ),
         ]

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -119,15 +119,20 @@ impl App {
             AudioSliceMarkers::Warp => warp_count,
         };
         let pad_count = vibez_core::track::DRUM_RACK_PAD_COUNT;
+        let bank_size = vibez_core::track::DRUM_RACK_BANK_SIZE;
+        let bank_count = vibez_core::track::DRUM_RACK_BANK_COUNT;
         let can_create = drum_rack_slice_can_create(selected_count);
         let guidance = if selected_count == 0 {
             "This marker type has no interior slices.".to_string()
         } else if selected_count > pad_count {
             format!(
-                "{selected_count} slices cannot fit {pad_count} pads. Use fewer markers or choose Warp markers."
+                "{selected_count} slices exceed the {pad_count}-pad rack. Use fewer markers or choose Warp markers."
             )
         } else {
-            format!("{selected_count} slices will fill {selected_count} of {pad_count} pads.")
+            let used_banks = selected_count.div_ceil(bank_size);
+            format!(
+                "{selected_count} slices will use {used_banks} of {bank_count} pad banks. Switch banks with [ and ]."
+            )
         };
         let cancel = button(text("Cancel").size(12).color(th::text()))
             .on_press(Message::CancelDrumRackSlice)
@@ -1123,6 +1128,7 @@ mod tests {
         assert!(!drum_rack_slice_can_create(0));
         assert!(drum_rack_slice_can_create(1));
         assert!(drum_rack_slice_can_create(16));
-        assert!(!drum_rack_slice_can_create(17));
+        assert!(drum_rack_slice_can_create(64));
+        assert!(!drum_rack_slice_can_create(65));
     }
 }

--- a/crates/vibez-ui/src/app/views_overlays.rs
+++ b/crates/vibez-ui/src/app/views_overlays.rs
@@ -130,9 +130,7 @@ impl App {
             )
         } else {
             let used_banks = selected_count.div_ceil(bank_size);
-            format!(
-                "{selected_count} slices will use {used_banks} of {bank_count} pad banks. Switch banks with [ and ]."
-            )
+            format!("{selected_count} slices will use {used_banks} of {bank_count} pad banks.")
         };
         let cancel = button(text("Cancel").size(12).color(th::text()))
             .on_press(Message::CancelDrumRackSlice)

--- a/crates/vibez-ui/src/app/views_perform_instrument.rs
+++ b/crates/vibez-ui/src/app/views_perform_instrument.rs
@@ -282,6 +282,12 @@ impl App {
         let target_overlay = self.state.perform.instrument_target_overlay;
         let range_or_bank = if target_overlay {
             format!("TARGET BANK {bank}")
+        } else if self.state.perform.instrument_target_is_drum_rack() {
+            format!(
+                "BANK {} / {}",
+                self.state.perform.drum_rack_bank() + 1,
+                vibez_core::track::DRUM_RACK_BANK_COUNT
+            )
         } else {
             format!("OCTAVE {:+}", self.state.perform.instrument_octave())
         };

--- a/crates/vibez-ui/src/domains/arrangement/slice_to_drum_rack.rs
+++ b/crates/vibez-ui/src/domains/arrangement/slice_to_drum_rack.rs
@@ -61,7 +61,7 @@ impl TimelineEditorState {
         let total_regions = boundaries.len() - 1;
         if total_regions > DRUM_RACK_PAD_COUNT {
             return failure(&format!(
-                "{total_regions} slices will not fit the {DRUM_RACK_PAD_COUNT}-pad Drum Rack; reduce the markers first"
+                "{total_regions} slices exceed the {DRUM_RACK_PAD_COUNT}-pad Drum Rack; reduce the markers first"
             ));
         }
         let source_frames = audio.num_frames() as f32;

--- a/crates/vibez-ui/src/domains/arrangement/tests/audio_markers.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests/audio_markers.rs
@@ -138,7 +138,7 @@ fn slice_to_drum_rack_turns_loop_wraps_into_distinct_flattened_pad_ranges() {
 }
 
 #[test]
-fn slice_to_drum_rack_rejects_more_regions_than_available_pads() {
+fn slice_to_drum_rack_spans_beyond_the_first_visible_pad_bank() {
     let mut arrangement = arrangement_with_tracks(1);
     let (source_track_id, source_clip_id) = add_audio_clip(&mut arrangement, 0, 0, 1_000);
     let original = &mut arrangement.tracks[0].clips[0];
@@ -167,12 +167,59 @@ fn slice_to_drum_rack_rejects_more_regions_than_available_pads() {
         },
     );
 
+    assert!(action.mark_dirty);
+    let drum_track = arrangement
+        .find_track(action.replay_project_track.unwrap())
+        .unwrap();
+    assert_eq!(
+        drum_track
+            .drum_rack_pads
+            .iter()
+            .filter(|pad| pad.source.is_some())
+            .count(),
+        20
+    );
+    assert_eq!(drum_track.note_clips[0].notes.len(), 20);
+    assert_eq!(drum_track.note_clips[0].notes[0].pitch, 36);
+    assert_eq!(drum_track.note_clips[0].notes[19].pitch, 55);
+}
+
+#[test]
+fn slice_to_drum_rack_rejects_more_than_four_pad_banks() {
+    let mut arrangement = arrangement_with_tracks(1);
+    let (source_track_id, source_clip_id) = add_audio_clip(&mut arrangement, 0, 0, 6_500);
+    let original = &mut arrangement.tracks[0].clips[0];
+    original.source = Some(MediaSourceRef::LocalFile {
+        path: "overfull-loop.wav".into(),
+    });
+    original
+        .transient_markers
+        .replace_suggestions((100..6_500).step_by(100));
+    let source = original.source.clone().unwrap();
+    let audio = Arc::clone(&original.audio);
+    let mut engine = RecordingEngine::default();
+
+    let action = arrangement.update(
+        ArrangementMsg::SliceAudioClipToDrumRack {
+            track_id: source_track_id,
+            clip_id: source_clip_id,
+            markers: AudioSliceMarkers::Transients,
+            source,
+            audio,
+        },
+        &mut engine,
+        ArrangementCtx {
+            samples_per_beat: 100.0,
+            ..ArrangementCtx::default()
+        },
+    );
+
     assert!(!action.mark_dirty);
     assert!(action.replay_project_track.is_none());
-    assert_eq!(arrangement.tracks.len(), 1);
-    let status = action.status.unwrap();
-    assert!(status.contains("20 slices"));
-    assert!(status.contains("will not fit"));
+    assert!(action
+        .status
+        .unwrap()
+        .contains("65 slices exceed the 64-pad"));
 }
 
 #[test]

--- a/crates/vibez-ui/src/domains/devices.rs
+++ b/crates/vibez-ui/src/domains/devices.rs
@@ -41,6 +41,7 @@ pub enum DevicesMsg {
     RemoveTrackInstrument(TrackId),
     SetInstrumentParam(TrackId, usize, f32),
     SelectDrumRackPad(TrackId, usize),
+    SelectDrumRackBank(TrackId, usize),
     ClearDrumRackPad(TrackId, usize),
     SetDrumPadParam {
         track_id: TrackId,
@@ -81,6 +82,7 @@ impl DevicesMsg {
             self,
             DevicesMsg::AuditionNote { .. }
                 | DevicesMsg::SelectDrumRackPad(..)
+                | DevicesMsg::SelectDrumRackBank(..)
                 | DevicesMsg::ShowContextMenu { .. }
                 | DevicesMsg::DismissContextMenu
                 | DevicesMsg::SetMenuCategory(_)
@@ -373,6 +375,18 @@ impl DevicesState {
                 if let Some(track) = find_track_mut(tracks, master, buses, track_id) {
                     let max_index = track.drum_rack_pads.len().saturating_sub(1);
                     track.selected_drum_pad = pad_index.min(max_index);
+                }
+                action.select_track = Some(track_id);
+            }
+            DevicesMsg::SelectDrumRackBank(track_id, bank_index) => {
+                if let Some(track) = find_track_mut(tracks, master, buses, track_id) {
+                    let bank_index =
+                        bank_index.min(vibez_core::track::DRUM_RACK_BANK_COUNT.saturating_sub(1));
+                    let slot = track.selected_drum_pad % vibez_core::track::DRUM_RACK_BANK_SIZE;
+                    track.selected_drum_pad = bank_index
+                        .saturating_mul(vibez_core::track::DRUM_RACK_BANK_SIZE)
+                        .saturating_add(slot)
+                        .min(track.drum_rack_pads.len().saturating_sub(1));
                 }
                 action.select_track = Some(track_id);
             }
@@ -677,6 +691,28 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn rack_bank_navigation_preserves_the_selected_slot_without_auditioning() {
+        let (mut tracks, track_id, _) = midi_track_with_effect();
+        tracks[0].drum_rack_pads = crate::state::default_drum_rack_pads();
+        tracks[0].selected_drum_pad = 3;
+        let mut devices = DevicesState::default();
+        let mut engine = RecordingEngine::default();
+
+        devices.update(
+            DevicesMsg::SelectDrumRackBank(track_id, 1),
+            &mut engine,
+            &mut tracks,
+            &mut crate::state::new_master_track(),
+            &mut [],
+            44_100,
+        );
+
+        assert_eq!(tracks[0].selected_drum_pad, 19);
+        assert!(engine.0.is_empty());
+        assert!(!DevicesMsg::SelectDrumRackBank(track_id, 2).marks_dirty());
     }
 
     #[test]

--- a/crates/vibez-ui/src/domains/perform.rs
+++ b/crates/vibez-ui/src/domains/perform.rs
@@ -603,6 +603,8 @@ impl PerformState {
                         PerformMode::Instrument => {
                             if self.instrument_target_overlay {
                                 self.banks.instrument = self.banks.instrument.saturating_sub(1);
+                            } else if self.instrument_target_is_drum_rack() {
+                                self.shift_drum_rack_bank(-1);
                             } else {
                                 self.shift_instrument_octave(-1);
                             }
@@ -646,6 +648,8 @@ impl PerformState {
                                 let last_bank = playable.saturating_sub(1) / 16;
                                 self.banks.instrument =
                                     self.banks.instrument.saturating_add(1).min(last_bank as u8);
+                            } else if self.instrument_target_is_drum_rack() {
+                                self.shift_drum_rack_bank(1);
                             } else {
                                 self.shift_instrument_octave(1);
                             }
@@ -680,9 +684,7 @@ impl PerformState {
                         .iter()
                         .any(|track| track.id == track_id && track.is_playable_midi_target())
                 {
-                    if ctx.selected_project_track != Some(track_id) {
-                        self.sync_instrument_target(Some(track_id));
-                    }
+                    self.sync_instrument_target_from_selection(Some(track_id), ctx.project_tracks);
                     return PerformAction {
                         select_project_track: Some(track_id),
                         ..PerformAction::default()
@@ -783,7 +785,7 @@ impl PerformState {
                     })
                     .flatten();
                 if let Some(track_id) = selected_instrument_target {
-                    self.sync_instrument_target(Some(track_id));
+                    self.sync_instrument_target_from_selection(Some(track_id), ctx.project_tracks);
                 }
                 let instrument_note =
                     if self.mode == PerformMode::Instrument && !self.instrument_target_overlay {

--- a/crates/vibez-ui/src/domains/perform/instrument.rs
+++ b/crates/vibez-ui/src/domains/perform/instrument.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 
 use vibez_core::id::TrackId;
+use vibez_core::midi::InstrumentKind;
 
 use crate::state::ProjectTrack;
 
@@ -166,6 +167,8 @@ impl SixteenLevelsAssignment {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(super) struct InstrumentPerformanceState {
     octave: i8,
+    drum_rack_bank: u8,
+    drum_rack_target: bool,
     computer_key_velocity: ComputerKeyVelocity,
     full_level: bool,
     sixteen_levels_enabled: bool,
@@ -186,19 +189,35 @@ impl PerformState {
         selected: Option<TrackId>,
         project_tracks: &[ProjectTrack],
     ) {
-        let playable_target = selected.filter(|track_id| {
+        let playable_target = selected.and_then(|track_id| {
             project_tracks
                 .iter()
-                .any(|track| track.id == *track_id && track.is_playable_midi_target())
+                .find(|track| track.id == track_id && track.is_playable_midi_target())
         });
-        if playable_target.is_some() {
-            self.sync_instrument_target(playable_target);
+        if let Some(track) = playable_target {
+            self.sync_instrument_target_kind(
+                track.id,
+                track.instrument_kind == Some(InstrumentKind::DrumRack),
+            );
         }
     }
 
     pub(crate) fn sync_instrument_target(&mut self, target: Option<TrackId>) {
         if self.instrument.target != target {
             self.instrument.target = target;
+            self.instrument.drum_rack_target = false;
+            self.instrument.drum_rack_bank = 0;
+            self.clear_instrument_source();
+        }
+    }
+
+    fn sync_instrument_target_kind(&mut self, target: TrackId, drum_rack: bool) {
+        let target_changed = self.instrument.target != Some(target);
+        let kind_changed = self.instrument.drum_rack_target != drum_rack;
+        if target_changed || kind_changed {
+            self.instrument.target = Some(target);
+            self.instrument.drum_rack_target = drum_rack;
+            self.instrument.drum_rack_bank = 0;
             self.clear_instrument_source();
         }
     }
@@ -215,6 +234,12 @@ impl PerformState {
             .octave
             .saturating_add(amount)
             .clamp(MIN_INSTRUMENT_OCTAVE, MAX_INSTRUMENT_OCTAVE);
+    }
+
+    pub(super) fn shift_drum_rack_bank(&mut self, amount: i8) {
+        let maximum = vibez_core::track::DRUM_RACK_BANK_COUNT.saturating_sub(1) as i16;
+        self.instrument.drum_rack_bank =
+            (i16::from(self.instrument.drum_rack_bank) + i16::from(amount)).clamp(0, maximum) as u8;
     }
 
     pub(super) fn toggle_full_level(&mut self) {
@@ -331,7 +356,22 @@ impl PerformState {
         self.instrument.octave
     }
 
+    pub const fn drum_rack_bank(&self) -> u8 {
+        self.instrument.drum_rack_bank
+    }
+
+    pub const fn instrument_target_is_drum_rack(&self) -> bool {
+        self.instrument.drum_rack_target
+    }
+
     pub fn instrument_pitch(&self, position: PadPosition) -> u8 {
+        if self.instrument.drum_rack_target {
+            let pad_index = usize::from(self.instrument.drum_rack_bank)
+                * vibez_core::track::DRUM_RACK_BANK_SIZE
+                + usize::from(position.ordinal(PerformMode::Instrument) - 1);
+            return vibez_core::track::drum_rack_pad_pitch(pad_index)
+                .expect("every configured Drum Rack bank is complete");
+        }
         let base = i16::from(INSTRUMENT_BASE_PITCH + position.ordinal(PerformMode::Instrument));
         (base + i16::from(self.instrument.octave) * 12).clamp(0, 127) as u8
     }

--- a/crates/vibez-ui/src/domains/perform/instrument_tests.rs
+++ b/crates/vibez-ui/src/domains/perform/instrument_tests.rs
@@ -301,7 +301,7 @@ fn perform_messages_send_transformed_notes_through_the_existing_engine_path() {
 }
 
 #[test]
-fn bracket_navigation_moves_a_drum_rack_by_complete_sixteen_pad_banks() {
+fn instrument_pads_fire_the_visible_drum_rack_bank() {
     let mut track = ProjectTrack::new(TrackId::new(), "Drum Rack".into(), 0);
     track.kind = vibez_core::midi::TrackKind::Midi;
     track.has_instrument = true;
@@ -317,11 +317,47 @@ fn bracket_navigation_moves_a_drum_rack_by_complete_sixteen_pad_banks() {
         ..PerformState::default()
     };
     let mut engine = RecordingEngine::default();
+    let now = std::time::Instant::now();
+
+    state.update(
+        PerformMsg::ComputerKeyPressed {
+            key: ComputerKey::Z,
+            key_id: "z".into(),
+            occurred_at: now,
+        },
+        &mut engine,
+        ctx,
+    );
+    assert!(matches!(
+        engine.0.last(),
+        Some(vibez_engine::commands::EngineCommand::ExternalNoteOn { pitch: 36, .. })
+    ));
+    state.update(
+        PerformMsg::ComputerKeyReleased {
+            key_id: "z".into(),
+            occurred_at: now,
+        },
+        &mut engine,
+        ctx,
+    );
 
     state.update(PerformMsg::NextBank, &mut engine, ctx);
 
     assert_eq!(state.instrument_pad_preview(position(0)).pitch, 52);
     assert_eq!(state.instrument_pad_preview(position(15)).pitch, 67);
+    state.update(
+        PerformMsg::ComputerKeyPressed {
+            key: ComputerKey::Z,
+            key_id: "z-bank-two".into(),
+            occurred_at: now,
+        },
+        &mut engine,
+        ctx,
+    );
+    assert!(matches!(
+        engine.0.last(),
+        Some(vibez_engine::commands::EngineCommand::ExternalNoteOn { pitch: 52, .. })
+    ));
 
     for _ in 0..8 {
         state.update(PerformMsg::NextBank, &mut engine, ctx);

--- a/crates/vibez-ui/src/domains/perform/instrument_tests.rs
+++ b/crates/vibez-ui/src/domains/perform/instrument_tests.rs
@@ -299,3 +299,37 @@ fn perform_messages_send_transformed_notes_through_the_existing_engine_path() {
         ]
     ));
 }
+
+#[test]
+fn bracket_navigation_moves_a_drum_rack_by_complete_sixteen_pad_banks() {
+    let mut track = ProjectTrack::new(TrackId::new(), "Drum Rack".into(), 0);
+    track.kind = vibez_core::midi::TrackKind::Midi;
+    track.has_instrument = true;
+    track.instrument_kind = Some(vibez_core::midi::InstrumentKind::DrumRack);
+    let tracks = vec![track];
+    let ctx = PerformCtx {
+        workspace_visible: true,
+        project_tracks: &tracks,
+        selected_project_track: Some(tracks[0].id),
+    };
+    let mut state = PerformState {
+        mode: PerformMode::Instrument,
+        ..PerformState::default()
+    };
+    let mut engine = RecordingEngine::default();
+
+    state.update(PerformMsg::NextBank, &mut engine, ctx);
+
+    assert_eq!(state.instrument_pad_preview(position(0)).pitch, 52);
+    assert_eq!(state.instrument_pad_preview(position(15)).pitch, 67);
+
+    for _ in 0..8 {
+        state.update(PerformMsg::NextBank, &mut engine, ctx);
+    }
+    assert_eq!(state.drum_rack_bank(), 3);
+    assert_eq!(state.instrument_pad_preview(position(15)).pitch, 99);
+
+    state.update(PerformMsg::PreviousBank, &mut engine, ctx);
+    assert_eq!(state.drum_rack_bank(), 2);
+    assert_eq!(state.instrument_pad_preview(position(0)).pitch, 68);
+}

--- a/crates/vibez-ui/src/icons.rs
+++ b/crates/vibez-ui/src/icons.rs
@@ -23,6 +23,7 @@ pub const TRASH_2: char = '\u{E18E}';
 pub const X: char = '\u{E1B2}';
 pub const CHEVRON_UP: char = '\u{E070}';
 pub const CHEVRON_DOWN: char = '\u{E06D}';
+pub const CHEVRON_LEFT: char = '\u{E06E}';
 pub const CHEVRON_RIGHT: char = '\u{E06F}';
 pub const SLIDERS_VERTICAL: char = '\u{E162}';
 pub const LAYOUT_LIST: char = '\u{E1D9}';


### PR DESCRIPTION
Expands the native Drum Rack from one 16-pad bank to four banks and makes Slice to Drum Rack use the complete 64-pad capacity.

What changed
- the core pad map and DSP instrument now own 64 pads across four 16-pad banks
- Slice to Drum Rack accepts up to 64 regions and maps reconstruction notes across every bank
- the slice modal reports how many banks the result will use
- Perform keeps ownership of the bracket shortcuts and moves its Instrument surface through complete 16-pad Drum Rack pages
- the Drum Rack device has separate local arrow controls with no bracket labels
- playing Perform pads in Instrument mode sends the notes for the visible Drum Rack bank
- synths and samplers retain octave navigation
- legacy 16-pad projects reopen into bank one without moving samples
- saves retain used later-bank pads while omitting empty tail banks

Root cause
The visible 4x4 surface size had been used as the Drum Rack domain capacity, so the slicer, engine and project model all inherited a UI limit.

Validation
- the Instrument path is tested through the real engine command boundary at notes 36 and 52
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check