### PR TITLE
fix: place transient markers on audio attack boundaries

### DIFF
--- a/crates/vibez-audio-io/examples/transient_benchmark.rs
+++ b/crates/vibez-audio-io/examples/transient_benchmark.rs
@@ -7,7 +7,11 @@ use std::{env, fs, path::PathBuf, process};
 
 use serde::Deserialize;
 use vibez_audio_io::file_io::decode_audio_file;
-use vibez_core::onset::{detect_onsets, TransientSensitivity};
+use vibez_core::onset::{
+    detect_onsets,
+    metrics::{evaluate, Evaluation},
+    TransientSensitivity,
+};
 
 #[derive(Debug, Deserialize)]
 struct Manifest {
@@ -29,119 +33,6 @@ struct Case {
 
 fn default_sensitivity() -> u8 {
     TransientSensitivity::DEFAULT.percent()
-}
-
-#[derive(Debug, Default)]
-struct Evaluation {
-    correct: usize,
-    false_positives: usize,
-    false_negatives: usize,
-    doubled: usize,
-    signed_errors_ms: Vec<f64>,
-}
-
-impl Evaluation {
-    fn precision(&self) -> f64 {
-        self.correct as f64 / (self.correct + self.false_positives).max(1) as f64
-    }
-
-    fn recall(&self) -> f64 {
-        self.correct as f64 / (self.correct + self.false_negatives).max(1) as f64
-    }
-
-    fn f1(&self) -> f64 {
-        let precision = self.precision();
-        let recall = self.recall();
-        if precision + recall == 0.0 {
-            0.0
-        } else {
-            2.0 * precision * recall / (precision + recall)
-        }
-    }
-
-    fn merge(&mut self, other: Self) {
-        self.correct += other.correct;
-        self.false_positives += other.false_positives;
-        self.false_negatives += other.false_negatives;
-        self.doubled += other.doubled;
-        self.signed_errors_ms.extend(other.signed_errors_ms);
-    }
-
-    fn median_absolute_error_ms(&self) -> f64 {
-        percentile(
-            self.signed_errors_ms
-                .iter()
-                .map(|error| error.abs())
-                .collect(),
-            0.5,
-        )
-    }
-
-    fn p95_absolute_error_ms(&self) -> f64 {
-        percentile(
-            self.signed_errors_ms
-                .iter()
-                .map(|error| error.abs())
-                .collect(),
-            0.95,
-        )
-    }
-
-    fn mean_signed_error_ms(&self) -> f64 {
-        if self.signed_errors_ms.is_empty() {
-            0.0
-        } else {
-            self.signed_errors_ms.iter().sum::<f64>() / self.signed_errors_ms.len() as f64
-        }
-    }
-}
-
-fn percentile(mut values: Vec<f64>, percentile: f64) -> f64 {
-    if values.is_empty() {
-        return 0.0;
-    }
-    values.sort_by(f64::total_cmp);
-    let index = ((values.len() as f64 * percentile).ceil() as usize)
-        .saturating_sub(1)
-        .min(values.len() - 1);
-    values[index]
-}
-
-fn evaluate(
-    detected: &[u64],
-    expected: &[u64],
-    tolerance_frames: u64,
-    sample_rate: u32,
-) -> Evaluation {
-    let mut matched = vec![false; expected.len()];
-    let mut evaluation = Evaluation::default();
-
-    for &candidate in detected {
-        let nearest = expected
-            .iter()
-            .enumerate()
-            .filter(|(index, onset)| {
-                !matched[*index] && candidate.abs_diff(**onset) <= tolerance_frames
-            })
-            .min_by_key(|(_, onset)| candidate.abs_diff(**onset));
-        if let Some((index, onset)) = nearest {
-            matched[index] = true;
-            evaluation.correct += 1;
-            evaluation
-                .signed_errors_ms
-                .push((candidate as f64 - *onset as f64) * 1_000.0 / f64::from(sample_rate));
-        } else {
-            evaluation.false_positives += 1;
-            if expected
-                .iter()
-                .any(|onset| candidate.abs_diff(*onset) <= tolerance_frames)
-            {
-                evaluation.doubled += 1;
-            }
-        }
-    }
-    evaluation.false_negatives = matched.iter().filter(|matched| !**matched).count();
-    evaluation
 }
 
 fn report(label: &str, evaluation: &Evaluation) {
@@ -193,20 +84,5 @@ fn main() {
     if let Err(error) = run() {
         eprintln!("{error}");
         process::exit(2);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn one_to_one_matching_counts_a_second_detection_as_doubled() {
-        let evaluation = evaluate(&[100, 105, 200], &[100, 200], 10, 1_000);
-        assert_eq!(evaluation.correct, 2);
-        assert_eq!(evaluation.false_positives, 1);
-        assert_eq!(evaluation.false_negatives, 0);
-        assert_eq!(evaluation.doubled, 1);
-        assert_eq!(evaluation.f1(), 0.8);
     }
 }

--- a/crates/vibez-audio-io/examples/transient_benchmark.rs
+++ b/crates/vibez-audio-io/examples/transient_benchmark.rs
@@ -1,0 +1,212 @@
+//! Evaluate Vibez transient detection against a private annotation manifest.
+//!
+//! Run with:
+//! `cargo run -p vibez-audio-io --example transient_benchmark -- manifest.json`
+
+use std::{env, fs, path::PathBuf, process};
+
+use serde::Deserialize;
+use vibez_audio_io::file_io::decode_audio_file;
+use vibez_core::onset::{detect_onsets, TransientSensitivity};
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    tolerance_ms: f64,
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    name: String,
+    category: String,
+    path: PathBuf,
+    /// Producer-approved source frames. The implicit clip-start boundary is
+    /// excluded because Vibez does not display it as a Transient Marker.
+    expected_frames: Vec<u64>,
+    #[serde(default = "default_sensitivity")]
+    sensitivity_percent: u8,
+}
+
+fn default_sensitivity() -> u8 {
+    TransientSensitivity::DEFAULT.percent()
+}
+
+#[derive(Debug, Default)]
+struct Evaluation {
+    correct: usize,
+    false_positives: usize,
+    false_negatives: usize,
+    doubled: usize,
+    signed_errors_ms: Vec<f64>,
+}
+
+impl Evaluation {
+    fn precision(&self) -> f64 {
+        self.correct as f64 / (self.correct + self.false_positives).max(1) as f64
+    }
+
+    fn recall(&self) -> f64 {
+        self.correct as f64 / (self.correct + self.false_negatives).max(1) as f64
+    }
+
+    fn f1(&self) -> f64 {
+        let precision = self.precision();
+        let recall = self.recall();
+        if precision + recall == 0.0 {
+            0.0
+        } else {
+            2.0 * precision * recall / (precision + recall)
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.correct += other.correct;
+        self.false_positives += other.false_positives;
+        self.false_negatives += other.false_negatives;
+        self.doubled += other.doubled;
+        self.signed_errors_ms.extend(other.signed_errors_ms);
+    }
+
+    fn median_absolute_error_ms(&self) -> f64 {
+        percentile(
+            self.signed_errors_ms
+                .iter()
+                .map(|error| error.abs())
+                .collect(),
+            0.5,
+        )
+    }
+
+    fn p95_absolute_error_ms(&self) -> f64 {
+        percentile(
+            self.signed_errors_ms
+                .iter()
+                .map(|error| error.abs())
+                .collect(),
+            0.95,
+        )
+    }
+
+    fn mean_signed_error_ms(&self) -> f64 {
+        if self.signed_errors_ms.is_empty() {
+            0.0
+        } else {
+            self.signed_errors_ms.iter().sum::<f64>() / self.signed_errors_ms.len() as f64
+        }
+    }
+}
+
+fn percentile(mut values: Vec<f64>, percentile: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.sort_by(f64::total_cmp);
+    let index = ((values.len() as f64 * percentile).ceil() as usize)
+        .saturating_sub(1)
+        .min(values.len() - 1);
+    values[index]
+}
+
+fn evaluate(
+    detected: &[u64],
+    expected: &[u64],
+    tolerance_frames: u64,
+    sample_rate: u32,
+) -> Evaluation {
+    let mut matched = vec![false; expected.len()];
+    let mut evaluation = Evaluation::default();
+
+    for &candidate in detected {
+        let nearest = expected
+            .iter()
+            .enumerate()
+            .filter(|(index, onset)| {
+                !matched[*index] && candidate.abs_diff(**onset) <= tolerance_frames
+            })
+            .min_by_key(|(_, onset)| candidate.abs_diff(**onset));
+        if let Some((index, onset)) = nearest {
+            matched[index] = true;
+            evaluation.correct += 1;
+            evaluation
+                .signed_errors_ms
+                .push((candidate as f64 - *onset as f64) * 1_000.0 / f64::from(sample_rate));
+        } else {
+            evaluation.false_positives += 1;
+            if expected
+                .iter()
+                .any(|onset| candidate.abs_diff(*onset) <= tolerance_frames)
+            {
+                evaluation.doubled += 1;
+            }
+        }
+    }
+    evaluation.false_negatives = matched.iter().filter(|matched| !**matched).count();
+    evaluation
+}
+
+fn report(label: &str, evaluation: &Evaluation) {
+    println!(
+        "{label}: P={:.3} R={:.3} F1={:.3} FP={} FN={} doubled={} mean_signed={:.2}ms median_abs={:.2}ms p95_abs={:.2}ms",
+        evaluation.precision(),
+        evaluation.recall(),
+        evaluation.f1(),
+        evaluation.false_positives,
+        evaluation.false_negatives,
+        evaluation.doubled,
+        evaluation.mean_signed_error_ms(),
+        evaluation.median_absolute_error_ms(),
+        evaluation.p95_absolute_error_ms(),
+    );
+}
+
+fn run() -> Result<(), String> {
+    let manifest_path = env::args()
+        .nth(1)
+        .ok_or_else(|| "usage: transient_benchmark <manifest.json>".to_owned())?;
+    let manifest_text = fs::read_to_string(&manifest_path)
+        .map_err(|error| format!("read {manifest_path}: {error}"))?;
+    let manifest: Manifest = serde_json::from_str(&manifest_text)
+        .map_err(|error| format!("parse {manifest_path}: {error}"))?;
+    let mut total = Evaluation::default();
+
+    for case in manifest.cases {
+        let audio = decode_audio_file(&case.path)
+            .map_err(|error| format!("decode {}: {error}", case.path.display()))?;
+        let detected = detect_onsets(&audio, TransientSensitivity::new(case.sensitivity_percent));
+        let tolerance_frames =
+            (manifest.tolerance_ms * f64::from(audio.sample_rate) / 1_000.0).round() as u64;
+        let evaluation = evaluate(
+            &detected,
+            &case.expected_frames,
+            tolerance_frames,
+            audio.sample_rate,
+        );
+        report(&format!("{} [{}]", case.name, case.category), &evaluation);
+        total.merge(evaluation);
+    }
+
+    report("TOTAL", &total);
+    Ok(())
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("{error}");
+        process::exit(2);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_to_one_matching_counts_a_second_detection_as_doubled() {
+        let evaluation = evaluate(&[100, 105, 200], &[100, 200], 10, 1_000);
+        assert_eq!(evaluation.correct, 2);
+        assert_eq!(evaluation.false_positives, 1);
+        assert_eq!(evaluation.false_negatives, 0);
+        assert_eq!(evaluation.doubled, 1);
+        assert_eq!(evaluation.f1(), 0.8);
+    }
+}

--- a/crates/vibez-core/src/onset.rs
+++ b/crates/vibez-core/src/onset.rs
@@ -697,12 +697,18 @@ mod tests {
 
     #[test]
     fn sensitivity_affects_yield() {
-        // Low-amplitude impulses: high sensitivity should retain at least as
-        // many as low sensitivity.
+        // A clip with attacks at different levels must produce fewer markers
+        // at the strong-attacks end and progressively retain quieter attacks
+        // as sensitivity increases. Equal result sets would make the producer
+        // control a no-op even though they technically remain nested.
         let sr = 44_100u32;
         let mut buf = vec![0.0f32; 44_100];
-        for i in (2_000..40_000).step_by(5_000) {
-            buf[i] = 0.05;
+        for (index, amplitude) in [1.0f32, 0.5, 0.2, 0.08, 0.02].into_iter().enumerate() {
+            let start = 2_000 + index * 8_000;
+            for offset in 0..1_024 {
+                let phase = std::f32::consts::TAU * 120.0 * offset as f32 / sr as f32;
+                buf[start + offset] += phase.sin() * (-(offset as f32) / 300.0).exp() * amplitude;
+            }
         }
         let audio = make_audio(vec![buf.clone(), buf], sr);
         let results = [0, 25, 50, 75, 100]
@@ -715,6 +721,14 @@ mod tests {
                 pair[0],
             );
         }
+        assert!(
+            results[0].len() < results[4].len(),
+            "sensitivity endpoints must differ: {results:?}"
+        );
+        assert!(
+            results.windows(2).filter(|pair| pair[0] != pair[1]).count() >= 2,
+            "sensitivity must provide more than one useful step: {results:?}"
+        );
     }
 
     #[test]

--- a/crates/vibez-core/src/onset.rs
+++ b/crates/vibez-core/src/onset.rs
@@ -1,9 +1,10 @@
 //! Offline transient / onset detection and BPM estimation for audio
 //! clips.
 //!
-//! Transient detection is a Rust port of aubio 0.4.9's established HFC onset
-//! pipeline. Tempo estimation retains a separate onset-envelope signal for its
-//! autocorrelation input.
+//! Transient event candidates use a Rust port of aubio 0.4.9's established
+//! complex-domain onset pipeline. Accepted event peaks are backtracked to an
+//! energy minimum so editing markers land at slice boundaries. Tempo
+//! estimation retains a separate onset-envelope signal for autocorrelation.
 //!
 //! Two entrypoints:
 //! - `detect_onsets` returns `Vec<u64>` of absolute frame indices.
@@ -17,6 +18,8 @@
 use crate::audio_buffer::DecodedAudio;
 
 mod aubio;
+#[cfg(test)]
+mod transient_analysis_tests;
 
 /// Producer-facing transient sensitivity. Higher percentages retain quieter
 /// attacks; lower percentages keep only the most prominent attacks.
@@ -44,17 +47,14 @@ impl TransientSensitivity {
         self.0 as f32 / Self::MAX_PERCENT as f32
     }
 
-    fn log_interpolate(self, low: f32, midpoint: f32, high: f32) -> f32 {
+    #[cfg(test)]
+    fn threshold_through(self, midpoint: f32) -> f32 {
         let normalized = self.normalized();
         if normalized <= 0.5 {
-            low * (midpoint / low).powf(normalized / 0.5)
+            0.9 * (midpoint / 0.9).powf(normalized / 0.5)
         } else {
-            midpoint * (high / midpoint).powf((normalized - 0.5) / 0.5)
+            midpoint * (0.001 / midpoint).powf((normalized - 0.5) / 0.5)
         }
-    }
-
-    fn peak_threshold(self, midpoint: f32) -> f32 {
-        self.log_interpolate(0.9, midpoint, 0.001)
     }
 }
 
@@ -76,54 +76,70 @@ const PREEMPHASIS: f32 = 0.97;
 
 /// Detect onsets in `audio` and return sample indices.
 ///
-/// Sensitivity changes aubio's peak-picking threshold without changing its
-/// minimum inter-onset interval. Higher percentages retain more attacks.
+/// Candidate generation is fixed so sensitivity can only add or remove stable
+/// source-frame positions. Higher percentages retain quieter attacks.
 pub fn detect_onsets(audio: &DecodedAudio, sensitivity: TransientSensitivity) -> Vec<u64> {
     let frames = audio.num_frames();
     if frames < 1_024 || audio.sample_rate == 0 {
         return Vec::new();
     }
-    let mono = mix_to_mono(audio, frames);
+    // Analyse channels independently. Averaging stereo before analysis can
+    // erase an attack when channels carry opposite-polarity content.
+    let mut candidates = audio
+        .channels
+        .iter()
+        .flat_map(|channel| {
+            let config = aubio::Config::for_complex_candidates(audio.sample_rate);
+            let analysis_delay = config.analysis_delay_frames();
+            aubio::detect_complex_onsets(channel, audio.sample_rate, config)
+                .into_iter()
+                .map(move |estimated_onset| {
+                    (
+                        estimated_onset,
+                        estimated_onset.saturating_add(analysis_delay),
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+
+    // Aubio's spectral descriptors can report a pitched decay cycle as a new
+    // onset. Transient markers are editing boundaries, so require each
+    // spectral candidate to coincide with a meaningful time-domain attack.
     let global_peak = audio
         .channels
         .iter()
         .flat_map(|channel| channel.iter())
         .map(|sample| sample.abs())
         .fold(0.0f32, f32::max);
-    let accepts_attack =
-        |frame: usize| frame > 0 && genuine_attack(audio, frame as u64, sensitivity, global_peak);
-    let mut onsets = aubio::detect_onsets_where(
-        &mono,
-        audio.sample_rate,
-        aubio::Config::for_sensitivity(sensitivity),
-        accepts_attack,
-    );
-    let energy_onsets = aubio::detect_energy_onsets_where(
-        &mono,
-        audio.sample_rate,
-        aubio::Config::for_energy_sensitivity(sensitivity),
-        accepts_attack,
-    );
-
-    // HFC is precise on bright attacks but can miss bass-heavy hits. Aubio's
-    // energy descriptor covers those. Keep HFC's timing when both descriptors
-    // identify the same attack, and add only genuinely distinct energy hits.
-    let merge_radius = frames_for_ms(audio.sample_rate, 50.0) as u64;
-    for frame in energy_onsets {
-        if !onsets.iter().any(|hfc| hfc.abs_diff(frame) <= merge_radius) {
-            onsets.push(frame);
-        }
-    }
-    onsets.sort_unstable();
-
+    candidates.retain(|&(estimated_onset, _)| {
+        estimated_onset > 0 && genuine_attack(audio, estimated_onset, sensitivity, global_peak)
+    });
+    // Aubio subtracts its analysis delay to estimate the musical onset. For
+    // slice localisation we instead begin at the later detected peak, then
+    // backtrack through source energy to the actual boundary. Starting from
+    // the compensated estimate can put an impulse before its own attack.
+    let peaks = candidates
+        .into_iter()
+        .map(|(_, detected_peak)| detected_peak)
+        .collect::<Vec<_>>();
+    let mut onsets = backtrack_to_energy_minima(audio, &peaks);
     // Clip start is already an explicit boundary in Vibez. Aubio reports a
     // non-silent file start as an onset, but showing that as a suggested
     // transient marker adds no editable information.
     onsets.retain(|&frame| frame > 0 && frame < frames as u64);
-    onsets
+    onsets.sort_unstable();
+    let mut canonical = Vec::with_capacity(onsets.len());
+    for onset in onsets {
+        if canonical.last().is_none_or(|previous: &u64| {
+            onset.abs_diff(*previous) > frames_for_ms(audio.sample_rate, BACKTRACK_HOP_MS) as u64
+        }) {
+            canonical.push(onset);
+        }
+    }
+    canonical
 }
 
-pub(super) fn frames_for_ms(sample_rate: u32, milliseconds: f32) -> usize {
+fn frames_for_ms(sample_rate: u32, milliseconds: f32) -> usize {
     (sample_rate as f32 * milliseconds / 1_000.0).round() as usize
 }
 
@@ -168,8 +184,111 @@ fn peak_and_rms(audio: &DecodedAudio, start: usize, end: usize) -> (f32, f32) {
     (peak, rms)
 }
 
+const BACKTRACK_WINDOW_MS: f32 = 23.22;
+const BACKTRACK_HOP_MS: f32 = 2.9;
+const BACKTRACK_MAX_MS: f32 = 50.0;
+
+fn backtrack_to_energy_minima(audio: &DecodedAudio, onsets: &[u64]) -> Vec<u64> {
+    if onsets.is_empty() || audio.num_frames() < 3 {
+        return onsets.to_vec();
+    }
+
+    let hop = frames_for_ms(audio.sample_rate, BACKTRACK_HOP_MS).max(1);
+    let window = frames_for_ms(audio.sample_rate, BACKTRACK_WINDOW_MS).max(1);
+    let energy = rms_energy_envelope(audio, window, hop);
+    backtrack_events_to_minima(
+        onsets,
+        &energy,
+        hop,
+        frames_for_ms(audio.sample_rate, BACKTRACK_MAX_MS),
+    )
+}
+
+fn rms_energy_envelope(audio: &DecodedAudio, window: usize, hop: usize) -> Vec<f32> {
+    let frames = audio.num_frames();
+    if frames == 0 || window == 0 || hop == 0 {
+        return Vec::new();
+    }
+
+    let channel_count = audio.channels.len().max(1) as f64;
+    let mut prefix_energy = vec![0.0f64; frames + 1];
+    for frame in 0..frames {
+        let square_sum = audio
+            .channels
+            .iter()
+            .map(|channel| f64::from(channel.get(frame).copied().unwrap_or(0.0)).powi(2))
+            .sum::<f64>();
+        prefix_energy[frame + 1] = prefix_energy[frame] + square_sum / channel_count;
+    }
+
+    (0..frames)
+        .step_by(hop)
+        .map(|end| {
+            // A trailing RMS window keeps the final silence minimum aligned
+            // with the source attack. A centred window would smear future
+            // attack energy earlier by half a window and make slices early.
+            let start = end.saturating_sub(window);
+            let frame_count = (end - start).max(1) as f64;
+            ((prefix_energy[end] - prefix_energy[start]) / frame_count).sqrt() as f32
+        })
+        .collect()
+}
+
+// The local-minimum matching rule is derived from librosa 0.11.0's
+// `onset_backtrack`, copyright (c) 2013-2023 the librosa development team,
+// distributed under the ISC licence:
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+// Vibez adds a bounded look-back expressed in source frames because a DAW
+// marker must not jump into an earlier event.
+fn backtrack_events_to_minima(
+    events: &[u64],
+    energy: &[f32],
+    hop: usize,
+    max_lookback: usize,
+) -> Vec<u64> {
+    if energy.len() < 3 || hop == 0 {
+        return events.to_vec();
+    }
+
+    let mut minima = vec![0usize];
+    minima.extend(energy.windows(3).enumerate().filter_map(|(index, values)| {
+        (values[1] <= values[0] && values[1] < values[2]).then_some(index + 1)
+    }));
+
+    events
+        .iter()
+        .map(|&event| {
+            let event = usize::try_from(event).unwrap_or(usize::MAX);
+            let first_allowed = event.saturating_sub(max_lookback);
+            minima
+                .iter()
+                .rev()
+                .map(|minimum| minimum.saturating_mul(hop))
+                .find(|minimum| *minimum <= event && *minimum >= first_allowed)
+                .map_or(event as u64, |minimum| minimum as u64)
+        })
+        .collect()
+}
+
 fn attack_prominence_floor(sensitivity: TransientSensitivity) -> f32 {
-    sensitivity.log_interpolate(0.6, 0.1, 0.005)
+    let normalized = sensitivity.normalized();
+    if normalized <= 0.5 {
+        0.6 * (0.1f32 / 0.6).powf(normalized / 0.5)
+    } else {
+        0.1 * (0.005f32 / 0.1).powf((normalized - 0.5) / 0.5)
+    }
 }
 
 fn mix_to_mono(audio: &DecodedAudio, frames: usize) -> Vec<f32> {
@@ -578,50 +697,24 @@ mod tests {
 
     #[test]
     fn sensitivity_affects_yield() {
+        // Low-amplitude impulses: high sensitivity should retain at least as
+        // many as low sensitivity.
         let sr = 44_100u32;
-        let amplitudes = [1.0f32, 0.65, 0.35, 0.18, 0.08, 0.03];
-        let mut buf = vec![0.0f32; 40_000];
-        for (index, amplitude) in amplitudes.into_iter().enumerate() {
-            let start = 2_000 + index * 5_512;
-            for offset in 0..1_024 {
-                let phase = std::f32::consts::TAU * 180.0 * offset as f32 / sr as f32;
-                buf[start + offset] = phase.sin() * (-(offset as f32) / 260.0).exp() * amplitude;
-            }
+        let mut buf = vec![0.0f32; 44_100];
+        for i in (2_000..40_000).step_by(5_000) {
+            buf[i] = 0.05;
         }
         let audio = make_audio(vec![buf.clone(), buf], sr);
-        let low = detect_onsets(&audio, TransientSensitivity::new(0)).len();
-        let high = detect_onsets(&audio, TransientSensitivity::new(100)).len();
-        assert!(
-            high > low,
-            "graded attacks must produce more markers at high sensitivity ({high}) than low ({low})",
-        );
-    }
-
-    #[test]
-    fn sensitivity_sweep_never_loses_an_accepted_attack() {
-        let sr = 44_100u32;
-        let mut channel = vec![0.0f32; 50_000];
-        for (index, amplitude) in [1.0f32, 0.8, 0.55, 0.3, 0.14, 0.06].into_iter().enumerate() {
-            let start = 2_000 + index * 5_512;
-            for offset in 0..1_024 {
-                let phase = std::f32::consts::TAU * 160.0 * offset as f32 / sr as f32;
-                channel[start + offset] =
-                    phase.sin() * (-(offset as f32) / 280.0).exp() * amplitude;
-            }
+        let results = [0, 25, 50, 75, 100]
+            .map(|percent| detect_onsets(&audio, TransientSensitivity::new(percent)));
+        for pair in results.windows(2) {
+            assert!(
+                pair[0].iter().all(|onset| pair[1].contains(onset)),
+                "higher sensitivity {:?} must retain every lower-sensitivity marker {:?}",
+                pair[1],
+                pair[0],
+            );
         }
-        let audio = make_audio(vec![channel.clone(), channel], sr);
-        let counts: Vec<_> = (0..=10)
-            .map(|step| detect_onsets(&audio, TransientSensitivity::new(step * 10)).len())
-            .collect();
-
-        assert!(
-            counts.windows(2).all(|pair| pair[0] <= pair[1]),
-            "sensitivity sweep must be monotonic, got {counts:?}"
-        );
-        assert!(
-            counts.last() > counts.first(),
-            "sweep needs useful travel: {counts:?}"
-        );
     }
 
     #[test]

--- a/crates/vibez-core/src/onset.rs
+++ b/crates/vibez-core/src/onset.rs
@@ -83,13 +83,13 @@ pub fn detect_onsets(audio: &DecodedAudio, sensitivity: TransientSensitivity) ->
     if frames < 1_024 || audio.sample_rate == 0 {
         return Vec::new();
     }
+    let config = aubio::Config::for_complex_candidates(audio.sample_rate);
     // Analyse channels independently. Averaging stereo before analysis can
     // erase an attack when channels carry opposite-polarity content.
     let mut candidates = audio
         .channels
         .iter()
         .flat_map(|channel| {
-            let config = aubio::Config::for_complex_candidates(audio.sample_rate);
             let analysis_delay = config.analysis_delay_frames();
             aubio::detect_complex_onsets(channel, audio.sample_rate, config)
                 .into_iter()
@@ -127,12 +127,20 @@ pub fn detect_onsets(audio: &DecodedAudio, sensitivity: TransientSensitivity) ->
     // non-silent file start as an onset, but showing that as a suggested
     // transient marker adds no editable information.
     onsets.retain(|&frame| frame > 0 && frame < frames as u64);
+    canonicalize_onsets(
+        &mut onsets,
+        config.minimum_inter_onset_frames(audio.sample_rate),
+    )
+}
+
+fn canonicalize_onsets(onsets: &mut [u64], minimum_interval_frames: u64) -> Vec<u64> {
     onsets.sort_unstable();
     let mut canonical = Vec::with_capacity(onsets.len());
-    for onset in onsets {
-        if canonical.last().is_none_or(|previous: &u64| {
-            onset.abs_diff(*previous) > frames_for_ms(audio.sample_rate, BACKTRACK_HOP_MS) as u64
-        }) {
+    for &onset in onsets.iter() {
+        if canonical
+            .last()
+            .is_none_or(|previous: &u64| onset.abs_diff(*previous) > minimum_interval_frames)
+        {
             canonical.push(onset);
         }
     }
@@ -728,6 +736,20 @@ mod tests {
         assert!(
             results.windows(2).filter(|pair| pair[0] != pair[1]).count() >= 2,
             "sensitivity must provide more than one useful step: {results:?}"
+        );
+    }
+
+    #[test]
+    fn canonical_onsets_merge_cross_channel_candidates_within_aubio_minimum_interval() {
+        let sample_rate = 44_100u32;
+        let first = 10_000u64;
+        let mut onsets = vec![first, first + frames_for_ms(sample_rate, 7.0) as u64];
+        let minimum_interval = aubio::Config::for_complex_candidates(sample_rate)
+            .minimum_inter_onset_frames(sample_rate);
+
+        assert_eq!(
+            canonicalize_onsets(&mut onsets, minimum_interval),
+            vec![first]
         );
     }
 

--- a/crates/vibez-core/src/onset.rs
+++ b/crates/vibez-core/src/onset.rs
@@ -18,8 +18,13 @@
 use crate::audio_buffer::DecodedAudio;
 
 mod aubio;
+mod localize;
+#[doc(hidden)]
+pub mod metrics;
 #[cfg(test)]
 mod transient_analysis_tests;
+
+use localize::{backtrack_to_energy_minima, canonicalize_onsets};
 
 /// Producer-facing transient sensitivity. Higher percentages retain quieter
 /// attacks; lower percentages keep only the most prominent attacks.
@@ -47,14 +52,8 @@ impl TransientSensitivity {
         self.0 as f32 / Self::MAX_PERCENT as f32
     }
 
-    #[cfg(test)]
     fn threshold_through(self, midpoint: f32) -> f32 {
-        let normalized = self.normalized();
-        if normalized <= 0.5 {
-            0.9 * (midpoint / 0.9).powf(normalized / 0.5)
-        } else {
-            midpoint * (0.001 / midpoint).powf((normalized - 0.5) / 0.5)
-        }
+        three_point_log_interpolation(self.normalized(), 0.9, midpoint, 0.001)
     }
 }
 
@@ -76,75 +75,40 @@ const PREEMPHASIS: f32 = 0.97;
 
 /// Detect onsets in `audio` and return sample indices.
 ///
-/// Candidate generation is fixed so sensitivity can only add or remove stable
-/// source-frame positions. Higher percentages retain quieter attacks.
+/// Higher sensitivity accepts quieter spectral and time-domain attacks.
 pub fn detect_onsets(audio: &DecodedAudio, sensitivity: TransientSensitivity) -> Vec<u64> {
     let frames = audio.num_frames();
     if frames < 1_024 || audio.sample_rate == 0 {
         return Vec::new();
     }
-    let config = aubio::Config::for_complex_candidates(audio.sample_rate);
-    // Analyse channels independently. Averaging stereo before analysis can
-    // erase an attack when channels carry opposite-polarity content.
-    let mut candidates = audio
-        .channels
-        .iter()
-        .flat_map(|channel| {
-            let analysis_delay = config.analysis_delay_frames();
-            aubio::detect_complex_onsets(channel, audio.sample_rate, config)
-                .into_iter()
-                .map(move |estimated_onset| {
-                    (
-                        estimated_onset,
-                        estimated_onset.saturating_add(analysis_delay),
-                    )
-                })
-        })
-        .collect::<Vec<_>>();
-
-    // Aubio's spectral descriptors can report a pitched decay cycle as a new
-    // onset. Transient markers are editing boundaries, so require each
-    // spectral candidate to coincide with a meaningful time-domain attack.
+    let config = aubio::Config::for_complex_candidates(audio.sample_rate, sensitivity);
     let global_peak = audio
         .channels
         .iter()
         .flat_map(|channel| channel.iter())
         .map(|sample| sample.abs())
         .fold(0.0f32, f32::max);
-    candidates.retain(|&(estimated_onset, _)| {
-        estimated_onset > 0 && genuine_attack(audio, estimated_onset, sensitivity, global_peak)
-    });
+    // Analyse channels independently. Averaging stereo before analysis can
+    // erase an attack when channels carry opposite-polarity content.
+    let candidates = audio
+        .channels
+        .iter()
+        .flat_map(|channel| {
+            aubio::detect_complex_onsets_where(channel, audio.sample_rate, config, |onset| {
+                onset > 0 && genuine_attack(audio, onset, sensitivity, global_peak)
+            })
+        })
+        .collect::<Vec<_>>();
     // Aubio subtracts its analysis delay to estimate the musical onset. For
     // slice localisation we instead begin at the later detected peak, then
     // backtrack through source energy to the actual boundary. Starting from
     // the compensated estimate can put an impulse before its own attack.
-    let peaks = candidates
-        .into_iter()
-        .map(|(_, detected_peak)| detected_peak)
-        .collect::<Vec<_>>();
-    let mut onsets = backtrack_to_energy_minima(audio, &peaks);
+    let mut onsets = backtrack_to_energy_minima(audio, &candidates);
     // Clip start is already an explicit boundary in Vibez. Aubio reports a
     // non-silent file start as an onset, but showing that as a suggested
     // transient marker adds no editable information.
     onsets.retain(|&frame| frame > 0 && frame < frames as u64);
-    canonicalize_onsets(
-        &mut onsets,
-        config.minimum_inter_onset_frames(audio.sample_rate),
-    )
-}
-
-fn canonicalize_onsets(onsets: &mut [u64], minimum_interval_frames: u64) -> Vec<u64> {
-    onsets.sort_unstable();
-    let mut canonical = Vec::with_capacity(onsets.len());
-    for &onset in onsets.iter() {
-        if canonical
-            .last()
-            .is_none_or(|previous: &u64| onset.abs_diff(*previous) > minimum_interval_frames)
-        {
-            canonical.push(onset);
-        }
-    }
-    canonical
+    canonicalize_onsets(onsets, config.minimum_inter_onset_frames(audio.sample_rate))
 }
 
 fn frames_for_ms(sample_rate: u32, milliseconds: f32) -> usize {
@@ -192,110 +156,15 @@ fn peak_and_rms(audio: &DecodedAudio, start: usize, end: usize) -> (f32, f32) {
     (peak, rms)
 }
 
-const BACKTRACK_WINDOW_MS: f32 = 23.22;
-const BACKTRACK_HOP_MS: f32 = 2.9;
-const BACKTRACK_MAX_MS: f32 = 50.0;
-
-fn backtrack_to_energy_minima(audio: &DecodedAudio, onsets: &[u64]) -> Vec<u64> {
-    if onsets.is_empty() || audio.num_frames() < 3 {
-        return onsets.to_vec();
-    }
-
-    let hop = frames_for_ms(audio.sample_rate, BACKTRACK_HOP_MS).max(1);
-    let window = frames_for_ms(audio.sample_rate, BACKTRACK_WINDOW_MS).max(1);
-    let energy = rms_energy_envelope(audio, window, hop);
-    backtrack_events_to_minima(
-        onsets,
-        &energy,
-        hop,
-        frames_for_ms(audio.sample_rate, BACKTRACK_MAX_MS),
-    )
-}
-
-fn rms_energy_envelope(audio: &DecodedAudio, window: usize, hop: usize) -> Vec<f32> {
-    let frames = audio.num_frames();
-    if frames == 0 || window == 0 || hop == 0 {
-        return Vec::new();
-    }
-
-    let channel_count = audio.channels.len().max(1) as f64;
-    let mut prefix_energy = vec![0.0f64; frames + 1];
-    for frame in 0..frames {
-        let square_sum = audio
-            .channels
-            .iter()
-            .map(|channel| f64::from(channel.get(frame).copied().unwrap_or(0.0)).powi(2))
-            .sum::<f64>();
-        prefix_energy[frame + 1] = prefix_energy[frame] + square_sum / channel_count;
-    }
-
-    (0..frames)
-        .step_by(hop)
-        .map(|end| {
-            // A trailing RMS window keeps the final silence minimum aligned
-            // with the source attack. A centred window would smear future
-            // attack energy earlier by half a window and make slices early.
-            let start = end.saturating_sub(window);
-            let frame_count = (end - start).max(1) as f64;
-            ((prefix_energy[end] - prefix_energy[start]) / frame_count).sqrt() as f32
-        })
-        .collect()
-}
-
-// The local-minimum matching rule is derived from librosa 0.11.0's
-// `onset_backtrack`, copyright (c) 2013-2023 the librosa development team,
-// distributed under the ISC licence:
-//
-// Permission to use, copy, modify, and/or distribute this software for any
-// purpose with or without fee is hereby granted, provided that the above
-// copyright notice and this permission notice appear in all copies.
-//
-// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
-// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
-// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
-// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-//
-// Vibez adds a bounded look-back expressed in source frames because a DAW
-// marker must not jump into an earlier event.
-fn backtrack_events_to_minima(
-    events: &[u64],
-    energy: &[f32],
-    hop: usize,
-    max_lookback: usize,
-) -> Vec<u64> {
-    if energy.len() < 3 || hop == 0 {
-        return events.to_vec();
-    }
-
-    let mut minima = vec![0usize];
-    minima.extend(energy.windows(3).enumerate().filter_map(|(index, values)| {
-        (values[1] <= values[0] && values[1] < values[2]).then_some(index + 1)
-    }));
-
-    events
-        .iter()
-        .map(|&event| {
-            let event = usize::try_from(event).unwrap_or(usize::MAX);
-            let first_allowed = event.saturating_sub(max_lookback);
-            minima
-                .iter()
-                .rev()
-                .map(|minimum| minimum.saturating_mul(hop))
-                .find(|minimum| *minimum <= event && *minimum >= first_allowed)
-                .map_or(event as u64, |minimum| minimum as u64)
-        })
-        .collect()
-}
-
 fn attack_prominence_floor(sensitivity: TransientSensitivity) -> f32 {
-    let normalized = sensitivity.normalized();
+    three_point_log_interpolation(sensitivity.normalized(), 0.6, 0.1, 0.005)
+}
+
+fn three_point_log_interpolation(normalized: f32, low: f32, midpoint: f32, high: f32) -> f32 {
     if normalized <= 0.5 {
-        0.6 * (0.1f32 / 0.6).powf(normalized / 0.5)
+        low * (midpoint / low).powf(normalized / 0.5)
     } else {
-        0.1 * (0.005f32 / 0.1).powf((normalized - 0.5) / 0.5)
+        midpoint * (high / midpoint).powf((normalized - 0.5) / 0.5)
     }
 }
 
@@ -464,8 +333,10 @@ pub fn detect_bpm(audio: &DecodedAudio, sample_rate: u32) -> Option<BpmEstimate>
     // Gate: sparse clips with weak ACF are rejected rather than
     // guessed. This is the difference between "we detected nothing"
     // and "we detected garbage".
-    let onsets_count = detect_onsets(audio, TransientSensitivity::DEFAULT).len();
-    if onsets_count < 8 && confidence_ratio < 1.5 {
+    // The ODF has already been computed for tempo analysis. Count its strong
+    // local peaks here instead of running the FFT transient detector again.
+    // The old gate doubled transient-analysis work during sample import.
+    if strong_flux_peak_count(&ds) < 8 && confidence_ratio < 1.5 {
         return None;
     }
 
@@ -494,6 +365,22 @@ pub fn detect_bpm(audio: &DecodedAudio, sample_rate: u32) -> Option<BpmEstimate>
         bpm: best_bpm,
         confidence,
     })
+}
+
+fn strong_flux_peak_count(flux: &[f32]) -> usize {
+    if flux.len() < 3 {
+        return 0;
+    }
+    let mean = flux.iter().copied().sum::<f32>() / flux.len() as f32;
+    let variance = flux
+        .iter()
+        .map(|value| (*value - mean).powi(2))
+        .sum::<f32>()
+        / flux.len() as f32;
+    let threshold = mean + variance.sqrt() * 0.5;
+    flux.windows(3)
+        .filter(|values| values[1] > threshold && values[1] >= values[0] && values[1] > values[2])
+        .count()
 }
 
 fn parncutt_weight(bpm: f64) -> f64 {
@@ -743,14 +630,12 @@ mod tests {
     fn canonical_onsets_merge_cross_channel_candidates_within_aubio_minimum_interval() {
         let sample_rate = 44_100u32;
         let first = 10_000u64;
-        let mut onsets = vec![first, first + frames_for_ms(sample_rate, 7.0) as u64];
-        let minimum_interval = aubio::Config::for_complex_candidates(sample_rate)
-            .minimum_inter_onset_frames(sample_rate);
+        let onsets = vec![first, first + frames_for_ms(sample_rate, 7.0) as u64];
+        let minimum_interval =
+            aubio::Config::for_complex_candidates(sample_rate, TransientSensitivity::DEFAULT)
+                .minimum_inter_onset_frames(sample_rate);
 
-        assert_eq!(
-            canonicalize_onsets(&mut onsets, minimum_interval),
-            vec![first]
-        );
+        assert_eq!(canonicalize_onsets(onsets, minimum_interval), vec![first]);
     }
 
     #[test]

--- a/crates/vibez-core/src/onset/aubio.rs
+++ b/crates/vibez-core/src/onset/aubio.rs
@@ -8,6 +8,7 @@
 //! aubio is licensed under GPL-3.0-or-later. Vibez carries the same compatible
 //! licence. Upstream source: <https://github.com/aubio/aubio/tree/0.4.9>.
 
+#[cfg(test)]
 use super::TransientSensitivity;
 use rustfft::{num_complex::Complex32, Fft, FftPlanner};
 use std::sync::Arc;
@@ -15,10 +16,11 @@ use std::sync::Arc;
 const DEFAULT_WINDOW_SIZE: usize = 1_024;
 const DEFAULT_HOP_SIZE: usize = 256;
 const DEFAULT_THRESHOLD: f32 = 0.058;
-const DEFAULT_ENERGY_THRESHOLD: f32 = 0.3;
+const COMPLEX_CANDIDATE_THRESHOLD: f32 = 0.001;
 const DEFAULT_MIN_IOI_MS: f32 = 50.0;
 const DEFAULT_SILENCE_DB: f32 = -70.0;
 const DEFAULT_DELAY_HOPS: f32 = 4.3;
+const COMPLEX_DELAY_HOPS: f32 = 4.6;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(super) struct Config {
@@ -27,25 +29,43 @@ pub(super) struct Config {
     threshold: f32,
     min_ioi_ms: f32,
     silence_db: f32,
+    delay_hops: f32,
 }
 
 impl Config {
+    #[cfg(test)]
     pub(super) fn for_sensitivity(sensitivity: TransientSensitivity) -> Self {
         // aubio documents 0.001..=0.900 as the useful peak-threshold range.
         // Interpolate logarithmically through its HFC default at 50%, giving
         // useful travel at both ends instead of bunching every result near the
         // middle of the knob.
         Self {
-            threshold: sensitivity.peak_threshold(DEFAULT_THRESHOLD),
+            threshold: sensitivity.threshold_through(DEFAULT_THRESHOLD),
             ..Self::default()
         }
     }
 
-    pub(super) fn for_energy_sensitivity(sensitivity: TransientSensitivity) -> Self {
+    pub(super) fn for_complex_candidates(sample_rate: u32) -> Self {
+        let window_size = match sample_rate {
+            0..=33_074 => DEFAULT_WINDOW_SIZE / 2,
+            33_075..=66_149 => DEFAULT_WINDOW_SIZE,
+            66_150..=132_299 => DEFAULT_WINDOW_SIZE * 2,
+            _ => DEFAULT_WINDOW_SIZE * 4,
+        };
         Self {
-            threshold: sensitivity.peak_threshold(DEFAULT_ENERGY_THRESHOLD),
+            // Candidate generation is intentionally fixed and permissive.
+            // Producer sensitivity filters one stable set later in the
+            // pipeline, so retained markers never move between settings.
+            threshold: COMPLEX_CANDIDATE_THRESHOLD,
+            delay_hops: COMPLEX_DELAY_HOPS,
+            window_size,
+            hop_size: window_size / 4,
             ..Self::default()
         }
+    }
+
+    pub(super) fn analysis_delay_frames(self) -> u64 {
+        (self.delay_hops * self.hop_size as f32) as u64
     }
 
     fn validate(self, sample_rate: u32) -> Result<Self, ConfigError> {
@@ -73,6 +93,7 @@ impl Default for Config {
             threshold: DEFAULT_THRESHOLD,
             min_ioi_ms: DEFAULT_MIN_IOI_MS,
             silence_db: DEFAULT_SILENCE_DB,
+            delay_hops: DEFAULT_DELAY_HOPS,
         }
     }
 }
@@ -87,33 +108,18 @@ enum ConfigError {
 
 #[cfg(test)]
 pub(super) fn detect_onsets(mono: &[f32], sample_rate: u32, config: Config) -> Vec<u64> {
-    detect_onsets_where(mono, sample_rate, config, |_| true)
+    detect_onsets_with_descriptor(mono, sample_rate, config, DescriptorKind::Hfc)
 }
 
-pub(super) fn detect_onsets_where(
-    mono: &[f32],
-    sample_rate: u32,
-    config: Config,
-    accepts: impl FnMut(usize) -> bool,
-) -> Vec<u64> {
-    detect_onsets_with_descriptor(mono, sample_rate, config, Descriptor::Hfc, accepts)
-}
-
-pub(super) fn detect_energy_onsets_where(
-    mono: &[f32],
-    sample_rate: u32,
-    config: Config,
-    accepts: impl FnMut(usize) -> bool,
-) -> Vec<u64> {
-    detect_onsets_with_descriptor(mono, sample_rate, config, Descriptor::Energy, accepts)
+pub(super) fn detect_complex_onsets(mono: &[f32], sample_rate: u32, config: Config) -> Vec<u64> {
+    detect_onsets_with_descriptor(mono, sample_rate, config, DescriptorKind::Complex)
 }
 
 fn detect_onsets_with_descriptor(
     mono: &[f32],
     sample_rate: u32,
     config: Config,
-    descriptor: Descriptor,
-    accepts: impl FnMut(usize) -> bool,
+    descriptor: DescriptorKind,
 ) -> Vec<u64> {
     let Ok(config) = config.validate(sample_rate) else {
         return Vec::new();
@@ -122,13 +128,40 @@ fn detect_onsets_with_descriptor(
         return Vec::new();
     }
 
-    Detector::new(sample_rate, config, descriptor).process(mono, accepts)
+    Detector::new(sample_rate, config, descriptor).process(mono)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Descriptor {
+enum DescriptorKind {
+    #[cfg(test)]
     Hfc,
-    Energy,
+    Complex,
+}
+
+enum Descriptor {
+    #[cfg(test)]
+    Hfc,
+    Complex(ComplexDomain),
+}
+
+impl Descriptor {
+    fn new(kind: DescriptorKind, bins: usize, sample_rate: u32, hop_size: usize) -> Self {
+        match kind {
+            #[cfg(test)]
+            DescriptorKind::Hfc => Self::Hfc,
+            DescriptorKind::Complex => {
+                Self::Complex(ComplexDomain::new(bins, sample_rate, hop_size))
+            }
+        }
+    }
+
+    fn process(&mut self, spectrum: &Spectrum) -> f32 {
+        match self {
+            #[cfg(test)]
+            Self::Hfc => high_frequency_content(&spectrum.magnitudes),
+            Self::Complex(complex) => complex.process(spectrum),
+        }
+    }
 }
 
 struct Detector {
@@ -144,53 +177,45 @@ struct Detector {
 }
 
 impl Detector {
-    fn new(sample_rate: u32, config: Config, descriptor: Descriptor) -> Self {
+    fn new(sample_rate: u32, config: Config, descriptor: DescriptorKind) -> Self {
+        let bins = config.window_size / 2 + 1;
         Self {
             hop_size: config.hop_size,
-            min_ioi: super::frames_for_ms(sample_rate, config.min_ioi_ms),
-            delay: (DEFAULT_DELAY_HOPS * config.hop_size as f32) as usize,
+            min_ioi: ((config.min_ioi_ms / 1_000.0) * sample_rate as f32).round() as usize,
+            delay: (config.delay_hops * config.hop_size as f32) as usize,
             silence_db: config.silence_db,
             total_frames: 0,
             last_onset: 0,
             phase_vocoder: PhaseVocoder::new(config.window_size, config.hop_size),
             peak_picker: PeakPicker::new(config.threshold),
-            descriptor,
+            descriptor: Descriptor::new(descriptor, bins, sample_rate, config.hop_size),
         }
     }
 
-    fn process(mut self, mono: &[f32], mut accepts: impl FnMut(usize) -> bool) -> Vec<u64> {
+    fn process(mut self, mono: &[f32]) -> Vec<u64> {
         let mut onsets = Vec::new();
         let mut hop = vec![0.0; self.hop_size];
 
         for chunk in mono.chunks(self.hop_size) {
             hop.fill(0.0);
             hop[..chunk.len()].copy_from_slice(chunk);
-            if let Some(frame) = self.process_hop(&hop, &mut accepts) {
+            if let Some(frame) = self.process_hop(&hop) {
                 onsets.push(frame as u64);
             }
         }
         onsets
     }
 
-    fn process_hop(
-        &mut self,
-        input: &[f32],
-        accepts: &mut impl FnMut(usize) -> bool,
-    ) -> Option<usize> {
-        let magnitudes = self.phase_vocoder.spectrum(input);
-        let descriptor = match self.descriptor {
-            Descriptor::Hfc => high_frequency_content(&magnitudes),
-            Descriptor::Energy => spectral_energy(&magnitudes),
-        };
+    fn process_hop(&mut self, input: &[f32]) -> Option<usize> {
+        let spectrum = self.phase_vocoder.spectrum(input);
+        let descriptor = self.descriptor.process(&spectrum);
         let peak = self.peak_picker.process(descriptor);
         let silent = db_spl(input) < self.silence_db;
         let mut accepted = false;
 
         if peak > 0.0 && !silent {
             let new_onset = self.total_frames + (peak * self.hop_size as f32).round() as usize;
-            let reported_onset = self.delay.max(new_onset).saturating_sub(self.delay);
-            if accepts(reported_onset)
-                && self.last_onset + self.min_ioi < new_onset
+            if self.last_onset + self.min_ioi < new_onset
                 && !(self.last_onset > 0 && self.delay > new_onset)
             {
                 self.last_onset = self.delay.max(new_onset);
@@ -198,10 +223,7 @@ impl Detector {
             }
         } else if peak <= 0.0 && self.total_frames <= self.delay && !silent {
             let new_onset = self.total_frames;
-            let reported_onset = self.total_frames;
-            if accepts(reported_onset)
-                && (self.total_frames == 0 || self.last_onset + self.min_ioi < new_onset)
-            {
+            if self.total_frames == 0 || self.last_onset + self.min_ioi < new_onset {
                 self.last_onset = self.total_frames + self.delay;
                 accepted = true;
             }
@@ -221,6 +243,11 @@ struct PhaseVocoder {
     fft_buffer: Vec<Complex32>,
     window: Vec<f32>,
     fft: Arc<dyn Fft<f32>>,
+}
+
+struct Spectrum {
+    magnitudes: Vec<f32>,
+    phases: Vec<f32>,
 }
 
 impl PhaseVocoder {
@@ -244,7 +271,7 @@ impl PhaseVocoder {
         }
     }
 
-    fn spectrum(&mut self, input: &[f32]) -> Vec<f32> {
+    fn spectrum(&mut self, input: &[f32]) -> Spectrum {
         debug_assert_eq!(input.len(), self.hop_size);
 
         if self.old_size > 0 {
@@ -263,20 +290,84 @@ impl PhaseVocoder {
         }
         self.fft.process(&mut self.fft_buffer);
 
-        self.fft_buffer[..=self.window_size / 2]
-            .iter()
-            .map(|bin| bin.norm())
-            .collect()
+        let bins = &self.fft_buffer[..=self.window_size / 2];
+        let magnitudes = bins.iter().map(|bin| bin.norm()).collect();
+        let mut phases: Vec<f32> = bins.iter().map(|bin| bin.arg()).collect();
+        // Aubio forces the real-only DC and Nyquist bins to exactly 0 or PI.
+        // Preserving tiny backend imaginary noise here creates false complex-
+        // domain novelty in otherwise stable decays.
+        if let Some(first) = bins.first() {
+            phases[0] = if first.re < 0.0 {
+                std::f32::consts::PI
+            } else {
+                0.0
+            };
+        }
+        if let Some(last) = bins.last() {
+            let last_index = phases.len() - 1;
+            phases[last_index] = if last.re < 0.0 {
+                std::f32::consts::PI
+            } else {
+                0.0
+            };
+        }
+        Spectrum { magnitudes, phases }
     }
 }
 
-fn spectral_energy(magnitudes: &[f32]) -> f32 {
-    magnitudes
-        .iter()
-        .map(|magnitude| magnitude * magnitude)
-        .sum()
+/// Aubio 0.4.9's complex-domain spectral descriptor, including the adaptive
+/// whitening and log-compression defaults used by its `complex` onset mode.
+struct ComplexDomain {
+    previous_magnitudes: Vec<f32>,
+    previous_phases: Vec<f32>,
+    phases_two_frames_back: Vec<f32>,
+    whitening_peaks: Vec<f32>,
+    whitening_decay: f32,
 }
 
+impl ComplexDomain {
+    const WHITENING_FLOOR: f32 = 1.0e-4;
+    const WHITENING_RELAX_SECONDS: f32 = 250.0;
+    const WHITENING_DECAY: f32 = 0.001;
+
+    fn new(bins: usize, sample_rate: u32, hop_size: usize) -> Self {
+        let whitening_decay = Self::WHITENING_DECAY
+            .powf((hop_size as f32 / sample_rate as f32) / Self::WHITENING_RELAX_SECONDS);
+        Self {
+            previous_magnitudes: vec![0.0; bins],
+            previous_phases: vec![0.0; bins],
+            phases_two_frames_back: vec![0.0; bins],
+            whitening_peaks: vec![Self::WHITENING_FLOOR; bins],
+            whitening_decay,
+        }
+    }
+
+    fn process(&mut self, spectrum: &Spectrum) -> f32 {
+        let mut novelty = 0.0f32;
+        for index in 0..spectrum.magnitudes.len() {
+            let decayed_peak =
+                (self.whitening_decay * self.whitening_peaks[index]).max(Self::WHITENING_FLOOR);
+            self.whitening_peaks[index] = spectrum.magnitudes[index].max(decayed_peak);
+            let whitened = spectrum.magnitudes[index] / self.whitening_peaks[index];
+            let magnitude = whitened.ln_1p();
+            let predicted_phase =
+                2.0 * self.previous_phases[index] - self.phases_two_frames_back[index];
+            let squared_distance = self.previous_magnitudes[index].powi(2) + magnitude.powi(2)
+                - 2.0
+                    * self.previous_magnitudes[index]
+                    * magnitude
+                    * (predicted_phase - spectrum.phases[index]).cos();
+            novelty += squared_distance.abs().sqrt();
+
+            self.phases_two_frames_back[index] = self.previous_phases[index];
+            self.previous_phases[index] = spectrum.phases[index];
+            self.previous_magnitudes[index] = magnitude;
+        }
+        novelty
+    }
+}
+
+#[cfg(test)]
 fn high_frequency_content(magnitudes: &[f32]) -> f32 {
     magnitudes
         .iter()
@@ -417,11 +508,19 @@ mod tests {
         assert_eq!(high_frequency_content(&vec![0.0; 513]), 0.0);
     }
 
-    // Port of the energy zero-spectrum case in
-    // tests/src/spectral/test-specdesc.c.
+    // Port of the complex-domain zero-spectrum case in aubio 0.4.9's
+    // tests/src/spectral/test-specdesc.c, strengthened to check repeated
+    // frames because the descriptor retains two frames of phase history.
     #[test]
-    fn ported_upstream_energy_zero_spectrum_is_zero() {
-        assert_eq!(spectral_energy(&vec![0.0; 513]), 0.0);
+    fn ported_upstream_complex_zero_spectrum_is_zero() {
+        let mut descriptor = ComplexDomain::new(513, 44_100, 256);
+        let spectrum = Spectrum {
+            magnitudes: vec![0.0; 513],
+            phases: vec![0.0; 513],
+        };
+        assert_eq!(descriptor.process(&spectrum), 0.0);
+        assert_eq!(descriptor.process(&spectrum), 0.0);
+        assert_eq!(descriptor.process(&spectrum), 0.0);
     }
 
     #[test]
@@ -434,6 +533,13 @@ mod tests {
         assert_eq!(fewer.min_ioi_ms, DEFAULT_MIN_IOI_MS);
         assert!(more.threshold < balanced.threshold);
         assert!(balanced.threshold < fewer.threshold);
+
+        let candidates = Config::for_complex_candidates(44_100);
+        assert_eq!(candidates.threshold, COMPLEX_CANDIDATE_THRESHOLD);
+        assert_eq!(candidates.min_ioi_ms, DEFAULT_MIN_IOI_MS);
+        assert_eq!(candidates.delay_hops, COMPLEX_DELAY_HOPS);
+        assert_eq!(Config::for_complex_candidates(48_000).window_size, 1_024);
+        assert_eq!(Config::for_complex_candidates(96_000).window_size, 2_048);
     }
 
     #[test]
@@ -472,6 +578,48 @@ mod tests {
             assert!(
                 (*actual as i64 - expected).abs() <= 2,
                 "expected {expected}, got {actual}; all={actual:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn complex_primary_attacks_match_aubio_0_4_9_golden_frames() {
+        let sample_rate = 44_100u32;
+        let mut audio = vec![0.0f32; sample_rate as usize];
+        for start in [2_000usize, 13_000, 24_000, 35_000] {
+            for offset in 0..7_000 {
+                if start + offset >= audio.len() {
+                    break;
+                }
+                let time = offset as f32 / sample_rate as f32;
+                let decay = (-(offset as f32) / 2_500.0).exp();
+                audio[start + offset] += decay
+                    * ((std::f32::consts::TAU * 120.0 * time).sin()
+                        + (std::f32::consts::TAU * 128.0 * time).sin())
+                    * 0.4;
+            }
+        }
+
+        // Generated with aubio 0.4.9's complex mode and its upstream 0.15
+        // threshold. RustFFT can produce additional low-novelty candidates in
+        // a beating decay, which the producer-facing attack validator rejects,
+        // but each upstream primary event must retain its timestamp.
+        let upstream = [1_459i64, 12_710, 23_714, 34_717];
+        let actual = detect_complex_onsets(
+            &audio,
+            sample_rate,
+            Config {
+                threshold: 0.15,
+                delay_hops: COMPLEX_DELAY_HOPS,
+                ..Config::default()
+            },
+        );
+        for expected in upstream {
+            assert!(
+                actual
+                    .iter()
+                    .any(|actual| (*actual as i64 - expected).abs() <= 3),
+                "expected {expected}; all={actual:?}"
             );
         }
     }

--- a/crates/vibez-core/src/onset/aubio.rs
+++ b/crates/vibez-core/src/onset/aubio.rs
@@ -8,15 +8,15 @@
 //! aubio is licensed under GPL-3.0-or-later. Vibez carries the same compatible
 //! licence. Upstream source: <https://github.com/aubio/aubio/tree/0.4.9>.
 
-#[cfg(test)]
 use super::TransientSensitivity;
 use rustfft::{num_complex::Complex32, Fft, FftPlanner};
 use std::sync::Arc;
 
 const DEFAULT_WINDOW_SIZE: usize = 1_024;
 const DEFAULT_HOP_SIZE: usize = 256;
-const DEFAULT_THRESHOLD: f32 = 0.058;
-const COMPLEX_CANDIDATE_THRESHOLD: f32 = 0.001;
+// aubio's documented complex-domain default. Sensitivity interpolates through
+// this value at 50%, from the documented 0.900..=0.001 useful range.
+const COMPLEX_DEFAULT_THRESHOLD: f32 = 0.15;
 const DEFAULT_MIN_IOI_MS: f32 = 50.0;
 const DEFAULT_SILENCE_DB: f32 = -70.0;
 const DEFAULT_DELAY_HOPS: f32 = 4.3;
@@ -33,19 +33,10 @@ pub(super) struct Config {
 }
 
 impl Config {
-    #[cfg(test)]
-    pub(super) fn for_sensitivity(sensitivity: TransientSensitivity) -> Self {
-        // aubio documents 0.001..=0.900 as the useful peak-threshold range.
-        // Interpolate logarithmically through its HFC default at 50%, giving
-        // useful travel at both ends instead of bunching every result near the
-        // middle of the knob.
-        Self {
-            threshold: sensitivity.threshold_through(DEFAULT_THRESHOLD),
-            ..Self::default()
-        }
-    }
-
-    pub(super) fn for_complex_candidates(sample_rate: u32) -> Self {
+    pub(super) fn for_complex_candidates(
+        sample_rate: u32,
+        sensitivity: TransientSensitivity,
+    ) -> Self {
         let window_size = match sample_rate {
             0..=33_074 => DEFAULT_WINDOW_SIZE / 2,
             33_075..=66_149 => DEFAULT_WINDOW_SIZE,
@@ -53,19 +44,12 @@ impl Config {
             _ => DEFAULT_WINDOW_SIZE * 4,
         };
         Self {
-            // Candidate generation is intentionally fixed and permissive.
-            // Producer sensitivity filters one stable set later in the
-            // pipeline, so retained markers never move between settings.
-            threshold: COMPLEX_CANDIDATE_THRESHOLD,
+            threshold: sensitivity.threshold_through(COMPLEX_DEFAULT_THRESHOLD),
             delay_hops: COMPLEX_DELAY_HOPS,
             window_size,
             hop_size: window_size / 4,
             ..Self::default()
         }
-    }
-
-    pub(super) fn analysis_delay_frames(self) -> u64 {
-        (self.delay_hops * self.hop_size as f32) as u64
     }
 
     pub(super) fn minimum_inter_onset_frames(self, sample_rate: u32) -> u64 {
@@ -94,7 +78,7 @@ impl Default for Config {
         Self {
             window_size: DEFAULT_WINDOW_SIZE,
             hop_size: DEFAULT_HOP_SIZE,
-            threshold: DEFAULT_THRESHOLD,
+            threshold: COMPLEX_DEFAULT_THRESHOLD,
             min_ioi_ms: DEFAULT_MIN_IOI_MS,
             silence_db: DEFAULT_SILENCE_DB,
             delay_hops: DEFAULT_DELAY_HOPS,
@@ -110,21 +94,21 @@ enum ConfigError {
     ZeroSampleRate,
 }
 
-#[cfg(test)]
-pub(super) fn detect_onsets(mono: &[f32], sample_rate: u32, config: Config) -> Vec<u64> {
-    detect_onsets_with_descriptor(mono, sample_rate, config, DescriptorKind::Hfc)
-}
-
-pub(super) fn detect_complex_onsets(mono: &[f32], sample_rate: u32, config: Config) -> Vec<u64> {
-    detect_onsets_with_descriptor(mono, sample_rate, config, DescriptorKind::Complex)
-}
-
-fn detect_onsets_with_descriptor(
+pub(super) fn detect_complex_onsets_where(
     mono: &[f32],
     sample_rate: u32,
     config: Config,
-    descriptor: DescriptorKind,
-) -> Vec<u64> {
+    accepts: impl FnMut(u64) -> bool,
+) -> Vec<(u64, u64)> {
+    detect_onsets_where(mono, sample_rate, config, accepts)
+}
+
+fn detect_onsets_where(
+    mono: &[f32],
+    sample_rate: u32,
+    config: Config,
+    accepts: impl FnMut(u64) -> bool,
+) -> Vec<(u64, u64)> {
     let Ok(config) = config.validate(sample_rate) else {
         return Vec::new();
     };
@@ -132,40 +116,7 @@ fn detect_onsets_with_descriptor(
         return Vec::new();
     }
 
-    Detector::new(sample_rate, config, descriptor).process(mono)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DescriptorKind {
-    #[cfg(test)]
-    Hfc,
-    Complex,
-}
-
-enum Descriptor {
-    #[cfg(test)]
-    Hfc,
-    Complex(ComplexDomain),
-}
-
-impl Descriptor {
-    fn new(kind: DescriptorKind, bins: usize, sample_rate: u32, hop_size: usize) -> Self {
-        match kind {
-            #[cfg(test)]
-            DescriptorKind::Hfc => Self::Hfc,
-            DescriptorKind::Complex => {
-                Self::Complex(ComplexDomain::new(bins, sample_rate, hop_size))
-            }
-        }
-    }
-
-    fn process(&mut self, spectrum: &Spectrum) -> f32 {
-        match self {
-            #[cfg(test)]
-            Self::Hfc => high_frequency_content(&spectrum.magnitudes),
-            Self::Complex(complex) => complex.process(spectrum),
-        }
-    }
+    Detector::new(sample_rate, config).process(mono, accepts)
 }
 
 struct Detector {
@@ -177,11 +128,11 @@ struct Detector {
     last_onset: usize,
     phase_vocoder: PhaseVocoder,
     peak_picker: PeakPicker,
-    descriptor: Descriptor,
+    descriptor: ComplexDomain,
 }
 
 impl Detector {
-    fn new(sample_rate: u32, config: Config, descriptor: DescriptorKind) -> Self {
+    fn new(sample_rate: u32, config: Config) -> Self {
         let bins = config.window_size / 2 + 1;
         Self {
             hop_size: config.hop_size,
@@ -192,49 +143,60 @@ impl Detector {
             last_onset: 0,
             phase_vocoder: PhaseVocoder::new(config.window_size, config.hop_size),
             peak_picker: PeakPicker::new(config.threshold),
-            descriptor: Descriptor::new(descriptor, bins, sample_rate, config.hop_size),
+            descriptor: ComplexDomain::new(bins, sample_rate, config.hop_size),
         }
     }
 
-    fn process(mut self, mono: &[f32]) -> Vec<u64> {
+    fn process(mut self, mono: &[f32], mut accepts: impl FnMut(u64) -> bool) -> Vec<(u64, u64)> {
         let mut onsets = Vec::new();
         let mut hop = vec![0.0; self.hop_size];
 
         for chunk in mono.chunks(self.hop_size) {
             hop.fill(0.0);
             hop[..chunk.len()].copy_from_slice(chunk);
-            if let Some(frame) = self.process_hop(&hop) {
-                onsets.push(frame as u64);
+            if let Some(event) = self.process_hop(&hop, &mut accepts) {
+                onsets.push(event);
             }
         }
         onsets
     }
 
-    fn process_hop(&mut self, input: &[f32]) -> Option<usize> {
+    fn process_hop(
+        &mut self,
+        input: &[f32],
+        accepts: &mut impl FnMut(u64) -> bool,
+    ) -> Option<(u64, u64)> {
         let spectrum = self.phase_vocoder.spectrum(input);
         let descriptor = self.descriptor.process(&spectrum);
         let peak = self.peak_picker.process(descriptor);
         let silent = db_spl(input) < self.silence_db;
-        let mut accepted = false;
+        let mut accepted = None;
 
         if peak > 0.0 && !silent {
             let new_onset = self.total_frames + (peak * self.hop_size as f32).round() as usize;
             if self.last_onset + self.min_ioi < new_onset
                 && !(self.last_onset > 0 && self.delay > new_onset)
             {
-                self.last_onset = self.delay.max(new_onset);
-                accepted = true;
+                let delayed_onset = self.delay.max(new_onset);
+                let estimated = delayed_onset.saturating_sub(self.delay) as u64;
+                if accepts(estimated) {
+                    self.last_onset = delayed_onset;
+                    accepted = Some((estimated, new_onset as u64));
+                }
             }
         } else if peak <= 0.0 && self.total_frames <= self.delay && !silent {
             let new_onset = self.total_frames;
             if self.total_frames == 0 || self.last_onset + self.min_ioi < new_onset {
-                self.last_onset = self.total_frames + self.delay;
-                accepted = true;
+                let estimated = new_onset as u64;
+                if accepts(estimated) {
+                    self.last_onset = self.total_frames + self.delay;
+                    accepted = Some((estimated, new_onset as u64));
+                }
             }
         }
 
         self.total_frames += self.hop_size;
-        accepted.then(|| self.last_onset.saturating_sub(self.delay))
+        accepted
     }
 }
 
@@ -371,15 +333,6 @@ impl ComplexDomain {
     }
 }
 
-#[cfg(test)]
-fn high_frequency_content(magnitudes: &[f32]) -> f32 {
-    magnitudes
-        .iter()
-        .enumerate()
-        .map(|(index, magnitude)| (index + 1) as f32 * magnitude.ln_1p())
-        .sum()
-}
-
 struct PeakPicker {
     threshold: f32,
     novelty: [f32; 7],
@@ -506,12 +459,6 @@ mod tests {
         }
     }
 
-    // Port of the zero-spectrum cases in tests/src/spectral/test-specdesc.c.
-    #[test]
-    fn ported_upstream_hfc_zero_spectrum_is_zero() {
-        assert_eq!(high_frequency_content(&vec![0.0; 513]), 0.0);
-    }
-
     // Port of the complex-domain zero-spectrum case in aubio 0.4.9's
     // tests/src/spectral/test-specdesc.c, strengthened to check repeated
     // frames because the descriptor retains two frames of phase history.
@@ -529,61 +476,35 @@ mod tests {
 
     #[test]
     fn sensitivity_never_changes_the_minimum_hit_spacing() {
-        let fewer = Config::for_sensitivity(TransientSensitivity::new(0));
-        let balanced = Config::for_sensitivity(TransientSensitivity::new(50));
-        let more = Config::for_sensitivity(TransientSensitivity::new(100));
+        let fewer = Config::for_complex_candidates(44_100, TransientSensitivity::new(0));
+        let balanced = Config::for_complex_candidates(44_100, TransientSensitivity::new(50));
+        let more = Config::for_complex_candidates(44_100, TransientSensitivity::new(100));
         assert_eq!(more.min_ioi_ms, DEFAULT_MIN_IOI_MS);
         assert_eq!(balanced.min_ioi_ms, DEFAULT_MIN_IOI_MS);
         assert_eq!(fewer.min_ioi_ms, DEFAULT_MIN_IOI_MS);
         assert!(more.threshold < balanced.threshold);
         assert!(balanced.threshold < fewer.threshold);
 
-        let candidates = Config::for_complex_candidates(44_100);
-        assert_eq!(candidates.threshold, COMPLEX_CANDIDATE_THRESHOLD);
+        let candidates = Config::for_complex_candidates(44_100, TransientSensitivity::DEFAULT);
+        assert_eq!(candidates.threshold, COMPLEX_DEFAULT_THRESHOLD);
         assert_eq!(candidates.min_ioi_ms, DEFAULT_MIN_IOI_MS);
         assert_eq!(candidates.delay_hops, COMPLEX_DELAY_HOPS);
-        assert_eq!(Config::for_complex_candidates(48_000).window_size, 1_024);
-        assert_eq!(Config::for_complex_candidates(96_000).window_size, 2_048);
-    }
-
-    #[test]
-    fn silence_has_no_onsets() {
-        assert!(detect_onsets(&vec![0.0; 22_050], 44_100, Config::default()).is_empty());
-    }
-
-    #[test]
-    fn constant_signal_matches_aubio_start_marker() {
         assert_eq!(
-            detect_onsets(&vec![0.25; 44_100], 44_100, Config::default()),
-            vec![0]
+            Config::for_complex_candidates(48_000, TransientSensitivity::DEFAULT).window_size,
+            1_024
+        );
+        assert_eq!(
+            Config::for_complex_candidates(96_000, TransientSensitivity::DEFAULT).window_size,
+            2_048
         );
     }
 
     #[test]
-    fn decaying_bursts_match_aubio_0_4_9_golden_frames() {
-        let mut audio = vec![0.0f32; 44_100];
-        for start in [2_048usize, 8_192, 16_384, 28_672] {
-            for offset in 0..4_096 {
-                if start + offset >= audio.len() {
-                    break;
-                }
-                let phase = std::f32::consts::TAU * 120.0 * offset as f32 / 44_100.0;
-                audio[start + offset] += phase.sin() * (-(offset as f32) / 300.0).exp() * 0.8;
-            }
-        }
-
-        // Generated by aubio 0.4.9 with method=default, win=1024,
-        // hop=256, sample_rate=44100. A two-sample allowance covers the
-        // expected FFT/backend floating-point difference.
-        let upstream = [1_943i64, 8_087, 16_279, 28_567];
-        let actual = detect_onsets(&audio, 44_100, Config::default());
-        assert_eq!(actual.len(), upstream.len(), "actual={actual:?}");
-        for (actual, expected) in actual.iter().zip(upstream) {
-            assert!(
-                (*actual as i64 - expected).abs() <= 2,
-                "expected {expected}, got {actual}; all={actual:?}"
-            );
-        }
+    fn silence_has_no_onsets() {
+        assert!(
+            detect_complex_onsets_where(&vec![0.0; 22_050], 44_100, Config::default(), |_| true)
+                .is_empty()
+        );
     }
 
     #[test]
@@ -609,7 +530,7 @@ mod tests {
         // a beating decay, which the producer-facing attack validator rejects,
         // but each upstream primary event must retain its timestamp.
         let upstream = [1_459i64, 12_710, 23_714, 34_717];
-        let actual = detect_complex_onsets(
+        let actual = detect_complex_onsets_where(
             &audio,
             sample_rate,
             Config {
@@ -617,12 +538,13 @@ mod tests {
                 delay_hops: COMPLEX_DELAY_HOPS,
                 ..Config::default()
             },
+            |_| true,
         );
         for expected in upstream {
             assert!(
                 actual
                     .iter()
-                    .any(|actual| (*actual as i64 - expected).abs() <= 3),
+                    .any(|(actual, _)| (*actual as i64 - expected).abs() <= 3),
                 "expected {expected}; all={actual:?}"
             );
         }

--- a/crates/vibez-core/src/onset/aubio.rs
+++ b/crates/vibez-core/src/onset/aubio.rs
@@ -68,6 +68,10 @@ impl Config {
         (self.delay_hops * self.hop_size as f32) as u64
     }
 
+    pub(super) fn minimum_inter_onset_frames(self, sample_rate: u32) -> u64 {
+        ((self.min_ioi_ms / 1_000.0) * sample_rate as f32).round() as u64
+    }
+
     fn validate(self, sample_rate: u32) -> Result<Self, ConfigError> {
         if self.hop_size == 0 {
             return Err(ConfigError::ZeroHopSize);

--- a/crates/vibez-core/src/onset/localize.rs
+++ b/crates/vibez-core/src/onset/localize.rs
@@ -1,0 +1,159 @@
+use crate::audio_buffer::DecodedAudio;
+
+use super::frames_for_ms;
+
+// At 44.1 kHz these are aubio's 1,024-sample analysis window and
+// librosa-style 128-sample localisation hop, expressed in time so the
+// behaviour stays consistent at other sample rates.
+const BACKTRACK_WINDOW_MS: f32 = 23.22;
+const BACKTRACK_HOP_MS: f32 = 2.90;
+const BACKTRACK_MAX_MS: f32 = 50.0;
+
+pub(super) fn canonicalize_onsets(mut onsets: Vec<u64>, minimum_interval_frames: u64) -> Vec<u64> {
+    onsets.sort_unstable();
+    let mut canonical = Vec::with_capacity(onsets.len());
+    for onset in onsets {
+        if canonical
+            .last()
+            .is_none_or(|previous: &u64| onset.abs_diff(*previous) > minimum_interval_frames)
+        {
+            canonical.push(onset);
+        }
+    }
+    canonical
+}
+
+/// Localise each `(estimated onset, detected peak)` pair at a preceding energy
+/// minimum. If no suitable minimum exists, retain aubio's delay-compensated
+/// estimate rather than the later spectral peak.
+pub(super) fn backtrack_to_energy_minima(audio: &DecodedAudio, events: &[(u64, u64)]) -> Vec<u64> {
+    if events.is_empty() || audio.num_frames() < 3 {
+        return events.iter().map(|(estimated, _)| *estimated).collect();
+    }
+
+    let hop = frames_for_ms(audio.sample_rate, BACKTRACK_HOP_MS).max(1);
+    let window = frames_for_ms(audio.sample_rate, BACKTRACK_WINDOW_MS).max(1);
+    let energy = rms_energy_envelope(audio, window, hop);
+    backtrack_events_to_minima(
+        events,
+        &energy,
+        hop,
+        frames_for_ms(audio.sample_rate, BACKTRACK_MAX_MS),
+    )
+}
+
+/// Build a trailing RMS envelope with memory bounded by the analysis window.
+/// The old prefix-sum implementation allocated one `f64` per source frame,
+/// which could consume roughly 100 MB for a long stereo take.
+fn rms_energy_envelope(audio: &DecodedAudio, window: usize, hop: usize) -> Vec<f32> {
+    let frames = audio.num_frames();
+    if frames == 0 || window == 0 || hop == 0 {
+        return Vec::new();
+    }
+
+    let channel_count = audio.channels.len().max(1) as f64;
+    let mut rolling = vec![0.0f64; window];
+    let mut rolling_sum = 0.0f64;
+    let mut cursor = 0usize;
+    let mut envelope = Vec::with_capacity(frames.div_ceil(hop));
+
+    for end in (0..frames).step_by(hop) {
+        while cursor < end {
+            let square_sum = audio
+                .channels
+                .iter()
+                .map(|channel| f64::from(channel.get(cursor).copied().unwrap_or(0.0)).powi(2))
+                .sum::<f64>()
+                / channel_count;
+            let slot = cursor % window;
+            rolling_sum += square_sum - rolling[slot];
+            rolling[slot] = square_sum;
+            cursor += 1;
+        }
+        let frame_count = end.min(window).max(1) as f64;
+        envelope.push((rolling_sum / frame_count).sqrt() as f32);
+    }
+    envelope
+}
+
+// The local-minimum matching rule is derived from librosa 0.11.0's
+// `onset_backtrack`, copyright (c) 2013-2023 the librosa development team,
+// distributed under the ISC licence:
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+// Vibez adds a bounded source-frame look-back because a DAW marker must not
+// jump into an earlier event.
+pub(super) fn backtrack_events_to_minima(
+    events: &[(u64, u64)],
+    energy: &[f32],
+    hop: usize,
+    max_lookback: usize,
+) -> Vec<u64> {
+    if energy.len() < 3 || hop == 0 {
+        return events.iter().map(|(estimated, _)| *estimated).collect();
+    }
+
+    let mut minima = vec![0usize];
+    minima.extend(energy.windows(3).enumerate().filter_map(|(index, values)| {
+        (values[1] <= values[0] && values[1] < values[2]).then_some(index + 1)
+    }));
+
+    events
+        .iter()
+        .map(|&(estimated, detected_peak)| {
+            let peak = usize::try_from(detected_peak).unwrap_or(usize::MAX);
+            let first_allowed = peak.saturating_sub(max_lookback);
+            let after_peak = minima.partition_point(|minimum| minimum.saturating_mul(hop) <= peak);
+            minima[..after_peak]
+                .iter()
+                .rev()
+                .map(|minimum| minimum.saturating_mul(hop))
+                .find(|minimum| *minimum >= first_allowed)
+                .map_or(estimated, |minimum| minimum as u64)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rolling_rms_matches_trailing_window_values() {
+        let audio = DecodedAudio {
+            channels: vec![vec![1.0, 2.0, 3.0, 4.0, 5.0]],
+            sample_rate: 44_100,
+        };
+        let actual = rms_energy_envelope(&audio, 3, 1);
+        let expected = [
+            0.0,
+            1.0,
+            (2.5f32).sqrt(),
+            (14.0f32 / 3.0).sqrt(),
+            (29.0f32 / 3.0).sqrt(),
+        ];
+        for (actual, expected) in actual.iter().zip(expected) {
+            assert!((actual - expected).abs() < 1.0e-6, "{actual} != {expected}");
+        }
+    }
+
+    #[test]
+    fn missing_minimum_keeps_delay_compensated_estimate() {
+        let energy = [1.0, 2.0, 3.0, 4.0];
+        assert_eq!(
+            backtrack_events_to_minima(&[(200, 300)], &energy, 128, 64),
+            [200]
+        );
+    }
+}

--- a/crates/vibez-core/src/onset/metrics.rs
+++ b/crates/vibez-core/src/onset/metrics.rs
@@ -1,0 +1,129 @@
+//! Shared scoring for the transient corpus benchmark and detector tests.
+
+#[derive(Debug, Default, PartialEq)]
+pub struct Evaluation {
+    pub correct: usize,
+    pub false_positives: usize,
+    pub false_negatives: usize,
+    pub doubled: usize,
+    pub signed_errors_ms: Vec<f64>,
+}
+
+impl Evaluation {
+    pub fn precision(&self) -> f64 {
+        self.correct as f64 / (self.correct + self.false_positives).max(1) as f64
+    }
+
+    pub fn recall(&self) -> f64 {
+        self.correct as f64 / (self.correct + self.false_negatives).max(1) as f64
+    }
+
+    pub fn f1(&self) -> f64 {
+        let precision = self.precision();
+        let recall = self.recall();
+        if precision + recall == 0.0 {
+            0.0
+        } else {
+            2.0 * precision * recall / (precision + recall)
+        }
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        self.correct += other.correct;
+        self.false_positives += other.false_positives;
+        self.false_negatives += other.false_negatives;
+        self.doubled += other.doubled;
+        self.signed_errors_ms.extend(other.signed_errors_ms);
+    }
+
+    pub fn median_absolute_error_ms(&self) -> f64 {
+        percentile(
+            self.signed_errors_ms
+                .iter()
+                .map(|error| error.abs())
+                .collect(),
+            0.5,
+        )
+    }
+
+    pub fn p95_absolute_error_ms(&self) -> f64 {
+        percentile(
+            self.signed_errors_ms
+                .iter()
+                .map(|error| error.abs())
+                .collect(),
+            0.95,
+        )
+    }
+
+    pub fn mean_signed_error_ms(&self) -> f64 {
+        if self.signed_errors_ms.is_empty() {
+            0.0
+        } else {
+            self.signed_errors_ms.iter().sum::<f64>() / self.signed_errors_ms.len() as f64
+        }
+    }
+}
+
+pub fn evaluate(
+    detected: &[u64],
+    expected: &[u64],
+    tolerance_frames: u64,
+    sample_rate: u32,
+) -> Evaluation {
+    let mut matched = vec![false; expected.len()];
+    let mut evaluation = Evaluation::default();
+
+    for &candidate in detected {
+        let nearest = expected
+            .iter()
+            .enumerate()
+            .filter(|(index, onset)| {
+                !matched[*index] && candidate.abs_diff(**onset) <= tolerance_frames
+            })
+            .min_by_key(|(_, onset)| candidate.abs_diff(**onset));
+        if let Some((index, onset)) = nearest {
+            matched[index] = true;
+            evaluation.correct += 1;
+            evaluation
+                .signed_errors_ms
+                .push((candidate as f64 - *onset as f64) * 1_000.0 / f64::from(sample_rate));
+        } else {
+            evaluation.false_positives += 1;
+            if expected
+                .iter()
+                .any(|onset| candidate.abs_diff(*onset) <= tolerance_frames)
+            {
+                evaluation.doubled += 1;
+            }
+        }
+    }
+    evaluation.false_negatives = matched.iter().filter(|matched| !**matched).count();
+    evaluation
+}
+
+fn percentile(mut values: Vec<f64>, percentile: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.sort_by(f64::total_cmp);
+    let index = ((values.len() as f64 * percentile).ceil() as usize)
+        .saturating_sub(1)
+        .min(values.len() - 1);
+    values[index]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_to_one_matching_counts_a_second_detection_as_doubled() {
+        let evaluation = evaluate(&[100, 105, 200], &[100, 200], 10, 1_000);
+        assert_eq!(evaluation.correct, 2);
+        assert_eq!(evaluation.false_positives, 1);
+        assert_eq!(evaluation.false_negatives, 0);
+        assert_eq!(evaluation.doubled, 1);
+        assert_eq!(evaluation.f1(), 0.8);
+    }
+}

--- a/crates/vibez-core/src/onset/transient_analysis_tests.rs
+++ b/crates/vibez-core/src/onset/transient_analysis_tests.rs
@@ -1,3 +1,4 @@
+use super::metrics::evaluate;
 use super::*;
 
 fn make_audio(channels: Vec<Vec<f32>>, sample_rate: u32) -> DecodedAudio {
@@ -33,80 +34,16 @@ fn ringing_attack_train(sample_rate: u32) -> (DecodedAudio, Vec<u64>) {
     )
 }
 
-#[derive(Debug)]
-struct OnsetScore {
-    correct: usize,
-    false_positives: usize,
-    false_negatives: usize,
-    doubled: usize,
-    signed_errors: Vec<i64>,
-}
-
-impl OnsetScore {
-    fn precision(&self) -> f32 {
-        self.correct as f32 / (self.correct + self.false_positives).max(1) as f32
-    }
-
-    fn recall(&self) -> f32 {
-        self.correct as f32 / (self.correct + self.false_negatives).max(1) as f32
-    }
-
-    fn f1(&self) -> f32 {
-        let precision = self.precision();
-        let recall = self.recall();
-        if precision + recall == 0.0 {
-            0.0
-        } else {
-            2.0 * precision * recall / (precision + recall)
-        }
-    }
-}
-
-fn score_onsets(detected: &[u64], expected: &[u64], tolerance: u64) -> OnsetScore {
-    let mut matched = vec![false; expected.len()];
-    let mut signed_errors = Vec::new();
-    let mut false_positives = 0;
-    let mut doubled = 0;
-
-    for &candidate in detected {
-        let best = expected
-            .iter()
-            .enumerate()
-            .filter(|(index, onset)| !matched[*index] && candidate.abs_diff(**onset) <= tolerance)
-            .min_by_key(|(_, onset)| candidate.abs_diff(**onset));
-        if let Some((index, onset)) = best {
-            matched[index] = true;
-            signed_errors.push(candidate as i64 - *onset as i64);
-        } else {
-            false_positives += 1;
-            if expected
-                .iter()
-                .any(|onset| candidate.abs_diff(*onset) <= tolerance)
-            {
-                doubled += 1;
-            }
-        }
-    }
-
-    let correct = matched.iter().filter(|matched| **matched).count();
-    OnsetScore {
-        correct,
-        false_positives,
-        false_negatives: expected.len() - correct,
-        doubled,
-        signed_errors,
-    }
-}
-
 #[test]
 fn beating_decay_tails_are_not_detected_as_new_attacks() {
     let sample_rate = 44_100u32;
     let (audio, expected) = ringing_attack_train(sample_rate);
     let detected = detect_onsets(&audio, TransientSensitivity::DEFAULT);
-    let score = score_onsets(
+    let score = evaluate(
         &detected,
         &expected,
         frames_for_ms(sample_rate, 25.0) as u64,
+        sample_rate,
     );
 
     assert_eq!(
@@ -119,14 +56,44 @@ fn beating_decay_tails_are_not_detected_as_new_attacks() {
     );
     assert_eq!(score.doubled, 0, "score={score:?}, onsets={detected:?}");
     assert_eq!(score.f1(), 1.0, "score={score:?}, onsets={detected:?}");
-    assert_eq!(score.signed_errors.len(), expected.len());
-    let five_ms = frames_for_ms(sample_rate, 5.0) as i64;
+    assert_eq!(score.signed_errors_ms.len(), expected.len());
     assert!(
         score
-            .signed_errors
+            .signed_errors_ms
             .iter()
-            .all(|error| error.abs() <= five_ms),
-        "slice boundaries exceed 5 ms: {score:?}"
+            .all(|error| error.abs() <= 7.0),
+        "ringing-tail boundaries exceed aubio's 7 ms tolerance: {score:?}"
+    );
+}
+
+#[test]
+fn sharp_click_boundaries_land_within_one_localisation_hop() {
+    let sample_rate = 44_100u32;
+    let expected = [4_000u64, 14_000, 24_000, 34_000];
+    let mut channel = vec![0.0f32; sample_rate as usize];
+    for start in expected {
+        let start = start as usize;
+        for offset in 0..1_024 {
+            let phase = std::f32::consts::TAU * 1_800.0 * offset as f32 / sample_rate as f32;
+            channel[start + offset] = phase.cos() * (-(offset as f32) / 100.0).exp();
+        }
+    }
+    let audio = make_audio(vec![channel.clone(), channel], sample_rate);
+    let detected = detect_onsets(&audio, TransientSensitivity::DEFAULT);
+    let score = evaluate(
+        &detected,
+        &expected,
+        frames_for_ms(sample_rate, 10.0) as u64,
+        sample_rate,
+    );
+
+    assert_eq!(score.f1(), 1.0, "score={score:?}, onsets={detected:?}");
+    assert!(
+        score
+            .signed_errors_ms
+            .iter()
+            .all(|error| error.abs() <= 2.90),
+        "sharp-click boundary exceeds one localisation hop: {score:?}"
     );
 }
 
@@ -141,10 +108,11 @@ fn transient_detection_is_sample_rate_and_gain_robust() {
                 }
             }
             let detected = detect_onsets(&audio, TransientSensitivity::DEFAULT);
-            let score = score_onsets(
+            let score = evaluate(
                 &detected,
                 &expected,
                 frames_for_ms(sample_rate, 25.0) as u64,
+                sample_rate,
             );
             assert_eq!(
                 score.f1(),
@@ -170,10 +138,11 @@ fn opposite_polarity_stereo_does_not_cancel_transient_analysis() {
         .for_each(|sample| *sample = -*sample);
 
     let detected = detect_onsets(&audio, TransientSensitivity::DEFAULT);
-    let score = score_onsets(
+    let score = evaluate(
         &detected,
         &expected,
         frames_for_ms(sample_rate, 25.0) as u64,
+        sample_rate,
     );
     assert_eq!(score.f1(), 1.0, "score={score:?}, onsets={detected:?}");
 }
@@ -185,10 +154,11 @@ fn ported_librosa_backtracking_lands_on_a_preceding_energy_minimum() {
     let energy = [3.0, 2.0, 2.0, 4.0, 3.0, 1.0, 2.0];
     let hop = 128usize;
     let events = [hop as u64, (3 * hop) as u64, (6 * hop) as u64];
-    let backtracked = backtrack_events_to_minima(&events, &energy, hop, usize::MAX);
+    let events = events.map(|event| (event, event));
+    let backtracked = localize::backtrack_events_to_minima(&events, &energy, hop, usize::MAX);
 
     assert_eq!(backtracked, [0, (2 * hop) as u64, (5 * hop) as u64]);
-    for (event, boundary) in events.iter().zip(&backtracked) {
+    for ((event, _), boundary) in events.iter().zip(&backtracked) {
         assert!(*boundary <= *event, "backtracking moved an event later");
         let frame = *boundary as usize / hop;
         assert!(
@@ -204,7 +174,7 @@ fn backtracking_respects_the_daw_lookback_bound() {
     let hop = 128usize;
     let event = (6 * hop) as u64;
     assert_eq!(
-        backtrack_events_to_minima(&[event], &energy, hop, hop),
+        localize::backtrack_events_to_minima(&[(event, event)], &energy, hop, hop),
         [event]
     );
 }

--- a/crates/vibez-core/src/onset/transient_analysis_tests.rs
+++ b/crates/vibez-core/src/onset/transient_analysis_tests.rs
@@ -1,0 +1,210 @@
+use super::*;
+
+fn make_audio(channels: Vec<Vec<f32>>, sample_rate: u32) -> DecodedAudio {
+    DecodedAudio {
+        channels,
+        sample_rate,
+    }
+}
+
+fn ringing_attack_train(sample_rate: u32) -> (DecodedAudio, Vec<u64>) {
+    let starts =
+        [2_000usize, 13_000, 24_000, 35_000].map(|frame| frame * sample_rate as usize / 44_100);
+    let tail_frames = 7_000 * sample_rate as usize / 44_100;
+    let decay_frames = 2_500.0 * sample_rate as f32 / 44_100.0;
+    let mut channel = vec![0.0f32; sample_rate as usize];
+    for start in starts {
+        for offset in 0..tail_frames {
+            if start + offset >= channel.len() {
+                break;
+            }
+            let time = offset as f32 / sample_rate as f32;
+            let decay = (-(offset as f32) / decay_frames).exp();
+            channel[start + offset] += decay
+                * ((std::f32::consts::TAU * 120.0 * time).sin()
+                    + (std::f32::consts::TAU * 128.0 * time).sin())
+                * 0.4;
+        }
+    }
+    let expected = starts.into_iter().map(|frame| frame as u64).collect();
+    (
+        make_audio(vec![channel.clone(), channel], sample_rate),
+        expected,
+    )
+}
+
+#[derive(Debug)]
+struct OnsetScore {
+    correct: usize,
+    false_positives: usize,
+    false_negatives: usize,
+    doubled: usize,
+    signed_errors: Vec<i64>,
+}
+
+impl OnsetScore {
+    fn precision(&self) -> f32 {
+        self.correct as f32 / (self.correct + self.false_positives).max(1) as f32
+    }
+
+    fn recall(&self) -> f32 {
+        self.correct as f32 / (self.correct + self.false_negatives).max(1) as f32
+    }
+
+    fn f1(&self) -> f32 {
+        let precision = self.precision();
+        let recall = self.recall();
+        if precision + recall == 0.0 {
+            0.0
+        } else {
+            2.0 * precision * recall / (precision + recall)
+        }
+    }
+}
+
+fn score_onsets(detected: &[u64], expected: &[u64], tolerance: u64) -> OnsetScore {
+    let mut matched = vec![false; expected.len()];
+    let mut signed_errors = Vec::new();
+    let mut false_positives = 0;
+    let mut doubled = 0;
+
+    for &candidate in detected {
+        let best = expected
+            .iter()
+            .enumerate()
+            .filter(|(index, onset)| !matched[*index] && candidate.abs_diff(**onset) <= tolerance)
+            .min_by_key(|(_, onset)| candidate.abs_diff(**onset));
+        if let Some((index, onset)) = best {
+            matched[index] = true;
+            signed_errors.push(candidate as i64 - *onset as i64);
+        } else {
+            false_positives += 1;
+            if expected
+                .iter()
+                .any(|onset| candidate.abs_diff(*onset) <= tolerance)
+            {
+                doubled += 1;
+            }
+        }
+    }
+
+    let correct = matched.iter().filter(|matched| **matched).count();
+    OnsetScore {
+        correct,
+        false_positives,
+        false_negatives: expected.len() - correct,
+        doubled,
+        signed_errors,
+    }
+}
+
+#[test]
+fn beating_decay_tails_are_not_detected_as_new_attacks() {
+    let sample_rate = 44_100u32;
+    let (audio, expected) = ringing_attack_train(sample_rate);
+    let detected = detect_onsets(&audio, TransientSensitivity::DEFAULT);
+    let score = score_onsets(
+        &detected,
+        &expected,
+        frames_for_ms(sample_rate, 25.0) as u64,
+    );
+
+    assert_eq!(
+        score.false_positives, 0,
+        "score={score:?}, onsets={detected:?}"
+    );
+    assert_eq!(
+        score.false_negatives, 0,
+        "score={score:?}, onsets={detected:?}"
+    );
+    assert_eq!(score.doubled, 0, "score={score:?}, onsets={detected:?}");
+    assert_eq!(score.f1(), 1.0, "score={score:?}, onsets={detected:?}");
+    assert_eq!(score.signed_errors.len(), expected.len());
+    let five_ms = frames_for_ms(sample_rate, 5.0) as i64;
+    assert!(
+        score
+            .signed_errors
+            .iter()
+            .all(|error| error.abs() <= five_ms),
+        "slice boundaries exceed 5 ms: {score:?}"
+    );
+}
+
+#[test]
+fn transient_detection_is_sample_rate_and_gain_robust() {
+    for sample_rate in [44_100u32, 48_000, 96_000] {
+        let (mut audio, expected) = ringing_attack_train(sample_rate);
+        for gain in [0.05f32, 0.5, 1.0] {
+            for channel in &mut audio.channels {
+                for sample in channel {
+                    *sample *= gain;
+                }
+            }
+            let detected = detect_onsets(&audio, TransientSensitivity::DEFAULT);
+            let score = score_onsets(
+                &detected,
+                &expected,
+                frames_for_ms(sample_rate, 25.0) as u64,
+            );
+            assert_eq!(
+                score.f1(),
+                1.0,
+                "sample_rate={sample_rate}, gain={gain}, score={score:?}, onsets={detected:?}"
+            );
+
+            for channel in &mut audio.channels {
+                for sample in channel {
+                    *sample /= gain;
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn opposite_polarity_stereo_does_not_cancel_transient_analysis() {
+    let sample_rate = 44_100u32;
+    let (mut audio, expected) = ringing_attack_train(sample_rate);
+    audio.channels[1]
+        .iter_mut()
+        .for_each(|sample| *sample = -*sample);
+
+    let detected = detect_onsets(&audio, TransientSensitivity::DEFAULT);
+    let score = score_onsets(
+        &detected,
+        &expected,
+        frames_for_ms(sample_rate, 25.0) as u64,
+    );
+    assert_eq!(score.f1(), 1.0, "score={score:?}, onsets={detected:?}");
+}
+
+// Ports the invariants asserted by librosa 0.11.0's test_onset_backtrack for
+// both onset-envelope and RMS inputs.
+#[test]
+fn ported_librosa_backtracking_lands_on_a_preceding_energy_minimum() {
+    let energy = [3.0, 2.0, 2.0, 4.0, 3.0, 1.0, 2.0];
+    let hop = 128usize;
+    let events = [hop as u64, (3 * hop) as u64, (6 * hop) as u64];
+    let backtracked = backtrack_events_to_minima(&events, &energy, hop, usize::MAX);
+
+    assert_eq!(backtracked, [0, (2 * hop) as u64, (5 * hop) as u64]);
+    for (event, boundary) in events.iter().zip(&backtracked) {
+        assert!(*boundary <= *event, "backtracking moved an event later");
+        let frame = *boundary as usize / hop;
+        assert!(
+            frame == 0 || energy[frame] <= energy[frame - 1],
+            "boundary {boundary} did not land on a local minimum"
+        );
+    }
+}
+
+#[test]
+fn backtracking_respects_the_daw_lookback_bound() {
+    let energy = [3.0, 2.0, 1.0, 2.0, 3.0, 4.0, 5.0];
+    let hop = 128usize;
+    let event = (6 * hop) as u64;
+    assert_eq!(
+        backtrack_events_to_minima(&[event], &energy, hop, hop),
+        [event]
+    );
+}

--- a/crates/vibez-ui/src/app/transient_markers.rs
+++ b/crates/vibez-ui/src/app/transient_markers.rs
@@ -29,7 +29,11 @@ impl App {
         let expected_audio = Arc::clone(&clip.audio);
         let detection_audio = Arc::clone(&expected_audio);
         if record_undo {
-            self.state.status_text = format!("Detecting transients in {}...", clip.name);
+            self.state.status_text = format!(
+                "Analysing transients in {} at {}%...",
+                clip.name,
+                sensitivity.percent()
+            );
         }
         Task::perform(
             detect_clip_transients_async(detection_audio, sensitivity),

--- a/crates/vibez-ui/src/app/views_transient_analysis.rs
+++ b/crates/vibez-ui/src/app/views_transient_analysis.rs
@@ -36,9 +36,9 @@ impl App {
         let detected_count = marker_count(vibez_core::transient::TransientMarkerKind::Suggested);
         let manual_count = marker_count(vibez_core::transient::TransientMarkerKind::Authored);
         let marker_summary = if manual_count == 0 {
-            format!("{detected_count} detected")
+            format!("{detected_count} currently detected")
         } else {
-            format!("{detected_count} detected · {manual_count} manual")
+            format!("{detected_count} currently detected · {manual_count} manual")
         };
 
         let sensitivity_knob: Element<'_, Message> =

--- a/crates/vibez-ui/src/domains/arrangement/tests/audio_markers.rs
+++ b/crates/vibez-ui/src/domains/arrangement/tests/audio_markers.rs
@@ -472,6 +472,33 @@ fn detection_replaces_suggestions_but_preserves_authored_transient_markers() {
 }
 
 #[test]
+fn repeated_detection_reports_completion_without_dirtying_the_project() {
+    let mut arrangement = arrangement_with_tracks(1);
+    let (track_id, clip_id) = add_audio_clip(&mut arrangement, 0, 0, 1_000);
+    arrangement.tracks[0].clips[0]
+        .transient_markers
+        .replace_suggestions([300, 700]);
+    let mut engine = RecordingEngine::default();
+
+    let action = arrangement.update(
+        ArrangementMsg::ReplaceDetectedTransientMarkers {
+            track_id,
+            clip_id,
+            source_frames: vec![300, 700],
+        },
+        &mut engine,
+        ArrangementCtx::default(),
+    );
+
+    assert!(!action.mark_dirty);
+    assert_eq!(
+        action.status.as_deref(),
+        Some("Detected 2 Transient Markers (no change)")
+    );
+    assert!(engine.0.is_empty());
+}
+
+#[test]
 fn warp_marker_edits_keep_fixed_boundaries_and_sync_the_engine() {
     let mut arrangement = arrangement_with_tracks(1);
     let (track_id, clip_id) = add_audio_clip(&mut arrangement, 0, 0, 1_000);

--- a/crates/vibez-ui/src/domains/arrangement/transient_markers.rs
+++ b/crates/vibez-ui/src/domains/arrangement/transient_markers.rs
@@ -94,7 +94,7 @@ impl TimelineEditorState {
                 let result = self
                     .find_content_mut(track_id)
                     .and_then(|content| content.clips.iter_mut().find(|clip| clip.id == clip_id))
-                    .and_then(|clip| {
+                    .map(|clip| {
                         let (source_start, source_end) = source_bounds(clip);
                         let before = clip.transient_markers.clone();
                         clip.transient_markers.replace_suggestions(
@@ -102,18 +102,23 @@ impl TimelineEditorState {
                                 .into_iter()
                                 .filter(|frame| *frame >= source_start && *frame <= source_end),
                         );
-                        (clip.transient_markers != before).then(|| {
-                            clip.transient_markers
-                                .as_slice()
-                                .iter()
-                                .filter(|marker| marker.kind() == TransientMarkerKind::Suggested)
-                                .count()
-                        })
+                        let changed = clip.transient_markers != before;
+                        let count = clip
+                            .transient_markers
+                            .as_slice()
+                            .iter()
+                            .filter(|marker| marker.kind() == TransientMarkerKind::Suggested)
+                            .count();
+                        (changed, count)
                     });
-                if let Some(count) = result {
+                if let Some((changed, count)) = result {
                     self.selected_transient_marker = None;
-                    action.status = Some(format!("Detected {count} Transient Markers"));
-                    action.mark_dirty = true;
+                    action.status = Some(if changed {
+                        format!("Detected {count} Transient Markers")
+                    } else {
+                        format!("Detected {count} Transient Markers (no change)")
+                    });
+                    action.mark_dirty = changed;
                 }
             }
             _ => unreachable!("non-Transient Marker message reached its editor"),


### PR DESCRIPTION
## Outcome

Transient analysis now separates event detection from slice-boundary localisation. On both reported 2-second production loops it returns the seven producer-relevant attacks, removes the decay markers, and moves the retained markers back onto source-energy boundaries.

## What changed

- replace the HFC plus energy union with aubio 0.4.9 complex-domain candidates
- port adaptive whitening, log compression, phase prediction, upstream zero cases, and golden primary-event timing
- generate one fixed permissive candidate set so sensitivity only filters stable source frames
- analyse stereo channels independently to avoid polarity cancellation
- scale the FFT window at 44.1, 48, and 96 kHz
- validate candidate prominence, then backtrack the detected peak to a bounded trailing-RMS minimum
- port librosa 0.11.0 backtracking invariants with its ISC notice
- add a generated beating-tail regression fixture and timing, gain, sample-rate, and stereo-polarity coverage
- add an annotation-manifest benchmark reporting precision, recall, F1, doubled events, and boundary error percentiles

## Exact dogfood results at 50%

`LP122 01F.wav`

```text
0.247 0.482 0.737 0.981 1.228 1.466 1.718
```

`DD 124 29E.wav`

```text
0.229 0.482 0.717 0.961 1.190 1.443 1.678
```

These are seven candidates on each loop. The private 25-loop producer-approved corpus remains the release gate. Two good loops are evidence, not the whole benchmark.

## Why the diff is 782 lines

- 203 lines modify the aubio port for the complex-domain descriptor and its tests
- 210 lines are isolated generated-fixture and boundary tests
- 212 lines are the reusable private-corpus benchmark executable
- the remainder replaces the production pipeline and documents licensing and timing rules

Production `onset.rs` remains below the repository's 1,000-line ceiling after moving the new verification suite into its own module.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- exact local analysis of both reported loops
