### PR TITLE
fix: show Drum Rack pad playback activity

### DIFF
--- a/crates/vibez-engine/src/engine_render.rs
+++ b/crates/vibez-engine/src/engine_render.rs
@@ -307,17 +307,15 @@ impl AudioEngine {
                 track.render(pos, frames, channels, loop_region)
             };
 
-            let triggered_notes = track.pending_note_activity();
-            if triggered_notes != 0
-                && self
-                    .event_tx
-                    .push(EngineEvent::TrackNoteActivity {
-                        track_id: track.id,
-                        triggered_notes,
-                    })
-                    .is_ok()
-            {
-                track.clear_note_activity(triggered_notes);
+            let triggered_notes = track.take_note_activity();
+            if triggered_notes != 0 {
+                // Pad flashes are cosmetic. Never retain them or let them
+                // compete with authoritative input and Capture events after a
+                // UI stall fills the shared ring.
+                let _ = self.event_tx.push(EngineEvent::TrackNoteActivity {
+                    track_id: track.id,
+                    triggered_notes,
+                });
             }
 
             if live_input.is_some_and(|input| input.target_track_raw == track.id.raw()) {

--- a/crates/vibez-engine/src/engine_render.rs
+++ b/crates/vibez-engine/src/engine_render.rs
@@ -307,6 +307,19 @@ impl AudioEngine {
                 track.render(pos, frames, channels, loop_region)
             };
 
+            let triggered_notes = track.pending_note_activity();
+            if triggered_notes != 0
+                && self
+                    .event_tx
+                    .push(EngineEvent::TrackNoteActivity {
+                        track_id: track.id,
+                        triggered_notes,
+                    })
+                    .is_ok()
+            {
+                track.clear_note_activity(triggered_notes);
+            }
+
             if live_input.is_some_and(|input| input.target_track_raw == track.id.raw()) {
                 let input = live_input.expect("checked live input");
                 if !rendered && track.instrument.is_none() {

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -1543,6 +1543,62 @@ fn note_clip_loop_renders() {
     );
 }
 
+#[test]
+fn note_clip_reports_triggered_pitches_for_device_feedback() {
+    use vibez_core::midi::{InstrumentKind, MidiNote};
+
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let clip_id = ClipId::new();
+
+    cmd_tx
+        .push(EngineCommand::AddInstrumentTrack(
+            track_id,
+            "Drums".into(),
+            InstrumentKind::DrumRack,
+        ))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddNoteClip {
+            track_id,
+            clip_id,
+            position_beats: 0.0,
+            duration_beats: 1.0,
+            start_marker_beats: 0.0,
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddNote {
+            track_id,
+            clip_id,
+            note: MidiNote {
+                pitch: 36,
+                velocity: 100,
+                start_beat: 0.0,
+                duration_beats: 0.25,
+            },
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut output = vec![0.0; 512 * 2];
+    engine.process(&mut output, 2);
+
+    assert!(std::iter::from_fn(|| event_rx.pop().ok()).any(|event| {
+        matches!(
+            event,
+            EngineEvent::TrackNoteActivity {
+                track_id: event_track_id,
+                triggered_notes,
+            } if event_track_id == track_id && triggered_notes == 1u128 << 36
+        )
+    }));
+}
+
 // ---- Automation ----
 
 fn rms(buf: &[f32]) -> f32 {

--- a/crates/vibez-engine/src/engine_tests.rs
+++ b/crates/vibez-engine/src/engine_tests.rs
@@ -1599,6 +1599,124 @@ fn note_clip_reports_triggered_pitches_for_device_feedback() {
     }));
 }
 
+#[test]
+fn synth_note_clip_does_not_report_drum_pad_activity() {
+    use vibez_core::midi::{InstrumentKind, MidiNote};
+
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let clip_id = ClipId::new();
+
+    cmd_tx
+        .push(EngineCommand::AddInstrumentTrack(
+            track_id,
+            "Synth".into(),
+            InstrumentKind::SubtractiveSynth,
+        ))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddNoteClip {
+            track_id,
+            clip_id,
+            position_beats: 0.0,
+            duration_beats: 1.0,
+            start_marker_beats: 0.0,
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddNote {
+            track_id,
+            clip_id,
+            note: MidiNote {
+                pitch: 60,
+                velocity: 100,
+                start_beat: 0.0,
+                duration_beats: 0.25,
+            },
+        })
+        .unwrap();
+    cmd_tx.push(EngineCommand::Play).unwrap();
+
+    let mut output = vec![0.0; 512 * 2];
+    engine.process(&mut output, 2);
+
+    assert!(!std::iter::from_fn(|| event_rx.pop().ok()).any(|event| {
+        matches!(
+            event,
+            EngineEvent::TrackNoteActivity {
+                track_id: event_track_id,
+                ..
+            } if event_track_id == track_id
+        )
+    }));
+}
+
+#[test]
+fn drum_pad_activity_dropped_by_a_full_event_ring_is_not_replayed_late() {
+    use vibez_core::midi::{InstrumentKind, MidiNote};
+
+    let (mut engine, mut cmd_tx, mut event_rx) = AudioEngine::new();
+    let track_id = TrackId::new();
+    let clip_id = ClipId::new();
+    cmd_tx
+        .push(EngineCommand::AddInstrumentTrack(
+            track_id,
+            "Drums".into(),
+            InstrumentKind::DrumRack,
+        ))
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddNoteClip {
+            track_id,
+            clip_id,
+            position_beats: 0.0,
+            duration_beats: 1.0,
+            start_marker_beats: 0.0,
+            loop_enabled: false,
+            loop_start_beats: 0.0,
+            loop_end_beats: 0.0,
+            groove_grid: vibez_core::perform::GrooveGrid::Off,
+        })
+        .unwrap();
+    cmd_tx
+        .push(EngineCommand::AddNote {
+            track_id,
+            clip_id,
+            note: MidiNote {
+                pitch: 36,
+                velocity: 100,
+                start_beat: 0.0,
+                duration_beats: 0.25,
+            },
+        })
+        .unwrap();
+
+    let mut output = vec![0.0; 64 * 2];
+    for _ in 0..600 {
+        engine.process(&mut output, 2);
+    }
+    cmd_tx.push(EngineCommand::Play).unwrap();
+    engine.process(&mut output, 2);
+
+    let queued_events = std::iter::from_fn(|| event_rx.pop().ok()).count();
+    assert_eq!(queued_events, vibez_core::constants::RING_BUFFER_CAPACITY);
+
+    engine.process(&mut output, 2);
+    assert!(!std::iter::from_fn(|| event_rx.pop().ok()).any(|event| {
+        matches!(
+            event,
+            EngineEvent::TrackNoteActivity {
+                track_id: event_track_id,
+                ..
+            } if event_track_id == track_id
+        )
+    }));
+}
+
 // ---- Automation ----
 
 fn rms(buf: &[f32]) -> f32 {

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -84,9 +84,9 @@ pub enum EngineEvent {
         peak_r: f32,
     },
 
-    /// Pitches triggered by resident MIDI clips during the latest audio
-    /// block. One bit per MIDI pitch keeps device feedback bounded to one
-    /// event per track and block, even when several notes land together.
+    /// Drum Rack pitches triggered by resident MIDI clips during the latest
+    /// audio block. One bit per MIDI pitch keeps device feedback bounded to
+    /// one event per track and block, even when several notes land together.
     TrackNoteActivity {
         track_id: TrackId,
         triggered_notes: u128,

--- a/crates/vibez-engine/src/events.rs
+++ b/crates/vibez-engine/src/events.rs
@@ -84,6 +84,14 @@ pub enum EngineEvent {
         peak_r: f32,
     },
 
+    /// Pitches triggered by resident MIDI clips during the latest audio
+    /// block. One bit per MIDI pitch keeps device feedback bounded to one
+    /// event per track and block, even when several notes land together.
+    TrackNoteActivity {
+        track_id: TrackId,
+        triggered_notes: u128,
+    },
+
     /// A track mute command became effective in the audio engine at this
     /// active engine-clock sample. This is the authoritative event Capture
     /// consumes.
@@ -277,6 +285,16 @@ impl PartialEq for EngineEvent {
                     && left_peak_l == right_peak_l
                     && left_peak_r == right_peak_r
             }
+            (
+                Self::TrackNoteActivity {
+                    track_id: left_track,
+                    triggered_notes: left_notes,
+                },
+                Self::TrackNoteActivity {
+                    track_id: right_track,
+                    triggered_notes: right_notes,
+                },
+            ) => left_track == right_track && left_notes == right_notes,
             (
                 Self::TrackMuteChanged {
                     track_id: left_track,

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -1,4 +1,5 @@
 use vibez_core::id::TrackId;
+use vibez_core::midi::InstrumentKind;
 use vibez_core::perform::{NoteRepeatRate, SwingAmount, SwingOffset};
 use vibez_core::time::TempoMap;
 use vibez_instruments::Instrument;
@@ -141,8 +142,8 @@ pub struct EngineTrack {
     /// adjacent sample positions, so a jump would otherwise strand
     /// every sounding note in the "held down" state forever.
     active_notes: u128,
-    /// MIDI pitches triggered by resident clips since the UI activity event
-    /// was last delivered. Retained if the event ring is temporarily full.
+    /// Drum Rack pitches triggered by resident clips during this render block.
+    /// Cosmetic feedback is deliberately lossy when the UI event ring is full.
     pending_note_activity: u128,
     pub(crate) suppress_source_notes: bool,
 }
@@ -217,6 +218,10 @@ impl EngineTrack {
         } = block;
         let buf_size = frames * channels;
         let mut rendered = false;
+        let reports_drum_pad_activity = self
+            .instrument
+            .as_ref()
+            .is_some_and(|instrument| instrument.instrument_kind() == InstrumentKind::DrumRack);
 
         self.timed_note_ons.clear();
         self.timed_note_offs.clear();
@@ -256,7 +261,9 @@ impl EngineTrack {
         }
         for &(frame, pitch, vel) in &self.timed_note_ons {
             instrument.note_on_at(pitch, vel, frame);
-            self.pending_note_activity |= 1u128 << pitch;
+            if reports_drum_pad_activity {
+                self.pending_note_activity |= 1u128 << pitch;
+            }
             rendered = true;
         }
         // Update the sounding-note mask in event order: within one
@@ -307,6 +314,10 @@ impl EngineTrack {
         } = block;
         let buf_size = frames * channels;
         let mut rendered = false;
+        let reports_drum_pad_activity = self
+            .instrument
+            .as_ref()
+            .is_some_and(|instrument| instrument.instrument_kind() == InstrumentKind::DrumRack);
         self.timed_note_ons.clear();
         self.timed_note_offs.clear();
         if !self.suppress_source_notes {
@@ -343,7 +354,9 @@ impl EngineTrack {
                 let (_, pitch, velocity) = self.timed_note_ons[note_on_index];
                 instrument.note_on(pitch, velocity);
                 self.active_notes |= 1u128 << pitch;
-                self.pending_note_activity |= 1u128 << pitch;
+                if reports_drum_pad_activity {
+                    self.pending_note_activity |= 1u128 << pitch;
+                }
                 rendered = true;
                 note_on_index += 1;
             }
@@ -369,12 +382,8 @@ impl EngineTrack {
         rendered
     }
 
-    pub(crate) fn pending_note_activity(&self) -> u128 {
-        self.pending_note_activity
-    }
-
-    pub(crate) fn clear_note_activity(&mut self, delivered: u128) {
-        self.pending_note_activity &= !delivered;
+    pub(crate) fn take_note_activity(&mut self) -> u128 {
+        std::mem::take(&mut self.pending_note_activity)
     }
 }
 

--- a/crates/vibez-engine/src/mixer.rs
+++ b/crates/vibez-engine/src/mixer.rs
@@ -141,6 +141,9 @@ pub struct EngineTrack {
     /// adjacent sample positions, so a jump would otherwise strand
     /// every sounding note in the "held down" state forever.
     active_notes: u128,
+    /// MIDI pitches triggered by resident clips since the UI activity event
+    /// was last delivered. Retained if the event ring is temporarily full.
+    pending_note_activity: u128,
     pub(crate) suppress_source_notes: bool,
 }
 
@@ -253,6 +256,7 @@ impl EngineTrack {
         }
         for &(frame, pitch, vel) in &self.timed_note_ons {
             instrument.note_on_at(pitch, vel, frame);
+            self.pending_note_activity |= 1u128 << pitch;
             rendered = true;
         }
         // Update the sounding-note mask in event order: within one
@@ -339,6 +343,7 @@ impl EngineTrack {
                 let (_, pitch, velocity) = self.timed_note_ons[note_on_index];
                 instrument.note_on(pitch, velocity);
                 self.active_notes |= 1u128 << pitch;
+                self.pending_note_activity |= 1u128 << pitch;
                 rendered = true;
                 note_on_index += 1;
             }
@@ -362,6 +367,14 @@ impl EngineTrack {
         }
 
         rendered
+    }
+
+    pub(crate) fn pending_note_activity(&self) -> u128 {
+        self.pending_note_activity
+    }
+
+    pub(crate) fn clear_note_activity(&mut self, delivered: u128) {
+        self.pending_note_activity &= !delivered;
     }
 }
 

--- a/crates/vibez-engine/src/mixer/channel_strip.rs
+++ b/crates/vibez-engine/src/mixer/channel_strip.rs
@@ -33,6 +33,7 @@ impl EngineTrack {
             timed_note_offs: Vec::new(),
             note_repeats: TrackNoteRepeats::default(),
             active_notes: 0,
+            pending_note_activity: 0,
             suppress_source_notes: false,
         }
     }

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -790,7 +790,7 @@ impl App {
         self.poll_engine_events();
         self.state
             .view
-            .prune_drum_pad_activity(std::time::Instant::now());
+            .prune_drum_pad_flashes(std::time::Instant::now());
         self.poll_spectrum();
         self.poll_plugin_loads();
         self.poll_plugin_windows();

--- a/crates/vibez-ui/src/app/actions.rs
+++ b/crates/vibez-ui/src/app/actions.rs
@@ -788,6 +788,9 @@ impl App {
             return task;
         }
         self.poll_engine_events();
+        self.state
+            .view
+            .prune_drum_pad_activity(std::time::Instant::now());
         self.poll_spectrum();
         self.poll_plugin_loads();
         self.poll_plugin_windows();

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -34,12 +34,43 @@ fn active_audition_status(status: &str) -> bool {
     )
 }
 
+fn apply_drum_pad_flash(
+    view: &mut crate::state::ViewState,
+    event: &EngineEvent,
+    now: std::time::Instant,
+) {
+    match event {
+        EngineEvent::TrackNoteActivity {
+            track_id,
+            triggered_notes,
+        } => {
+            let mut notes = *triggered_notes;
+            while notes != 0 {
+                let pitch = notes.trailing_zeros() as u8;
+                view.trigger_drum_pad_flash(*track_id, pitch, now);
+                notes &= notes - 1;
+            }
+        }
+        EngineEvent::NoteRepeated {
+            track_id, pitch, ..
+        }
+        | EngineEvent::InstrumentNoteInput {
+            track_id,
+            pitch,
+            on: true,
+            ..
+        } => view.trigger_drum_pad_flash(*track_id, *pitch, now),
+        _ => {}
+    }
+}
+
 impl App {
     pub(super) fn poll_engine_events(&mut self) {
         let mut completed_section_recordings = Vec::new();
         let mut completed_captures = Vec::new();
         if let Some(ref mut rx) = self.event_rx {
             while let Ok(event) = rx.pop() {
+                apply_drum_pad_flash(&mut self.state.view, &event, std::time::Instant::now());
                 match event {
                     EngineEvent::DisposeEffect(cell) => {
                         // Plugin teardown remains on the UI thread.
@@ -114,17 +145,7 @@ impl App {
                             track.peak_r = peak_r.max(track.peak_r * 0.85);
                         }
                     }
-                    EngineEvent::TrackNoteActivity {
-                        track_id,
-                        mut triggered_notes,
-                    } => {
-                        let now = std::time::Instant::now();
-                        while triggered_notes != 0 {
-                            let pitch = triggered_notes.trailing_zeros() as u8;
-                            self.state.view.trigger_drum_pad(track_id, pitch, now);
-                            triggered_notes &= triggered_notes - 1;
-                        }
-                    }
+                    EngineEvent::TrackNoteActivity { .. } => {}
                     EngineEvent::TrackMuteChanged {
                         track_id,
                         muted,
@@ -193,11 +214,6 @@ impl App {
                         canonical_section_position_samples,
                         ..
                     } => {
-                        self.state.view.trigger_drum_pad(
-                            track_id,
-                            pitch,
-                            std::time::Instant::now(),
-                        );
                         self.state.perform.capture.repeated_note(
                             track_id,
                             pitch,
@@ -225,13 +241,6 @@ impl App {
                         section_id,
                         section_position_samples,
                     } => {
-                        if on {
-                            self.state.view.trigger_drum_pad(
-                                track_id,
-                                pitch,
-                                std::time::Instant::now(),
-                            );
-                        }
                         self.state.perform.capture.input_note(
                             track_id,
                             pitch,
@@ -452,5 +461,58 @@ mod tests {
             state.perform.pending_track_mute(track_id),
             None::<PendingTrackMute>
         );
+    }
+
+    #[test]
+    fn every_drum_pad_feedback_event_path_drives_the_same_flash_state() {
+        use vibez_core::perform::NoteRepeatRate;
+
+        let track_id = TrackId::new();
+        let now = std::time::Instant::now();
+        let mut view = crate::state::ViewState::default();
+        let clip_activity = EngineEvent::TrackNoteActivity {
+            track_id,
+            triggered_notes: (1u128 << 41) | (1u128 << 44),
+        };
+        let repeated = EngineEvent::NoteRepeated {
+            track_id,
+            pitch: 42,
+            velocity: 100,
+            rate: NoteRepeatRate::Eighth,
+            effective_at_samples: 0,
+            canonical_at_samples: 0,
+            section_id: None,
+            section_position_samples: None,
+            canonical_section_position_samples: None,
+        };
+        let input = EngineEvent::InstrumentNoteInput {
+            track_id,
+            pitch: 43,
+            velocity: 100,
+            on: true,
+            effective_at_samples: 0,
+            section_id: None,
+            section_position_samples: None,
+        };
+        let input_note_off = EngineEvent::InstrumentNoteInput {
+            track_id,
+            pitch: 45,
+            velocity: 0,
+            on: false,
+            effective_at_samples: 0,
+            section_id: None,
+            section_position_samples: None,
+        };
+
+        apply_drum_pad_flash(&mut view, &clip_activity, now);
+        apply_drum_pad_flash(&mut view, &repeated, now);
+        apply_drum_pad_flash(&mut view, &input, now);
+        apply_drum_pad_flash(&mut view, &input_note_off, now);
+
+        assert!(view.drum_pad_is_flashing(track_id, 41, now));
+        assert!(view.drum_pad_is_flashing(track_id, 42, now));
+        assert!(view.drum_pad_is_flashing(track_id, 43, now));
+        assert!(view.drum_pad_is_flashing(track_id, 44, now));
+        assert!(!view.drum_pad_is_flashing(track_id, 45, now));
     }
 }

--- a/crates/vibez-ui/src/app/engine_events.rs
+++ b/crates/vibez-ui/src/app/engine_events.rs
@@ -114,6 +114,17 @@ impl App {
                             track.peak_r = peak_r.max(track.peak_r * 0.85);
                         }
                     }
+                    EngineEvent::TrackNoteActivity {
+                        track_id,
+                        mut triggered_notes,
+                    } => {
+                        let now = std::time::Instant::now();
+                        while triggered_notes != 0 {
+                            let pitch = triggered_notes.trailing_zeros() as u8;
+                            self.state.view.trigger_drum_pad(track_id, pitch, now);
+                            triggered_notes &= triggered_notes - 1;
+                        }
+                    }
                     EngineEvent::TrackMuteChanged {
                         track_id,
                         muted,
@@ -182,6 +193,11 @@ impl App {
                         canonical_section_position_samples,
                         ..
                     } => {
+                        self.state.view.trigger_drum_pad(
+                            track_id,
+                            pitch,
+                            std::time::Instant::now(),
+                        );
                         self.state.perform.capture.repeated_note(
                             track_id,
                             pitch,
@@ -209,6 +225,13 @@ impl App {
                         section_id,
                         section_position_samples,
                     } => {
+                        if on {
+                            self.state.view.trigger_drum_pad(
+                                track_id,
+                                pitch,
+                                std::time::Instant::now(),
+                            );
+                        }
                         self.state.perform.capture.input_note(
                             track_id,
                             pitch,

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -723,13 +723,20 @@ impl App {
             Some(Message::remove_track_instrument(track_id)),
         ));
 
+        let activity_now = std::time::Instant::now();
         let mut grid = column![].spacing(4);
         for row_index in 0..4 {
             let mut pad_row = row![].spacing(4);
             for col_index in 0..4 {
                 let pad_index = bank_start + row_index * 4 + col_index;
                 let pad = &track.drum_rack_pads[pad_index];
-                let active = selected_pad == pad_index;
+                let pad_pitch = vibez_core::track::drum_rack_pad_pitch(pad_index)
+                    .expect("Drum Rack UI renders only valid pad slots");
+                let active = selected_pad == pad_index
+                    || self
+                        .state
+                        .view
+                        .drum_pad_is_active(track_id, pad_pitch, activity_now);
                 let drop_target = matches!(
                     self.state.browser.drag_target,
                     Some(crate::state::BrowserDropTarget::DrumRackPad {
@@ -755,10 +762,7 @@ impl App {
                 // Use container + mouse_area so press events reach us and
                 // drag-drop works. iced Button would capture ButtonPressed
                 // and hide it from mouse_area.
-                let pad_note = crate::widgets::piano_roll::pitch_name(
-                    vibez_core::track::drum_rack_pad_pitch(pad_index)
-                        .expect("Drum Rack UI renders only valid pad slots"),
-                );
+                let pad_note = crate::widgets::piano_roll::pitch_name(pad_pitch);
                 let pad_body = container(
                     column![
                         text(format!("{:02}  {pad_note}", pad_index + 1))

--- a/crates/vibez-ui/src/app/views_devices.rs
+++ b/crates/vibez-ui/src/app/views_devices.rs
@@ -18,6 +18,23 @@ use crate::widgets::effect_slot::view_effect_slot;
 
 use super::*;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DrumPadVisualState {
+    Idle,
+    Selected,
+    Firing,
+}
+
+fn drum_pad_visual_state(selected: bool, firing: bool) -> DrumPadVisualState {
+    if firing {
+        DrumPadVisualState::Firing
+    } else if selected {
+        DrumPadVisualState::Selected
+    } else {
+        DrumPadVisualState::Idle
+    }
+}
+
 impl App {
     /// Build the device chain for the detail panel.
     pub(super) fn view_device_chain<'a>(
@@ -724,6 +741,16 @@ impl App {
         ));
 
         let activity_now = std::time::Instant::now();
+        let earlier_bank_firing = (0..selected_bank).any(|bank| {
+            self.state
+                .view
+                .drum_pad_bank_is_flashing(track_id, bank, activity_now)
+        });
+        let later_bank_firing = ((selected_bank + 1)..bank_count).any(|bank| {
+            self.state
+                .view
+                .drum_pad_bank_is_flashing(track_id, bank, activity_now)
+        });
         let mut grid = column![].spacing(4);
         for row_index in 0..4 {
             let mut pad_row = row![].spacing(4);
@@ -732,11 +759,14 @@ impl App {
                 let pad = &track.drum_rack_pads[pad_index];
                 let pad_pitch = vibez_core::track::drum_rack_pad_pitch(pad_index)
                     .expect("Drum Rack UI renders only valid pad slots");
-                let active = selected_pad == pad_index
-                    || self
-                        .state
+                let visual_state = drum_pad_visual_state(
+                    selected_pad == pad_index,
+                    self.state
                         .view
-                        .drum_pad_is_active(track_id, pad_pitch, activity_now);
+                        .drum_pad_is_flashing(track_id, pad_pitch, activity_now),
+                );
+                let firing = visual_state == DrumPadVisualState::Firing;
+                let selected = visual_state == DrumPadVisualState::Selected;
                 let drop_target = matches!(
                     self.state.browser.drag_target,
                     Some(crate::state::BrowserDropTarget::DrumRackPad {
@@ -767,10 +797,20 @@ impl App {
                     column![
                         text(format!("{:02}  {pad_note}", pad_index + 1))
                             .size(9)
-                            .color(if active { th::accent() } else { th::text_dim() }),
-                        text(label)
-                            .size(8)
-                            .color(if active { th::accent() } else { th::text() })
+                            .color(if firing {
+                                th::bg_dark()
+                            } else if selected {
+                                th::accent()
+                            } else {
+                                th::text_dim()
+                            }),
+                        text(label).size(8).color(if firing {
+                            th::bg_dark()
+                        } else if selected {
+                            th::accent()
+                        } else {
+                            th::text()
+                        })
                     ]
                     .spacing(2)
                     .align_x(iced::Alignment::Center),
@@ -780,23 +820,25 @@ impl App {
                 .height(Length::Fixed(30.0))
                 .style(move |_theme: &Theme| container::Style {
                     background: Some(
-                        if drop_target || active {
+                        if firing {
+                            th::accent()
+                        } else if drop_target || selected {
                             th::accent_dim()
                         } else {
                             th::bg_dark()
                         }
                         .into(),
                     ),
-                    text_color: Some(if active { th::accent() } else { th::text() }),
+                    text_color: Some(if firing { th::bg_dark() } else { th::text() }),
                     border: iced::Border {
-                        color: if drop_target {
+                        color: if firing || drop_target {
                             th::accent()
-                        } else if active {
+                        } else if selected {
                             th::accent_dim()
                         } else {
                             th::border()
                         },
-                        width: if drop_target { 2.0 } else { 1.0 },
+                        width: if firing || drop_target { 2.0 } else { 1.0 },
                         radius: 0.0.into(),
                     },
                     ..Default::default()
@@ -819,41 +861,52 @@ impl App {
             grid = grid.push(pad_row);
         }
 
-        let bank_button = |icon: char, bank: Option<usize>| {
-            button(icons::icon(icon).size(9).color(th::text_dim()))
-                .on_press_maybe(bank.map(|bank| {
-                    Message::Devices(crate::domains::devices::DevicesMsg::SelectDrumRackBank(
-                        track_id, bank,
-                    ))
-                }))
-                .padding([1, 7])
-                .style(move |_theme: &Theme, status| button::Style {
-                    background: Some(
-                        if matches!(status, button::Status::Hovered | button::Status::Pressed) {
-                            th::bg_hover()
-                        } else {
-                            th::bg_dark()
-                        }
-                        .into(),
-                    ),
-                    text_color: th::text_dim(),
-                    border: iced::Border {
-                        color: th::border(),
-                        width: 1.0,
-                        radius: 2.0.into(),
-                    },
-                    ..Default::default()
-                })
+        let bank_button = |icon: char, bank: Option<usize>, firing: bool| {
+            button(icons::icon(icon).size(9).color(if firing {
+                th::accent()
+            } else {
+                th::text_dim()
+            }))
+            .on_press_maybe(bank.map(|bank| {
+                Message::Devices(crate::domains::devices::DevicesMsg::SelectDrumRackBank(
+                    track_id, bank,
+                ))
+            }))
+            .padding([1, 7])
+            .style(move |_theme: &Theme, status| button::Style {
+                background: Some(
+                    if firing {
+                        th::accent_dim()
+                    } else if matches!(status, button::Status::Hovered | button::Status::Pressed) {
+                        th::bg_hover()
+                    } else {
+                        th::bg_dark()
+                    }
+                    .into(),
+                ),
+                text_color: if firing { th::accent() } else { th::text_dim() },
+                border: iced::Border {
+                    color: if firing { th::accent() } else { th::border() },
+                    width: 1.0,
+                    radius: 2.0.into(),
+                },
+                ..Default::default()
+            })
         };
         let bank_navigation = row![
             text(format!("BANK {} / {bank_count}", selected_bank + 1))
                 .size(9)
                 .color(th::text_muted()),
             horizontal_space(),
-            bank_button(icons::CHEVRON_LEFT, selected_bank.checked_sub(1)),
+            bank_button(
+                icons::CHEVRON_LEFT,
+                selected_bank.checked_sub(1),
+                earlier_bank_firing
+            ),
             bank_button(
                 icons::CHEVRON_RIGHT,
-                (selected_bank + 1 < bank_count).then_some(selected_bank + 1)
+                (selected_bank + 1 < bank_count).then_some(selected_bank + 1),
+                later_bank_firing
             ),
         ]
         .spacing(4)
@@ -1161,5 +1214,26 @@ impl App {
                 .width(Length::Fixed(120.0))
                 .align_x(iced::Alignment::Center),
         )
+    }
+}
+
+#[cfg(test)]
+mod drum_pad_visual_tests {
+    use super::*;
+
+    #[test]
+    fn firing_has_precedence_over_selection() {
+        assert_eq!(
+            drum_pad_visual_state(true, true),
+            DrumPadVisualState::Firing
+        );
+        assert_eq!(
+            drum_pad_visual_state(true, false),
+            DrumPadVisualState::Selected
+        );
+        assert_eq!(
+            drum_pad_visual_state(false, false),
+            DrumPadVisualState::Idle
+        );
     }
 }

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -123,7 +123,7 @@ pub struct ViewState {
     pub edit_name_text: String,
     /// Short-lived, engine-authored note flashes for device feedback.
     /// This is view state only and is never persisted with the project.
-    pub(crate) drum_pad_activity: HashMap<(TrackId, u8), std::time::Instant>,
+    pub(crate) drum_pad_flash_until: HashMap<(TrackId, u8), std::time::Instant>,
 }
 impl Default for ViewState {
     fn default() -> Self {
@@ -151,32 +151,53 @@ impl Default for ViewState {
             editing_track_name: None,
             editing_clip_name: None,
             edit_name_text: String::new(),
-            drum_pad_activity: HashMap::new(),
+            drum_pad_flash_until: HashMap::new(),
         }
     }
 }
 
 impl ViewState {
-    const DRUM_PAD_ACTIVITY_HOLD: std::time::Duration = std::time::Duration::from_millis(140);
+    const DRUM_PAD_FLASH_HOLD: std::time::Duration = std::time::Duration::from_millis(140);
 
-    pub fn trigger_drum_pad(&mut self, track_id: TrackId, pitch: u8, now: std::time::Instant) {
-        self.drum_pad_activity
-            .insert((track_id, pitch), now + Self::DRUM_PAD_ACTIVITY_HOLD);
+    pub fn trigger_drum_pad_flash(
+        &mut self,
+        track_id: TrackId,
+        pitch: u8,
+        now: std::time::Instant,
+    ) {
+        self.drum_pad_flash_until
+            .insert((track_id, pitch), now + Self::DRUM_PAD_FLASH_HOLD);
     }
 
-    pub fn drum_pad_is_active(
+    pub fn drum_pad_is_flashing(
         &self,
         track_id: TrackId,
         pitch: u8,
         now: std::time::Instant,
     ) -> bool {
-        self.drum_pad_activity
+        self.drum_pad_flash_until
             .get(&(track_id, pitch))
             .is_some_and(|expires_at| *expires_at > now)
     }
 
-    pub fn prune_drum_pad_activity(&mut self, now: std::time::Instant) {
-        self.drum_pad_activity
+    pub fn drum_pad_bank_is_flashing(
+        &self,
+        track_id: TrackId,
+        bank: usize,
+        now: std::time::Instant,
+    ) -> bool {
+        let first_pad = bank.saturating_mul(vibez_core::track::DRUM_RACK_BANK_SIZE);
+        let end_pad = first_pad
+            .saturating_add(vibez_core::track::DRUM_RACK_BANK_SIZE)
+            .min(vibez_core::track::DRUM_RACK_PAD_COUNT);
+        (first_pad..end_pad).any(|pad| {
+            vibez_core::track::drum_rack_pad_pitch(pad)
+                .is_some_and(|pitch| self.drum_pad_is_flashing(track_id, pitch, now))
+        })
+    }
+
+    pub fn prune_drum_pad_flashes(&mut self, now: std::time::Instant) {
+        self.drum_pad_flash_until
             .retain(|_, expires_at| *expires_at > now);
     }
 
@@ -1323,16 +1344,30 @@ mod tests {
         let other_track_id = TrackId::new();
         let now = std::time::Instant::now();
 
-        view.trigger_drum_pad(track_id, 52, now);
+        view.trigger_drum_pad_flash(track_id, 52, now);
 
-        assert!(view.drum_pad_is_active(track_id, 52, now));
-        assert!(!view.drum_pad_is_active(track_id, 51, now));
-        assert!(!view.drum_pad_is_active(other_track_id, 52, now));
+        assert!(view.drum_pad_is_flashing(track_id, 52, now));
+        assert!(!view.drum_pad_is_flashing(track_id, 51, now));
+        assert!(!view.drum_pad_is_flashing(other_track_id, 52, now));
 
-        let after_hold = now + ViewState::DRUM_PAD_ACTIVITY_HOLD;
-        assert!(!view.drum_pad_is_active(track_id, 52, after_hold));
-        view.prune_drum_pad_activity(after_hold);
-        assert!(view.drum_pad_activity.is_empty());
+        let after_hold = now + ViewState::DRUM_PAD_FLASH_HOLD;
+        assert!(!view.drum_pad_is_flashing(track_id, 52, after_hold));
+        view.prune_drum_pad_flashes(after_hold);
+        assert!(view.drum_pad_flash_until.is_empty());
+    }
+
+    #[test]
+    fn drum_pad_bank_activity_finds_flashes_outside_the_selected_bank() {
+        let mut view = ViewState::default();
+        let track_id = TrackId::new();
+        let now = std::time::Instant::now();
+        let second_bank_pitch =
+            vibez_core::track::drum_rack_pad_pitch(vibez_core::track::DRUM_RACK_BANK_SIZE).unwrap();
+
+        view.trigger_drum_pad_flash(track_id, second_bank_pitch, now);
+
+        assert!(!view.drum_pad_bank_is_flashing(track_id, 0, now));
+        assert!(view.drum_pad_bank_is_flashing(track_id, 1, now));
     }
 
     #[test]

--- a/crates/vibez-ui/src/state/mod.rs
+++ b/crates/vibez-ui/src/state/mod.rs
@@ -121,6 +121,9 @@ pub struct ViewState {
     pub editing_track_name: Option<TrackId>,
     pub editing_clip_name: Option<(TrackId, ClipId)>,
     pub edit_name_text: String,
+    /// Short-lived, engine-authored note flashes for device feedback.
+    /// This is view state only and is never persisted with the project.
+    pub(crate) drum_pad_activity: HashMap<(TrackId, u8), std::time::Instant>,
 }
 impl Default for ViewState {
     fn default() -> Self {
@@ -148,11 +151,35 @@ impl Default for ViewState {
             editing_track_name: None,
             editing_clip_name: None,
             edit_name_text: String::new(),
+            drum_pad_activity: HashMap::new(),
         }
     }
 }
 
 impl ViewState {
+    const DRUM_PAD_ACTIVITY_HOLD: std::time::Duration = std::time::Duration::from_millis(140);
+
+    pub fn trigger_drum_pad(&mut self, track_id: TrackId, pitch: u8, now: std::time::Instant) {
+        self.drum_pad_activity
+            .insert((track_id, pitch), now + Self::DRUM_PAD_ACTIVITY_HOLD);
+    }
+
+    pub fn drum_pad_is_active(
+        &self,
+        track_id: TrackId,
+        pitch: u8,
+        now: std::time::Instant,
+    ) -> bool {
+        self.drum_pad_activity
+            .get(&(track_id, pitch))
+            .is_some_and(|expires_at| *expires_at > now)
+    }
+
+    pub fn prune_drum_pad_activity(&mut self, now: std::time::Instant) {
+        self.drum_pad_activity
+            .retain(|_, expires_at| *expires_at > now);
+    }
+
     pub fn grid_config(&self) -> GridConfig {
         GridConfig::new(
             self.snap_grid,
@@ -1287,6 +1314,25 @@ mod tests {
 
         assert!(view.drum_rack_slice_dialog.is_none());
         assert!(view.transient_analysis_dialog.is_none());
+    }
+
+    #[test]
+    fn drum_pad_activity_is_track_and_pitch_specific_and_expires() {
+        let mut view = ViewState::default();
+        let track_id = TrackId::new();
+        let other_track_id = TrackId::new();
+        let now = std::time::Instant::now();
+
+        view.trigger_drum_pad(track_id, 52, now);
+
+        assert!(view.drum_pad_is_active(track_id, 52, now));
+        assert!(!view.drum_pad_is_active(track_id, 51, now));
+        assert!(!view.drum_pad_is_active(other_track_id, 52, now));
+
+        let after_hold = now + ViewState::DRUM_PAD_ACTIVITY_HOLD;
+        assert!(!view.drum_pad_is_active(track_id, 52, after_hold));
+        view.prune_drum_pad_activity(after_hold);
+        assert!(view.drum_pad_activity.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- report resident MIDI clip note triggers as one bounded per-track bitmask per audio block
- illuminate the matching Drum Rack pads for Arrange, Section, live input and Note Repeat playback
- retain short flashes in view-only state so brief drum notes remain visible at the UI frame rate
- preserve activity for retry if the engine event ring is temporarily full

## Verification

- `cargo test -p vibez-engine`
- `cargo test -p vibez-ui --lib`
- `cargo clippy -p vibez-engine -p vibez-ui --all-targets -- -D warnings`
- `cargo fmt --all -- --check`